### PR TITLE
feat: 支持 Linux 从源码运行 codexhost

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,7 @@
   - `launcher/`: native application launch
   - `shim/`: process proxying
   - `updater/`: update installation
-  - `platform/`: shared Windows/macOS integration
+  - `platform/`: shared Windows/macOS/Linux integration
 
 ### TypeScript Workspace
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -109,6 +109,7 @@ dependencies = [
  "libproc",
  "nix",
  "plist",
+ "serde_json",
  "sha2",
  "system-configuration",
  "windows",

--- a/README.md
+++ b/README.md
@@ -67,6 +67,19 @@ xattr -dr com.apple.quarantine /Applications/codexhost.app
 ```
 然后重新打开 `codexhost`。
 
+**Linux：从源码运行**
+
+npm 包与安装包目前仅覆盖 macOS 与 Windows。Linux 已支持从源码运行，前提是已安装官方 Codex Desktop 的 `chatgpt` 包（默认位于 `/usr/lib/chatgpt`）：
+
+```bash
+git clone https://github.com/BytePioneer-AI/codex-host.git
+cd codex-host
+npm install
+npm start
+```
+
+需要 Node.js 24 与 Rust 工具链。`npm start` 会先停掉正在运行的 Codex Desktop，再由 codexhost 重新拉起。
+
 <details>
 <summary><h3>怎么做的</h3></summary>
 

--- a/crates/launcher/src/compatibility.rs
+++ b/crates/launcher/src/compatibility.rs
@@ -177,6 +177,9 @@ enum AcknowledgedDesktopIdentity {
     MacOsBundle {
         bundle_identifier: String,
     },
+    LinuxPackage {
+        package_name: String,
+    },
 }
 
 impl From<&DesktopIdentity> for AcknowledgedDesktopIdentity {
@@ -191,6 +194,9 @@ impl From<&DesktopIdentity> for AcknowledgedDesktopIdentity {
             },
             DesktopIdentity::MacOsBundle { bundle_identifier } => Self::MacOsBundle {
                 bundle_identifier: bundle_identifier.clone(),
+            },
+            DesktopIdentity::LinuxPackage { package_name } => Self::LinuxPackage {
+                package_name: package_name.clone(),
             },
         }
     }
@@ -272,7 +278,14 @@ pub fn default_acknowledgement_path() -> io::Result<PathBuf> {
         .map(|home| home.join("Library").join("Application Support"))
         .ok_or_else(|| io::Error::new(io::ErrorKind::NotFound, "HOME is unavailable"))?;
 
-    #[cfg(not(any(target_os = "windows", target_os = "macos")))]
+    #[cfg(target_os = "linux")]
+    let root = env::var_os("XDG_CONFIG_HOME")
+        .map(PathBuf::from)
+        .filter(|path| path.is_absolute())
+        .or_else(|| env::var_os("HOME").map(|home| PathBuf::from(home).join(".config")))
+        .ok_or_else(|| io::Error::new(io::ErrorKind::NotFound, "HOME is unavailable"))?;
+
+    #[cfg(not(any(target_os = "windows", target_os = "macos", target_os = "linux")))]
     let root = env::var_os("HOME")
         .map(PathBuf::from)
         .ok_or_else(|| io::Error::new(io::ErrorKind::NotFound, "HOME is unavailable"))?;

--- a/crates/launcher/src/main.rs
+++ b/crates/launcher/src/main.rs
@@ -15,7 +15,7 @@ use std::ffi::OsString;
 use std::fmt::{self, Display, Formatter};
 use std::io::{Read, Write};
 use std::path::{Path, PathBuf};
-#[cfg(not(target_os = "macos"))]
+#[cfg(not(any(target_os = "macos", target_os = "linux")))]
 use std::process::{Child, ExitStatus};
 use std::process::{Command, ExitCode, Stdio};
 use std::sync::{OnceLock, mpsc};
@@ -24,9 +24,9 @@ use std::time::{Duration, Instant};
 
 #[cfg(target_os = "macos")]
 use active_update::start_pending_update;
-#[cfg(not(target_os = "macos"))]
+#[cfg(not(any(target_os = "macos", target_os = "linux")))]
 use codexhost_platform::launch_desktop;
-#[cfg(target_os = "macos")]
+#[cfg(any(target_os = "macos", target_os = "linux"))]
 use codexhost_platform::launch_desktop_session;
 use codexhost_platform::{
     CompatibilityChoice, CompatibilityPrompt, CompatibilityUpdateAvailability, DesktopIdentity,
@@ -132,6 +132,10 @@ fn print_installation(installation: &DesktopInstallation, process_ids: &[u32]) {
         DesktopIdentity::MacOsBundle { bundle_identifier } => {
             println!("platform=macos");
             println!("bundle_identifier={bundle_identifier}");
+        }
+        DesktopIdentity::LinuxPackage { package_name } => {
+            println!("platform=linux");
+            println!("package_name={package_name}");
         }
     }
     println!("desktop_version={}", installation.version);
@@ -478,7 +482,11 @@ fn wait_for_launched_desktop_ownership(
     }
 }
 
-#[cfg(all(not(target_os = "windows"), not(target_os = "macos")))]
+#[cfg(all(
+    not(target_os = "windows"),
+    not(target_os = "macos"),
+    not(target_os = "linux")
+))]
 fn wait_for_launched_desktop_ownership(
     _desktop: &mut Child,
     _timeout: Duration,
@@ -486,7 +494,7 @@ fn wait_for_launched_desktop_ownership(
     Ok(())
 }
 
-#[cfg(not(target_os = "macos"))]
+#[cfg(not(any(target_os = "macos", target_os = "linux")))]
 fn wait_for_desktop_exit(
     desktop: &mut Child,
     timeout: Duration,
@@ -624,7 +632,7 @@ fn notify_stock_launch() -> Result<(), Box<dyn Error>> {
     Ok(())
 }
 
-#[cfg(target_os = "macos")]
+#[cfg(any(target_os = "macos", target_os = "linux"))]
 fn supervise_desktop(
     installation: &DesktopInstallation,
     options: &ResolvedLaunchOptions,
@@ -633,10 +641,16 @@ fn supervise_desktop(
     control: &RuntimeControl,
 ) -> Result<(), Box<dyn Error>> {
     startup_trace("launching Codex Desktop");
+    // LaunchServices owns App activation on macOS; Linux ships a plain ELF
+    // Desktop that is executed directly.
+    #[cfg(target_os = "macos")]
+    let launch_mode = DesktopLaunchMode::LaunchServices;
+    #[cfg(target_os = "linux")]
+    let launch_mode = DesktopLaunchMode::DirectExecutable;
     let mut desktop = launch_desktop_session(
         installation,
         &options.shim,
-        DesktopLaunchMode::LaunchServices,
+        launch_mode,
         desktop_arguments,
         environment,
         Duration::from_secs(30),
@@ -673,8 +687,12 @@ fn supervise_desktop(
     let _runtime = publish_runtime_descriptor(control)?;
     startup_trace("runtime descriptor published");
     notify_ready_and_detach()?;
+    // Background update installation is macOS-only for now; Linux runs from a
+    // source checkout and has no installer flow to hand off to.
+    #[cfg(target_os = "macos")]
     let mut started_update_request = None;
     loop {
+        #[cfg(target_os = "macos")]
         if let Err(error) = start_pending_update(&mut started_update_request) {
             eprintln!("codexhost launcher: pending update could not be started: {error}");
         }
@@ -694,7 +712,7 @@ fn supervise_desktop(
     }
 }
 
-#[cfg(not(target_os = "macos"))]
+#[cfg(not(any(target_os = "macos", target_os = "linux")))]
 fn supervise_desktop(
     installation: &DesktopInstallation,
     options: &ResolvedLaunchOptions,
@@ -839,7 +857,7 @@ fn desktop_environment(
 /// Forcefully stop a Desktop that codexhost does not own (an official instance
 /// or a controlled instance whose Launcher exited), then relaunch cleanly.
 fn stop_external_desktop(installation: &DesktopInstallation) -> Result<(), Box<dyn Error>> {
-    #[cfg(target_os = "macos")]
+    #[cfg(any(target_os = "macos", target_os = "linux"))]
     {
         codexhost_platform::force_stop_desktop(installation, Duration::from_secs(10))?;
     }

--- a/crates/launcher/src/runtime_instance.rs
+++ b/crates/launcher/src/runtime_instance.rs
@@ -109,7 +109,14 @@ pub fn default_descriptor_path() -> io::Result<PathBuf> {
         .map(|home| home.join("Library").join("Application Support"))
         .ok_or_else(|| io::Error::new(io::ErrorKind::NotFound, "HOME is unavailable"))?;
 
-    #[cfg(not(any(target_os = "windows", target_os = "macos")))]
+    #[cfg(target_os = "linux")]
+    let root = env::var_os("XDG_CONFIG_HOME")
+        .map(PathBuf::from)
+        .filter(|path| path.is_absolute())
+        .or_else(|| env::var_os("HOME").map(|home| PathBuf::from(home).join(".config")))
+        .ok_or_else(|| io::Error::new(io::ErrorKind::NotFound, "HOME is unavailable"))?;
+
+    #[cfg(not(any(target_os = "windows", target_os = "macos", target_os = "linux")))]
     let root = env::var_os("HOME")
         .map(PathBuf::from)
         .ok_or_else(|| io::Error::new(io::ErrorKind::NotFound, "HOME is unavailable"))?;

--- a/crates/platform/Cargo.toml
+++ b/crates/platform/Cargo.toml
@@ -11,11 +11,16 @@ sha2 = "0.10.9"
 [lib]
 path = "src/lib.rs"
 
+[target.'cfg(unix)'.dependencies]
+nix = { version = "0.31.3", features = ["fs", "process", "signal"] }
+
 [target.'cfg(target_os = "macos")'.dependencies]
 libproc = "0.14.11"
-nix = { version = "0.31.3", features = ["fs", "process", "signal"] }
 plist = { version = "1.10.0", default-features = false }
 system-configuration = "0.7.0"
+
+[target.'cfg(target_os = "linux")'.dependencies]
+serde_json = "1.0.149"
 
 [target.'cfg(target_os = "windows")'.dependencies]
 windows = { version = "0.62.2", features = [

--- a/crates/platform/src/background.rs
+++ b/crates/platform/src/background.rs
@@ -5,13 +5,13 @@ use super::PlatformError;
 /// Detach the current process from its controlling terminal so it can keep
 /// supervising the Desktop after the invoking command returns.
 ///
-/// On macOS the process becomes a new session leader without a controlling
+/// On Unix the process becomes a new session leader without a controlling
 /// terminal and redirects its standard streams to `/dev/null`, so terminal
 /// close (SIGHUP) and Ctrl+C (SIGINT to the foreground process group) can no
 /// longer reach it. On Windows the process ignores console control events
 /// (Ctrl+C, break, and console close). The Launcher must call this only after
 /// startup is complete, so Ctrl+C during startup still cancels the launch.
-#[cfg(target_os = "macos")]
+#[cfg(unix)]
 pub fn detach_from_terminal() -> Result<(), PlatformError> {
     use nix::errno::Errno;
     use nix::unistd::{dup2_stderr, dup2_stdin, dup2_stdout, getpid, getsid, setsid};
@@ -70,12 +70,12 @@ pub fn detach_from_terminal() -> Result<(), PlatformError> {
     Ok(())
 }
 
-#[cfg(not(any(target_os = "macos", target_os = "windows")))]
+#[cfg(not(any(unix, target_os = "windows")))]
 pub fn detach_from_terminal() -> Result<(), PlatformError> {
     Ok(())
 }
 
-#[cfg(all(test, target_os = "macos"))]
+#[cfg(all(test, unix))]
 mod tests {
     use std::io;
     use std::process::Command;

--- a/crates/platform/src/desktop_launch.rs
+++ b/crates/platform/src/desktop_launch.rs
@@ -1,14 +1,14 @@
 use std::ffi::OsString;
-#[cfg(target_os = "macos")]
+#[cfg(any(target_os = "macos", target_os = "linux"))]
 use std::os::unix::process::CommandExt;
 use std::path::Path;
 use std::process::{Child, Command, Stdio};
-#[cfg(target_os = "macos")]
+#[cfg(any(target_os = "macos", target_os = "linux"))]
 use std::thread;
-#[cfg(target_os = "macos")]
+#[cfg(any(target_os = "macos", target_os = "linux"))]
 use std::time::{Duration, Instant};
 
-#[cfg(target_os = "macos")]
+#[cfg(any(target_os = "macos", target_os = "linux"))]
 use super::process::{
     ObservedProcessTree, ProcessSnapshot, desktop_process_tree, process_snapshots,
 };
@@ -53,11 +53,18 @@ pub fn launch_stock_desktop(installation: &DesktopInstallation) -> Result<Child,
         .map_err(PlatformError::Io)
 }
 
-#[cfg(any(target_os = "windows", target_os = "macos"))]
+#[cfg(any(target_os = "windows", target_os = "macos", target_os = "linux"))]
 fn latest_release_command() -> Command {
     #[cfg(target_os = "macos")]
     let mut command = {
         let mut command = Command::new("/usr/bin/open");
+        command.arg(CODEXHOST_RELEASES_LATEST_URL);
+        command
+    };
+
+    #[cfg(target_os = "linux")]
+    let mut command = {
+        let mut command = Command::new("xdg-open");
         command.arg(CODEXHOST_RELEASES_LATEST_URL);
         command
     };
@@ -74,17 +81,17 @@ fn latest_release_command() -> Command {
 }
 
 pub fn open_latest_codexhost_release() -> Result<(), PlatformError> {
-    #[cfg(not(any(target_os = "windows", target_os = "macos")))]
+    #[cfg(not(any(target_os = "windows", target_os = "macos", target_os = "linux")))]
     return Err(PlatformError::Unsupported(
-        "opening the codexhost Releases page is supported on Windows and macOS only",
+        "opening the codexhost Releases page is supported on Windows, macOS, and Linux only",
     ));
 
-    #[cfg(any(target_os = "windows", target_os = "macos"))]
+    #[cfg(any(target_os = "windows", target_os = "macos", target_os = "linux"))]
     latest_release_command().spawn()?.wait()?;
     Ok(())
 }
 
-#[cfg(any(target_os = "windows", target_os = "macos"))]
+#[cfg(any(target_os = "windows", target_os = "macos", target_os = "linux"))]
 fn configure_external_command(command: &mut Command) {
     remove_codexhost_environment(command, std::env::vars_os().map(|(name, _)| name));
     command
@@ -146,7 +153,24 @@ fn desktop_launch_command(
         }
     };
 
-    #[cfg(not(target_os = "macos"))]
+    #[cfg(target_os = "linux")]
+    let mut command = {
+        if mode != DesktopLaunchMode::DirectExecutable {
+            return Err(PlatformError::Unsupported(
+                "LaunchServices is available on macOS only",
+            ));
+        }
+        // The Desktop root must lead its own process group so the supervised
+        // tree can be signalled without reaching the Launcher's own group.
+        let mut command = Command::new(&installation.desktop_executable);
+        command
+            .args(additional_arguments)
+            .envs(environment)
+            .process_group(0);
+        command
+    };
+
+    #[cfg(not(any(target_os = "macos", target_os = "linux")))]
     let mut command = {
         if mode != DesktopLaunchMode::DirectExecutable {
             return Err(PlatformError::Unsupported(
@@ -183,7 +207,7 @@ pub fn launch_desktop(
     .map_err(PlatformError::Io)
 }
 
-#[cfg(target_os = "macos")]
+#[cfg(any(target_os = "macos", target_os = "linux"))]
 fn cleanup_failed_desktop_launch(launch_process: &mut Child, mode: DesktopLaunchMode) {
     if mode == DesktopLaunchMode::DirectExecutable {
         use nix::sys::signal::{Signal, killpg};
@@ -197,14 +221,14 @@ fn cleanup_failed_desktop_launch(launch_process: &mut Child, mode: DesktopLaunch
     let _ = launch_process.wait();
 }
 
-#[cfg(target_os = "macos")]
+#[cfg(any(target_os = "macos", target_os = "linux"))]
 pub struct DesktopSession {
     launch_process: Child,
     tree: ObservedProcessTree,
     armed: bool,
 }
 
-#[cfg(target_os = "macos")]
+#[cfg(any(target_os = "macos", target_os = "linux"))]
 impl DesktopSession {
     #[must_use]
     pub fn root_snapshot(&self) -> &ProcessSnapshot {
@@ -311,7 +335,7 @@ impl DesktopSession {
     }
 }
 
-#[cfg(target_os = "macos")]
+#[cfg(any(target_os = "macos", target_os = "linux"))]
 impl Drop for DesktopSession {
     fn drop(&mut self) {
         if self.armed {
@@ -320,7 +344,7 @@ impl Drop for DesktopSession {
     }
 }
 
-#[cfg(target_os = "macos")]
+#[cfg(any(target_os = "macos", target_os = "linux"))]
 pub fn launch_desktop_session(
     installation: &DesktopInstallation,
     shim_path: &Path,

--- a/crates/platform/src/installation.rs
+++ b/crates/platform/src/installation.rs
@@ -1,17 +1,17 @@
 #[cfg(target_os = "windows")]
 use std::env;
-#[cfg(any(target_os = "windows", target_os = "macos"))]
+#[cfg(any(target_os = "windows", target_os = "macos", target_os = "linux"))]
 use std::fs::File;
-#[cfg(any(target_os = "windows", target_os = "macos"))]
+#[cfg(any(target_os = "windows", target_os = "macos", target_os = "linux"))]
 use std::io::Read;
-#[cfg(target_os = "macos")]
+#[cfg(any(target_os = "macos", target_os = "linux"))]
 use std::os::unix::fs::PermissionsExt;
-#[cfg(any(target_os = "windows", target_os = "macos"))]
+#[cfg(any(target_os = "windows", target_os = "macos", target_os = "linux"))]
 use std::path::{Path, PathBuf};
 
 #[cfg(target_os = "macos")]
 use plist::Value;
-#[cfg(any(target_os = "windows", target_os = "macos"))]
+#[cfg(any(target_os = "windows", target_os = "macos", target_os = "linux"))]
 use sha2::{Digest, Sha256};
 #[cfg(target_os = "windows")]
 use windows::Management::Deployment::PackageManager;
@@ -20,7 +20,7 @@ use windows::core::HSTRING;
 
 use super::{DesktopIdentity, DesktopInstallation, PlatformError};
 
-#[cfg(any(target_os = "windows", target_os = "macos"))]
+#[cfg(any(target_os = "windows", target_os = "macos", target_os = "linux"))]
 fn sha256_file(path: &Path) -> Result<String, PlatformError> {
     let metadata = path.metadata().map_err(|error| {
         PlatformError::NotFound(format!(
@@ -527,9 +527,11 @@ fn inspect_bundle(bundle: &Path) -> Result<DesktopInstallation, PlatformError> {
     })
 }
 
-#[cfg(target_os = "macos")]
+#[cfg(any(target_os = "macos", target_os = "linux"))]
 fn discover_from_candidates(
     candidates: impl IntoIterator<Item = PathBuf>,
+    inspect: impl Fn(&Path) -> Result<DesktopInstallation, PlatformError>,
+    missing: &str,
 ) -> Result<DesktopInstallation, PlatformError> {
     let mut installations = Vec::new();
     let mut invalid = Vec::new();
@@ -537,22 +539,20 @@ fn discover_from_candidates(
         if !candidate.exists() {
             continue;
         }
-        match inspect_bundle(&candidate) {
+        match inspect(&candidate) {
             Ok(installation) => installations.push(installation),
             Err(error) => invalid.push(format!("{}: {error}", candidate.display())),
         }
     }
     match installations.len() {
         1 => Ok(installations.remove(0)),
-        0 if invalid.is_empty() => Err(PlatformError::NotFound(
-            "official Codex App was not found in /Applications or ~/Applications".into(),
-        )),
+        0 if invalid.is_empty() => Err(PlatformError::NotFound(missing.to_owned())),
         0 => Err(PlatformError::Invalid(format!(
-            "no valid official Codex App candidate: {}",
+            "no valid official Codex Desktop candidate: {}",
             invalid.join("; ")
         ))),
         _ => Err(PlatformError::Invalid(format!(
-            "multiple valid official Codex App installations were found: {}",
+            "multiple valid official Codex Desktop installations were found: {}",
             installations
                 .iter()
                 .map(|installation| installation.install_root.display().to_string())
@@ -573,13 +573,149 @@ pub fn discover_codex_desktop() -> Result<DesktopInstallation, PlatformError> {
         candidates.push(applications.join("Codex.app"));
         candidates.push(applications.join("ChatGPT.app"));
     }
-    discover_from_candidates(candidates)
+    discover_from_candidates(
+        candidates,
+        inspect_bundle,
+        "official Codex App was not found in /Applications or ~/Applications",
+    )
 }
 
-#[cfg(not(any(target_os = "windows", target_os = "macos")))]
+#[cfg(target_os = "linux")]
+const LINUX_CODEX_PACKAGE_NAME: &str = "chatgpt";
+#[cfg(target_os = "linux")]
+const ELF_MAGIC: [u8; 4] = [0x7f, b'E', b'L', b'F'];
+
+#[cfg(target_os = "linux")]
+fn linux_executable(path: &Path, label: &str) -> Result<PathBuf, PlatformError> {
+    let metadata = path.metadata().map_err(|error| {
+        PlatformError::NotFound(format!(
+            "{label} '{}' is unavailable: {error}",
+            path.display()
+        ))
+    })?;
+    if !metadata.is_file() || metadata.permissions().mode() & 0o111 == 0 {
+        return Err(PlatformError::Invalid(format!(
+            "{label} '{}' is not an executable file",
+            path.display()
+        )));
+    }
+    let mut magic = [0_u8; 4];
+    File::open(path)?.read_exact(&mut magic).map_err(|error| {
+        PlatformError::Invalid(format!(
+            "{label} '{}' has no complete ELF header: {error}",
+            path.display()
+        ))
+    })?;
+    if magic != ELF_MAGIC {
+        return Err(PlatformError::Invalid(format!(
+            "{label} '{}' is not an ELF executable",
+            path.display()
+        )));
+    }
+    path.canonicalize().map_err(PlatformError::Io)
+}
+
+/// Read the packaged Desktop version from `resources/linux-package-metadata.json`.
+///
+/// This is the Linux counterpart of `CFBundleShortVersionString`: the official
+/// deb ships the marketing version there, while the top-level `version` file
+/// carries the Electron runtime build.
+#[cfg(target_os = "linux")]
+fn linux_package_version(install_root: &Path) -> Result<String, PlatformError> {
+    let metadata_path = install_root.join("resources/linux-package-metadata.json");
+    let text = std::fs::read_to_string(&metadata_path).map_err(|error| {
+        PlatformError::NotFound(format!(
+            "Codex Desktop metadata '{}' is unavailable: {error}",
+            metadata_path.display()
+        ))
+    })?;
+    let value = serde_json::from_str::<serde_json::Value>(&text).map_err(|error| {
+        PlatformError::Invalid(format!(
+            "Codex Desktop metadata '{}' is invalid: {error}",
+            metadata_path.display()
+        ))
+    })?;
+    value
+        .get("version")
+        .and_then(serde_json::Value::as_str)
+        .filter(|version| !version.is_empty())
+        .map(str::to_owned)
+        .ok_or_else(|| {
+            PlatformError::Invalid(format!(
+                "Codex Desktop metadata '{}' has no string version",
+                metadata_path.display()
+            ))
+        })
+}
+
+#[cfg(target_os = "linux")]
+fn inspect_linux_installation(install_root: &Path) -> Result<DesktopInstallation, PlatformError> {
+    let install_root = install_root.canonicalize().map_err(|error| {
+        PlatformError::NotFound(format!(
+            "Codex Desktop directory '{}' is unavailable: {error}",
+            install_root.display()
+        ))
+    })?;
+    let version = linux_package_version(&install_root)?;
+    let build = std::fs::read_to_string(install_root.join("version"))
+        .map(|value| value.trim().to_owned())
+        .ok()
+        .filter(|value| !value.is_empty())
+        .unwrap_or_else(|| version.clone());
+    let desktop_executable = linux_executable(&install_root.join("ChatGPT"), "Desktop executable")?;
+    let packaged_codex_cli = linux_executable(&install_root.join("resources/codex"), "Codex CLI")?;
+    if !desktop_executable.starts_with(&install_root)
+        || !packaged_codex_cli.starts_with(&install_root)
+    {
+        return Err(PlatformError::Invalid(format!(
+            "Codex Desktop directory '{}' resolves an executable outside the installation",
+            install_root.display()
+        )));
+    }
+    let asar_integrity = sha256_file(&install_root.join("resources/app.asar"))?;
+
+    Ok(DesktopInstallation {
+        identity: DesktopIdentity::LinuxPackage {
+            package_name: LINUX_CODEX_PACKAGE_NAME.to_owned(),
+        },
+        version,
+        build,
+        asar_integrity,
+        install_root,
+        desktop_executable,
+        // The packaged CLI is a directly executable ELF binary, so unlike
+        // Windows there is no separate Desktop-managed cache to match.
+        packaged_codex_cli: packaged_codex_cli.clone(),
+        executable_codex_cli: packaged_codex_cli,
+    })
+}
+
+#[cfg(target_os = "linux")]
+pub fn discover_codex_desktop() -> Result<DesktopInstallation, PlatformError> {
+    if let Some(root) =
+        std::env::var_os(super::PROBE_INSTALL_ROOT_ENV).filter(|value| !value.is_empty())
+    {
+        return inspect_linux_installation(&PathBuf::from(root));
+    }
+    let mut candidates = vec![
+        PathBuf::from("/usr/lib/chatgpt"),
+        PathBuf::from("/opt/chatgpt"),
+        PathBuf::from("/usr/share/chatgpt"),
+    ];
+    if let Some(home) = std::env::var_os("HOME") {
+        candidates.push(PathBuf::from(home).join(".local/lib/chatgpt"));
+    }
+    discover_from_candidates(
+        candidates,
+        inspect_linux_installation,
+        "official Codex Desktop was not found in /usr/lib/chatgpt, /opt/chatgpt, or /usr/share/chatgpt",
+    )
+}
+
+#[cfg(not(any(target_os = "windows", target_os = "macos", target_os = "linux")))]
 pub fn discover_codex_desktop() -> Result<DesktopInstallation, PlatformError> {
     Err(PlatformError::Unsupported(
-        "the Codex Desktop probe currently supports Windows and macOS only",
+        "the Codex Desktop probe currently supports Windows, macOS, and Linux only",
     ))
 }
 
@@ -589,8 +725,14 @@ mod tests {
     use std::os::unix::fs::{PermissionsExt, symlink};
     use std::path::PathBuf;
 
-    use super::{DesktopIdentity, PlatformError, discover_from_candidates};
+    use super::{DesktopIdentity, DesktopInstallation, PlatformError, discover_from_candidates};
     use crate::temporary_directory;
+
+    fn discover(
+        candidates: impl IntoIterator<Item = PathBuf>,
+    ) -> Result<DesktopInstallation, PlatformError> {
+        discover_from_candidates(candidates, super::inspect_bundle, "no Codex App candidate")
+    }
 
     fn temporary_bundle(name: &str, bundle_identifier: &str, include_cli: bool) -> PathBuf {
         let bundle = temporary_directory("codexhost-platform-bundle").join(name);
@@ -635,7 +777,7 @@ mod tests {
     fn discovers_a_valid_macos_bundle_under_current_or_legacy_app_names() {
         for app_name in ["Codex.app", "ChatGPT.app"] {
             let bundle = temporary_bundle(app_name, "com.openai.codex", true);
-            let installation = discover_from_candidates([bundle.clone()]).expect("valid bundle");
+            let installation = discover([bundle.clone()]).expect("valid bundle");
             assert_eq!(installation.version, "1.2.3");
             assert_eq!(installation.build, "456");
             assert!(installation.asar_integrity.starts_with("sha256:"));
@@ -660,12 +802,9 @@ mod tests {
     fn rejects_wrong_bundle_identity_and_missing_cli() {
         let wrong = temporary_bundle("Wrong.app", "example.invalid", true);
         let missing = temporary_bundle("Missing.app", "com.openai.codex", false);
+        assert!(matches!(discover([wrong]), Err(PlatformError::Invalid(_))));
         assert!(matches!(
-            discover_from_candidates([wrong]),
-            Err(PlatformError::Invalid(_))
-        ));
-        assert!(matches!(
-            discover_from_candidates([missing]),
+            discover([missing]),
             Err(PlatformError::Invalid(_))
         ));
     }
@@ -678,10 +817,7 @@ mod tests {
         fs::set_permissions(&external, fs::Permissions::from_mode(0o755))
             .expect("make external CLI executable");
         symlink(&external, bundle.join("Contents/Resources/codex")).expect("link external CLI");
-        assert!(matches!(
-            discover_from_candidates([bundle]),
-            Err(PlatformError::Invalid(_))
-        ));
+        assert!(matches!(discover([bundle]), Err(PlatformError::Invalid(_))));
     }
 
     #[test]
@@ -689,7 +825,114 @@ mod tests {
         let first = temporary_bundle("First.app", "com.openai.codex", true);
         let second = temporary_bundle("Second.app", "com.openai.codex", true);
         assert!(matches!(
-            discover_from_candidates([first, second]),
+            discover([first, second]),
+            Err(PlatformError::Invalid(message)) if message.contains("multiple valid")
+        ));
+    }
+}
+
+#[cfg(all(test, target_os = "linux"))]
+mod linux_tests {
+    use std::fs;
+    use std::os::unix::fs::{PermissionsExt, symlink};
+    use std::path::PathBuf;
+
+    use super::{
+        DesktopIdentity, DesktopInstallation, PlatformError, discover_from_candidates,
+        inspect_linux_installation,
+    };
+    use crate::temporary_directory;
+
+    fn discover(
+        candidates: impl IntoIterator<Item = PathBuf>,
+    ) -> Result<DesktopInstallation, PlatformError> {
+        discover_from_candidates(
+            candidates,
+            inspect_linux_installation,
+            "no Codex Desktop candidate",
+        )
+    }
+
+    fn temporary_installation(name: &str, version: &str, include_cli: bool) -> PathBuf {
+        let root = temporary_directory("codexhost-linux-installation").join(name);
+        fs::create_dir_all(root.join("resources")).expect("create resources directory");
+        fs::write(
+            root.join("resources/linux-package-metadata.json"),
+            format!(
+                "{{\"codexAppBrand\":\"chatgpt\",\"codexBuildFlavor\":\"prod\",\"version\":\"{version}\"}}"
+            ),
+        )
+        .expect("write package metadata");
+        fs::write(root.join("version"), "42.3.0\n").expect("write runtime version");
+        fs::write(root.join("resources/app.asar"), b"reviewed app asar").expect("write app.asar");
+        for path in [
+            Some(root.join("ChatGPT")),
+            include_cli.then(|| root.join("resources/codex")),
+        ]
+        .into_iter()
+        .flatten()
+        {
+            fs::write(&path, [0x7f, b'E', b'L', b'F']).expect("write ELF marker");
+            fs::set_permissions(&path, fs::Permissions::from_mode(0o755))
+                .expect("make fixture executable");
+        }
+        root
+    }
+
+    #[test]
+    fn discovers_a_valid_linux_installation() {
+        let root = temporary_installation("chatgpt", "26.803.81509", true);
+        let installation = discover([root.clone()]).expect("valid installation");
+        assert_eq!(installation.version, "26.803.81509");
+        assert_eq!(installation.build, "42.3.0");
+        assert!(installation.asar_integrity.starts_with("sha256:"));
+        assert_eq!(
+            installation.identity,
+            DesktopIdentity::LinuxPackage {
+                package_name: "chatgpt".into()
+            }
+        );
+        assert_eq!(
+            installation.install_root,
+            root.canonicalize().expect("canonical install root")
+        );
+        // The packaged ELF CLI runs in place, so both CLI paths agree.
+        assert_eq!(
+            installation.packaged_codex_cli,
+            installation.executable_codex_cli
+        );
+    }
+
+    #[test]
+    fn rejects_a_missing_cli_and_a_non_elf_executable() {
+        let missing = temporary_installation("missing-cli", "26.803.81509", false);
+        assert!(matches!(
+            discover([missing]),
+            Err(PlatformError::Invalid(_))
+        ));
+
+        let script = temporary_installation("script-desktop", "26.803.81509", true);
+        fs::write(script.join("ChatGPT"), b"#!/bin/sh\nexit 0\n").expect("overwrite Desktop");
+        assert!(matches!(discover([script]), Err(PlatformError::Invalid(_))));
+    }
+
+    #[test]
+    fn rejects_a_cli_symlinked_outside_the_installation() {
+        let root = temporary_installation("escaping-cli", "26.803.81509", false);
+        let external = root.parent().expect("parent").join("external-codex");
+        fs::write(&external, [0x7f, b'E', b'L', b'F']).expect("write external CLI");
+        fs::set_permissions(&external, fs::Permissions::from_mode(0o755))
+            .expect("make external CLI executable");
+        symlink(&external, root.join("resources/codex")).expect("link external CLI");
+        assert!(matches!(discover([root]), Err(PlatformError::Invalid(_))));
+    }
+
+    #[test]
+    fn rejects_ambiguous_valid_installations() {
+        let first = temporary_installation("first", "26.803.81509", true);
+        let second = temporary_installation("second", "26.803.81509", true);
+        assert!(matches!(
+            discover([first, second]),
             Err(PlatformError::Invalid(message)) if message.contains("multiple valid")
         ));
     }

--- a/crates/platform/src/lib.rs
+++ b/crates/platform/src/lib.rs
@@ -12,6 +12,8 @@ mod background;
 mod background;
 mod desktop_launch;
 mod installation;
+#[cfg(target_os = "linux")]
+mod linux_process;
 #[cfg(target_os = "macos")]
 mod macos_ui;
 mod process;
@@ -26,7 +28,7 @@ mod windows_process;
 mod windows_ui;
 
 pub use background::detach_from_terminal;
-#[cfg(target_os = "macos")]
+#[cfg(any(target_os = "macos", target_os = "linux"))]
 pub use desktop_launch::{DesktopSession, launch_desktop_session};
 pub use desktop_launch::{launch_desktop, launch_stock_desktop, open_latest_codexhost_release};
 pub use installation::discover_codex_desktop;
@@ -36,7 +38,7 @@ pub use process::{
     ProcessSnapshot, descendant_executable_exists, desktop_process_ids, desktop_root_process_ids,
     parent_process_id, process_executable_path, process_exists, terminate_process_by_id,
 };
-#[cfg(target_os = "macos")]
+#[cfg(any(target_os = "macos", target_os = "linux"))]
 pub use process::{desktop_process_tree, force_stop_desktop, process_snapshot, process_snapshots};
 pub use process_supervision::{ChildProcessGuard, SupervisedChild, spawn_supervised};
 #[cfg(target_os = "macos")]
@@ -110,6 +112,9 @@ pub enum DesktopIdentity {
     },
     MacOsBundle {
         bundle_identifier: String,
+    },
+    LinuxPackage {
+        package_name: String,
     },
 }
 

--- a/crates/platform/src/linux_process.rs
+++ b/crates/platform/src/linux_process.rs
@@ -1,0 +1,125 @@
+//! Linux process inspection backed by the `/proc` filesystem.
+//!
+//! These functions mirror the macOS `libproc` snapshots in [`super::process`]:
+//! a snapshot carries the identity needed to prove that a PID still refers to
+//! the same process instance before a signal is delivered.
+
+use std::fs;
+use std::io;
+
+use super::PlatformError;
+use super::process::ProcessSnapshot;
+
+/// Clock ticks per second for `/proc/<pid>/stat` field 22 (`starttime`).
+///
+/// Linux reports `_SC_CLK_TCK` to user space as a stable ABI value of 100,
+/// decoupled from the kernel's internal `CONFIG_HZ`. Start times are therefore
+/// accurate to 10ms, which the PID reuse checks combine with the parent,
+/// process group, and executable path rather than relying on alone.
+const CLOCK_TICKS_PER_SECOND: u64 = 100;
+const MICROS_PER_SECOND: u64 = 1_000_000;
+
+fn unreadable(process_id: u32, entry: &str, error: &io::Error) -> PlatformError {
+    PlatformError::NotFound(format!("cannot read /proc/{process_id}/{entry}: {error}"))
+}
+
+/// Split the `/proc/<pid>/stat` fields that follow `comm`.
+///
+/// `comm` is wrapped in parentheses and may itself contain spaces and
+/// parentheses, so the remaining fields are split after the final `)`. The
+/// returned slice starts at field 3 (`state`), so `/proc` field *N* lives at
+/// index *N* - 3.
+fn stat_fields(stat: &str) -> Option<Vec<&str>> {
+    let comm_end = stat.rfind(')')?;
+    Some(stat[comm_end + 1..].split_whitespace().collect())
+}
+
+fn stat_field(fields: &[&str], field: usize, process_id: u32) -> Result<u64, PlatformError> {
+    fields
+        .get(field - 3)
+        .and_then(|value| value.parse::<u64>().ok())
+        .ok_or_else(|| {
+            PlatformError::Invalid(format!(
+                "/proc/{process_id}/stat has no numeric field {field}"
+            ))
+        })
+}
+
+fn stat_identifier(fields: &[&str], field: usize, process_id: u32) -> Result<u32, PlatformError> {
+    let value = stat_field(fields, field, process_id)?;
+    u32::try_from(value).map_err(|_| {
+        PlatformError::Invalid(format!(
+            "/proc/{process_id}/stat field {field} exceeds u32::MAX"
+        ))
+    })
+}
+
+pub(crate) fn linux_process_snapshot(process_id: u32) -> Result<ProcessSnapshot, PlatformError> {
+    let stat = fs::read_to_string(format!("/proc/{process_id}/stat"))
+        .map_err(|error| unreadable(process_id, "stat", &error))?;
+    let fields = stat_fields(&stat).ok_or_else(|| {
+        PlatformError::Invalid(format!("/proc/{process_id}/stat has no comm field"))
+    })?;
+    // A kernel thread has no `exe` link, and a process owned by another user
+    // rejects the read. Both surface as NotFound so full-system scans skip them.
+    let executable = fs::read_link(format!("/proc/{process_id}/exe"))
+        .map_err(|error| unreadable(process_id, "exe", &error))?;
+    Ok(ProcessSnapshot {
+        id: process_id,
+        parent_id: stat_identifier(&fields, 4, process_id)?,
+        process_group_id: stat_identifier(&fields, 5, process_id)?,
+        executable,
+        started_at_micros: stat_field(&fields, 22, process_id)?.saturating_mul(MICROS_PER_SECOND)
+            / CLOCK_TICKS_PER_SECOND,
+    })
+}
+
+pub(crate) fn linux_process_snapshots() -> Result<Vec<ProcessSnapshot>, PlatformError> {
+    let mut snapshots = Vec::new();
+    for entry in fs::read_dir("/proc")? {
+        let Ok(process_id) = entry?.file_name().to_string_lossy().parse::<u32>() else {
+            continue;
+        };
+        if let Ok(snapshot) = linux_process_snapshot(process_id) {
+            snapshots.push(snapshot);
+        }
+    }
+    Ok(snapshots)
+}
+
+pub(crate) fn linux_process_exists(process_id: u32) -> bool {
+    fs::metadata(format!("/proc/{process_id}")).is_ok_and(|metadata| metadata.is_dir())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{linux_process_exists, linux_process_snapshot, stat_fields};
+
+    #[test]
+    fn snapshots_the_current_linux_process_from_proc() {
+        let snapshot =
+            linux_process_snapshot(std::process::id()).expect("current process snapshot");
+        assert_eq!(snapshot.id, std::process::id());
+        assert!(snapshot.parent_id > 0);
+        assert!(snapshot.process_group_id > 0);
+        assert!(snapshot.executable.is_absolute());
+        assert!(snapshot.started_at_micros > 0);
+    }
+
+    #[test]
+    fn splits_stat_fields_after_a_comm_containing_spaces_and_parentheses() {
+        // Field 3 is `state`, so field 4 (ppid) is index 1 and field 5 (pgrp)
+        // is index 2 even though `comm` itself contains `)` and a space.
+        let stat = "42 (od d) na:me) S 7 9 9 0 -1 4194304";
+        let fields = stat_fields(stat).expect("fields after comm");
+        assert_eq!(fields[0], "S");
+        assert_eq!(fields[1], "7");
+        assert_eq!(fields[2], "9");
+    }
+
+    #[test]
+    fn reports_liveness_for_the_current_process_and_not_for_an_unused_pid() {
+        assert!(linux_process_exists(std::process::id()));
+        assert!(!linux_process_exists(u32::MAX));
+    }
+}

--- a/crates/platform/src/process.rs
+++ b/crates/platform/src/process.rs
@@ -1,11 +1,11 @@
 use std::path::{Path, PathBuf};
-#[cfg(target_os = "macos")]
+#[cfg(any(target_os = "macos", target_os = "linux"))]
 use std::thread;
-#[cfg(target_os = "macos")]
+#[cfg(any(target_os = "macos", target_os = "linux"))]
 use std::time::{Duration, Instant};
 
 use super::PlatformError;
-#[cfg(target_os = "macos")]
+#[cfg(any(target_os = "macos", target_os = "linux"))]
 use super::{DesktopInstallation, discover_codex_desktop};
 #[cfg(target_os = "windows")]
 use super::{node_entrypoint_path, windows_process};
@@ -51,6 +51,11 @@ pub fn process_snapshot(process_id: u32) -> Result<ProcessSnapshot, PlatformErro
     macos_process_snapshot(process_id)
 }
 
+#[cfg(target_os = "linux")]
+pub fn process_snapshot(process_id: u32) -> Result<ProcessSnapshot, PlatformError> {
+    super::linux_process::linux_process_snapshot(process_id)
+}
+
 #[cfg(target_os = "macos")]
 pub fn process_snapshots() -> Result<Vec<ProcessSnapshot>, PlatformError> {
     use libproc::processes::{ProcFilter, pids_by_type};
@@ -61,17 +66,22 @@ pub fn process_snapshots() -> Result<Vec<ProcessSnapshot>, PlatformError> {
         .collect())
 }
 
-#[cfg(target_os = "macos")]
+#[cfg(target_os = "linux")]
+pub fn process_snapshots() -> Result<Vec<ProcessSnapshot>, PlatformError> {
+    super::linux_process::linux_process_snapshots()
+}
+
+#[cfg(any(target_os = "macos", target_os = "linux"))]
 fn same_process_instance(expected: &ProcessSnapshot, current: &ProcessSnapshot) -> bool {
     expected.id == current.id && expected.started_at_micros == current.started_at_micros
 }
 
-#[cfg(target_os = "macos")]
+#[cfg(any(target_os = "macos", target_os = "linux"))]
 fn same_process_identity(expected: &ProcessSnapshot, current: &ProcessSnapshot) -> bool {
     same_process_instance(expected, current) && expected.executable == current.executable
 }
 
-#[cfg(target_os = "macos")]
+#[cfg(any(target_os = "macos", target_os = "linux"))]
 fn descendant_snapshots(roots: &[u32], snapshots: &[ProcessSnapshot]) -> Vec<ProcessSnapshot> {
     let mut owned_ids = roots.to_vec();
     let mut descendants = Vec::new();
@@ -90,7 +100,7 @@ fn descendant_snapshots(roots: &[u32], snapshots: &[ProcessSnapshot]) -> Vec<Pro
     }
 }
 
-#[cfg(target_os = "macos")]
+#[cfg(any(target_os = "macos", target_os = "linux"))]
 fn desktop_process_tree_from_snapshots(
     desktop_executable: &Path,
     snapshots: &[ProcessSnapshot],
@@ -107,7 +117,7 @@ fn desktop_process_tree_from_snapshots(
     tree
 }
 
-#[cfg(target_os = "macos")]
+#[cfg(any(target_os = "macos", target_os = "linux"))]
 pub fn desktop_process_tree(
     installation: &DesktopInstallation,
 ) -> Result<Vec<ProcessSnapshot>, PlatformError> {
@@ -117,13 +127,13 @@ pub fn desktop_process_tree(
     ))
 }
 
-#[cfg(target_os = "macos")]
+#[cfg(any(target_os = "macos", target_os = "linux"))]
 pub(crate) struct ObservedProcessTree {
     pub(crate) root: ProcessSnapshot,
     known: Vec<ProcessSnapshot>,
 }
 
-#[cfg(target_os = "macos")]
+#[cfg(any(target_os = "macos", target_os = "linux"))]
 impl ObservedProcessTree {
     pub(crate) fn new(root: ProcessSnapshot) -> Self {
         Self {
@@ -217,7 +227,7 @@ impl ObservedProcessTree {
         use nix::unistd::Pid;
 
         for expected in processes {
-            let current = match macos_process_snapshot(expected.id) {
+            let current = match process_snapshot(expected.id) {
                 Ok(current) => current,
                 Err(PlatformError::NotFound(_)) => continue,
                 Err(error) => return Err(error),
@@ -279,7 +289,7 @@ pub fn desktop_root_process_ids() -> Result<Vec<u32>, PlatformError> {
         .collect())
 }
 
-#[cfg(target_os = "macos")]
+#[cfg(any(target_os = "macos", target_os = "linux"))]
 pub fn desktop_process_ids() -> Result<Vec<u32>, PlatformError> {
     let installation = discover_codex_desktop()?;
     Ok(desktop_process_tree(&installation)?
@@ -289,19 +299,19 @@ pub fn desktop_process_ids() -> Result<Vec<u32>, PlatformError> {
         .collect())
 }
 
-#[cfg(target_os = "macos")]
+#[cfg(any(target_os = "macos", target_os = "linux"))]
 pub fn desktop_root_process_ids() -> Result<Vec<u32>, PlatformError> {
     desktop_process_ids()
 }
 
-#[cfg(not(any(target_os = "windows", target_os = "macos")))]
+#[cfg(not(any(target_os = "windows", target_os = "macos", target_os = "linux")))]
 pub fn desktop_process_ids() -> Result<Vec<u32>, PlatformError> {
     Err(PlatformError::Unsupported(
-        "Desktop process discovery currently supports Windows and macOS only",
+        "Desktop process discovery currently supports Windows, macOS, and Linux only",
     ))
 }
 
-#[cfg(not(any(target_os = "windows", target_os = "macos")))]
+#[cfg(not(any(target_os = "windows", target_os = "macos", target_os = "linux")))]
 pub fn desktop_root_process_ids() -> Result<Vec<u32>, PlatformError> {
     desktop_process_ids()
 }
@@ -340,7 +350,7 @@ pub fn descendant_executable_exists(
     }))
 }
 
-#[cfg(target_os = "macos")]
+#[cfg(any(target_os = "macos", target_os = "linux"))]
 pub fn descendant_executable_exists(
     root_process_id: u32,
     executable: &Path,
@@ -351,13 +361,13 @@ pub fn descendant_executable_exists(
         .any(|process| process.executable == executable))
 }
 
-#[cfg(not(any(target_os = "windows", target_os = "macos")))]
+#[cfg(not(any(target_os = "windows", target_os = "macos", target_os = "linux")))]
 pub fn descendant_executable_exists(
     _root_process_id: u32,
     _executable: &Path,
 ) -> Result<bool, PlatformError> {
     Err(PlatformError::Unsupported(
-        "descendant process discovery currently supports Windows and macOS only",
+        "descendant process discovery currently supports Windows, macOS, and Linux only",
     ))
 }
 
@@ -369,15 +379,15 @@ pub fn parent_process_id(process_id: u32) -> Result<Option<u32>, PlatformError> 
         .map(|process| process.parent_id))
 }
 
-#[cfg(target_os = "macos")]
+#[cfg(any(target_os = "macos", target_os = "linux"))]
 pub fn parent_process_id(process_id: u32) -> Result<Option<u32>, PlatformError> {
-    macos_process_snapshot(process_id).map(|process| Some(process.parent_id))
+    process_snapshot(process_id).map(|process| Some(process.parent_id))
 }
 
-#[cfg(not(any(target_os = "windows", target_os = "macos")))]
+#[cfg(not(any(target_os = "windows", target_os = "macos", target_os = "linux")))]
 pub fn parent_process_id(_process_id: u32) -> Result<Option<u32>, PlatformError> {
     Err(PlatformError::Unsupported(
-        "parent process discovery currently supports Windows and macOS only",
+        "parent process discovery currently supports Windows, macOS, and Linux only",
     ))
 }
 
@@ -386,15 +396,15 @@ pub fn process_executable_path(process_id: u32) -> Result<PathBuf, PlatformError
     windows_process::process_image_path(process_id).map_err(PlatformError::Io)
 }
 
-#[cfg(target_os = "macos")]
+#[cfg(any(target_os = "macos", target_os = "linux"))]
 pub fn process_executable_path(process_id: u32) -> Result<PathBuf, PlatformError> {
     process_snapshot(process_id).map(|process| process.executable)
 }
 
-#[cfg(not(any(target_os = "windows", target_os = "macos")))]
+#[cfg(not(any(target_os = "windows", target_os = "macos", target_os = "linux")))]
 pub fn process_executable_path(_process_id: u32) -> Result<PathBuf, PlatformError> {
     Err(PlatformError::Unsupported(
-        "process executable discovery currently supports Windows and macOS only",
+        "process executable discovery currently supports Windows, macOS, and Linux only",
     ))
 }
 
@@ -423,7 +433,12 @@ pub fn process_exists(process_id: u32) -> bool {
     i32::try_from(process_id).is_ok_and(|process_id| pidpath(process_id).is_ok())
 }
 
-#[cfg(target_os = "macos")]
+#[cfg(target_os = "linux")]
+pub fn process_exists(process_id: u32) -> bool {
+    super::linux_process::linux_process_exists(process_id)
+}
+
+#[cfg(any(target_os = "macos", target_os = "linux"))]
 fn signal_processes_checked(
     snapshots: &[ProcessSnapshot],
     signal: nix::sys::signal::Signal,
@@ -433,7 +448,7 @@ fn signal_processes_checked(
     use nix::unistd::Pid;
 
     for expected in snapshots {
-        let current = match macos_process_snapshot(expected.id) {
+        let current = match process_snapshot(expected.id) {
             Ok(current) => current,
             Err(PlatformError::NotFound(_)) => continue,
             Err(error) => return Err(error),
@@ -460,7 +475,7 @@ fn signal_processes_checked(
 /// Forcefully stop the entire Desktop process tree, including descendants such
 /// as the injected Shim, Host Runtime, and app-server. The Desktop is verified
 /// by identity before every signal so a reused PID is never terminated.
-#[cfg(target_os = "macos")]
+#[cfg(any(target_os = "macos", target_os = "linux"))]
 pub fn force_stop_desktop(
     installation: &DesktopInstallation,
     grace: Duration,
@@ -506,7 +521,7 @@ pub fn force_stop_desktop(
     }
 }
 
-#[cfg(not(any(target_os = "windows", target_os = "macos")))]
+#[cfg(not(any(target_os = "windows", target_os = "macos", target_os = "linux")))]
 pub fn process_exists(_process_id: u32) -> bool {
     false
 }
@@ -526,7 +541,7 @@ mod windows_tests {
     }
 }
 
-#[cfg(all(test, target_os = "macos"))]
+#[cfg(all(test, any(target_os = "macos", target_os = "linux")))]
 mod tests {
     use std::path::Path;
 
@@ -551,7 +566,7 @@ mod tests {
     }
 
     #[test]
-    fn snapshots_the_current_macos_process_with_native_libproc() {
+    fn snapshots_the_current_process_with_native_platform_apis() {
         let snapshot = process_snapshot(std::process::id()).expect("current process snapshot");
         assert_eq!(snapshot.id, std::process::id());
         assert!(snapshot.parent_id > 0);

--- a/crates/platform/src/process_supervision.rs
+++ b/crates/platform/src/process_supervision.rs
@@ -2,8 +2,8 @@ use std::io;
 use std::process::{Child, ChildStderr, ChildStdin, ChildStdout, Command, ExitStatus};
 
 use super::PlatformError;
-#[cfg(target_os = "macos")]
-use super::process::{ObservedProcessTree, macos_process_snapshot};
+#[cfg(any(target_os = "macos", target_os = "linux"))]
+use super::process::{ObservedProcessTree, process_snapshot};
 #[cfg(target_os = "windows")]
 use super::windows_process;
 
@@ -12,13 +12,13 @@ pub struct ChildProcessGuard {
     job: windows_process::ChildJob,
 }
 
-#[cfg(target_os = "macos")]
+#[cfg(any(target_os = "macos", target_os = "linux"))]
 pub struct ChildProcessGuard {
     tree: std::sync::Mutex<ObservedProcessTree>,
     armed: bool,
 }
 
-#[cfg(target_os = "macos")]
+#[cfg(any(target_os = "macos", target_os = "linux"))]
 impl ChildProcessGuard {
     fn with_tree<T>(
         &self,
@@ -83,7 +83,7 @@ impl ChildProcessGuard {
     }
 }
 
-#[cfg(target_os = "macos")]
+#[cfg(any(target_os = "macos", target_os = "linux"))]
 impl Drop for ChildProcessGuard {
     fn drop(&mut self) {
         if self.armed {
@@ -92,7 +92,7 @@ impl Drop for ChildProcessGuard {
     }
 }
 
-#[cfg(not(any(target_os = "windows", target_os = "macos")))]
+#[cfg(not(any(target_os = "windows", target_os = "macos", target_os = "linux")))]
 pub struct ChildProcessGuard;
 
 pub struct SupervisedChild {
@@ -131,7 +131,7 @@ impl SupervisedChild {
         if let Some(guard) = &self.guard {
             return guard.job.terminate(1).map_err(PlatformError::Io);
         }
-        #[cfg(target_os = "macos")]
+        #[cfg(any(target_os = "macos", target_os = "linux"))]
         if let Some(guard) = &self.guard {
             return guard.signal(nix::sys::signal::Signal::SIGTERM);
         }
@@ -143,14 +143,14 @@ impl SupervisedChild {
         if let Some(guard) = &self.guard {
             return guard.job.terminate(1).map_err(PlatformError::Io);
         }
-        #[cfg(target_os = "macos")]
+        #[cfg(any(target_os = "macos", target_os = "linux"))]
         if let Some(guard) = &self.guard {
             return guard.signal(nix::sys::signal::Signal::SIGKILL);
         }
         self.child.kill().map_err(PlatformError::Io)
     }
 
-    #[cfg(target_os = "macos")]
+    #[cfg(any(target_os = "macos", target_os = "linux"))]
     pub fn forward_signal(&self, signal: i32) -> Result<(), PlatformError> {
         let signal = nix::sys::signal::Signal::try_from(signal)
             .map_err(|_| PlatformError::Invalid(format!("unsupported Unix signal {signal}")))?;
@@ -161,20 +161,20 @@ impl SupervisedChild {
     }
 
     pub fn disarm_cleanup(&mut self) {
-        #[cfg(target_os = "macos")]
+        #[cfg(any(target_os = "macos", target_os = "linux"))]
         if let Some(guard) = &mut self.guard {
             guard.armed = false;
         }
     }
 
-    #[cfg(target_os = "macos")]
+    #[cfg(any(target_os = "macos", target_os = "linux"))]
     pub fn has_live_processes(&self) -> Result<bool, PlatformError> {
         self.guard
             .as_ref()
             .map_or(Ok(false), ChildProcessGuard::has_live_members)
     }
 
-    #[cfg(target_os = "macos")]
+    #[cfg(any(target_os = "macos", target_os = "linux"))]
     #[must_use]
     pub fn process_group_id(&self) -> u32 {
         self.guard
@@ -195,13 +195,13 @@ pub fn spawn_supervised(command: &mut Command) -> Result<SupervisedChild, Platfo
     Ok(SupervisedChild { child, guard })
 }
 
-#[cfg(target_os = "macos")]
+#[cfg(any(target_os = "macos", target_os = "linux"))]
 pub fn spawn_supervised(command: &mut Command) -> Result<SupervisedChild, PlatformError> {
     use std::os::unix::process::CommandExt;
 
     command.process_group(0);
     let mut child = command.spawn()?;
-    let root = match macos_process_snapshot(child.id()) {
+    let root = match process_snapshot(child.id()) {
         Ok(root) => root,
         Err(_) if child.try_wait()?.is_some() => {
             return Ok(SupervisedChild { child, guard: None });
@@ -229,9 +229,9 @@ pub fn spawn_supervised(command: &mut Command) -> Result<SupervisedChild, Platfo
     })
 }
 
-#[cfg(not(any(target_os = "windows", target_os = "macos")))]
+#[cfg(not(any(target_os = "windows", target_os = "macos", target_os = "linux")))]
 pub fn spawn_supervised(_command: &mut Command) -> Result<SupervisedChild, PlatformError> {
     Err(PlatformError::Unsupported(
-        "supervised child processes currently support Windows and macOS only",
+        "supervised child processes currently support Windows, macOS, and Linux only",
     ))
 }

--- a/crates/shim/Cargo.toml
+++ b/crates/shim/Cargo.toml
@@ -20,6 +20,6 @@ required-features = ["test-utils"]
 [dependencies]
 codexhost-platform = { path = "../platform" }
 
-[target.'cfg(target_os = "macos")'.dependencies]
+[target.'cfg(unix)'.dependencies]
 nix = { version = "0.31.3", features = ["process", "signal"] }
 signal-hook = "0.4.4"

--- a/crates/shim/src/lib.rs
+++ b/crates/shim/src/lib.rs
@@ -40,13 +40,13 @@ where
     Ok(copied)
 }
 
-#[cfg(target_os = "macos")]
+#[cfg(any(target_os = "macos", target_os = "linux"))]
 struct ShutdownSignals {
     pending: std::sync::Arc<std::sync::atomic::AtomicUsize>,
     registrations: Vec<signal_hook::SigId>,
 }
 
-#[cfg(target_os = "macos")]
+#[cfg(any(target_os = "macos", target_os = "linux"))]
 impl ShutdownSignals {
     fn install() -> ShimResult<Self> {
         use nix::sys::signal::{SigSet, Signal};
@@ -84,7 +84,7 @@ impl ShutdownSignals {
     }
 }
 
-#[cfg(target_os = "macos")]
+#[cfg(any(target_os = "macos", target_os = "linux"))]
 impl Drop for ShutdownSignals {
     fn drop(&mut self) {
         for registration in self.registrations.drain(..) {
@@ -93,10 +93,10 @@ impl Drop for ShutdownSignals {
     }
 }
 
-#[cfg(not(target_os = "macos"))]
+#[cfg(not(any(target_os = "macos", target_os = "linux")))]
 struct ShutdownSignals;
 
-#[cfg(not(target_os = "macos"))]
+#[cfg(not(any(target_os = "macos", target_os = "linux")))]
 impl ShutdownSignals {
     fn install() -> ShimResult<Self> {
         Ok(Self)
@@ -110,7 +110,7 @@ struct ChildOutcome {
     terminated_descendants: bool,
 }
 
-#[cfg(target_os = "macos")]
+#[cfg(any(target_os = "macos", target_os = "linux"))]
 fn wait_for_child(
     child: &mut codexhost_platform::SupervisedChild,
     signals: &ShutdownSignals,
@@ -155,7 +155,7 @@ fn wait_for_child(
     }
 }
 
-#[cfg(not(target_os = "macos"))]
+#[cfg(not(any(target_os = "macos", target_os = "linux")))]
 fn wait_for_child(
     child: &mut codexhost_platform::SupervisedChild,
     _signals: &ShutdownSignals,
@@ -171,14 +171,14 @@ fn wait_for_child(
         .map_err(Into::into)
 }
 
-#[cfg(target_os = "macos")]
+#[cfg(any(target_os = "macos", target_os = "linux"))]
 fn exit_signal(status: &ExitStatus) -> Option<i32> {
     use std::os::unix::process::ExitStatusExt;
 
     status.signal()
 }
 
-#[cfg(not(target_os = "macos"))]
+#[cfg(not(any(target_os = "macos", target_os = "linux")))]
 fn exit_signal(_status: &ExitStatus) -> Option<i32> {
     None
 }
@@ -355,7 +355,7 @@ pub fn run_from_environment() -> ShimResult<i32> {
 mod tests {
     use std::ffi::OsString;
 
-    #[cfg(target_os = "macos")]
+    #[cfg(any(target_os = "macos", target_os = "linux"))]
     use super::ShutdownSignals;
     use super::app_server_subcommand_index;
 
@@ -389,7 +389,7 @@ mod tests {
         assert_eq!(app_server_subcommand_index(&arguments(&["-c"])), None);
     }
 
-    #[cfg(target_os = "macos")]
+    #[cfg(any(target_os = "macos", target_os = "linux"))]
     fn observe_sigterm(signals: &ShutdownSignals) {
         use nix::sys::signal::{Signal, kill};
         use nix::unistd::Pid;
@@ -410,14 +410,14 @@ mod tests {
         assert_eq!(observed, Some(SIGTERM));
     }
 
-    #[cfg(target_os = "macos")]
+    #[cfg(any(target_os = "macos", target_os = "linux"))]
     #[test]
     fn records_sigterm_in_an_atomic_flag() {
         let signals = ShutdownSignals::install().expect("install shutdown signals");
         observe_sigterm(&signals);
     }
 
-    #[cfg(target_os = "macos")]
+    #[cfg(any(target_os = "macos", target_os = "linux"))]
     #[test]
     fn records_sigterm_after_spawning_a_supervised_child() {
         use std::process::Command;
@@ -430,7 +430,7 @@ mod tests {
         observe_sigterm(&signals);
     }
 
-    #[cfg(target_os = "macos")]
+    #[cfg(any(target_os = "macos", target_os = "linux"))]
     #[test]
     fn records_sigterm_while_a_supervised_child_is_running() {
         use std::process::Command;

--- a/crates/shim/tests/fixtures/fake-codex-cli.rs
+++ b/crates/shim/tests/fixtures/fake-codex-cli.rs
@@ -23,7 +23,7 @@ fn write_ready_file(path: &Path, contents: &str) {
     fs::rename(temporary, path).expect("publish ready file");
 }
 
-#[cfg(target_os = "macos")]
+#[cfg(any(target_os = "macos", target_os = "linux"))]
 fn run_signal_observer() -> bool {
     use signal_hook::consts::{SIGHUP, SIGINT, SIGTERM};
     use signal_hook::flag::register_usize;
@@ -56,7 +56,7 @@ fn run_signal_observer() -> bool {
     }
 }
 
-#[cfg(not(target_os = "macos"))]
+#[cfg(not(any(target_os = "macos", target_os = "linux")))]
 fn run_signal_observer() -> bool {
     false
 }
@@ -67,10 +67,11 @@ fn main() {
     let arguments = env::args().skip(1).collect::<Vec<_>>();
     #[cfg(unix)]
     if env::var_os("FAKE_CODEX_CRASH").is_some() {
-        use std::os::unix::process::CommandExt;
-
-        let error = Command::new("/bin/sh").args(["-c", "kill -SEGV $$"]).exec();
-        panic!("failed to exec crashing process: {error}");
+        // Abort in place rather than exec'ing a crashing shell. The Shim
+        // supervises the official CLI by executable identity, so replacing this
+        // process image would be observed as the supervised root changing
+        // identity instead of as a crash.
+        process::abort();
     }
     if run_signal_observer() {
         return;
@@ -79,7 +80,7 @@ fn main() {
         .first()
         .is_some_and(|value| value == "--child-sleep")
     {
-        #[cfg(target_os = "macos")]
+        #[cfg(any(target_os = "macos", target_os = "linux"))]
         if env::var_os("FAKE_CODEX_CHILD_NEW_GROUP").is_some() {
             use nix::unistd::{Pid, setpgid};
 

--- a/crates/shim/tests/proxy.rs
+++ b/crates/shim/tests/proxy.rs
@@ -5,12 +5,12 @@ use std::io::{BufRead, BufReader};
 use std::path::PathBuf;
 use std::process::{self, Command, Stdio};
 use std::sync::atomic::{AtomicU64, Ordering};
-#[cfg(any(target_os = "windows", target_os = "macos"))]
+#[cfg(any(target_os = "windows", target_os = "macos", target_os = "linux"))]
 use std::thread;
-#[cfg(any(target_os = "windows", target_os = "macos"))]
+#[cfg(any(target_os = "windows", target_os = "macos", target_os = "linux"))]
 use std::time::{Duration, Instant};
 
-#[cfg(any(target_os = "windows", target_os = "macos"))]
+#[cfg(any(target_os = "windows", target_os = "macos", target_os = "linux"))]
 use codexhost_platform::process_exists;
 use codexhost_platform::{CODEX_CLI_PATH_ENV, STOCK_CODEX_PATH_ENV};
 
@@ -175,7 +175,7 @@ fn rejects_missing_official_cli_without_falling_back_to_path() {
     assert!(String::from_utf8_lossy(&output.stderr).contains("does not exist"));
 }
 
-#[cfg(target_os = "macos")]
+#[cfg(any(target_os = "macos", target_os = "linux"))]
 #[test]
 fn reports_an_official_cli_crash_without_polluting_stdout() {
     let output = run_shim(b"", &[], &[("FAKE_CODEX_CRASH", "1")]);
@@ -184,7 +184,7 @@ fn reports_an_official_cli_crash_without_polluting_stdout() {
     assert!(String::from_utf8_lossy(&output.stderr).contains("terminated by signal"));
 }
 
-#[cfg(target_os = "macos")]
+#[cfg(any(target_os = "macos", target_os = "linux"))]
 fn wait_for_file(path: &std::path::Path, timeout: Duration) -> String {
     let started = Instant::now();
     loop {
@@ -200,7 +200,7 @@ fn wait_for_file(path: &std::path::Path, timeout: Duration) -> String {
     }
 }
 
-#[cfg(target_os = "macos")]
+#[cfg(any(target_os = "macos", target_os = "linux"))]
 fn run_external_signal_case(signal: &str, expected_signal: i32, ignore_signal: bool) {
     let directory = temporary_directory();
     let ready = directory.join("ready");
@@ -260,25 +260,25 @@ fn run_external_signal_case(signal: &str, expected_signal: i32, ignore_signal: b
     );
 }
 
-#[cfg(target_os = "macos")]
+#[cfg(any(target_os = "macos", target_os = "linux"))]
 #[test]
 fn forwards_external_sigterm_to_the_official_cli_group() {
     run_external_signal_case("TERM", 15, false);
 }
 
-#[cfg(target_os = "macos")]
+#[cfg(any(target_os = "macos", target_os = "linux"))]
 #[test]
 fn forwards_external_sigint_to_the_official_cli_group() {
     run_external_signal_case("INT", 2, false);
 }
 
-#[cfg(target_os = "macos")]
+#[cfg(any(target_os = "macos", target_os = "linux"))]
 #[test]
 fn forwards_external_sighup_to_the_official_cli_group() {
     run_external_signal_case("HUP", 1, false);
 }
 
-#[cfg(target_os = "macos")]
+#[cfg(any(target_os = "macos", target_os = "linux"))]
 #[test]
 fn converges_once_when_multiple_shutdown_signals_arrive() {
     let directory = temporary_directory();
@@ -328,13 +328,13 @@ fn converges_once_when_multiple_shutdown_signals_arrive() {
     assert!(!process_exists(child_id));
 }
 
-#[cfg(target_os = "macos")]
+#[cfg(any(target_os = "macos", target_os = "linux"))]
 #[test]
 fn escalates_when_the_official_cli_ignores_sigterm() {
     run_external_signal_case("TERM", 15, true);
 }
 
-#[cfg(target_os = "macos")]
+#[cfg(any(target_os = "macos", target_os = "linux"))]
 #[test]
 fn cleans_an_escaped_descendant_after_the_cli_root_exits() {
     let directory = temporary_directory();

--- a/crates/updater/src/install.rs
+++ b/crates/updater/src/install.rs
@@ -1,25 +1,35 @@
 #[cfg(target_os = "macos")]
 use std::env;
 use std::error::Error;
+#[cfg(any(target_os = "windows", target_os = "macos"))]
 use std::fs::{self, File};
+#[cfg(any(target_os = "windows", target_os = "macos"))]
 use std::io::Read;
+#[cfg(any(target_os = "windows", target_os = "macos"))]
 use std::path::Path;
 use std::process::{Command, Stdio};
 
 use codexhost_platform::configure_background_command;
+#[cfg(any(target_os = "windows", target_os = "macos"))]
 use serde::Deserialize;
+#[cfg(any(target_os = "windows", target_os = "macos"))]
 use sha2::{Digest, Sha256};
 
+#[cfg(any(target_os = "windows", target_os = "macos"))]
+use crate::request::validate_version;
 use crate::request::{
     Installation, MacOsInstallation, NpmInstallation, UpdateRequest, WindowsInstallation,
-    validate_version,
 };
 #[cfg(target_os = "macos")]
 use crate::status::unix_seconds;
 
 const NPM_PACKAGE_NAME: &str = "@codexhost/cli";
+// Artifact and distribution verification only runs where codexhost ships an
+// installer; the Linux build is source-only and has no installer flow.
+#[cfg(any(target_os = "windows", target_os = "macos"))]
 const DISTRIBUTION_FILE: &str = "codexhost-distribution.json";
 
+#[cfg(any(target_os = "windows", target_os = "macos"))]
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 struct DistributionMetadata {
@@ -29,6 +39,7 @@ struct DistributionMetadata {
     target: String,
 }
 
+#[cfg(any(target_os = "windows", target_os = "macos"))]
 fn sha256_file(path: &Path) -> Result<String, Box<dyn Error>> {
     let mut file = File::open(path)?;
     let mut hasher = Sha256::new();
@@ -47,6 +58,7 @@ fn sha256_file(path: &Path) -> Result<String, Box<dyn Error>> {
         .collect())
 }
 
+#[cfg(any(target_os = "windows", target_os = "macos"))]
 fn verify_artifact(path: &Path, expected: &str) -> Result<(), Box<dyn Error>> {
     let actual = sha256_file(path)?;
     if actual != expected {
@@ -57,6 +69,7 @@ fn verify_artifact(path: &Path, expected: &str) -> Result<(), Box<dyn Error>> {
     Ok(())
 }
 
+#[cfg(any(target_os = "windows", target_os = "macos"))]
 fn distribution_metadata(path: &Path) -> Result<DistributionMetadata, Box<dyn Error>> {
     let metadata = serde_json::from_slice::<DistributionMetadata>(&fs::read(path)?)?;
     if metadata.schema_version != 1 || metadata.target.is_empty() {
@@ -66,6 +79,7 @@ fn distribution_metadata(path: &Path) -> Result<DistributionMetadata, Box<dyn Er
     Ok(metadata)
 }
 
+#[cfg(any(target_os = "windows", target_os = "macos"))]
 fn verify_distribution(
     path: &Path,
     version: &str,
@@ -252,7 +266,7 @@ pub(crate) fn relaunch(request: &UpdateRequest) -> Result<(), Box<dyn Error>> {
     Ok(())
 }
 
-#[cfg(test)]
+#[cfg(all(test, any(target_os = "windows", target_os = "macos")))]
 mod tests {
     use super::DistributionMetadata;
 

--- a/docs/README.en.md
+++ b/docs/README.en.md
@@ -65,6 +65,19 @@ xattr -dr com.apple.quarantine /Applications/codexhost.app
 ```
 Then open `codexhost` again.
 
+**Linux: run from source**
+
+The npm package and installers currently cover macOS and Windows only. Linux is supported when running from source, provided the official Codex Desktop `chatgpt` package is installed (by default under `/usr/lib/chatgpt`):
+
+```bash
+git clone https://github.com/BytePioneer-AI/codex-host.git
+cd codex-host
+npm install
+npm start
+```
+
+Node.js 24 and a Rust toolchain are required. `npm start` first stops any running Codex Desktop, then relaunches it under codexhost.
+
 <details>
 <summary><h3>How it works</h3></summary>
 

--- a/tools/dev-desktop/run.mjs
+++ b/tools/dev-desktop/run.mjs
@@ -166,6 +166,103 @@ done
 echo 'codexhost dev: stopped the running Codex Desktop'
 `;
 
+const linuxDesktopCleanupScript = String.raw`
+set -eu
+
+# Anchored at the start of the command line so this script's own shell, whose
+# command line embeds the pattern, is never matched.
+desktop_pattern='^(/usr/lib|/opt|/usr/share)/chatgpt/ChatGPT'
+desktop_running() {
+  pgrep -f "$desktop_pattern" >/dev/null 2>&1
+}
+
+if desktop_running; then
+  pkill -KILL -f "$desktop_pattern" >/dev/null 2>&1 || true
+  attempt=0
+  while desktop_running; do
+    if [ "$attempt" -ge 200 ]; then
+      echo 'Codex Desktop did not exit before timeout.' >&2
+      exit 1
+    fi
+    attempt=$((attempt + 1))
+    sleep 0.05
+  done
+fi
+
+# Resolved without shell parameter expansion braces so the surrounding
+# String.raw template does not treat them as JavaScript interpolation.
+config_home="$XDG_CONFIG_HOME"
+if [ -z "$config_home" ]; then
+  config_home="$HOME/.config"
+fi
+runtime_descriptor="$config_home/codexhost/desktop-runtime-v1.json"
+descriptor_value() {
+  if [ ! -f "$runtime_descriptor" ]; then
+    return 0
+  fi
+  sed -nE "s/.*\"$1\"[[:space:]]*:[[:space:]]*([0-9]+).*/\1/p" "$runtime_descriptor" |
+    head -n 1
+}
+
+controller_pid() {
+  control_port="$(descriptor_value control_port)"
+  if [ -z "$control_port" ]; then
+    return 0
+  fi
+  candidate="$(
+    ss -lptnH "sport = :$control_port" 2>/dev/null |
+      sed -nE 's/.*pid=([0-9]+).*/\1/p' |
+      head -n 1
+  )"
+  if [ -z "$candidate" ]; then
+    return 0
+  fi
+  command_line="$(ps -p "$candidate" -o args= 2>/dev/null || true)"
+  case "$command_line" in
+    *"packages/desktop-control/dist/release-main.js"*)
+      printf '%s\n' "$candidate"
+      ;;
+  esac
+}
+
+runtime_running() {
+  pgrep -x codexhost >/dev/null 2>&1 ||
+    pgrep -x codexhost-shim >/dev/null 2>&1 ||
+    [ -n "$(controller_pid)" ]
+}
+
+controller="$(controller_pid)"
+if [ -n "$controller" ]; then
+  kill -TERM "$controller" >/dev/null 2>&1 || true
+fi
+
+attempt=0
+while runtime_running && [ "$attempt" -lt 40 ]; do
+  attempt=$((attempt + 1))
+  sleep 0.05
+done
+if runtime_running; then
+  controller="$(controller_pid)"
+  if [ -n "$controller" ]; then
+    kill -KILL "$controller" >/dev/null 2>&1 || true
+  fi
+  pkill -KILL -x codexhost >/dev/null 2>&1 || true
+  pkill -KILL -x codexhost-shim >/dev/null 2>&1 || true
+fi
+
+attempt=0
+while runtime_running; do
+  if [ "$attempt" -ge 200 ]; then
+    echo 'The previous codexhost runtime did not exit before timeout.' >&2
+    exit 1
+  fi
+  attempt=$((attempt + 1))
+  sleep 0.05
+done
+
+echo 'codexhost dev: stopped the running Codex Desktop'
+`;
+
 export function usage() {
   return `usage: npm start -- [--agent <codex|pi>] [--no-build]
 
@@ -315,6 +412,9 @@ export function runningDesktopCleanupInvocation(platform = process.platform) {
   }
   if (platform === "darwin") {
     return { command: "/bin/sh", arguments: ["-c", macOsDesktopCleanupScript] };
+  }
+  if (platform === "linux") {
+    return { command: "/bin/sh", arguments: ["-c", linuxDesktopCleanupScript] };
   }
   return null;
 }

--- a/tools/dev-desktop/run.test.mjs
+++ b/tools/dev-desktop/run.test.mjs
@@ -148,7 +148,19 @@ describe("development Desktop start", () => {
     expect(macOsScript).toContain("packages/desktop-control/dist/release-main.js");
     expect(macOsScript).toContain("kill -TERM");
     expect(macOsScript).toContain("pkill -KILL");
-    expect(runningDesktopCleanupInvocation("linux")).toBeNull();
+
+    const linuxInvocation = runningDesktopCleanupInvocation("linux");
+    expect(linuxInvocation?.command).toBe("/bin/sh");
+    const linuxScript = linuxInvocation?.arguments.at(-1);
+    expect(linuxScript).toContain("^(/usr/lib|/opt|/usr/share)/chatgpt/ChatGPT");
+    expect(linuxScript).toContain("desktop-runtime-v1.json");
+    expect(linuxScript).toContain("ss -lptnH");
+    expect(linuxScript).toContain("ps -p");
+    expect(linuxScript).toContain("packages/desktop-control/dist/release-main.js");
+    expect(linuxScript).toContain("kill -TERM");
+    expect(linuxScript).toContain("pkill -KILL");
+
+    expect(runningDesktopCleanupInvocation("freebsd")).toBeNull();
   });
 
   it("constructs npm and native launcher commands without internal Host environment", () => {


### PR DESCRIPTION
## 概述 / Summary

为 codexhost 增加在 Linux 上从源码运行的能力，与 macOS / Windows 并列。本次为**源码运行**（source-only）支持，不包含安装包 / npm 包分发。

Closes #13

## 改动 / Changes

### 平台层 `crates/platform`
- 新增 `DesktopIdentity::LinuxPackage { package_name }` 身份识别
- `discover_codex_desktop` 探测 `/usr/lib/chatgpt`、`/opt/chatgpt`、`/usr/share/chatgpt`、`~/.local/lib/chatgpt`，支持 `CODEXHOST_PROBE_INSTALL_ROOT` 覆盖
- ELF 校验 Desktop 与内置 Codex CLI，并拒绝通过软链接逃逸出安装目录的 CLI
- 新增 `linux_process.rs`：基于 `/proc/<pid>/stat` 与 `/proc/<pid>/exe` 实现 `ProcessSnapshot`，与 macOS `libproc` 快照语义一致，复用 PID 复用 / 信号身份校验
- Desktop 启动方式由 `LaunchServices` 改为 `DirectExecutable`，复用 macOS 会话监督与 Unix 信号转发路径
- `detach_from_terminal`、`ShutdownSignals` 扩展为 Unix

### 启动器 `crates/launcher`
- `supervise_desktop` 在 Linux 走会话路径；后台更新安装仅 macOS 启用
- 兼容性确认 / runtime 路径使用 `XDG_CONFIG_HOME` / `~/.config`

### 垫片 `crates/shim`
- crash 检测改为 `process::abort()`，避免被监督方观察到根进程身份变更
- `cfg` 由 `macos` 扩展为 `macos + linux` / `unix`

### 更新器 `crates/updater`
- 安装包 / 制品校验仅在 macOS / Windows 启用；Linux 源码运行无安装流程

### 工具与文档
- `tools/dev-desktop/run.mjs` 增加 Linux Desktop 清理脚本（匹配 `^(/usr/lib|/opt|/usr/share)/chatgpt/ChatGPT`，通过 `ss` 解析控制端口定位 Desktop Controller）
- README / docs/README.en.md 增加 Linux 从源码运行说明

## 验证 / Verification

在本机 Linux (Ubuntu 24.04, Rust 1.97.1) 上：
- `cargo build -p codexhost-platform -p codexhost-shim -p codexhost-launcher` 编译通过
- `cargo test -p codexhost-platform` → 17 passed（含新增 `linux_process` 单测与 `linux_tests` 安装发现单测）
- `cargo test -p codexhost-shim -p codexhost-launcher` → 22 passed（含 Linux 启用的信号转发 / 崩溃 / 逃逸清理用例）
- `tools/dev-desktop/run.test.mjs` 中 Linux 清理脚本构造用例通过（其余失败为本机 Node 22 不满足 `npm start` 要求的 Node 24，与本次改动无关）

## 备注

Linux 暂不提供安装包，仅支持按 README 从源码 `npm install && npm start` 运行（需 Node.js 24 + Rust 工具链，并已安装官方 Codex Desktop 的 `chatgpt` 包）。