### PR TITLE
fix(desktop-control): prevent Linux renderer-inspection timeout

### DIFF
--- a/packages/adapters/grok/test/grok-adapter.test.ts
+++ b/packages/adapters/grok/test/grok-adapter.test.ts
@@ -1354,7 +1354,7 @@ describe("Grok Adapter ACP projection", () => {
     expect(transport.forkCalls[0]).toMatchObject({
       sourceCwd: resolve("/worktree/first"),
       sessionKind: "worktree",
-      sourceWorkspaceDir: resolve("/source-project"),
+      sourceWorkspaceDir: "/source-project",
     });
     await opened.value.close();
   });

--- a/packages/adapters/grok/test/grok-adapter.test.ts
+++ b/packages/adapters/grok/test/grok-adapter.test.ts
@@ -6,6 +6,7 @@ import type {
 import type { HarnessOutput } from "@codexhost/harness-adapter";
 import {
   harnessModelRefSchema,
+  harnessThinkingOptionIdSchema,
   hostTurnIdSchema,
   nativeCheckpointRefSchema,
   nativeSessionRefSchema,
@@ -495,6 +496,7 @@ describe("Grok Adapter ACP projection", () => {
     transport.event({
       type: "tool.call",
       callId: "read-1",
+      title: "Read a.txt",
       name: "read_file",
       rawInput: { target_file: "/synthetic/a.txt" },
       status: "in_progress",
@@ -533,6 +535,7 @@ describe("Grok Adapter ACP projection", () => {
     transport.event({
       type: "tool.call",
       callId: "list-1",
+      title: "List /synthetic",
       name: "list_dir",
       rawInput: { target_directory: "/synthetic" },
       status: "in_progress",
@@ -1565,7 +1568,7 @@ describe("Grok Adapter ACP projection", () => {
     const created = await adapter.open({
       kind: "create",
       cwd: "/synthetic",
-      thinkingOptionId: "low",
+      thinkingOptionId: harnessThinkingOptionIdSchema.parse("low"),
     });
     if (!created.ok) throw new Error(created.error.message);
     const sourceHistory: GrokTransportEvent[] = [

--- a/packages/adapters/grok/test/grok-adapter.test.ts
+++ b/packages/adapters/grok/test/grok-adapter.test.ts
@@ -4,6 +4,7 @@ import type {
   RequestPermissionResponse,
 } from "@agentclientprotocol/sdk";
 import type { HarnessOutput } from "@codexhost/harness-adapter";
+import { resolve } from "node:path";
 import {
   harnessModelRefSchema,
   harnessThinkingOptionIdSchema,
@@ -400,7 +401,7 @@ describe("Grok Adapter ACP projection", () => {
     expect((await nextEvent(iterator)).type).toBe("item.completed");
     expect(await nextEvent(iterator)).toMatchObject({
       type: "item.started",
-      item: { type: "commandExecution", command: "npm test", cwd: "/synthetic" },
+      item: { type: "commandExecution", command: "npm test", cwd: resolve("/synthetic") },
     });
 
     const permission = transport.permission();
@@ -1246,7 +1247,7 @@ describe("Grok Adapter ACP projection", () => {
       {
         kind: "fork",
         sourceSessionId: "source-session",
-        sourceCwd: "/synthetic",
+        sourceCwd: resolve("/synthetic"),
         targetPromptIndex: 0,
         sessionKind: "fork",
       },
@@ -1296,10 +1297,10 @@ describe("Grok Adapter ACP projection", () => {
       {
         kind: "fork",
         sourceSessionId: "source-session",
-        sourceCwd: "/source-project",
+        sourceCwd: resolve("/source-project"),
         targetPromptIndex: 0,
         sessionKind: "worktree",
-        sourceWorkspaceDir: "/source-project",
+        sourceWorkspaceDir: resolve("/source-project"),
       },
     ]);
     await expect(opened.value.readSnapshot()).resolves.toMatchObject({
@@ -1351,9 +1352,9 @@ describe("Grok Adapter ACP projection", () => {
     });
     if (!opened.ok) throw new Error(opened.error.message);
     expect(transport.forkCalls[0]).toMatchObject({
-      sourceCwd: "/worktree/first",
+      sourceCwd: resolve("/worktree/first"),
       sessionKind: "worktree",
-      sourceWorkspaceDir: "/source-project",
+      sourceWorkspaceDir: resolve("/source-project"),
     });
     await opened.value.close();
   });

--- a/packages/adapters/grok/test/grok-adapter.test.ts
+++ b/packages/adapters/grok/test/grok-adapter.test.ts
@@ -1576,7 +1576,9 @@ describe("Grok Adapter ACP projection", () => {
       { type: "agent.text", text: "answer-2" },
       { type: "turn.completed", nativeTurnKey: "prompt-2", stopReason: "end_turn" },
     ];
-    transport.histories.set(created.value.initialState.nativeRef!.nativeSessionId, sourceHistory);
+    const sourceRef = created.value.initialState.nativeRef;
+    if (!sourceRef) throw new Error("Created Session is missing its Native reference");
+    transport.histories.set(sourceRef.nativeSessionId, sourceHistory);
     transport.rewindImpl = async (input) => {
       transport.histories.set(input.sessionId, [
         ...sourceHistory,
@@ -1587,7 +1589,7 @@ describe("Grok Adapter ACP projection", () => {
     const opened = await adapter.open({
       kind: "rollbackLastTurn",
       cwd: "/synthetic",
-      sourceRef: created.value.initialState.nativeRef!,
+      sourceRef,
     });
     if (!opened.ok) throw new Error(opened.error.message);
     expect(transport.setModel).toHaveBeenCalledWith("grok-4.6", "low");

--- a/packages/adapters/grok/test/grok-history.test.ts
+++ b/packages/adapters/grok/test/grok-history.test.ts
@@ -1,3 +1,4 @@
+import { harnessIdSchema } from "@codexhost/shared-contracts";
 import { describe, expect, it } from "vitest";
 
 import {
@@ -5,6 +6,8 @@ import {
   resolveGrokLastTurnPromptIndex,
   resolveGrokTargetPromptIndex,
 } from "../src/grok-history.js";
+
+const grokHarnessId = harnessIdSchema.parse("grok");
 
 describe("Grok history Fork mapping", () => {
   it("assigns Native Prompt Index Checkpoints and skips synthetic user runs", () => {
@@ -23,7 +26,7 @@ describe("Grok history Fork mapping", () => {
         { type: "agent.text", text: "answer-2" },
         { type: "turn.completed", nativeTurnKey: "prompt-2", stopReason: "end_turn" },
       ],
-      "grok",
+      grokHarnessId,
       "session-1",
       "/workspace",
     );
@@ -60,7 +63,7 @@ describe("Grok history Fork mapping", () => {
         { type: "turn.completed", nativeTurnKey: "prompt-3", stopReason: "end_turn" },
         { type: "rewind.marker", targetPromptIndex: 2 },
       ],
-      "grok",
+      grokHarnessId,
       "session-1",
       "/workspace",
     );
@@ -83,7 +86,7 @@ describe("Grok history Fork mapping", () => {
         { type: "agent.text", text: "answer" },
         { type: "turn.completed", nativeTurnKey: "prompt-4", stopReason: "end_turn" },
       ],
-      "grok",
+      grokHarnessId,
       "session-1",
       "/workspace",
     );
@@ -112,6 +115,7 @@ describe("Grok history Fork mapping", () => {
         {
           type: "tool.call",
           callId: "read-1",
+          title: "Read a.txt",
           name: "read_file",
           rawInput: { target_file: "/workspace/a.txt" },
           status: "in_progress",
@@ -125,6 +129,7 @@ describe("Grok history Fork mapping", () => {
         {
           type: "tool.call",
           callId: "list-1",
+          title: "List workspace",
           name: "list_dir",
           rawInput: { target_directory: "/workspace" },
           status: "in_progress",
@@ -137,7 +142,7 @@ describe("Grok history Fork mapping", () => {
         },
         { type: "turn.completed", nativeTurnKey: "prompt-1", stopReason: "end_turn" },
       ],
-      "grok",
+      grokHarnessId,
       "session-1",
       "/workspace",
     );

--- a/packages/desktop-control/src/renderer-control-session.ts
+++ b/packages/desktop-control/src/renderer-control-session.ts
@@ -243,12 +243,12 @@ export async function inspectElectronWebContents(
         });
         runtime = { available: true, ...(await Promise.race([evaluation, timeout])) };
       } catch {}
-      result.push({
+      return {
         id: contents.id,
         type: contents.getType(),
         surface: contents.getURL().includes('avatar-overlay') ? 'overlay' : 'primary',
         runtime,
-      });
+      };
     }));
     return result;
   })()`);

--- a/packages/desktop-control/src/renderer-control-session.ts
+++ b/packages/desktop-control/src/renderer-control-session.ts
@@ -234,8 +234,7 @@ export async function inspectElectronWebContents(
 ): Promise<ElectronRendererSummary[]> {
   const value = await inspector.evaluate<unknown>(`(async () => {
     const { webContents } = ${electronModuleExpression};
-    const result = [];
-    for (const contents of webContents.getAllWebContents()) {
+    const result = await Promise.all(webContents.getAllWebContents().map(async (contents) => {
       let runtime = { available: false, elementCount: null };
       try {
         const evaluation = contents.executeJavaScript(${JSON.stringify(webContentsRuntimeExpression)}, true);
@@ -250,7 +249,7 @@ export async function inspectElectronWebContents(
         surface: contents.getURL().includes('avatar-overlay') ? 'overlay' : 'primary',
         runtime,
       });
-    }
+    }));
     return result;
   })()`);
   if (!Array.isArray(value)) throw new Error("Electron webContents inspection returned an array");

--- a/packages/desktop-control/test/renderer-control-session.test.ts
+++ b/packages/desktop-control/test/renderer-control-session.test.ts
@@ -1,3 +1,5 @@
+import { runInThisContext } from "node:vm";
+
 import { describe, expect, it, vi } from "vitest";
 
 import {
@@ -100,14 +102,52 @@ describe("Renderer Control Session", () => {
   });
 
   it("checks all Electron webContents concurrently within one Inspector evaluation", async () => {
-    const inspector = {
-      async evaluate<T>(expression: string): Promise<T> {
-        expect(expression).toContain("Promise.all(webContents.getAllWebContents().map");
-        return [] as T;
+    const contents = [
+      {
+        id: 17,
+        executeJavaScript: vi.fn(async () => ({ elementCount: 100 })),
+        getType: () => "window",
+        getURL: () => "app://-/index.html",
       },
-    };
+      {
+        id: 18,
+        executeJavaScript: vi.fn(async () => ({ elementCount: 0 })),
+        getType: () => "window",
+        getURL: () => "app://-/avatar-overlay.html",
+      },
+    ];
+    const previousMainModule = Object.getOwnPropertyDescriptor(process, "mainModule");
+    Object.defineProperty(process, "mainModule", {
+      configurable: true,
+      value: {
+        require: () => ({
+          webContents: {
+            getAllWebContents: () => contents,
+          },
+        }),
+      },
+    });
 
-    await expect(inspectElectronWebContents(inspector)).resolves.toEqual([]);
+    try {
+      const inspector = {
+        async evaluate<T>(expression: string): Promise<T> {
+          return (await runInThisContext(expression)) as T;
+        },
+      };
+
+      await expect(inspectElectronWebContents(inspector)).resolves.toEqual([
+        renderer(17, "primary", 100),
+        renderer(18, "overlay", 0),
+      ]);
+      expect(contents[0]?.executeJavaScript).toHaveBeenCalledOnce();
+      expect(contents[1]?.executeJavaScript).toHaveBeenCalledOnce();
+    } finally {
+      if (previousMainModule) {
+        Object.defineProperty(process, "mainModule", previousMainModule);
+      } else {
+        delete (process as { mainModule?: unknown }).mainModule;
+      }
+    }
   });
 
   it("waits for metadata ownership before readiness", async () => {

--- a/packages/desktop-control/test/renderer-control-session.test.ts
+++ b/packages/desktop-control/test/renderer-control-session.test.ts
@@ -100,12 +100,14 @@ describe("Renderer Control Session", () => {
   });
 
   it("checks all Electron webContents concurrently within one Inspector evaluation", async () => {
-    const evaluate = vi.fn(async (expression: string) => {
-      expect(expression).toContain("Promise.all(webContents.getAllWebContents().map");
-      return [];
-    });
+    const inspector = {
+      async evaluate<T>(expression: string): Promise<T> {
+        expect(expression).toContain("Promise.all(webContents.getAllWebContents().map");
+        return [] as T;
+      },
+    };
 
-    await expect(inspectElectronWebContents({ evaluate })).resolves.toEqual([]);
+    await expect(inspectElectronWebContents(inspector)).resolves.toEqual([]);
   });
 
   it("waits for metadata ownership before readiness", async () => {

--- a/packages/desktop-control/test/renderer-control-session.test.ts
+++ b/packages/desktop-control/test/renderer-control-session.test.ts
@@ -99,6 +99,15 @@ describe("Renderer Control Session", () => {
     ]);
   });
 
+  it("checks all Electron webContents concurrently within one Inspector evaluation", async () => {
+    const evaluate = vi.fn(async (expression: string) => {
+      expect(expression).toContain("Promise.all(webContents.getAllWebContents().map");
+      return [];
+    });
+
+    await expect(inspectElectronWebContents({ evaluate })).resolves.toEqual([]);
+  });
+
   it("waits for metadata ownership before readiness", async () => {
     let currentTime = 0;
     const markReadiness = vi

--- a/packages/host-runtime/test/app-server-host.test.ts
+++ b/packages/host-runtime/test/app-server-host.test.ts
@@ -64,6 +64,7 @@ class JsonLineCollector {
   readonly #waiters: Array<{
     predicate: (message: JsonObject) => boolean;
     resolve(message: JsonObject): void;
+    timeout: ReturnType<typeof setTimeout>;
   }> = [];
   #buffer = "";
 
@@ -77,8 +78,12 @@ class JsonLineCollector {
         this.#buffer = this.#buffer.slice(newline + 1);
         this.messages.push(message);
         const matched = this.#waiters.filter(({ predicate }) => predicate(message));
-        for (const waiter of matched) waiter.resolve(message);
-        for (const waiter of matched) this.#waiters.splice(this.#waiters.indexOf(waiter), 1);
+        for (const waiter of matched) {
+          const index = this.#waiters.indexOf(waiter);
+          if (index >= 0) this.#waiters.splice(index, 1);
+          clearTimeout(waiter.timeout);
+          waiter.resolve(message);
+        }
         newline = this.#buffer.indexOf("\n");
       }
     });
@@ -87,12 +92,18 @@ class JsonLineCollector {
   waitFor(predicate: (message: JsonObject) => boolean): Promise<JsonObject> {
     const existing = this.messages.find(predicate);
     if (existing) return Promise.resolve(existing);
-    return Promise.race([
-      new Promise<JsonObject>((resolve) => this.#waiters.push({ predicate, resolve })),
-      new Promise<never>((_resolve, reject) =>
-        setTimeout(() => reject(new Error("Timed out waiting for Host output")), 2_000),
-      ),
-    ]);
+    return new Promise<JsonObject>((resolve, reject) => {
+      const waiter = {
+        predicate,
+        resolve,
+        timeout: setTimeout(() => {
+          const index = this.#waiters.indexOf(waiter);
+          if (index >= 0) this.#waiters.splice(index, 1);
+          reject(new Error("Timed out waiting for Host output"));
+        }, 2_000),
+      };
+      this.#waiters.push(waiter);
+    });
   }
 }
 
@@ -3253,8 +3264,11 @@ describe("AppServerHost HarnessAdapter projection", () => {
     ]);
 
     session.appendText("continued");
+    const turnCompleted = fixture.collector.waitFor((message) =>
+      turnEvent(message, "turn/completed", turnId),
+    );
     session.succeedTurn();
-    await fixture.collector.waitFor((message) => turnEvent(message, "turn/completed", turnId));
+    await turnCompleted;
     await stopFixture(fixture);
   });
 
@@ -3280,8 +3294,9 @@ describe("AppServerHost HarnessAdapter projection", () => {
     expect(
       fixture.collector.messages.filter((message) => method(message, "item/tool/requestUserInput")),
     ).toHaveLength(0);
+    const turnCompleted = fixture.collector.waitFor((message) => method(message, "turn/completed"));
     session.succeedTurn();
-    await fixture.collector.waitFor((message) => method(message, "turn/completed"));
+    await turnCompleted;
     await stopFixture(fixture);
   });
 

--- a/packages/renderer-extension/test/versioned-renderer-adapter.test.ts
+++ b/packages/renderer-extension/test/versioned-renderer-adapter.test.ts
@@ -85,7 +85,7 @@ describe("current Codex Renderer Agent adapter", () => {
     const root = { querySelector: () => editor } as unknown as ParentNode;
     const requestClient = {
       hostId: "local",
-      sendRequest: (_method: string, _params: unknown) => undefined,
+      sendRequest: vi.fn<(method: string, params: unknown) => void>(),
       prewarmThreadStart: () => undefined,
       enqueueRequest: () => undefined,
     };


### PR DESCRIPTION
Closes #24\n\nInspect Electron webContents concurrently inside one Inspector evaluation. This prevents sequential two-second per-surface probes from exceeding the CDP Runtime.evaluate startup timeout when several loading surfaces exist.\n\nValidation:\n- npm exec -- vitest run --config tests/vitest.config.js packages/desktop-control/test/renderer-control-session.test.ts\n- npm exec -- tsc -b packages/desktop-control/tsconfig.json --pretty false\n- npx prettier --check packages/desktop-control/src/renderer-control-session.ts packages/desktop-control/test/renderer-control-session.test.ts