### PR TITLE
feat(windows): discover portable Codex Desktop installations (fixes #15)

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,19 @@ xattr -dr com.apple.quarantine /Applications/codexhost.app
 ```
 Then open `codexhost` again.
 
+On Windows, a portable Codex Desktop — an official MSIX extracted and run in place, with no AppX package registered — cannot be found through the system package manager, so `codexhost` reports `official OpenAI.Codex AppX package is not installed for the current user`. Point `CODEXHOST_INSTALL_ROOT` at the extracted root (the directory that contains `app\ChatGPT.exe`):
+
+```powershell
+$env:CODEXHOST_INSTALL_ROOT = "D:\CodexPortable"
+codexhost
+```
+
+You can also pass it per command; both `codexhost inspect` and `codexhost launch` accept it:
+
+```powershell
+codexhost inspect --custom-install D:\CodexPortable
+```
+
 <details>
 <summary><h3>How it works</h3></summary>
 

--- a/crates/launcher/src/main.rs
+++ b/crates/launcher/src/main.rs
@@ -97,7 +97,7 @@ impl Error for UnmanagedDesktopConflict {}
 
 fn usage() {
     eprintln!(
-        "usage:\n  codexhost\n  codexhost inspect\n  codexhost launch --agent <codex|pi> [--shim <absolute-file>] [--node <absolute-file>] [--host-runtime <absolute-file>] [--desktop-controller <absolute-file>] [--renderer <absolute-file>] [--pi <absolute-file>]"
+        "usage:\n  codexhost\n  codexhost inspect [--custom-install <absolute-directory>]\n  codexhost launch --agent <codex|pi> [--shim <absolute-file>] [--node <absolute-file>] [--host-runtime <absolute-file>] [--desktop-controller <absolute-file>] [--renderer <absolute-file>] [--pi <absolute-file>] [--custom-install <absolute-directory>]"
     );
 }
 
@@ -181,8 +181,26 @@ fn print_installation(installation: &DesktopInstallation, process_ids: &[u32]) {
     println!("desktop_process_ids={process_list}");
 }
 
-fn inspect() -> Result<(), Box<dyn Error>> {
-    let installation = discover_codex_desktop()?;
+/// Resolve the Codex Desktop installation for this run.
+///
+/// An explicitly supplied installation root wins over the platform's own
+/// discovery; without one the platform probe applies, which on Windows already
+/// falls back to the portable-installation override before consulting the AppX
+/// PackageManager.
+fn discover_desktop(
+    custom_install_root: Option<&Path>,
+) -> Result<DesktopInstallation, Box<dyn Error>> {
+    match custom_install_root {
+        #[cfg(target_os = "windows")]
+        Some(root) => Ok(codexhost_platform::discover_codex_desktop_from_root(root)?),
+        #[cfg(not(target_os = "windows"))]
+        Some(_) => Err("--custom-install is supported on Windows only".into()),
+        None => Ok(discover_codex_desktop()?),
+    }
+}
+
+fn inspect(custom_install_root: Option<&Path>) -> Result<(), Box<dyn Error>> {
+    let installation = discover_desktop(custom_install_root)?;
     let process_ids = codexhost_platform::desktop_process_ids_for_installation(&installation)?;
     print_installation(&installation, &process_ids);
     Ok(())
@@ -220,6 +238,7 @@ struct LaunchOptions {
     desktop_controller: Option<PathBuf>,
     renderer_extension: Option<PathBuf>,
     pi: Option<PathBuf>,
+    custom_install_root: Option<PathBuf>,
 }
 
 #[derive(Debug)]
@@ -231,6 +250,7 @@ struct ResolvedLaunchOptions {
     desktop_controller: PathBuf,
     renderer_extension: PathBuf,
     pi: Option<PathBuf>,
+    custom_install_root: Option<PathBuf>,
 }
 
 fn required_path(arguments: &[String], index: &mut usize, option: &str) -> Result<PathBuf, String> {
@@ -261,6 +281,7 @@ fn parse_launch_options(arguments: &[String]) -> Result<LaunchOptions, String> {
     let mut desktop_controller = None;
     let mut renderer_extension = None;
     let mut pi = None;
+    let mut custom_install_root = None;
     let mut index = 0;
     while index < arguments.len() {
         match arguments[index].as_str() {
@@ -285,6 +306,10 @@ fn parse_launch_options(arguments: &[String]) -> Result<LaunchOptions, String> {
                 renderer_extension = Some(required_path(arguments, &mut index, "--renderer")?)
             }
             "--pi" => pi = Some(required_path(arguments, &mut index, "--pi")?),
+            "--custom-install" => {
+                custom_install_root =
+                    Some(required_path(arguments, &mut index, "--custom-install")?)
+            }
             unknown => return Err(format!("unknown launch option: {unknown}")),
         }
         index += 1;
@@ -297,7 +322,35 @@ fn parse_launch_options(arguments: &[String]) -> Result<LaunchOptions, String> {
         desktop_controller,
         renderer_extension,
         pi,
+        custom_install_root,
     })
+}
+
+/// Parse the options accepted by `codexhost inspect`.
+fn parse_inspect_options(arguments: &[String]) -> Result<Option<PathBuf>, String> {
+    let mut custom_install_root = None;
+    let mut index = 0;
+    while index < arguments.len() {
+        match arguments[index].as_str() {
+            "--custom-install" => {
+                custom_install_root =
+                    Some(required_path(arguments, &mut index, "--custom-install")?)
+            }
+            unknown => return Err(format!("unknown inspect option: {unknown}")),
+        }
+        index += 1;
+    }
+    Ok(custom_install_root)
+}
+
+fn absolute_directory(path: &Path, label: &str) -> Result<PathBuf, Box<dyn Error>> {
+    if !path.is_absolute() {
+        return Err(format!("{label} must be an absolute path").into());
+    }
+    if !path.is_dir() {
+        return Err(format!("{label} '{}' is not an existing directory", path.display()).into());
+    }
+    Ok(path.to_path_buf())
 }
 
 fn absolute_file(path: &Path, label: &str) -> Result<PathBuf, Box<dyn Error>> {
@@ -353,6 +406,10 @@ impl LaunchOptions {
             pi: self
                 .pi
                 .map(|path| absolute_file(&path, "--pi"))
+                .transpose()?,
+            custom_install_root: self
+                .custom_install_root
+                .map(|path| absolute_directory(&path, "--custom-install"))
                 .transpose()?,
         })
     }
@@ -1054,7 +1111,7 @@ fn launch(
     startup_trace("launch requested");
     let options = options.resolve()?;
     startup_trace("resources resolved");
-    let installation = discover_codex_desktop()?;
+    let installation = discover_desktop(options.custom_install_root.as_deref())?;
     startup_trace("Codex Desktop installation discovered");
     startup_trace("acquiring Launcher ownership");
     let _launcher_guard = match acquire_launcher_ownership(&installation, Duration::from_secs(120))?
@@ -1175,7 +1232,7 @@ fn launch(
     startup_trace("launch requested");
     let options = options.resolve()?;
     startup_trace("resources resolved");
-    let installation = discover_codex_desktop()?;
+    let installation = discover_desktop(options.custom_install_root.as_deref())?;
     startup_trace("Codex Desktop installation discovered");
     startup_trace("acquiring Launcher ownership");
     let _launcher_guard = match acquire_launcher_ownership(&installation, Duration::from_secs(120))?
@@ -1245,6 +1302,7 @@ fn default_launch_options() -> LaunchOptions {
         desktop_controller: None,
         renderer_extension: None,
         pi: None,
+        custom_install_root: None,
     }
 }
 
@@ -1252,7 +1310,12 @@ fn run(arguments: &[String]) -> Result<(), Box<dyn Error>> {
     match arguments.first().map(String::as_str) {
         None => launch(default_launch_options(), false),
         Some(START_MENU_ARGUMENT) if arguments.len() == 1 => launch(default_launch_options(), true),
-        Some("inspect") if arguments.len() == 1 => inspect(),
+        Some("inspect") => {
+            let custom_install_root = parse_inspect_options(&arguments[1..])?
+                .map(|path| absolute_directory(&path, "--custom-install"))
+                .transpose()?;
+            inspect(custom_install_root.as_deref())
+        }
         Some("launch") => launch(parse_launch_options(&arguments[1..])?, false),
         _ => {
             usage();
@@ -1317,9 +1380,10 @@ mod tests {
     use super::{
         Agent, CONTROL_NONCE_ENV, CONTROL_PORT_ENV, DEFAULT_AGENT_ENV, HOST_NODE_PATH_ENV,
         LAUNCHER_EXECUTABLE_ENV, LAUNCHER_PID_ENV, RUNTIME_DESCRIPTOR_PATH_ENV,
-        ResolvedLaunchOptions, RuntimeControl, STARTUP_TRACE_ENV, allocate_runtime_control,
-        default_launch_options, desktop_controller_command, desktop_environment, emit_ready_line,
-        parse_launch_options, read_bounded_controller_line,
+        ResolvedLaunchOptions, RuntimeControl, STARTUP_TRACE_ENV, absolute_directory,
+        allocate_runtime_control, default_launch_options, desktop_controller_command,
+        desktop_environment, emit_ready_line, parse_inspect_options, parse_launch_options,
+        read_bounded_controller_line,
     };
     #[cfg(target_os = "linux")]
     use crate::compatibility::{
@@ -1543,6 +1607,52 @@ mod tests {
         assert!(options.renderer_extension.is_some());
     }
 
+    #[test]
+    fn custom_install_root_is_accepted_by_launch_and_inspect() {
+        let options = parse_launch_options(&[
+            "--agent".into(),
+            "codex".into(),
+            "--custom-install".into(),
+            "/opt/CodexPortable".into(),
+        ])
+        .expect("launch accepts a custom install root");
+        assert_eq!(
+            options.custom_install_root.as_deref(),
+            Some(Path::new("/opt/CodexPortable"))
+        );
+
+        assert_eq!(
+            parse_inspect_options(&["--custom-install".into(), "/opt/CodexPortable".into()])
+                .expect("inspect accepts a custom install root")
+                .as_deref(),
+            Some(Path::new("/opt/CodexPortable"))
+        );
+        assert_eq!(parse_inspect_options(&[]).expect("bare inspect"), None);
+    }
+
+    #[test]
+    fn custom_install_root_rejects_missing_values_and_unknown_options() {
+        assert!(
+            parse_launch_options(&["--agent".into(), "codex".into(), "--custom-install".into()])
+                .is_err()
+        );
+        assert!(parse_inspect_options(&["--custom-install".into()]).is_err());
+        assert!(parse_inspect_options(&["--unknown".into()]).is_err());
+    }
+
+    #[test]
+    fn custom_install_root_must_be_an_existing_absolute_directory() {
+        assert!(absolute_directory(Path::new("relative/path"), "--custom-install").is_err());
+        assert!(
+            absolute_directory(Path::new("/definitely/absent/codex"), "--custom-install").is_err()
+        );
+        let existing = std::env::temp_dir();
+        assert_eq!(
+            absolute_directory(&existing, "--custom-install").expect("existing directory"),
+            existing
+        );
+    }
+
     fn resolved_options() -> ResolvedLaunchOptions {
         ResolvedLaunchOptions {
             agent: Agent::Pi,
@@ -1552,6 +1662,7 @@ mod tests {
             desktop_controller: PathBuf::from("/opt/desktop-controller.mjs"),
             renderer_extension: PathBuf::from("/opt/renderer-extension.js"),
             pi: None,
+            custom_install_root: None,
         }
     }
 

--- a/crates/launcher/src/main.rs
+++ b/crates/launcher/src/main.rs
@@ -43,8 +43,8 @@ use codexhost_platform::{DesktopSession, launch_desktop_session};
 use codexhost_platform::{LinuxCompatibilityChoice, prompt_linux_compatibility_warning};
 #[cfg(target_os = "windows")]
 use codexhost_platform::{
-    RunningDesktopChoice, desktop_root_process_ids, hide_console_window, process_executable_path,
-    process_exists, prompt_running_desktop, show_error_dialog, terminate_process_by_id,
+    RunningDesktopChoice, hide_console_window, process_executable_path, process_exists,
+    prompt_running_desktop, show_error_dialog, terminate_process_by_id,
 };
 use compatibility::{
     CompatibilityAcknowledgementKey, CompatibilityState, ControllerReadiness,
@@ -526,13 +526,14 @@ fn start_desktop_controller(
 
 #[cfg(target_os = "windows")]
 fn wait_for_launched_desktop_ownership(
+    installation: &DesktopInstallation,
     desktop: &mut Child,
     timeout: Duration,
 ) -> Result<(), Box<dyn Error>> {
     let desktop_pid = desktop.id();
     let started = Instant::now();
     loop {
-        let roots = desktop_root_process_ids()?;
+        let roots = desktop_root_process_ids_for_installation(installation)?;
         if roots.iter().any(|process_id| *process_id != desktop_pid) {
             if desktop.try_wait()?.is_none() {
                 let _ = desktop.kill();
@@ -917,7 +918,7 @@ fn supervise_desktop(
     )?;
     startup_trace("Codex Desktop launched");
     let desktop_pid = desktop.id();
-    wait_for_launched_desktop_ownership(&mut desktop, Duration::from_secs(5))?;
+    wait_for_launched_desktop_ownership(installation, &mut desktop, Duration::from_secs(5))?;
     let (mut controller, readiness) = match start_desktop_controller(options, control, environment)
     {
         Ok(started) => started,

--- a/crates/platform/src/installation.rs
+++ b/crates/platform/src/installation.rs
@@ -52,8 +52,8 @@ pub(super) fn sha256_file(path: &Path) -> Result<String, PlatformError> {
 }
 #[cfg(target_os = "windows")]
 use super::{
-    PROBE_DESKTOP_VERSION_ENV, PROBE_INSTALL_ROOT_ENV, PROBE_PACKAGE_FAMILY_ENV,
-    PROBE_PACKAGE_NAME_ENV,
+    CUSTOM_INSTALL_ROOT_ENV, PROBE_DESKTOP_VERSION_ENV, PROBE_INSTALL_ROOT_ENV,
+    PROBE_PACKAGE_FAMILY_ENV, PROBE_PACKAGE_NAME_ENV,
 };
 
 #[cfg(target_os = "windows")]
@@ -267,15 +267,124 @@ fn windows_installation(
 }
 
 #[cfg(target_os = "windows")]
+fn windows_local_app_data() -> Result<PathBuf, PlatformError> {
+    env::var_os("LOCALAPPDATA")
+        .map(PathBuf::from)
+        .ok_or_else(|| {
+            PlatformError::NotFound(
+                "LOCALAPPDATA is unavailable; cannot locate the Desktop CLI cache".into(),
+            )
+        })
+}
+
+/// Read the standalone portable-installation override.
+///
+/// This is deliberately independent of the Gate A `CODEXHOST_PROBE_*` set: it
+/// names an installation root on its own, so an unpacked Desktop can be located
+/// without supplying package identity and version as well.
+#[cfg(target_os = "windows")]
+fn custom_install_root(
+    value: impl Fn(&'static str) -> Option<std::ffi::OsString>,
+) -> Option<PathBuf> {
+    value(CUSTOM_INSTALL_ROOT_ENV)
+        .filter(|value| !value.is_empty())
+        .map(PathBuf::from)
+}
+
+#[cfg(target_os = "windows")]
 pub fn discover_codex_desktop() -> Result<DesktopInstallation, PlatformError> {
-    let details =
-        probe_package_details(env::var_os)?.map_or_else(discover_installed_windows_package, Ok)?;
-    let local_app_data = env::var_os("LOCALAPPDATA").ok_or_else(|| {
-        PlatformError::NotFound(
-            "LOCALAPPDATA is unavailable; cannot locate the Desktop CLI cache".into(),
-        )
+    if let Some(details) = probe_package_details(env::var_os)? {
+        return windows_installation(details, &windows_local_app_data()?);
+    }
+    // A portable installation - an MSIX that was extracted rather than
+    // installed - registers no AppX package, so the PackageManager lookup below
+    // cannot find it. Honouring the override here rather than at each call site
+    // keeps every entry point working, including the argument-less `codexhost`
+    // and `codexhost inspect`.
+    if let Some(root) = custom_install_root(env::var_os) {
+        return discover_codex_desktop_from_root(&root);
+    }
+    let details = discover_installed_windows_package()?;
+    windows_installation(details, &windows_local_app_data()?)
+}
+
+/// Best-effort read of the packaged Desktop version from `AppxManifest.xml`.
+///
+/// A portable/unpacked installation has no registered AppX package, so the
+/// version is not available from the Windows PackageManager. The official MSIX
+/// embeds the marketing version in the `<Identity Version="..."/>` attribute of
+/// its manifest; fall back to a placeholder when it cannot be parsed.
+#[cfg(target_os = "windows")]
+fn portable_package_version(install_root: &Path) -> Option<String> {
+    let content = std::fs::read_to_string(install_root.join("AppxManifest.xml")).ok()?;
+    let identity = content.find("<Identity")?;
+    let rest = &content[identity..];
+    let marker = rest.find("Version=")?;
+    let after = &rest[marker + "Version=".len()..];
+    let value = after.strip_prefix('"')?;
+    let version = value[..value.find('"')?].to_owned();
+    if !version.is_empty()
+        && version.len() <= 64
+        && version
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || byte == b'.')
+    {
+        Some(version)
+    } else {
+        None
+    }
+}
+
+/// Discover Codex Desktop from an explicitly supplied installation directory.
+///
+/// This supports portable/unpacked installations (for example an MSIX that was
+/// extracted rather than installed) where no AppX package is registered for the
+/// current user, so the Windows PackageManager lookup would otherwise fail.
+#[cfg(target_os = "windows")]
+pub fn discover_codex_desktop_from_root(
+    install_root: &Path,
+) -> Result<DesktopInstallation, PlatformError> {
+    let install_root = install_root.canonicalize().map_err(|error| {
+        PlatformError::NotFound(format!(
+            "Codex Desktop directory '{}' is unavailable: {error}",
+            install_root.display()
+        ))
     })?;
-    windows_installation(details, &PathBuf::from(local_app_data))
+    let desktop_executable = install_root.join("app/ChatGPT.exe");
+    let packaged_codex_cli = install_root.join("app/resources/codex.exe");
+    let asar_path = install_root.join("app/resources/app.asar");
+    if !desktop_executable.is_file() || !packaged_codex_cli.is_file() || !asar_path.is_file() {
+        return Err(PlatformError::NotFound(format!(
+            "Codex Desktop directory '{}' does not contain the required ChatGPT.exe, codex.exe, and app.asar resources",
+            install_root.display()
+        )));
+    }
+    // A portable installation may never have been launched through the official
+    // Desktop, so the Desktop-managed CLI cache may be absent. Prefer a matching
+    // cached CLI when one exists, otherwise fall back to the packaged CLI.
+    let executable_codex_cli = windows_local_app_data()
+        .ok()
+        .and_then(|local_app_data| {
+            find_executable_codex_cli(&packaged_codex_cli, &local_app_data).ok()
+        })
+        .unwrap_or_else(|| packaged_codex_cli.clone());
+
+    let version = portable_package_version(&install_root).unwrap_or_else(|| "0.0.0.0".to_owned());
+
+    Ok(DesktopInstallation {
+        identity: DesktopIdentity::WindowsPackage {
+            package_name: WINDOWS_CODEX_PACKAGE_NAME.to_owned(),
+            package_family_name: format!("{WINDOWS_CODEX_PACKAGE_NAME}_portable"),
+        },
+        build: version.clone(),
+        version,
+        asar_integrity: sha256_file(&asar_path)?,
+        install_root,
+        desktop_launcher: desktop_executable.clone(),
+        desktop_executable,
+        packaged_codex_cli,
+        executable_codex_cli,
+    })
 }
 
 #[cfg(all(test, target_os = "windows"))]
@@ -286,11 +395,11 @@ mod windows_tests {
     use std::path::PathBuf;
 
     use super::{WindowsPackageDetails, probe_package_details, windows_installation};
-    use crate::{DesktopIdentity, PlatformError, temporary_directory};
     use crate::{
-        PROBE_DESKTOP_VERSION_ENV, PROBE_INSTALL_ROOT_ENV, PROBE_PACKAGE_FAMILY_ENV,
-        PROBE_PACKAGE_NAME_ENV,
+        CUSTOM_INSTALL_ROOT_ENV, PROBE_DESKTOP_VERSION_ENV, PROBE_INSTALL_ROOT_ENV,
+        PROBE_PACKAGE_FAMILY_ENV, PROBE_PACKAGE_NAME_ENV,
     };
+    use crate::{DesktopIdentity, PlatformError, temporary_directory};
 
     #[test]
     fn gate_override_is_optional_but_must_be_complete() {
@@ -378,6 +487,122 @@ mod windows_tests {
         );
 
         fs::remove_dir_all(root).expect("remove Windows installation fixture");
+    }
+
+    fn portable_fixture(name: &str, manifest: Option<&[u8]>) -> (PathBuf, PathBuf) {
+        let root = temporary_directory(name);
+        let install_root = root.join("CodexPortable");
+        let desktop = install_root.join("app/ChatGPT.exe");
+        let packaged_cli = install_root.join("app/resources/codex.exe");
+        let app_asar = install_root.join("app/resources/app.asar");
+        fs::create_dir_all(packaged_cli.parent().expect("CLI parent"))
+            .expect("create portable layout");
+        fs::write(&desktop, b"desktop").expect("write Desktop executable");
+        fs::write(&packaged_cli, b"packaged codex cli").expect("write packaged CLI");
+        fs::write(&app_asar, b"portable app asar").expect("write app.asar");
+        if let Some(manifest) = manifest {
+            fs::write(install_root.join("AppxManifest.xml"), manifest).expect("write AppxManifest");
+        }
+        (root, install_root)
+    }
+
+    #[test]
+    fn custom_root_discovers_a_portable_installation_without_a_registered_package() {
+        let (root, install_root) = portable_fixture(
+            "codexhost-windows-custom-root",
+            Some(
+                b"<?xml version=\"1.0\"?><Package><Identity Name=\"OpenAI.Codex\" Version=\"2.5.1.0\"/></Package>",
+            ),
+        );
+
+        let installation =
+            super::discover_codex_desktop_from_root(&install_root).expect("portable installation");
+
+        assert_eq!(
+            installation.identity,
+            DesktopIdentity::WindowsPackage {
+                package_name: "OpenAI.Codex".into(),
+                package_family_name: "OpenAI.Codex_portable".into(),
+            }
+        );
+        assert_eq!(installation.version, "2.5.1.0");
+        assert_eq!(installation.build, "2.5.1.0");
+        assert_eq!(
+            installation.desktop_executable,
+            install_root
+                .canonicalize()
+                .expect("canonical install root")
+                .join("app/ChatGPT.exe")
+        );
+        assert_eq!(
+            installation.desktop_launcher,
+            installation.desktop_executable
+        );
+        assert!(installation.asar_integrity.starts_with("sha256:"));
+        // A portable installation may never have been launched through the
+        // official Desktop, so the resolved CLI falls back to the packaged one
+        // when no Desktop-managed cache matches.
+        assert!(installation.executable_codex_cli.is_file());
+
+        fs::remove_dir_all(root).expect("remove portable fixture");
+    }
+
+    #[test]
+    fn custom_root_without_a_manifest_falls_back_to_a_placeholder_version() {
+        let (root, install_root) = portable_fixture("codexhost-windows-no-manifest", None);
+
+        let installation =
+            super::discover_codex_desktop_from_root(&install_root).expect("portable installation");
+
+        assert_eq!(installation.version, "0.0.0.0");
+        assert_eq!(installation.build, "0.0.0.0");
+
+        fs::remove_dir_all(root).expect("remove portable fixture");
+    }
+
+    #[test]
+    fn custom_root_rejects_directories_without_the_desktop_payload() {
+        let root = temporary_directory("codexhost-windows-empty-root");
+        assert!(matches!(
+            super::discover_codex_desktop_from_root(&root),
+            Err(PlatformError::NotFound(_))
+        ));
+        assert!(matches!(
+            super::discover_codex_desktop_from_root(&root.join("absent")),
+            Err(PlatformError::NotFound(_))
+        ));
+        fs::remove_dir_all(root).expect("remove empty fixture");
+    }
+
+    #[test]
+    fn portable_version_parsing_is_best_effort() {
+        let root = temporary_directory("codexhost-version-parse");
+        assert_eq!(super::portable_package_version(&root), None);
+        fs::write(
+            root.join("AppxManifest.xml"),
+            b"<Package><Identity Name=\"OpenAI.Codex\" Version=\"1.2.3.4\"/></Package>",
+        )
+        .expect("write versioned manifest");
+        assert_eq!(
+            super::portable_package_version(&root).as_deref(),
+            Some("1.2.3.4")
+        );
+        fs::write(root.join("AppxManifest.xml"), b"not xml").expect("write invalid manifest");
+        assert_eq!(super::portable_package_version(&root), None);
+        fs::remove_dir_all(root).expect("remove version fixture");
+    }
+
+    #[test]
+    fn custom_install_root_override_stands_alone() {
+        // Unlike the Gate A set, this override is read on its own and an empty
+        // value is treated as absent.
+        assert_eq!(super::custom_install_root(|_| None), None);
+        assert_eq!(super::custom_install_root(|_| Some(OsString::new())), None);
+        assert_eq!(
+            super::custom_install_root(|name| (name == CUSTOM_INSTALL_ROOT_ENV)
+                .then(|| OsString::from(r"C:\CodexPortable"))),
+            Some(PathBuf::from(r"C:\CodexPortable"))
+        );
     }
 }
 

--- a/crates/platform/src/lib.rs
+++ b/crates/platform/src/lib.rs
@@ -33,6 +33,8 @@ pub use desktop_launch::{DesktopSession, launch_desktop_session};
 pub use desktop_launch::{launch_desktop, launch_stock_desktop, open_latest_codexhost_release};
 #[cfg(not(target_os = "linux"))]
 pub use installation::discover_codex_desktop;
+#[cfg(target_os = "windows")]
+pub use installation::discover_codex_desktop_from_root;
 #[cfg(target_os = "linux")]
 pub use linux_installation::discover_codex_desktop;
 #[cfg(target_os = "macos")]
@@ -67,6 +69,13 @@ pub const PROBE_PACKAGE_NAME_ENV: &str = "CODEXHOST_PROBE_PACKAGE_NAME";
 pub const PROBE_PACKAGE_FAMILY_ENV: &str = "CODEXHOST_PROBE_PACKAGE_FAMILY";
 pub const PROBE_DESKTOP_VERSION_ENV: &str = "CODEXHOST_PROBE_DESKTOP_VERSION";
 pub const PROBE_INSTALL_ROOT_ENV: &str = "CODEXHOST_PROBE_INSTALL_ROOT";
+/// Points at a portable/unpacked Codex Desktop installation root.
+///
+/// Unlike the `CODEXHOST_PROBE_*` Gate A overrides, which must be supplied as a
+/// complete set, this one stands alone: it names the directory that holds
+/// `app/ChatGPT.exe` so that installations with no registered AppX package can
+/// still be discovered.
+pub const CUSTOM_INSTALL_ROOT_ENV: &str = "CODEXHOST_INSTALL_ROOT";
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum CompatibilityChoice {

--- a/docs/README.zh-CN.md
+++ b/docs/README.zh-CN.md
@@ -84,6 +84,19 @@ xattr -dr com.apple.quarantine /Applications/codexhost.app
 ```
 然后重新打开 `codexhost`。
 
+Windows 上如果使用的是解压版 Codex Desktop（把官方 MSIX 解压出来直接运行，没有注册 AppX 包），系统包管理器查不到它，`codexhost` 会提示 `official OpenAI.Codex AppX package is not installed for the current user`。把 `CODEXHOST_INSTALL_ROOT` 指向解压根目录（即包含 `app\ChatGPT.exe` 的那一层）即可：
+
+```powershell
+$env:CODEXHOST_INSTALL_ROOT = "D:\CodexPortable"
+codexhost
+```
+
+也可以在单次命令上显式指定，`codexhost inspect` 与 `codexhost launch` 均支持：
+
+```powershell
+codexhost inspect --custom-install D:\CodexPortable
+```
+
 <details>
 <summary><h3>怎么做的</h3></summary>
 


### PR DESCRIPTION
按 #18 的关闭意见重做：基于最新 main，只针对 Windows 的窄补丁，不含任何 Linux 改动。

## 目的

修复 #15。官方 MSIX 解压后 `app/ChatGPT.exe` 可以直接运行，但没有注册 AppX 包，`codexhost` 在 PackageManager 查找处失败，报 `official OpenAI.Codex AppX package is not installed for the current user`。

## 改动

**关键点：回退做在 `discover_codex_desktop()` 内部，而不是在各入口分别穿参。** #15 的复现路径是**无参**跑 `codexhost`，所以只加命令行旗标（哪怕加到 `inspect` 上）也救不了它。放在探测函数内部，无参入口、`--start-menu`、`inspect`、`launch` 一次全覆盖。

- 新增 `discover_codex_desktop_from_root()`（仅 Windows）：从安装根按 `app/ChatGPT.exe`、`app/resources/codex.exe`、`app/resources/app.asar` 三者识别；版本尽力从 `AppxManifest.xml` 的 `<Identity Version>` 解析，拿不到时退回 `0.0.0.0`。便携安装可能从未启动过官方 Desktop，因此 Desktop 托管的 CLI 缓存不存在时回退到随包 CLI。
- `CODEXHOST_INSTALL_ROOT` 单独一个变量即可生效，独立于需要四个变量齐备的 Gate A `CODEXHOST_PROBE_*` 覆盖。
- `--custom-install <absolute-directory>` 在 `inspect` 与 `launch` 上均可显式指定，优先于环境变量。
- 中英文 README 各补一段解压版说明。

## 兼容性

两者都不设置时行为不变——已注册的包仍然原路走 PackageManager。新分支只插在 Gate A 探针返回 `None` 之后、PackageManager 查找之前。

另外，当前 main 的 `desktop_process_ids_for_installation` 已经是 installation 作用域的，所以 #18 里那两笔"把 custom install 穿参给进程发现"不再需要，补丁比原来更小。

## 验证

- Linux：`cargo clippy --all-targets` 干净，`cargo test` 66 项全过
- Windows 目标（`x86_64-pc-windows-gnu` 交叉）：`codexhost-platform` 与 `codexhost-launcher` 的 `cargo clippy --all-targets` 均干净
- 新增单测：便携安装发现、无 manifest 时的占位版本、缺少资源时报 `NotFound`、`AppxManifest` 版本解析的尽力而为行为、`CODEXHOST_INSTALL_ROOT` 独立生效；launcher 侧新增 `--custom-install` 的解析与绝对目录校验测试（跨平台运行）
- **未在真实 Windows 上跑过**：本地只有 Linux，`cfg(target_os = "windows")` 的单测只验证了编译，断言未实际执行；也没有在解压版 Desktop 上做过端到端验证。这部分需要 CI 或有环境的同学确认。

## 关联

- fixes #15
- 取代 #18（那条分支停在 Linux x64 合入之前，且第一笔提交是已关闭的 #14 的 Linux 改动）

如果你们已经在做同一枚补丁，直接关掉这个 PR 即可，不必迁就。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
