### PR TITLE
fix(linux): preserve Electron Inspector during managed launch

### DIFF
--- a/crates/platform/src/desktop_launch.rs
+++ b/crates/platform/src/desktop_launch.rs
@@ -170,7 +170,7 @@ fn desktop_launch_command(
                 "LaunchServices is available on macOS only",
             ));
         }
-        let mut command = Command::new(&installation.desktop_launcher);
+        let mut command = Command::new(&installation.desktop_executable);
         command.args(additional_arguments).envs(environment);
         #[cfg(target_os = "linux")]
         command.process_group(0);
@@ -668,10 +668,9 @@ pub fn launch_desktop_session(
 #[cfg(all(test, any(target_os = "macos", target_os = "linux")))]
 mod tests {
     use std::ffi::OsString;
+    #[cfg(target_os = "macos")]
     use std::fs;
     use std::io::{BufRead, BufReader};
-    #[cfg(target_os = "linux")]
-    use std::os::unix::fs::PermissionsExt;
     use std::os::unix::process::CommandExt;
     #[cfg(target_os = "linux")]
     use std::path::Path;
@@ -686,11 +685,12 @@ mod tests {
     };
     #[cfg(target_os = "linux")]
     use super::{
-        desktop_launch_command, is_managed_desktop_root, launch_desktop_session,
-        select_managed_desktop_root, stock_desktop_command,
+        desktop_launch_command, is_managed_desktop_root, select_managed_desktop_root,
+        stock_desktop_command,
     };
     use crate::process::{ObservedProcessTree, ProcessSnapshot, unix_process_snapshot};
     use crate::process_exists;
+    #[cfg(target_os = "macos")]
     use crate::temporary_directory;
     #[cfg(target_os = "macos")]
     use crate::{DesktopIdentity, DesktopInstallation, DesktopLaunchMode};
@@ -751,7 +751,7 @@ mod tests {
 
     #[cfg(target_os = "linux")]
     #[test]
-    fn linux_launches_through_the_official_launcher_but_tracks_the_desktop_executable() {
+    fn linux_managed_launches_the_desktop_executable_without_the_official_launcher() {
         let installation = linux_installation();
         let stock = stock_desktop_command(&installation).expect("stock Desktop command");
         assert_eq!(stock.get_program(), installation.desktop_launcher);
@@ -763,51 +763,11 @@ mod tests {
             &[],
         )
         .expect("managed Desktop command");
-        assert_eq!(managed.get_program(), installation.desktop_launcher);
+        assert_eq!(managed.get_program(), installation.desktop_executable);
         assert_ne!(
             installation.desktop_launcher,
             installation.desktop_executable
         );
-    }
-
-    #[cfg(target_os = "linux")]
-    #[test]
-    fn managed_launch_accepts_the_official_shell_wrapper_interpreter() {
-        let directory = temporary_directory("codexhost-shell-launcher");
-        let desktop = directory.join("ChatGPT");
-        fs::copy("/bin/sleep", &desktop).expect("copy fake Desktop");
-        fs::set_permissions(&desktop, fs::Permissions::from_mode(0o755))
-            .expect("make fake Desktop executable");
-        let desktop = desktop.canonicalize().expect("canonical fake Desktop");
-        let launcher = directory.join("codex-launcher");
-        fs::write(
-            &launcher,
-            format!("#!/bin/sh\nsleep 0.1\nexec \"{}\" 30\n", desktop.display()),
-        )
-        .expect("write shell launcher");
-        fs::set_permissions(&launcher, fs::Permissions::from_mode(0o755))
-            .expect("make shell launcher executable");
-        let mut installation = linux_installation();
-        installation.install_root = directory.clone();
-        installation.desktop_launcher = launcher;
-        installation.desktop_executable = desktop.clone();
-        installation.packaged_codex_cli = "/bin/true".into();
-        installation.executable_codex_cli = "/bin/true".into();
-
-        let mut session = launch_desktop_session(
-            &installation,
-            Path::new("/bin/true"),
-            DesktopLaunchMode::DirectExecutable,
-            &[],
-            &[],
-            Duration::from_secs(2),
-        )
-        .expect("launch Desktop through shell wrapper");
-        assert_eq!(session.root_snapshot().executable, desktop);
-        session
-            .shutdown(Duration::from_secs(2))
-            .expect("stop fake Desktop");
-        fs::remove_dir_all(directory).expect("remove shell launcher fixture");
     }
 
     #[cfg(target_os = "linux")]

--- a/crates/platform/src/desktop_launch.rs
+++ b/crates/platform/src/desktop_launch.rs
@@ -170,7 +170,11 @@ fn desktop_launch_command(
                 "LaunchServices is available on macOS only",
             ));
         }
-        let mut command = Command::new(&installation.desktop_executable);
+        #[cfg(target_os = "linux")]
+        let program = &installation.desktop_executable;
+        #[cfg(target_os = "windows")]
+        let program = &installation.desktop_launcher;
+        let mut command = Command::new(program);
         command.args(additional_arguments).envs(environment);
         #[cfg(target_os = "linux")]
         command.process_group(0);

--- a/crates/platform/src/desktop_launch.rs
+++ b/crates/platform/src/desktop_launch.rs
@@ -489,22 +489,19 @@ pub fn launch_desktop_session(
             )));
         }
 
-        let official_launcher = installation.desktop_launcher.canonicalize()?;
         let spawner_executable = process_snapshot(std::process::id())?.executable;
-        let shell_interpreter = Path::new("/bin/sh").canonicalize()?;
-        // The child may still expose this Launcher before exec, may be running
-        // under the official wrapper's interpreter, or may already be Desktop.
-        if launcher_instance.executable != official_launcher
-            && launcher_instance.executable != installation.desktop_executable
+        // The child may still expose this process before exec, or may already
+        // be the Desktop executable. Managed Linux launch no longer goes
+        // through the official wrapper or its interpreter.
+        if launcher_instance.executable != installation.desktop_executable
             && launcher_instance.executable != spawner_executable
-            && launcher_instance.executable != shell_interpreter
         {
             let _ = cleanup_failed_desktop_launch(
                 &mut launch_process,
                 std::slice::from_ref(&launcher_instance),
             );
             return Err(PlatformError::Invalid(format!(
-                "Desktop launcher PID {} did not retain an official launcher or Desktop executable identity",
+                "Desktop launcher PID {} did not retain a Desktop executable identity",
                 launcher_instance.id
             )));
         }
@@ -668,9 +665,10 @@ pub fn launch_desktop_session(
 #[cfg(all(test, any(target_os = "macos", target_os = "linux")))]
 mod tests {
     use std::ffi::OsString;
-    #[cfg(target_os = "macos")]
     use std::fs;
     use std::io::{BufRead, BufReader};
+    #[cfg(target_os = "linux")]
+    use std::os::unix::fs::PermissionsExt;
     use std::os::unix::process::CommandExt;
     #[cfg(target_os = "linux")]
     use std::path::Path;
@@ -685,12 +683,11 @@ mod tests {
     };
     #[cfg(target_os = "linux")]
     use super::{
-        desktop_launch_command, is_managed_desktop_root, select_managed_desktop_root,
-        stock_desktop_command,
+        desktop_launch_command, is_managed_desktop_root, launch_desktop_session,
+        select_managed_desktop_root, stock_desktop_command,
     };
     use crate::process::{ObservedProcessTree, ProcessSnapshot, unix_process_snapshot};
     use crate::process_exists;
-    #[cfg(target_os = "macos")]
     use crate::temporary_directory;
     #[cfg(target_os = "macos")]
     use crate::{DesktopIdentity, DesktopInstallation, DesktopLaunchMode};
@@ -768,6 +765,42 @@ mod tests {
             installation.desktop_launcher,
             installation.desktop_executable
         );
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn managed_launch_supervises_the_desktop_executable_directly() {
+        let directory = temporary_directory("codexhost-direct-desktop");
+        let desktop = directory.join("ChatGPT");
+        fs::copy("/bin/sleep", &desktop).expect("copy fake Desktop");
+        fs::set_permissions(&desktop, fs::Permissions::from_mode(0o755))
+            .expect("make fake Desktop executable");
+        let desktop = desktop.canonicalize().expect("canonical fake Desktop");
+        let launcher = directory.join("codex-launcher");
+        fs::write(&launcher, b"#!/bin/sh\nexit 1\n").expect("write unused official launcher");
+        fs::set_permissions(&launcher, fs::Permissions::from_mode(0o755))
+            .expect("make unused launcher executable");
+        let mut installation = linux_installation();
+        installation.install_root = directory.clone();
+        installation.desktop_launcher = launcher;
+        installation.desktop_executable = desktop.clone();
+        installation.packaged_codex_cli = "/bin/true".into();
+        installation.executable_codex_cli = "/bin/true".into();
+
+        let mut session = launch_desktop_session(
+            &installation,
+            Path::new("/bin/true"),
+            DesktopLaunchMode::DirectExecutable,
+            &[OsString::from("30")],
+            &[],
+            Duration::from_secs(2),
+        )
+        .expect("launch Desktop executable directly");
+        assert_eq!(session.root_snapshot().executable, desktop);
+        session
+            .shutdown(Duration::from_secs(2))
+            .expect("stop fake Desktop");
+        fs::remove_dir_all(directory).expect("remove direct Desktop fixture");
     }
 
     #[cfg(target_os = "linux")]

--- a/docs/linux.md
+++ b/docs/linux.md
@@ -23,7 +23,7 @@ When the Desktop Controller reports a warning or degraded capability, codexhost 
 
 ## Process ownership
 
-codexhost refuses to take over an independently running ChatGPT App. Quit ChatGPT completely before launching codexhost. A managed launch uses the official launcher but identifies and supervises the real Desktop executable through `/proc`; shutdown signals are sent only after PID, start time, and executable identity are revalidated.
+codexhost refuses to take over an independently running ChatGPT App. Quit ChatGPT completely before launching codexhost. A managed launch starts the verified Desktop executable directly and supervises it through `/proc`; stock ChatGPT launches still use the official launcher. Shutdown signals are sent only after PID, start time, and executable identity are revalidated.
 
 ## Diagnosis
 

--- a/docs/linux.zh-CN.md
+++ b/docs/linux.zh-CN.md
@@ -23,7 +23,7 @@ Desktop Controller 报告警告或能力降级时，codexhost 会在启动受管
 
 ## 进程所有权
 
-codexhost 不会接管独立运行的 ChatGPT App。启动 codexhost 前，请完全退出 ChatGPT。受管启动会使用官方启动器，但通过 `/proc` 识别和监督真实 Desktop 可执行文件；只有重新校验 PID、启动时间和可执行文件身份后才会发送关闭信号。
+codexhost 不会接管独立运行的 ChatGPT App。启动 codexhost 前，请完全退出 ChatGPT。受管启动会直接启动已校验的 Desktop 可执行文件，并通过 `/proc` 监督它；普通 ChatGPT 启动仍使用官方启动器。只有重新校验 PID、启动时间和可执行文件身份后才会发送关闭信号。
 
 ## 诊断
 


### PR DESCRIPTION
Closes #25

Managed Linux launches currently invoke the official codex-launcher wrapper even in DirectExecutable mode. The wrapper then execs the packaged ChatGPT binary, creating a process/Inspector transition after the launcher has already attached. Start the verified Desktop executable directly for managed launches so --inspect is owned by the actual Electron process from the beginning. Stock Desktop launches continue using the official launcher.

Validation:
- cargo fmt --all --check
- cargo test -p codexhost-platform desktop_launch --lib (12 passed)
- git diff --check