### PR TITLE
fix: isolate Chat composer input

### DIFF
--- a/openspec/specs/versioned-renderer-agent-routing/spec.md
+++ b/openspec/specs/versioned-renderer-agent-routing/spec.md
@@ -13,6 +13,12 @@ The Renderer Extension SHALL keep Agent state isolated by logical Composer, SHAL
 - **WHEN** the Renderer contains an editable form with a Send button outside a verified Codex composer root
 - **THEN** the Renderer Extension does not mount Agent controls or intercept that form's input and submission events
 
+#### Scenario: Renderer switches from Work to Chat
+
+- **WHEN** a previously mounted Composer is no longer inside a verified Codex composer root
+- **THEN** the Renderer Extension removes its controls and stops intercepting that Composer's input and submission events
+- **AND** a later verified Codex composer is discovered normally without reloading the Renderer
+
 #### Scenario: User switches after editing
 
 - **WHEN** a user types, pastes, composes with an IME, deletes content, inserts an attachment, or adds a line break before submission

--- a/openspec/specs/versioned-renderer-agent-routing/spec.md
+++ b/openspec/specs/versioned-renderer-agent-routing/spec.md
@@ -8,6 +8,11 @@ Define the supported Desktop build contract for Composer-scoped Codex, Pi, and C
 
 The Renderer Extension SHALL keep Agent state isolated by logical Composer, SHALL keep the selected Agent mutable while the user edits a draft, SHALL synchronously freeze the final Agent when that draft is submitted, and SHALL persist the Agent of the most recently submitted Composer for later new-Thread drafts across codexhost Renderer windows.
 
+#### Scenario: Ordinary Chat composer is present
+
+- **WHEN** the Renderer contains an editable form with a Send button outside a verified Codex composer root
+- **THEN** the Renderer Extension does not mount Agent controls or intercept that form's input and submission events
+
 #### Scenario: User switches after editing
 
 - **WHEN** a user types, pastes, composes with an IME, deletes content, inserts an attachment, or adds a line break before submission

--- a/packages/renderer-extension/src/renderer-binding-probe.ts
+++ b/packages/renderer-extension/src/renderer-binding-probe.ts
@@ -361,8 +361,13 @@ export function installRendererBindingProbe(
   const usageRefreshTimers = new Map<Element, number>();
   const usageRefreshAttempts = new Map<Element, number>();
 
+  const isMountedComposer = (composer: Element): boolean =>
+    composer.isConnected &&
+    composer.matches(CODEX_COMPOSER_SELECTOR) &&
+    mountedByComposer.has(composer);
+
   const isCurrentModelRequest = (mounted: MountedComposer, generation: number): boolean =>
-    mounted.composer.isConnected &&
+    isMountedComposer(mounted.composer) &&
     mountedByComposer.get(mounted.composer) === mounted &&
     controller.isCurrentModelRequest(mounted.composer, generation);
 
@@ -1307,7 +1312,13 @@ export function installRendererBindingProbe(
   };
 
   const mount = (composer: Element): void => {
-    if (mountedByComposer.has(composer) || !composer.isConnected) return;
+    if (
+      mountedByComposer.has(composer) ||
+      !composer.isConnected ||
+      !composer.matches(CODEX_COMPOSER_SELECTOR)
+    ) {
+      return;
+    }
     const allButtons = [...composer.querySelectorAll<HTMLButtonElement>("button")];
     const sendButton = sendButtonWithin(composer) ?? allButtons.at(-1) ?? null;
     if (!sendButton) return;
@@ -1410,7 +1421,18 @@ export function installRendererBindingProbe(
       }
     }
     for (const [composer, mounted] of mountedByComposer) {
-      if (!composer.isConnected || !mounted.control.root.isConnected) {
+      if (
+        !composer.isConnected ||
+        !composer.matches(CODEX_COMPOSER_SELECTOR) ||
+        !mounted.control.root.isConnected
+      ) {
+        mounted.usageRequestGeneration += 1;
+        usageRefreshAttempts.delete(composer);
+        const timer = usageRefreshTimers.get(composer);
+        if (timer !== undefined) {
+          window.clearTimeout(timer);
+          usageRefreshTimers.delete(composer);
+        }
         disposeComposerAgentControl(mounted.control);
         mountedByComposer.delete(composer);
         continue;
@@ -1525,7 +1547,8 @@ export function installRendererBindingProbe(
   const composerForTarget = (target: EventTarget | null): Element | null => {
     const element = eventElement(target);
     const editor = element ? editorForElement(element) : null;
-    return editor ? composerForEditor(editor) : null;
+    const composer = editor ? composerForEditor(editor) : null;
+    return composer && isMountedComposer(composer) ? composer : null;
   };
   const onBeforeInput = (event: InputEvent): void => {
     const composer = composerForTarget(event.target);
@@ -1536,7 +1559,8 @@ export function installRendererBindingProbe(
   };
   const onSubmit = (event: Event): void => {
     const element = eventElement(event.target);
-    const composer = element ? composerForElement(element) : null;
+    const candidate = element ? composerForElement(element) : null;
+    const composer = candidate && isMountedComposer(candidate) ? candidate : null;
     if (!composer) return;
     const prepared = prepareComposer(composer);
     if (prepared === null) return;
@@ -1572,7 +1596,8 @@ export function installRendererBindingProbe(
     const element = eventElement(event.target);
     const button = element?.closest<HTMLButtonElement>("button");
     if (!button) return;
-    const composer = composerForElement(button);
+    const candidate = composerForElement(button);
+    const composer = candidate && isMountedComposer(candidate) ? candidate : null;
     const mounted = composer ? mountedByComposer.get(composer) : undefined;
     if (!composer || mounted?.control.sendButton !== button) return;
     if (!prepareComposer(composer)) {
@@ -1603,7 +1628,7 @@ export function installRendererBindingProbe(
   };
   mutationObserver.observe(document.documentElement, {
     attributes: true,
-    attributeFilter: ["hidden", "aria-hidden"],
+    attributeFilter: ["hidden", "aria-hidden", "data-codex-composer-root"],
     characterData: true,
     childList: true,
     subtree: true,

--- a/packages/renderer-extension/src/renderer-composer-dom.ts
+++ b/packages/renderer-extension/src/renderer-composer-dom.ts
@@ -110,31 +110,11 @@ export function isComposerSubmissionKey(event: KeyboardEvent): boolean {
 }
 
 export function composerForEditor(editor: Element): Element | null {
-  const codexComposer = editor.closest(CODEX_COMPOSER_SELECTOR);
-  if (codexComposer) return codexComposer;
-  const form = editor.closest("form");
-  if (form && sendButtonWithin(form)) return form;
-  let candidate = editor.parentElement;
-  for (let depth = 0; candidate && candidate !== document.body && depth < 8; depth += 1) {
-    if (sendButtonWithin(candidate)) return candidate;
-    candidate = candidate.parentElement;
-  }
-  return null;
+  return editor.closest(CODEX_COMPOSER_SELECTOR);
 }
 
 export function composerForElement(element: Element): Element | null {
-  const codexComposer = element.closest(CODEX_COMPOSER_SELECTOR);
-  if (codexComposer) return codexComposer;
-  const mounted = element.closest(`[${CONTROL_ATTRIBUTE}]`);
-  if (mounted) return mounted.parentElement;
-  const editor = editorForElement(element);
-  if (editor) return composerForEditor(editor);
-  let candidate: Element | null = element;
-  for (let depth = 0; candidate && candidate !== document.body && depth < 8; depth += 1) {
-    if (candidate.querySelector(`[${CONTROL_ATTRIBUTE}]`)) return candidate;
-    candidate = candidate.parentElement;
-  }
-  return null;
+  return element.closest(CODEX_COMPOSER_SELECTOR);
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/tests/e2e/renderer-chat-composer-isolation.spec.ts
+++ b/tests/e2e/renderer-chat-composer-isolation.spec.ts
@@ -34,9 +34,11 @@ const { outputFiles } = await build({
 });
 
 const browserBundle = outputFiles[0]?.text;
-if (!browserBundle) throw new Error("Renderer Chat isolation E2E bundle was not generated");
+if (typeof browserBundle !== "string") {
+  throw new Error("Renderer Chat isolation E2E bundle was not generated");
+}
 
-async function installChatComposer(page: Page): Promise<void> {
+async function installChatComposer(page: Page, script: string): Promise<void> {
   await page.setContent(`
     <!doctype html>
     <body>
@@ -46,8 +48,8 @@ async function installChatComposer(page: Page): Promise<void> {
       </form>
     </body>
   `);
-  await page.addScriptTag({ content: browserBundle });
-  await page.evaluate(() => new Promise((resolve) => queueMicrotask(resolve)));
+  await page.addScriptTag({ content: script });
+  await page.evaluate(() => new Promise<void>((resolve) => queueMicrotask(resolve)));
 }
 
 async function dispatchInputIntents(page: Page): Promise<unknown> {
@@ -81,7 +83,7 @@ const unmodifiedInputResults = {
 };
 
 test("ordinary Chat composers remain untouched", async ({ page }) => {
-  await installChatComposer(page);
+  await installChatComposer(page, browserBundle);
 
   await expect(page.locator("[data-codexhost-agent-control]")).toHaveCount(0);
   await expect(page.locator("[data-codexhost-model-control]")).toHaveCount(0);

--- a/tests/e2e/renderer-chat-composer-isolation.spec.ts
+++ b/tests/e2e/renderer-chat-composer-isolation.spec.ts
@@ -1,0 +1,78 @@
+import { expect, test, type Page } from "@playwright/test";
+import { build } from "esbuild";
+import path from "node:path";
+
+const repositoryRoot = path.resolve(import.meta.dirname, "../..");
+const browserExecutable = process.env.CODEXHOST_PLAYWRIGHT_EXECUTABLE_PATH;
+if (browserExecutable) test.use({ launchOptions: { executablePath: browserExecutable } });
+
+await build({
+  entryPoints: [path.join(repositoryRoot, "packages/shared-contracts/src/index.ts")],
+  bundle: true,
+  format: "esm",
+  platform: "browser",
+  target: "es2024",
+  outfile: path.join(repositoryRoot, "packages/shared-contracts/dist/index.js"),
+});
+
+const { outputFiles } = await build({
+  stdin: {
+    contents: `
+      import { installRendererBindingProbe } from "./packages/renderer-extension/src/renderer-binding-probe.ts";
+      installRendererBindingProbe({ enabledAgents: ["codex", "pi"], defaultAgent: "pi" });
+    `,
+    resolveDir: repositoryRoot,
+    sourcefile: "renderer-chat-composer-isolation-e2e-entry.ts",
+    loader: "ts",
+  },
+  bundle: true,
+  format: "iife",
+  platform: "browser",
+  target: "es2024",
+  loader: { ".css": "text", ".png": "dataurl" },
+  write: false,
+});
+
+const browserBundle = outputFiles[0]?.text;
+if (!browserBundle) throw new Error("Renderer Chat isolation E2E bundle was not generated");
+
+async function installChatComposer(page: Page): Promise<void> {
+  await page.setContent(`
+    <!doctype html>
+    <body>
+      <form data-chat-composer>
+        <div contenteditable="true" role="textbox">draft</div>
+        <button type="submit" aria-label="Send">Send</button>
+      </form>
+    </body>
+  `);
+  await page.addScriptTag({ content: browserBundle });
+  await page.evaluate(() => new Promise((resolve) => queueMicrotask(resolve)));
+}
+
+test("ordinary Chat composers remain untouched", async ({ page }) => {
+  await installChatComposer(page);
+
+  await expect(page.locator("[data-codexhost-agent-control]")).toHaveCount(0);
+  await expect(page.locator("[data-codexhost-model-control]")).toHaveCount(0);
+  await expect(page.locator("[data-codexhost-permission-mode-control]")).toHaveCount(0);
+  await expect(page.locator("[data-chat-composer] button[type=submit]")).toBeEnabled();
+
+  const results = await page.locator('[role="textbox"]').evaluate((editor) => {
+    const dispatch = (event: Event) => {
+      const accepted = editor.dispatchEvent(event);
+      return { accepted, prevented: event.defaultPrevented };
+    };
+    return {
+      backspace: dispatch(new KeyboardEvent("keydown", { key: "Backspace", bubbles: true, cancelable: true })),
+      paste: dispatch(new KeyboardEvent("keydown", { key: "v", ctrlKey: true, bubbles: true, cancelable: true })),
+      beforeInput: dispatch(new InputEvent("beforeinput", { inputType: "deleteContentBackward", bubbles: true, cancelable: true })),
+    };
+  });
+
+  expect(results).toEqual({
+    backspace: { accepted: true, prevented: false },
+    paste: { accepted: true, prevented: false },
+    beforeInput: { accepted: true, prevented: false },
+  });
+});

--- a/tests/e2e/renderer-chat-composer-isolation.spec.ts
+++ b/tests/e2e/renderer-chat-composer-isolation.spec.ts
@@ -50,15 +50,8 @@ async function installChatComposer(page: Page): Promise<void> {
   await page.evaluate(() => new Promise((resolve) => queueMicrotask(resolve)));
 }
 
-test("ordinary Chat composers remain untouched", async ({ page }) => {
-  await installChatComposer(page);
-
-  await expect(page.locator("[data-codexhost-agent-control]")).toHaveCount(0);
-  await expect(page.locator("[data-codexhost-model-control]")).toHaveCount(0);
-  await expect(page.locator("[data-codexhost-permission-mode-control]")).toHaveCount(0);
-  await expect(page.locator("[data-chat-composer] button[type=submit]")).toBeEnabled();
-
-  const results = await page.locator('[role="textbox"]').evaluate((editor) => {
+async function dispatchInputIntents(page: Page): Promise<unknown> {
+  return page.locator('[role="textbox"]').evaluate((editor) => {
     const dispatch = (event: Event) => {
       const accepted = editor.dispatchEvent(event);
       return { accepted, prevented: event.defaultPrevented };
@@ -79,10 +72,45 @@ test("ordinary Chat composers remain untouched", async ({ page }) => {
       ),
     };
   });
+}
 
-  expect(results).toEqual({
-    backspace: { accepted: true, prevented: false },
-    paste: { accepted: true, prevented: false },
-    beforeInput: { accepted: true, prevented: false },
+const unmodifiedInputResults = {
+  backspace: { accepted: true, prevented: false },
+  paste: { accepted: true, prevented: false },
+  beforeInput: { accepted: true, prevented: false },
+};
+
+test("ordinary Chat composers remain untouched", async ({ page }) => {
+  await installChatComposer(page);
+
+  await expect(page.locator("[data-codexhost-agent-control]")).toHaveCount(0);
+  await expect(page.locator("[data-codexhost-model-control]")).toHaveCount(0);
+  await expect(page.locator("[data-codexhost-permission-mode-control]")).toHaveCount(0);
+  await expect(page.locator("[data-chat-composer] button[type=submit]")).toBeEnabled();
+
+  expect(await dispatchInputIntents(page)).toEqual(unmodifiedInputResults);
+});
+
+test("a composer stops affecting input when the Codex marker is removed", async ({ page }) => {
+  await page.setContent(`
+    <!doctype html>
+    <body>
+      <form data-codex-composer-root data-mode="work">
+        <div contenteditable="true" role="textbox">draft</div>
+        <button type="submit" aria-label="Send">Send</button>
+      </form>
+    </body>
+  `);
+  await page.addScriptTag({ content: browserBundle });
+  await expect(page.locator("[data-codexhost-agent-control]")).toHaveCount(1);
+
+  await page.locator("[data-mode=work]").evaluate((composer) => {
+    composer.removeAttribute("data-codex-composer-root");
+    composer.setAttribute("data-chat-composer", "true");
+    composer.setAttribute("data-mode", "chat");
   });
+
+  await expect(page.locator("[data-codexhost-agent-control]")).toHaveCount(0);
+  await expect(page.locator("[data-mode=chat] button[type=submit]")).toBeEnabled();
+  expect(await dispatchInputIntents(page)).toEqual(unmodifiedInputResults);
 });

--- a/tests/e2e/renderer-chat-composer-isolation.spec.ts
+++ b/tests/e2e/renderer-chat-composer-isolation.spec.ts
@@ -64,9 +64,19 @@ test("ordinary Chat composers remain untouched", async ({ page }) => {
       return { accepted, prevented: event.defaultPrevented };
     };
     return {
-      backspace: dispatch(new KeyboardEvent("keydown", { key: "Backspace", bubbles: true, cancelable: true })),
-      paste: dispatch(new KeyboardEvent("keydown", { key: "v", ctrlKey: true, bubbles: true, cancelable: true })),
-      beforeInput: dispatch(new InputEvent("beforeinput", { inputType: "deleteContentBackward", bubbles: true, cancelable: true })),
+      backspace: dispatch(
+        new KeyboardEvent("keydown", { key: "Backspace", bubbles: true, cancelable: true }),
+      ),
+      paste: dispatch(
+        new KeyboardEvent("keydown", { key: "v", ctrlKey: true, bubbles: true, cancelable: true }),
+      ),
+      beforeInput: dispatch(
+        new InputEvent("beforeinput", {
+          inputType: "deleteContentBackward",
+          bubbles: true,
+          cancelable: true,
+        }),
+      ),
     };
   });
 


### PR DESCRIPTION
## 中文

### 问题

在 Chat 模式中，CodexHost 的 Agent 选择器会错误出现在普通 Chat 输入框里。Pi 和 Claude Code 因此变得可选，CodexHost 还可能接管这个输入框的键盘和粘贴事件。

问题出在 composer 定位的兜底逻辑。只要页面上存在可编辑的 form 和发送按钮，它就可能被当成 Codex composer。

### 复现

下图顶部已经选中 Chat，但普通 Chat 输入框仍然显示了 CodexHost Agent 选择器。

<img width="1010" height="1468" alt="codexhost-pr-11-reproduction" src="https://github.com/user-attachments/assets/f725bc5d-20e3-4218-bdb9-c3bb3ce153a4" />

预期行为是 Chat 模式保持原样，不显示 CodexHost Agent 选项。

### 修复

- 只在官方 `data-codex-composer-root` 标记存在时绑定 CodexHost Composer
- 删除根据通用 form 和发送按钮猜测 Codex composer 的逻辑
- 离开受支持的 Codex composer 后，清理已经挂载的绑定
- 在 Renderer 路由规范中写明 Chat 和 Codex 输入框必须隔离

### 测试

- 新增 Playwright 浏览器回归测试，修复前失败，修复后通过
- Renderer 相关单元测试共 16 项，全部通过
- TypeScript 构建通过

---

## English

### Problem

In Chat mode, the CodexHost agent selector could appear on the regular Chat composer. This made Pi and Claude Code selectable where they did not belong, and could also let CodexHost intercept keyboard and paste events from the Chat input.

The fallback composer lookup was too broad. Any editable form with a Send button could be mistaken for a Codex composer.

### Reproduction

The screenshot above shows Chat selected at the top, while the regular Chat composer still displays the CodexHost agent selector.

Expected behavior: Chat mode stays unchanged and does not show CodexHost agent options.

### Fix

- bind CodexHost Composer only when the official `data-codex-composer-root` marker is present
- remove the generic form and Send button fallback
- dispose existing bindings after leaving a supported Codex composer
- document the required separation between Chat and Codex composers

### Tests

- added a Playwright browser regression that fails before the fix and passes after it
- all 16 focused Renderer unit tests pass
- the TypeScript build passes
