### PR TITLE
fix: handle the Linux launcher before exec

### DIFF
--- a/crates/platform/src/desktop_launch.rs
+++ b/crates/platform/src/desktop_launch.rs
@@ -490,11 +490,14 @@ pub fn launch_desktop_session(
         }
 
         let official_launcher = installation.desktop_launcher.canonicalize()?;
-        // The official wrapper may have exec'd the Desktop before /proc is
-        // sampled. In either case the PID came directly from this spawn; only
-        // that wrapper or its documented Desktop replacement is eligible.
+        let spawner_executable = process_snapshot(std::process::id())?.executable;
+        let shell_interpreter = Path::new("/bin/sh").canonicalize()?;
+        // The child may still expose this Launcher before exec, may be running
+        // under the official wrapper's interpreter, or may already be Desktop.
         if launcher_instance.executable != official_launcher
             && launcher_instance.executable != installation.desktop_executable
+            && launcher_instance.executable != spawner_executable
+            && launcher_instance.executable != shell_interpreter
         {
             let _ = cleanup_failed_desktop_launch(
                 &mut launch_process,
@@ -665,9 +668,10 @@ pub fn launch_desktop_session(
 #[cfg(all(test, any(target_os = "macos", target_os = "linux")))]
 mod tests {
     use std::ffi::OsString;
-    #[cfg(target_os = "macos")]
     use std::fs;
     use std::io::{BufRead, BufReader};
+    #[cfg(target_os = "linux")]
+    use std::os::unix::fs::PermissionsExt;
     use std::os::unix::process::CommandExt;
     #[cfg(target_os = "linux")]
     use std::path::Path;
@@ -682,15 +686,16 @@ mod tests {
     };
     #[cfg(target_os = "linux")]
     use super::{
-        desktop_launch_command, is_managed_desktop_root, select_managed_desktop_root,
-        stock_desktop_command,
+        desktop_launch_command, is_managed_desktop_root, launch_desktop_session,
+        select_managed_desktop_root, stock_desktop_command,
     };
     use crate::process::{ObservedProcessTree, ProcessSnapshot, unix_process_snapshot};
     use crate::process_exists;
+    use crate::temporary_directory;
+    #[cfg(target_os = "macos")]
+    use crate::{DesktopIdentity, DesktopInstallation, DesktopLaunchMode};
     #[cfg(target_os = "linux")]
     use crate::{DesktopIdentity, DesktopInstallation, DesktopLaunchMode, PlatformError};
-    #[cfg(target_os = "macos")]
-    use crate::{DesktopIdentity, DesktopInstallation, DesktopLaunchMode, temporary_directory};
 
     #[cfg(target_os = "linux")]
     fn linux_installation() -> DesktopInstallation {
@@ -763,6 +768,46 @@ mod tests {
             installation.desktop_launcher,
             installation.desktop_executable
         );
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn managed_launch_accepts_the_official_shell_wrapper_interpreter() {
+        let directory = temporary_directory("codexhost-shell-launcher");
+        let desktop = directory.join("ChatGPT");
+        fs::copy("/bin/sleep", &desktop).expect("copy fake Desktop");
+        fs::set_permissions(&desktop, fs::Permissions::from_mode(0o755))
+            .expect("make fake Desktop executable");
+        let desktop = desktop.canonicalize().expect("canonical fake Desktop");
+        let launcher = directory.join("codex-launcher");
+        fs::write(
+            &launcher,
+            format!("#!/bin/sh\nsleep 0.1\nexec \"{}\" 30\n", desktop.display()),
+        )
+        .expect("write shell launcher");
+        fs::set_permissions(&launcher, fs::Permissions::from_mode(0o755))
+            .expect("make shell launcher executable");
+        let mut installation = linux_installation();
+        installation.install_root = directory.clone();
+        installation.desktop_launcher = launcher;
+        installation.desktop_executable = desktop.clone();
+        installation.packaged_codex_cli = "/bin/true".into();
+        installation.executable_codex_cli = "/bin/true".into();
+
+        let mut session = launch_desktop_session(
+            &installation,
+            Path::new("/bin/true"),
+            DesktopLaunchMode::DirectExecutable,
+            &[],
+            &[],
+            Duration::from_secs(2),
+        )
+        .expect("launch Desktop through shell wrapper");
+        assert_eq!(session.root_snapshot().executable, desktop);
+        session
+            .shutdown(Duration::from_secs(2))
+            .expect("stop fake Desktop");
+        fs::remove_dir_all(directory).expect("remove shell launcher fixture");
     }
 
     #[cfg(target_os = "linux")]


### PR DESCRIPTION
## 中文

### 问题

在官方支持的 Linux x64 安装中，`codexhost` 会在启动 Desktop 时立即报错：

```text
codexhost launcher: Desktop launcher PID <pid> did not retain an official launcher or Desktop executable identity
```

`/usr/bin/chatgpt` 最终指向 `#!/bin/sh` 包装脚本。`Command::spawn` 返回时，`/proc/<pid>/exe` 可能仍指向 codexhost Launcher，也可能已经变成 `/bin/sh` 的实际解释器。在复现环境中，这个解释器是 `/usr/bin/dash`。此时进程还没有完成到 Desktop 的 `exec`，但现有预检已经将其判定为身份异常并终止启动。

### 复现

1. 安装官方 ChatGPT `.deb` 包和 `@codexhost/cli@0.2.2`
2. 完全退出 ChatGPT App
3. 运行 `codexhost`

该错误在 Debian GNU/Linux x86-64 上可以稳定复现。预期行为是 launcher 完成 `exec`，然后继续建立受管 Desktop 会话。

### 修复

- 在启动后的首次身份检查中，识别尚未 `exec` 的 codexhost Launcher 和包装脚本使用的规范化 `/bin/sh` 解释器
- 保持现有 PID、启动时间、进程组、进程谱系和最终 Desktop 可执行文件校验不变
- 增加一个 shell wrapper 回归测试，让包装脚本延迟 `exec`，稳定覆盖这个时间窗口

### 测试

- 新增回归测试在修复前复现同一错误，修复后通过
- 使用仓库锁定的 Node 24.13.1、npm 11.8.0 和 Rust 1.97.1 运行 `npm run check`，全部通过
- fork 上的 Ubuntu、macOS 和 Windows CI 矩阵全部通过；Ubuntu 另通过 100 次 launcher 回归压力运行和 Linux npm package smoke
- 使用官方 Debian ChatGPT 包完成实机启动，Desktop Controller、Renderer 注入和 Host chain 均成功就绪

---

## English

### Problem

On the officially supported Linux x64 setup, `codexhost` can fail immediately while launching Desktop:

```text
codexhost launcher: Desktop launcher PID <pid> did not retain an official launcher or Desktop executable identity
```

`/usr/bin/chatgpt` ultimately points to a `#!/bin/sh` wrapper script. When `Command::spawn` returns, `/proc/<pid>/exe` may still point to the codexhost Launcher, or it may already point to the actual `/bin/sh` interpreter. On the reproduced system, that interpreter is `/usr/bin/dash`. The process has not yet completed its `exec` into Desktop, but the current precheck treats this state as an identity mismatch and aborts the launch.

### Reproduction

1. Install the official ChatGPT `.deb` package and `@codexhost/cli@0.2.2`
2. Fully quit the ChatGPT App
3. Run `codexhost`

The error reproduces consistently on Debian GNU/Linux x86-64. The launcher should be allowed to complete its `exec` before codexhost continues establishing the managed Desktop session.

### Fix

- recognize the exact codexhost Launcher before `exec` and the canonical `/bin/sh` interpreter used by the wrapper during the initial identity check
- leave the existing PID, start time, process group, lineage, and final Desktop executable checks unchanged
- add a shell wrapper regression test that delays `exec` long enough to cover this window reliably

### Tests

- added a regression test that reproduces the same error before the fix and passes afterward
- ran `npm run check` with the repository-pinned Node 24.13.1, npm 11.8.0, and Rust 1.97.1; all checks passed
- passed the fork CI matrix on Ubuntu, macOS, and Windows; Ubuntu also passed 100 launcher regression stress runs and the Linux npm package smoke
- completed a live launch with the official Debian ChatGPT package through Desktop Controller readiness, Renderer injection, and Host chain readiness
