### PR TITLE
fix: support Windows Store launch and Claude detection on Windows

### DIFF
--- a/crates/launcher/src/compatibility.rs
+++ b/crates/launcher/src/compatibility.rs
@@ -200,6 +200,7 @@ impl From<&DesktopIdentity> for AcknowledgedDesktopIdentity {
             DesktopIdentity::WindowsPackage {
                 package_name,
                 package_family_name,
+                ..
             } => Self::WindowsPackage {
                 package_name: package_name.clone(),
                 package_family_name: package_family_name.clone(),

--- a/crates/launcher/src/main.rs
+++ b/crates/launcher/src/main.rs
@@ -18,7 +18,7 @@ use std::fmt::{self, Display, Formatter};
 use std::io::{Read, Write};
 use std::path::{Path, PathBuf};
 #[cfg(target_os = "windows")]
-use std::process::{Child, ExitStatus};
+use std::process::ExitStatus;
 use std::process::{Command, ExitCode, Stdio};
 use std::sync::{OnceLock, mpsc};
 use std::thread;
@@ -28,7 +28,9 @@ use std::time::{Duration, Instant};
 use active_update::start_pending_update;
 use active_update::update_waiting_for_launcher_exit;
 #[cfg(target_os = "windows")]
-use codexhost_platform::launch_desktop;
+use codexhost_platform::{
+    APPX_RESUME_ARGUMENT, DesktopProcess, launch_desktop, resume_packaged_application,
+};
 #[cfg(not(target_os = "linux"))]
 use codexhost_platform::{CompatibilityChoice, prompt_compatibility_warning};
 use codexhost_platform::{
@@ -146,6 +148,7 @@ fn print_installation(installation: &DesktopInstallation, process_ids: &[u32]) {
         DesktopIdentity::WindowsPackage {
             package_name,
             package_family_name,
+            ..
         } => {
             println!("platform=windows");
             println!("package_name={package_name}");
@@ -495,7 +498,7 @@ fn start_desktop_controller(
 #[cfg(target_os = "windows")]
 fn wait_for_launched_desktop_ownership(
     installation: &DesktopInstallation,
-    desktop: &mut Child,
+    desktop: &mut DesktopProcess,
     timeout: Duration,
 ) -> Result<(), Box<dyn Error>> {
     let desktop_pid = desktop.id();
@@ -529,7 +532,7 @@ fn wait_for_launched_desktop_ownership(
 
 #[cfg(target_os = "windows")]
 fn wait_for_desktop_exit(
-    desktop: &mut Child,
+    desktop: &mut DesktopProcess,
     timeout: Duration,
 ) -> std::io::Result<Option<ExitStatus>> {
     let started = Instant::now();
@@ -571,7 +574,7 @@ fn stop_managed_desktop_for_update(
 
 #[cfg(target_os = "windows")]
 fn stop_managed_desktop_for_update(
-    desktop: &mut Child,
+    desktop: &mut DesktopProcess,
     controller: &mut SupervisedChild,
 ) -> Result<(), Box<dyn Error>> {
     let _ = stop_desktop_controller(controller);
@@ -1293,6 +1296,10 @@ fn default_launch_options() -> LaunchOptions {
 
 fn run(arguments: &[String]) -> Result<(), Box<dyn Error>> {
     match arguments.first().map(String::as_str) {
+        #[cfg(target_os = "windows")]
+        Some(APPX_RESUME_ARGUMENT) => {
+            resume_packaged_application(&arguments[1..]).map_err(Into::into)
+        }
         None => launch(default_launch_options(), false),
         Some(START_MENU_ARGUMENT) if arguments.len() == 1 => launch(default_launch_options(), true),
         Some("inspect") => {
@@ -1314,7 +1321,11 @@ fn main() -> ExitCode {
     #[cfg(target_os = "windows")]
     let start_menu_launch = arguments.as_slice() == [START_MENU_ARGUMENT];
     #[cfg(target_os = "windows")]
-    if start_menu_launch {
+    let appx_resume = arguments
+        .first()
+        .is_some_and(|argument| argument == APPX_RESUME_ARGUMENT);
+    #[cfg(target_os = "windows")]
+    if start_menu_launch || appx_resume {
         hide_console_window();
     }
     match run(&arguments) {
@@ -1538,10 +1549,11 @@ mod tests {
     #[cfg(target_os = "windows")]
     #[test]
     fn observes_a_normal_desktop_exit_during_controller_shutdown() {
-        let mut desktop = Command::new("cmd.exe")
+        let desktop = Command::new("cmd.exe")
             .args(["/d", "/c", "exit", "0"])
             .spawn()
             .expect("spawn exiting Desktop fixture");
+        let mut desktop = codexhost_platform::DesktopProcess::from_child(desktop);
 
         let status = wait_for_desktop_exit(&mut desktop, Duration::from_secs(1))
             .expect("observe Desktop exit")

--- a/crates/launcher/tests/cli.rs
+++ b/crates/launcher/tests/cli.rs
@@ -8,6 +8,27 @@ fn launcher_path() -> PathBuf {
 }
 
 #[test]
+fn windows_packaged_desktop_uses_appx_activation() {
+    let platform_root = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../platform/src");
+    let launch_source =
+        fs::read_to_string(platform_root.join("desktop_launch.rs")).expect("read launch source");
+    let packaged_source =
+        fs::read_to_string(platform_root.join("windows_desktop.rs")).expect("read AppX source");
+
+    let windows_branch = launch_source
+        .split("#[cfg(target_os = \"windows\")]\npub fn launch_desktop")
+        .nth(1)
+        .expect("Windows launch branch");
+    assert!(windows_branch.contains("activate_packaged_desktop"));
+    assert!(!windows_branch.contains("Command::new(&installation.desktop_executable)"));
+    assert!(packaged_source.contains("ActivateApplication"));
+    assert!(packaged_source.contains("EnableDebugging"));
+    assert!(packaged_source.contains("APPX_RESUME_ARGUMENT"));
+    assert!(packaged_source.contains("ResumeThread"));
+    assert!(packaged_source.contains("DisableDebugging"));
+}
+
+#[test]
 fn production_launcher_uses_the_three_state_running_desktop_flow() {
     let source = fs::read_to_string(PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("src/main.rs"))
         .expect("read Launcher source");

--- a/crates/launcher/tests/cli.rs
+++ b/crates/launcher/tests/cli.rs
@@ -8,27 +8,6 @@ fn launcher_path() -> PathBuf {
 }
 
 #[test]
-fn windows_packaged_desktop_uses_appx_activation() {
-    let platform_root = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../platform/src");
-    let launch_source =
-        fs::read_to_string(platform_root.join("desktop_launch.rs")).expect("read launch source");
-    let packaged_source =
-        fs::read_to_string(platform_root.join("windows_desktop.rs")).expect("read AppX source");
-
-    let windows_branch = launch_source
-        .split("#[cfg(target_os = \"windows\")]\npub fn launch_desktop")
-        .nth(1)
-        .expect("Windows launch branch");
-    assert!(windows_branch.contains("activate_packaged_desktop"));
-    assert!(!windows_branch.contains("Command::new(&installation.desktop_executable)"));
-    assert!(packaged_source.contains("ActivateApplication"));
-    assert!(packaged_source.contains("EnableDebugging"));
-    assert!(packaged_source.contains("APPX_RESUME_ARGUMENT"));
-    assert!(packaged_source.contains("ResumeThread"));
-    assert!(packaged_source.contains("DisableDebugging"));
-}
-
-#[test]
 fn production_launcher_uses_the_three_state_running_desktop_flow() {
     let source = fs::read_to_string(PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("src/main.rs"))
         .expect("read Launcher source");

--- a/crates/platform/Cargo.toml
+++ b/crates/platform/Cargo.toml
@@ -27,10 +27,15 @@ system-configuration = "0.7.0"
 [target.'cfg(target_os = "windows")'.dependencies]
 windows = { version = "0.62.2", features = [
   "ApplicationModel",
+  "ApplicationModel_Core",
+  "Foundation_Collections",
   "Management_Deployment",
   "Storage_Search",
   "Win32_Foundation",
+  "Win32_System_Com",
   "Win32_System_Console",
+  "Win32_System_Threading",
   "Win32_UI_Controls",
+  "Win32_UI_Shell",
   "Win32_UI_WindowsAndMessaging",
 ] }

--- a/crates/platform/src/desktop_launch.rs
+++ b/crates/platform/src/desktop_launch.rs
@@ -2,12 +2,16 @@ use std::ffi::OsString;
 #[cfg(any(target_os = "macos", target_os = "linux"))]
 use std::os::unix::process::CommandExt;
 use std::path::Path;
-use std::process::{Child, Command, Stdio};
+#[cfg(not(target_os = "windows"))]
+use std::process::Child;
+use std::process::{Command, Stdio};
 #[cfg(any(target_os = "macos", target_os = "linux"))]
 use std::thread;
 #[cfg(any(target_os = "macos", target_os = "linux"))]
 use std::time::{Duration, Instant};
 
+#[cfg(target_os = "windows")]
+use super::DesktopIdentity;
 #[cfg(target_os = "macos")]
 use super::process::desktop_root_snapshots_for_installation;
 #[cfg(any(target_os = "macos", target_os = "linux"))]
@@ -21,6 +25,11 @@ use super::{
     CODEX_CLI_PATH_ENV, DesktopInstallation, DesktopLaunchMode, PlatformError,
     STOCK_CODEX_PATH_ENV, canonical_existing_file,
 };
+
+#[cfg(target_os = "windows")]
+pub type DesktopProcess = super::windows_desktop::WindowsDesktopProcess;
+#[cfg(not(target_os = "windows"))]
+pub type DesktopProcess = Child;
 
 const CODEXHOST_RELEASES_LATEST_URL: &str =
     "https://github.com/BytePioneer-AI/codex-host/releases/latest";
@@ -37,6 +46,26 @@ fn remove_codexhost_environment(command: &mut Command, names: impl IntoIterator<
             command.env_remove(name);
         }
     }
+}
+
+fn managed_desktop_environment(
+    installation: &DesktopInstallation,
+    shim_path: &Path,
+    additional_environment: &[(OsString, OsString)],
+) -> Result<Vec<(OsString, OsString)>, PlatformError> {
+    let shim_path = canonical_existing_file(shim_path)?;
+    let mut environment = vec![
+        (
+            OsString::from(CODEX_CLI_PATH_ENV),
+            shim_path.as_os_str().to_owned(),
+        ),
+        (
+            OsString::from(STOCK_CODEX_PATH_ENV),
+            installation.executable_codex_cli.as_os_str().to_owned(),
+        ),
+    ];
+    environment.extend_from_slice(additional_environment);
+    Ok(environment)
 }
 
 fn configure_managed_desktop_environment(
@@ -82,10 +111,45 @@ fn stock_desktop_command(installation: &DesktopInstallation) -> Result<Command, 
     Ok(command)
 }
 
-pub fn launch_stock_desktop(installation: &DesktopInstallation) -> Result<Child, PlatformError> {
+#[cfg(not(target_os = "windows"))]
+pub fn launch_stock_desktop(
+    installation: &DesktopInstallation,
+) -> Result<DesktopProcess, PlatformError> {
     stock_desktop_command(installation)?
         .spawn()
         .map_err(PlatformError::Io)
+}
+
+#[cfg(target_os = "windows")]
+pub fn launch_stock_desktop(
+    installation: &DesktopInstallation,
+) -> Result<DesktopProcess, PlatformError> {
+    let DesktopIdentity::WindowsPackage {
+        package_full_name,
+        app_user_model_id,
+        ..
+    } = &installation.identity
+    else {
+        return Err(PlatformError::Invalid(
+            "Windows Codex Desktop has no package identity".into(),
+        ));
+    };
+    match (package_full_name, app_user_model_id) {
+        (Some(package_full_name), Some(app_user_model_id)) => {
+            super::windows_desktop::activate_stock_desktop(package_full_name, app_user_model_id)
+        }
+        (None, None) => {
+            let child = stock_desktop_command(installation)?
+                .spawn()
+                .map_err(PlatformError::Io)?;
+            Ok(super::windows_desktop::WindowsDesktopProcess::from_child(
+                child,
+            ))
+        }
+        _ => Err(PlatformError::Invalid(
+            "Windows Codex Desktop has incomplete AppX identity".into(),
+        )),
+    }
 }
 
 #[cfg(any(target_os = "windows", target_os = "macos", target_os = "linux"))]
@@ -143,18 +207,7 @@ fn desktop_launch_command(
     additional_arguments: &[OsString],
     additional_environment: &[(OsString, OsString)],
 ) -> Result<Command, PlatformError> {
-    let shim_path = canonical_existing_file(shim_path)?;
-    let mut environment = vec![
-        (
-            OsString::from(CODEX_CLI_PATH_ENV),
-            shim_path.as_os_str().to_owned(),
-        ),
-        (
-            OsString::from(STOCK_CODEX_PATH_ENV),
-            installation.executable_codex_cli.as_os_str().to_owned(),
-        ),
-    ];
-    environment.extend_from_slice(additional_environment);
+    let environment = managed_desktop_environment(installation, shim_path, additional_environment)?;
 
     #[cfg(target_os = "macos")]
     let mut command = match mode {
@@ -217,13 +270,14 @@ fn desktop_launch_command(
     Ok(command)
 }
 
+#[cfg(not(target_os = "windows"))]
 pub fn launch_desktop(
     installation: &DesktopInstallation,
     shim_path: &Path,
     mode: DesktopLaunchMode,
     additional_arguments: &[OsString],
     additional_environment: &[(OsString, OsString)],
-) -> Result<Child, PlatformError> {
+) -> Result<DesktopProcess, PlatformError> {
     desktop_launch_command(
         installation,
         shim_path,
@@ -233,6 +287,60 @@ pub fn launch_desktop(
     )?
     .spawn()
     .map_err(PlatformError::Io)
+}
+
+#[cfg(target_os = "windows")]
+pub fn launch_desktop(
+    installation: &DesktopInstallation,
+    shim_path: &Path,
+    mode: DesktopLaunchMode,
+    additional_arguments: &[OsString],
+    additional_environment: &[(OsString, OsString)],
+) -> Result<DesktopProcess, PlatformError> {
+    if mode != DesktopLaunchMode::DirectExecutable {
+        return Err(PlatformError::Unsupported(
+            "Windows packaged Desktop requires AppX activation",
+        ));
+    }
+    let DesktopIdentity::WindowsPackage {
+        package_full_name,
+        app_user_model_id,
+        ..
+    } = &installation.identity
+    else {
+        return Err(PlatformError::Invalid(
+            "Windows Codex Desktop has no package identity".into(),
+        ));
+    };
+    match (package_full_name, app_user_model_id) {
+        (Some(package_full_name), Some(app_user_model_id)) => {
+            let environment =
+                managed_desktop_environment(installation, shim_path, additional_environment)?;
+            super::windows_desktop::activate_packaged_desktop(
+                package_full_name,
+                app_user_model_id,
+                additional_arguments,
+                &environment,
+            )
+        }
+        (None, None) => {
+            let child = desktop_launch_command(
+                installation,
+                shim_path,
+                mode,
+                additional_arguments,
+                additional_environment,
+            )?
+            .spawn()
+            .map_err(PlatformError::Io)?;
+            Ok(super::windows_desktop::WindowsDesktopProcess::from_child(
+                child,
+            ))
+        }
+        _ => Err(PlatformError::Invalid(
+            "Windows Codex Desktop has incomplete AppX identity".into(),
+        )),
+    }
 }
 
 #[cfg(target_os = "linux")]
@@ -687,6 +795,59 @@ pub fn launch_desktop_session(
                 }
             }
         }
+    }
+}
+
+#[cfg(all(test, target_os = "windows"))]
+mod windows_tests {
+    use std::path::PathBuf;
+
+    use super::{launch_desktop, launch_stock_desktop};
+    use crate::{DesktopIdentity, DesktopInstallation, DesktopLaunchMode, PlatformError};
+
+    fn incomplete_package_installation() -> DesktopInstallation {
+        DesktopInstallation {
+            identity: DesktopIdentity::WindowsPackage {
+                package_name: "OpenAI.Codex".into(),
+                package_family_name: "OpenAI.Codex_family".into(),
+                package_full_name: Some("OpenAI.Codex_1.2.3.4_x64_family".into()),
+                app_user_model_id: None,
+            },
+            version: "1.2.3.4".into(),
+            build: "1.2.3.4".into(),
+            asar_integrity: format!("sha256:{}", "0".repeat(64)),
+            install_root: PathBuf::from(r"C:\Codex"),
+            desktop_launcher: PathBuf::from(r"C:\Codex\app\ChatGPT.exe"),
+            desktop_executable: PathBuf::from(r"C:\Codex\app\ChatGPT.exe"),
+            packaged_codex_cli: PathBuf::from(r"C:\Codex\app\resources\codex.exe"),
+            executable_codex_cli: PathBuf::from(r"C:\Codex\app\resources\codex.exe"),
+        }
+    }
+
+    #[test]
+    fn incomplete_appx_identity_never_falls_back_to_direct_execution() {
+        let installation = incomplete_package_installation();
+        let managed_error = match launch_desktop(
+            &installation,
+            std::path::Path::new(r"C:\missing-shim.exe"),
+            DesktopLaunchMode::DirectExecutable,
+            &[],
+            &[],
+        ) {
+            Ok(_) => panic!("incomplete identity must not launch"),
+            Err(error) => error,
+        };
+        assert!(
+            matches!(managed_error, PlatformError::Invalid(message) if message.contains("incomplete AppX identity"))
+        );
+
+        let stock_error = match launch_stock_desktop(&installation) {
+            Ok(_) => panic!("incomplete identity must not launch stock Desktop"),
+            Err(error) => error,
+        };
+        assert!(
+            matches!(stock_error, PlatformError::Invalid(message) if message.contains("incomplete AppX identity"))
+        );
     }
 }
 

--- a/crates/platform/src/desktop_launch.rs
+++ b/crates/platform/src/desktop_launch.rs
@@ -125,20 +125,19 @@ pub fn launch_stock_desktop(
     installation: &DesktopInstallation,
 ) -> Result<DesktopProcess, PlatformError> {
     let DesktopIdentity::WindowsPackage {
-        package_full_name,
-        app_user_model_id,
-        ..
+        appx_activation, ..
     } = &installation.identity
     else {
         return Err(PlatformError::Invalid(
             "Windows Codex Desktop has no package identity".into(),
         ));
     };
-    match (package_full_name, app_user_model_id) {
-        (Some(package_full_name), Some(app_user_model_id)) => {
-            super::windows_desktop::activate_stock_desktop(package_full_name, app_user_model_id)
-        }
-        (None, None) => {
+    match appx_activation {
+        Some(appx_activation) => super::windows_desktop::activate_stock_desktop(
+            &appx_activation.package_full_name,
+            &appx_activation.app_user_model_id,
+        ),
+        None => {
             let child = stock_desktop_command(installation)?
                 .spawn()
                 .map_err(PlatformError::Io)?;
@@ -146,9 +145,6 @@ pub fn launch_stock_desktop(
                 child,
             ))
         }
-        _ => Err(PlatformError::Invalid(
-            "Windows Codex Desktop has incomplete AppX identity".into(),
-        )),
     }
 }
 
@@ -303,27 +299,25 @@ pub fn launch_desktop(
         ));
     }
     let DesktopIdentity::WindowsPackage {
-        package_full_name,
-        app_user_model_id,
-        ..
+        appx_activation, ..
     } = &installation.identity
     else {
         return Err(PlatformError::Invalid(
             "Windows Codex Desktop has no package identity".into(),
         ));
     };
-    match (package_full_name, app_user_model_id) {
-        (Some(package_full_name), Some(app_user_model_id)) => {
+    match appx_activation {
+        Some(appx_activation) => {
             let environment =
                 managed_desktop_environment(installation, shim_path, additional_environment)?;
             super::windows_desktop::activate_packaged_desktop(
-                package_full_name,
-                app_user_model_id,
+                &appx_activation.package_full_name,
+                &appx_activation.app_user_model_id,
                 additional_arguments,
                 &environment,
             )
         }
-        (None, None) => {
+        None => {
             let child = desktop_launch_command(
                 installation,
                 shim_path,
@@ -337,9 +331,6 @@ pub fn launch_desktop(
                 child,
             ))
         }
-        _ => Err(PlatformError::Invalid(
-            "Windows Codex Desktop has incomplete AppX identity".into(),
-        )),
     }
 }
 
@@ -795,59 +786,6 @@ pub fn launch_desktop_session(
                 }
             }
         }
-    }
-}
-
-#[cfg(all(test, target_os = "windows"))]
-mod windows_tests {
-    use std::path::PathBuf;
-
-    use super::{launch_desktop, launch_stock_desktop};
-    use crate::{DesktopIdentity, DesktopInstallation, DesktopLaunchMode, PlatformError};
-
-    fn incomplete_package_installation() -> DesktopInstallation {
-        DesktopInstallation {
-            identity: DesktopIdentity::WindowsPackage {
-                package_name: "OpenAI.Codex".into(),
-                package_family_name: "OpenAI.Codex_family".into(),
-                package_full_name: Some("OpenAI.Codex_1.2.3.4_x64_family".into()),
-                app_user_model_id: None,
-            },
-            version: "1.2.3.4".into(),
-            build: "1.2.3.4".into(),
-            asar_integrity: format!("sha256:{}", "0".repeat(64)),
-            install_root: PathBuf::from(r"C:\Codex"),
-            desktop_launcher: PathBuf::from(r"C:\Codex\app\ChatGPT.exe"),
-            desktop_executable: PathBuf::from(r"C:\Codex\app\ChatGPT.exe"),
-            packaged_codex_cli: PathBuf::from(r"C:\Codex\app\resources\codex.exe"),
-            executable_codex_cli: PathBuf::from(r"C:\Codex\app\resources\codex.exe"),
-        }
-    }
-
-    #[test]
-    fn incomplete_appx_identity_never_falls_back_to_direct_execution() {
-        let installation = incomplete_package_installation();
-        let managed_error = match launch_desktop(
-            &installation,
-            std::path::Path::new(r"C:\missing-shim.exe"),
-            DesktopLaunchMode::DirectExecutable,
-            &[],
-            &[],
-        ) {
-            Ok(_) => panic!("incomplete identity must not launch"),
-            Err(error) => error,
-        };
-        assert!(
-            matches!(managed_error, PlatformError::Invalid(message) if message.contains("incomplete AppX identity"))
-        );
-
-        let stock_error = match launch_stock_desktop(&installation) {
-            Ok(_) => panic!("incomplete identity must not launch stock Desktop"),
-            Err(error) => error,
-        };
-        assert!(
-            matches!(stock_error, PlatformError::Invalid(message) if message.contains("incomplete AppX identity"))
-        );
     }
 }
 

--- a/crates/platform/src/installation.rs
+++ b/crates/platform/src/installation.rs
@@ -52,8 +52,9 @@ pub(super) fn sha256_file(path: &Path) -> Result<String, PlatformError> {
 }
 #[cfg(target_os = "windows")]
 use super::{
-    CUSTOM_INSTALL_ROOT_ENV, PROBE_DESKTOP_VERSION_ENV, PROBE_INSTALL_ROOT_ENV,
-    PROBE_PACKAGE_FAMILY_ENV, PROBE_PACKAGE_NAME_ENV,
+    CUSTOM_INSTALL_ROOT_ENV, PROBE_APP_USER_MODEL_ID_ENV, PROBE_DESKTOP_VERSION_ENV,
+    PROBE_INSTALL_ROOT_ENV, PROBE_PACKAGE_FAMILY_ENV, PROBE_PACKAGE_FULL_NAME_ENV,
+    PROBE_PACKAGE_NAME_ENV,
 };
 
 #[cfg(target_os = "windows")]
@@ -92,6 +93,8 @@ const WINDOWS_CODEX_PACKAGE_NAME: &str = "OpenAI.Codex";
 struct WindowsPackageDetails {
     package_name: String,
     package_family_name: String,
+    package_full_name: Option<String>,
+    app_user_model_id: Option<String>,
     version: String,
     install_root: PathBuf,
 }
@@ -131,6 +134,14 @@ fn probe_package_details(
     let values = [
         (PROBE_PACKAGE_NAME_ENV, value(PROBE_PACKAGE_NAME_ENV)),
         (PROBE_PACKAGE_FAMILY_ENV, value(PROBE_PACKAGE_FAMILY_ENV)),
+        (
+            PROBE_PACKAGE_FULL_NAME_ENV,
+            value(PROBE_PACKAGE_FULL_NAME_ENV),
+        ),
+        (
+            PROBE_APP_USER_MODEL_ID_ENV,
+            value(PROBE_APP_USER_MODEL_ID_ENV),
+        ),
         (PROBE_DESKTOP_VERSION_ENV, value(PROBE_DESKTOP_VERSION_ENV)),
         (PROBE_INSTALL_ROOT_ENV, value(PROBE_INSTALL_ROOT_ENV)),
     ];
@@ -158,8 +169,10 @@ fn probe_package_details(
     Ok(Some(WindowsPackageDetails {
         package_name: text(0),
         package_family_name: text(1),
-        version: text(2),
-        install_root: PathBuf::from(values[3].1.as_ref().expect("complete Gate A override")),
+        package_full_name: Some(text(2)),
+        app_user_model_id: Some(text(3)),
+        version: text(4),
+        install_root: PathBuf::from(values[5].1.as_ref().expect("complete Gate A override")),
     }))
 }
 
@@ -200,6 +213,27 @@ fn discover_installed_windows_package() -> Result<WindowsPackageDetails, Platfor
             .FamilyName()
             .map_err(|error| windows_api_error("cannot read Codex package family", error))?
             .to_string_lossy();
+        let package_full_name = id
+            .FullName()
+            .map_err(|error| windows_api_error("cannot read Codex package full name", error))?
+            .to_string_lossy();
+        let app_entries = package.GetAppListEntries().map_err(|error| {
+            windows_api_error("cannot enumerate Codex package applications", error)
+        })?;
+        if app_entries
+            .Size()
+            .map_err(|error| windows_api_error("cannot count Codex package applications", error))?
+            != 1
+        {
+            return Err(PlatformError::Invalid(
+                "Codex AppX package must expose exactly one application entry".into(),
+            ));
+        }
+        let app_user_model_id = app_entries
+            .GetAt(0)
+            .and_then(|entry| entry.AppUserModelId())
+            .map_err(|error| windows_api_error("cannot read Codex AppUserModelId", error))?
+            .to_string_lossy();
         let install_root = package
             .InstalledLocation()
             .and_then(|folder| folder.Path())
@@ -209,6 +243,8 @@ fn discover_installed_windows_package() -> Result<WindowsPackageDetails, Platfor
             WindowsPackageDetails {
                 package_name,
                 package_family_name,
+                package_full_name: Some(package_full_name),
+                app_user_model_id: Some(app_user_model_id),
                 version: format!(
                     "{}.{}.{}.{}",
                     version_key[0], version_key[1], version_key[2], version_key[3]
@@ -254,6 +290,8 @@ fn windows_installation(
         identity: DesktopIdentity::WindowsPackage {
             package_name: details.package_name,
             package_family_name: details.package_family_name,
+            package_full_name: details.package_full_name,
+            app_user_model_id: details.app_user_model_id,
         },
         build: details.version.clone(),
         version: details.version,
@@ -375,6 +413,8 @@ pub fn discover_codex_desktop_from_root(
         identity: DesktopIdentity::WindowsPackage {
             package_name: WINDOWS_CODEX_PACKAGE_NAME.to_owned(),
             package_family_name: format!("{WINDOWS_CODEX_PACKAGE_NAME}_portable"),
+            package_full_name: None,
+            app_user_model_id: None,
         },
         build: version.clone(),
         version,
@@ -396,8 +436,9 @@ mod windows_tests {
 
     use super::{WindowsPackageDetails, probe_package_details, windows_installation};
     use crate::{
-        CUSTOM_INSTALL_ROOT_ENV, PROBE_DESKTOP_VERSION_ENV, PROBE_INSTALL_ROOT_ENV,
-        PROBE_PACKAGE_FAMILY_ENV, PROBE_PACKAGE_NAME_ENV,
+        CUSTOM_INSTALL_ROOT_ENV, PROBE_APP_USER_MODEL_ID_ENV, PROBE_DESKTOP_VERSION_ENV,
+        PROBE_INSTALL_ROOT_ENV, PROBE_PACKAGE_FAMILY_ENV, PROBE_PACKAGE_FULL_NAME_ENV,
+        PROBE_PACKAGE_NAME_ENV,
     };
     use crate::{DesktopIdentity, PlatformError, temporary_directory};
 
@@ -421,6 +462,14 @@ mod windows_tests {
                 PROBE_PACKAGE_FAMILY_ENV,
                 OsString::from("OpenAI.Codex_family"),
             ),
+            (
+                PROBE_PACKAGE_FULL_NAME_ENV,
+                OsString::from("OpenAI.Codex_1.2.3.4_x64_family"),
+            ),
+            (
+                PROBE_APP_USER_MODEL_ID_ENV,
+                OsString::from("OpenAI.Codex_family!App"),
+            ),
             (PROBE_DESKTOP_VERSION_ENV, OsString::from("1.2.3.4")),
             (PROBE_INSTALL_ROOT_ENV, OsString::from("C:\\Codex")),
         ]);
@@ -430,6 +479,8 @@ mod windows_tests {
             Some(WindowsPackageDetails {
                 package_name: "OpenAI.Codex".into(),
                 package_family_name: "OpenAI.Codex_family".into(),
+                package_full_name: Some("OpenAI.Codex_1.2.3.4_x64_family".into()),
+                app_user_model_id: Some("OpenAI.Codex_family!App".into()),
                 version: "1.2.3.4".into(),
                 install_root: PathBuf::from("C:\\Codex"),
             })
@@ -460,6 +511,8 @@ mod windows_tests {
             WindowsPackageDetails {
                 package_name: "OpenAI.Codex".into(),
                 package_family_name: "OpenAI.Codex_family".into(),
+                package_full_name: Some("OpenAI.Codex_1.2.3.4_x64_family".into()),
+                app_user_model_id: Some("OpenAI.Codex_family!App".into()),
                 version: "1.2.3.4".into(),
                 install_root: install_root.clone(),
             },
@@ -472,6 +525,8 @@ mod windows_tests {
             DesktopIdentity::WindowsPackage {
                 package_name: "OpenAI.Codex".into(),
                 package_family_name: "OpenAI.Codex_family".into(),
+                package_full_name: Some("OpenAI.Codex_1.2.3.4_x64_family".into()),
+                app_user_model_id: Some("OpenAI.Codex_family!App".into()),
             }
         );
         assert_eq!(installation.version, "1.2.3.4");
@@ -523,6 +578,8 @@ mod windows_tests {
             DesktopIdentity::WindowsPackage {
                 package_name: "OpenAI.Codex".into(),
                 package_family_name: "OpenAI.Codex_portable".into(),
+                package_full_name: None,
+                app_user_model_id: None,
             }
         );
         assert_eq!(installation.version, "2.5.1.0");

--- a/crates/platform/src/installation.rs
+++ b/crates/platform/src/installation.rs
@@ -23,6 +23,8 @@ use super::DesktopIdentity;
 #[cfg(not(target_os = "linux"))]
 use super::DesktopInstallation;
 use super::PlatformError;
+#[cfg(target_os = "windows")]
+use super::WindowsAppxActivationIdentity;
 
 #[cfg(any(target_os = "windows", target_os = "macos", target_os = "linux"))]
 pub(super) fn sha256_file(path: &Path) -> Result<String, PlatformError> {
@@ -93,8 +95,7 @@ const WINDOWS_CODEX_PACKAGE_NAME: &str = "OpenAI.Codex";
 struct WindowsPackageDetails {
     package_name: String,
     package_family_name: String,
-    package_full_name: Option<String>,
-    app_user_model_id: Option<String>,
+    appx_activation: WindowsAppxActivationIdentity,
     version: String,
     install_root: PathBuf,
 }
@@ -169,8 +170,10 @@ fn probe_package_details(
     Ok(Some(WindowsPackageDetails {
         package_name: text(0),
         package_family_name: text(1),
-        package_full_name: Some(text(2)),
-        app_user_model_id: Some(text(3)),
+        appx_activation: WindowsAppxActivationIdentity {
+            package_full_name: text(2),
+            app_user_model_id: text(3),
+        },
         version: text(4),
         install_root: PathBuf::from(values[5].1.as_ref().expect("complete Gate A override")),
     }))
@@ -243,8 +246,10 @@ fn discover_installed_windows_package() -> Result<WindowsPackageDetails, Platfor
             WindowsPackageDetails {
                 package_name,
                 package_family_name,
-                package_full_name: Some(package_full_name),
-                app_user_model_id: Some(app_user_model_id),
+                appx_activation: WindowsAppxActivationIdentity {
+                    package_full_name,
+                    app_user_model_id,
+                },
                 version: format!(
                     "{}.{}.{}.{}",
                     version_key[0], version_key[1], version_key[2], version_key[3]
@@ -290,8 +295,7 @@ fn windows_installation(
         identity: DesktopIdentity::WindowsPackage {
             package_name: details.package_name,
             package_family_name: details.package_family_name,
-            package_full_name: details.package_full_name,
-            app_user_model_id: details.app_user_model_id,
+            appx_activation: Some(details.appx_activation),
         },
         build: details.version.clone(),
         version: details.version,
@@ -413,8 +417,7 @@ pub fn discover_codex_desktop_from_root(
         identity: DesktopIdentity::WindowsPackage {
             package_name: WINDOWS_CODEX_PACKAGE_NAME.to_owned(),
             package_family_name: format!("{WINDOWS_CODEX_PACKAGE_NAME}_portable"),
-            package_full_name: None,
-            app_user_model_id: None,
+            appx_activation: None,
         },
         build: version.clone(),
         version,
@@ -440,7 +443,9 @@ mod windows_tests {
         PROBE_INSTALL_ROOT_ENV, PROBE_PACKAGE_FAMILY_ENV, PROBE_PACKAGE_FULL_NAME_ENV,
         PROBE_PACKAGE_NAME_ENV,
     };
-    use crate::{DesktopIdentity, PlatformError, temporary_directory};
+    use crate::{
+        DesktopIdentity, PlatformError, WindowsAppxActivationIdentity, temporary_directory,
+    };
 
     #[test]
     fn gate_override_is_optional_but_must_be_complete() {
@@ -479,8 +484,10 @@ mod windows_tests {
             Some(WindowsPackageDetails {
                 package_name: "OpenAI.Codex".into(),
                 package_family_name: "OpenAI.Codex_family".into(),
-                package_full_name: Some("OpenAI.Codex_1.2.3.4_x64_family".into()),
-                app_user_model_id: Some("OpenAI.Codex_family!App".into()),
+                appx_activation: WindowsAppxActivationIdentity {
+                    package_full_name: "OpenAI.Codex_1.2.3.4_x64_family".into(),
+                    app_user_model_id: "OpenAI.Codex_family!App".into(),
+                },
                 version: "1.2.3.4".into(),
                 install_root: PathBuf::from("C:\\Codex"),
             })
@@ -511,8 +518,10 @@ mod windows_tests {
             WindowsPackageDetails {
                 package_name: "OpenAI.Codex".into(),
                 package_family_name: "OpenAI.Codex_family".into(),
-                package_full_name: Some("OpenAI.Codex_1.2.3.4_x64_family".into()),
-                app_user_model_id: Some("OpenAI.Codex_family!App".into()),
+                appx_activation: WindowsAppxActivationIdentity {
+                    package_full_name: "OpenAI.Codex_1.2.3.4_x64_family".into(),
+                    app_user_model_id: "OpenAI.Codex_family!App".into(),
+                },
                 version: "1.2.3.4".into(),
                 install_root: install_root.clone(),
             },
@@ -525,8 +534,10 @@ mod windows_tests {
             DesktopIdentity::WindowsPackage {
                 package_name: "OpenAI.Codex".into(),
                 package_family_name: "OpenAI.Codex_family".into(),
-                package_full_name: Some("OpenAI.Codex_1.2.3.4_x64_family".into()),
-                app_user_model_id: Some("OpenAI.Codex_family!App".into()),
+                appx_activation: Some(WindowsAppxActivationIdentity {
+                    package_full_name: "OpenAI.Codex_1.2.3.4_x64_family".into(),
+                    app_user_model_id: "OpenAI.Codex_family!App".into(),
+                }),
             }
         );
         assert_eq!(installation.version, "1.2.3.4");
@@ -578,8 +589,7 @@ mod windows_tests {
             DesktopIdentity::WindowsPackage {
                 package_name: "OpenAI.Codex".into(),
                 package_family_name: "OpenAI.Codex_portable".into(),
-                package_full_name: None,
-                app_user_model_id: None,
+                appx_activation: None,
             }
         );
         assert_eq!(installation.version, "2.5.1.0");

--- a/crates/platform/src/lib.rs
+++ b/crates/platform/src/lib.rs
@@ -23,15 +23,20 @@ mod proxy_environment;
 mod system_proxy;
 #[cfg(target_os = "windows")]
 #[allow(unsafe_code)]
+mod windows_desktop;
+#[cfg(target_os = "windows")]
+#[allow(unsafe_code)]
 mod windows_process;
 #[cfg(target_os = "windows")]
 #[allow(unsafe_code)]
 mod windows_ui;
 
 pub use background::detach_from_terminal;
+pub use desktop_launch::{
+    DesktopProcess, launch_desktop, launch_stock_desktop, open_latest_codexhost_release,
+};
 #[cfg(any(target_os = "macos", target_os = "linux"))]
 pub use desktop_launch::{DesktopSession, launch_desktop_session};
-pub use desktop_launch::{launch_desktop, launch_stock_desktop, open_latest_codexhost_release};
 #[cfg(not(target_os = "linux"))]
 pub use installation::discover_codex_desktop;
 #[cfg(target_os = "windows")]
@@ -59,16 +64,22 @@ pub use proxy_environment::proxy_environment;
 #[cfg(target_os = "macos")]
 pub use system_proxy::{SystemProxySettings, system_proxy_settings};
 #[cfg(target_os = "windows")]
+pub use windows_desktop::resume_packaged_application;
+#[cfg(target_os = "windows")]
 pub use windows_ui::{
     RunningDesktopChoice, hide_console_window, prompt_compatibility_warning,
     prompt_running_desktop, show_error_dialog,
 };
 
 pub const CRATE_NAME: &str = "codexhost-platform";
+#[cfg(target_os = "windows")]
+pub const APPX_RESUME_ARGUMENT: &str = "--codexhost-resume-appx-thread";
 pub const CODEX_CLI_PATH_ENV: &str = "CODEX_CLI_PATH";
 pub const STOCK_CODEX_PATH_ENV: &str = "CODEXHOST_STOCK_CODEX_PATH";
 pub const PROBE_PACKAGE_NAME_ENV: &str = "CODEXHOST_PROBE_PACKAGE_NAME";
 pub const PROBE_PACKAGE_FAMILY_ENV: &str = "CODEXHOST_PROBE_PACKAGE_FAMILY";
+pub const PROBE_PACKAGE_FULL_NAME_ENV: &str = "CODEXHOST_PROBE_PACKAGE_FULL_NAME";
+pub const PROBE_APP_USER_MODEL_ID_ENV: &str = "CODEXHOST_PROBE_APP_USER_MODEL_ID";
 pub const PROBE_DESKTOP_VERSION_ENV: &str = "CODEXHOST_PROBE_DESKTOP_VERSION";
 pub const PROBE_INSTALL_ROOT_ENV: &str = "CODEXHOST_PROBE_INSTALL_ROOT";
 /// Points at a portable/unpacked Codex Desktop installation root.
@@ -147,6 +158,8 @@ pub enum DesktopIdentity {
     WindowsPackage {
         package_name: String,
         package_family_name: String,
+        package_full_name: Option<String>,
+        app_user_model_id: Option<String>,
     },
     MacOsBundle {
         bundle_identifier: String,

--- a/crates/platform/src/lib.rs
+++ b/crates/platform/src/lib.rs
@@ -154,12 +154,17 @@ impl DesktopLaunchMode {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WindowsAppxActivationIdentity {
+    pub package_full_name: String,
+    pub app_user_model_id: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum DesktopIdentity {
     WindowsPackage {
         package_name: String,
         package_family_name: String,
-        package_full_name: Option<String>,
-        app_user_model_id: Option<String>,
+        appx_activation: Option<WindowsAppxActivationIdentity>,
     },
     MacOsBundle {
         bundle_identifier: String,

--- a/crates/platform/src/windows_desktop.rs
+++ b/crates/platform/src/windows_desktop.rs
@@ -14,9 +14,9 @@ use windows::Win32::System::Com::{
     CoInitializeEx, CoUninitialize,
 };
 use windows::Win32::System::Threading::{
-    GetExitCodeProcess, GetProcessIdOfThread, OpenProcess, OpenThread, PROCESS_SYNCHRONIZE,
-    PROCESS_TERMINATE, ResumeThread, THREAD_QUERY_LIMITED_INFORMATION, THREAD_SUSPEND_RESUME,
-    TerminateProcess, WaitForSingleObject,
+    GetExitCodeProcess, GetProcessIdOfThread, OpenProcess, OpenThread,
+    PROCESS_QUERY_LIMITED_INFORMATION, PROCESS_SYNCHRONIZE, PROCESS_TERMINATE, ResumeThread,
+    THREAD_QUERY_LIMITED_INFORMATION, THREAD_SUSPEND_RESUME, TerminateProcess, WaitForSingleObject,
 };
 use windows::Win32::UI::Shell::{
     ACTIVATEOPTIONS, ApplicationActivationManager, IApplicationActivationManager,
@@ -206,6 +206,33 @@ impl WindowsDesktopProcess {
     }
 }
 
+struct ActivatedProcessGuard {
+    process: Option<WindowsDesktopProcess>,
+}
+
+impl ActivatedProcessGuard {
+    fn new(process: WindowsDesktopProcess) -> Self {
+        Self {
+            process: Some(process),
+        }
+    }
+
+    fn disarm(mut self) -> WindowsDesktopProcess {
+        self.process.take().expect("armed activated process")
+    }
+}
+
+impl Drop for ActivatedProcessGuard {
+    fn drop(&mut self) {
+        let Some(process) = &mut self.process else {
+            return;
+        };
+        if process.try_wait().ok().flatten().is_none() && process.kill().is_ok() {
+            let _ = process.wait();
+        }
+    }
+}
+
 pub fn quote_windows_argument(argument: &OsStr) -> OsString {
     let value = argument.to_string_lossy();
     if !value.is_empty() && !value.contains([' ', '\t', '"']) {
@@ -333,12 +360,12 @@ pub fn resume_packaged_application(arguments: &[String]) -> Result<(), PlatformE
 fn wait_for_desktop_root(
     activation_process_id: u32,
     timeout: Duration,
-) -> Result<WindowsDesktopProcess, PlatformError> {
+) -> Result<(), PlatformError> {
     let started = Instant::now();
     loop {
         match desktop_root_process_ids()?.as_slice() {
             [process_id] if *process_id == activation_process_id => {
-                return supervise_desktop(*process_id);
+                return Ok(());
             }
             [] if started.elapsed() < timeout => thread::sleep(Duration::from_millis(20)),
             [] => {
@@ -381,15 +408,21 @@ pub fn activate_packaged_desktop(
         )
     }
     .map_err(|error| windows_error("cannot activate Codex Desktop AppX package", error))?;
-    let desktop = wait_for_desktop_root(activation_process_id, Duration::from_secs(5))?;
+    let desktop = ActivatedProcessGuard::new(supervise_desktop(activation_process_id)?);
+    wait_for_desktop_root(activation_process_id, Duration::from_secs(5))?;
     package_environment.disable()?;
-    Ok(desktop)
+    Ok(desktop.disarm())
 }
 
 pub fn supervise_desktop(process_id: u32) -> Result<WindowsDesktopProcess, PlatformError> {
-    let process =
-        unsafe { OpenProcess(PROCESS_SYNCHRONIZE | PROCESS_TERMINATE, false, process_id) }
-            .map_err(|error| windows_error("cannot supervise activated Codex Desktop", error))?;
+    let process = unsafe {
+        OpenProcess(
+            PROCESS_QUERY_LIMITED_INFORMATION | PROCESS_SYNCHRONIZE | PROCESS_TERMINATE,
+            false,
+            process_id,
+        )
+    }
+    .map_err(|error| windows_error("cannot supervise activated Codex Desktop", error))?;
     Ok(WindowsDesktopProcess {
         process_id,
         process: WindowsDesktopBacking::Activated(unsafe { Owned::new(process) }),
@@ -424,15 +457,19 @@ pub fn activate_stock_desktop(
         )
     }
     .map_err(|error| windows_error("cannot activate stock Codex Desktop", error))?;
-    wait_for_desktop_root(activation_process_id, Duration::from_secs(5))
+    let desktop = ActivatedProcessGuard::new(supervise_desktop(activation_process_id)?);
+    wait_for_desktop_root(activation_process_id, Duration::from_secs(5))?;
+    Ok(desktop.disarm())
 }
 
 #[cfg(test)]
 mod tests {
     use std::ffi::{OsStr, OsString};
+    use std::process::Command;
 
     use super::{
-        quote_windows_argument, resume_packaged_application, windows_command_line,
+        ActivatedProcessGuard, WindowsDesktopProcess, quote_windows_argument,
+        resume_packaged_application, supervise_desktop, windows_command_line,
         windows_environment_block,
     };
 
@@ -486,5 +523,33 @@ mod tests {
         assert!(
             windows_environment_block(&[(OsString::from("bad=name"), OsString::new())]).is_err()
         );
+    }
+
+    #[test]
+    fn reads_exit_status_from_a_supervised_process() {
+        let mut child = Command::new("cmd.exe")
+            .args(["/d", "/c", "ping -n 2 127.0.0.1 >nul & exit /b 7"])
+            .spawn()
+            .expect("spawn supervised process fixture");
+        let mut process = supervise_desktop(child.id()).expect("supervise process fixture");
+
+        let status = process.wait().expect("read supervised process exit status");
+        let _ = child.wait();
+
+        assert_eq!(status.code(), Some(7));
+    }
+
+    #[test]
+    fn armed_activation_guard_terminates_its_process() {
+        let child = Command::new("cmd.exe")
+            .args(["/d", "/c", "ping -n 30 127.0.0.1 >nul"])
+            .spawn()
+            .expect("spawn guarded process fixture");
+        let process_id = child.id();
+        let guard = ActivatedProcessGuard::new(WindowsDesktopProcess::from_child(child));
+
+        drop(guard);
+
+        assert!(!crate::process_exists(process_id));
     }
 }

--- a/crates/platform/src/windows_desktop.rs
+++ b/crates/platform/src/windows_desktop.rs
@@ -1,0 +1,490 @@
+use std::ffi::{OsStr, OsString};
+use std::io;
+use std::os::windows::ffi::OsStrExt;
+use std::os::windows::process::ExitStatusExt;
+use std::process::{Child, ExitStatus};
+use std::thread;
+use std::time::{Duration, Instant};
+
+use windows::Win32::Foundation::{
+    HANDLE, RPC_E_CHANGED_MODE, STILL_ACTIVE, WAIT_OBJECT_0, WAIT_TIMEOUT,
+};
+use windows::Win32::System::Com::{
+    CLSCTX_INPROC_SERVER, CLSCTX_LOCAL_SERVER, COINIT_APARTMENTTHREADED, CoCreateInstance,
+    CoInitializeEx, CoUninitialize,
+};
+use windows::Win32::System::Threading::{
+    GetExitCodeProcess, GetProcessIdOfThread, OpenProcess, OpenThread, PROCESS_SYNCHRONIZE,
+    PROCESS_TERMINATE, ResumeThread, THREAD_QUERY_LIMITED_INFORMATION, THREAD_SUSPEND_RESUME,
+    TerminateProcess, WaitForSingleObject,
+};
+use windows::Win32::UI::Shell::{
+    ACTIVATEOPTIONS, ApplicationActivationManager, IApplicationActivationManager,
+    IPackageDebugSettings, PackageDebugSettings,
+};
+use windows::core::{HSTRING, Owned};
+
+use super::process::desktop_root_process_ids;
+use super::{APPX_RESUME_ARGUMENT, PlatformError};
+
+fn windows_error(context: &str, error: windows::core::Error) -> PlatformError {
+    PlatformError::Invalid(format!("{context}: {error}"))
+}
+
+struct ComApartment {
+    uninitialize: bool,
+}
+
+impl ComApartment {
+    fn initialize() -> Result<Self, PlatformError> {
+        let result = unsafe { CoInitializeEx(None, COINIT_APARTMENTTHREADED) };
+        if result.is_ok() {
+            Ok(Self { uninitialize: true })
+        } else if result == RPC_E_CHANGED_MODE {
+            Ok(Self {
+                uninitialize: false,
+            })
+        } else {
+            Err(windows_error(
+                "cannot initialize packaged-app activation",
+                result.into(),
+            ))
+        }
+    }
+}
+
+impl Drop for ComApartment {
+    fn drop(&mut self) {
+        if self.uninitialize {
+            unsafe { CoUninitialize() };
+        }
+    }
+}
+
+struct PackageEnvironment {
+    settings: IPackageDebugSettings,
+    package_full_name: HSTRING,
+    armed: bool,
+}
+
+impl PackageEnvironment {
+    fn enable(package_full_name: &str, environment: &[u16]) -> Result<Self, PlatformError> {
+        let debugger_executable = std::env::current_exe().map_err(PlatformError::Io)?;
+        let debugger_command = windows_command_line(&[
+            debugger_executable.into_os_string(),
+            OsString::from(APPX_RESUME_ARGUMENT),
+        ]);
+        let debugger_command = debugger_command
+            .encode_wide()
+            .chain([0])
+            .collect::<Vec<_>>();
+        let settings: IPackageDebugSettings =
+            unsafe { CoCreateInstance(&PackageDebugSettings, None, CLSCTX_INPROC_SERVER) }
+                .map_err(|error| {
+                    windows_error("cannot initialize AppX package environment", error)
+                })?;
+        let package_full_name = HSTRING::from(package_full_name);
+        // Debug settings persist if a previous Launcher is force-terminated.
+        // Clear any stale registration before replacing it for this activation.
+        let _ = unsafe { settings.DisableDebugging(&package_full_name) };
+        unsafe {
+            // Windows 10 rejects a non-empty environment with E_INVALIDARG
+            // unless a debugger command is also supplied. AppX appends
+            // `-p <pid> -tid <tid>` and starts this helper while the application
+            // thread is suspended; the helper validates and resumes that thread.
+            settings.EnableDebugging(
+                &package_full_name,
+                windows::core::PCWSTR(debugger_command.as_ptr()),
+                windows::core::PCWSTR(environment.as_ptr()),
+            )
+        }
+        .map_err(|error| windows_error("cannot install the temporary AppX environment", error))?;
+        Ok(Self {
+            settings,
+            package_full_name,
+            armed: true,
+        })
+    }
+
+    fn disable(&mut self) -> Result<(), PlatformError> {
+        if self.armed {
+            unsafe { self.settings.DisableDebugging(&self.package_full_name) }.map_err(
+                |error| windows_error("cannot remove the temporary AppX environment", error),
+            )?;
+            self.armed = false;
+        }
+        Ok(())
+    }
+}
+
+impl Drop for PackageEnvironment {
+    fn drop(&mut self) {
+        if self.armed {
+            let _ = unsafe { self.settings.DisableDebugging(&self.package_full_name) };
+        }
+    }
+}
+
+enum WindowsDesktopBacking {
+    Child(Child),
+    Activated(Owned<HANDLE>),
+}
+
+pub struct WindowsDesktopProcess {
+    process_id: u32,
+    process: WindowsDesktopBacking,
+    status: Option<ExitStatus>,
+}
+
+impl WindowsDesktopProcess {
+    pub fn from_child(child: Child) -> Self {
+        Self {
+            process_id: child.id(),
+            process: WindowsDesktopBacking::Child(child),
+            status: None,
+        }
+    }
+
+    #[must_use]
+    pub fn id(&self) -> u32 {
+        self.process_id
+    }
+
+    pub fn try_wait(&mut self) -> io::Result<Option<ExitStatus>> {
+        if let Some(status) = self.status {
+            return Ok(Some(status));
+        }
+        if let WindowsDesktopBacking::Child(child) = &mut self.process {
+            return child.try_wait();
+        }
+        let WindowsDesktopBacking::Activated(process) = &self.process else {
+            unreachable!("child process handled above")
+        };
+        let result = unsafe { WaitForSingleObject(**process, 0) };
+        if result == WAIT_TIMEOUT {
+            return Ok(None);
+        }
+        if result != WAIT_OBJECT_0 {
+            return Err(io::Error::last_os_error());
+        }
+        let mut exit_code = STILL_ACTIVE.0 as u32;
+        unsafe { GetExitCodeProcess(**process, &mut exit_code) }
+            .map_err(|error| io::Error::other(format!("cannot read Desktop exit code: {error}")))?;
+        let status = ExitStatus::from_raw(exit_code);
+        self.status = Some(status);
+        Ok(Some(status))
+    }
+
+    pub fn wait(&mut self) -> io::Result<ExitStatus> {
+        if let Some(status) = self.status {
+            return Ok(status);
+        }
+        if let WindowsDesktopBacking::Child(child) = &mut self.process {
+            return child.wait();
+        }
+        let WindowsDesktopBacking::Activated(process) = &self.process else {
+            unreachable!("child process handled above")
+        };
+        let result = unsafe { WaitForSingleObject(**process, u32::MAX) };
+        if result != WAIT_OBJECT_0 {
+            return Err(io::Error::last_os_error());
+        }
+        self.try_wait()?.ok_or_else(|| {
+            io::Error::other("packaged Codex Desktop remained active after its wait completed")
+        })
+    }
+
+    pub fn kill(&mut self) -> io::Result<()> {
+        if let WindowsDesktopBacking::Child(child) = &mut self.process {
+            return child.kill();
+        }
+        let WindowsDesktopBacking::Activated(process) = &self.process else {
+            unreachable!("child process handled above")
+        };
+        unsafe { TerminateProcess(**process, 1) }
+            .map_err(|error| io::Error::other(format!("cannot terminate Desktop: {error}")))
+    }
+}
+
+pub fn quote_windows_argument(argument: &OsStr) -> OsString {
+    let value = argument.to_string_lossy();
+    if !value.is_empty() && !value.contains([' ', '\t', '"']) {
+        return argument.to_owned();
+    }
+    let mut output = String::from("\"");
+    let mut backslashes = 0;
+    for character in value.chars() {
+        match character {
+            '\\' => backslashes += 1,
+            '"' => {
+                output.push_str(&"\\".repeat(backslashes * 2 + 1));
+                output.push('"');
+                backslashes = 0;
+            }
+            _ => {
+                output.push_str(&"\\".repeat(backslashes));
+                output.push(character);
+                backslashes = 0;
+            }
+        }
+    }
+    output.push_str(&"\\".repeat(backslashes * 2));
+    output.push('"');
+    OsString::from(output)
+}
+
+pub fn windows_command_line(arguments: &[OsString]) -> OsString {
+    arguments
+        .iter()
+        .map(|argument| quote_windows_argument(argument))
+        .collect::<Vec<_>>()
+        .join(OsStr::new(" "))
+}
+
+pub fn windows_environment_block(
+    environment: &[(OsString, OsString)],
+) -> Result<Vec<u16>, PlatformError> {
+    for (name, value) in environment {
+        let name = name.encode_wide().collect::<Vec<_>>();
+        let value = value.encode_wide().collect::<Vec<_>>();
+        if name.is_empty()
+            || name.contains(&0)
+            || name.contains(&('=' as u16))
+            || value.contains(&0)
+        {
+            return Err(PlatformError::Invalid(
+                "AppX environment contains an invalid name or value".into(),
+            ));
+        }
+    }
+    let mut entries = environment.to_vec();
+    entries.sort_by(|left, right| {
+        left.0
+            .to_string_lossy()
+            .to_lowercase()
+            .cmp(&right.0.to_string_lossy().to_lowercase())
+    });
+    let mut block = Vec::new();
+    for (name, value) in entries {
+        block.extend(name.encode_wide());
+        block.push('=' as u16);
+        block.extend(value.encode_wide());
+        block.push(0);
+    }
+    block.push(0);
+    if block.len() == 1 {
+        block.push(0);
+    }
+    Ok(block)
+}
+
+/// Resume the initial thread created by AppX package debugging.
+///
+/// This is an internal Launcher entry point. Windows supplies both identifiers;
+/// checking their relationship prevents the helper from resuming an unrelated
+/// thread if it is invoked manually with mismatched arguments.
+pub fn resume_packaged_application(arguments: &[String]) -> Result<(), PlatformError> {
+    let [process_flag, process_id, thread_flag, thread_id] = arguments else {
+        return Err(PlatformError::Invalid(
+            "AppX resume helper requires '-p <pid> -tid <tid>'".into(),
+        ));
+    };
+    if process_flag != "-p" || thread_flag != "-tid" {
+        return Err(PlatformError::Invalid(
+            "AppX resume helper received invalid process arguments".into(),
+        ));
+    }
+    let process_id = process_id
+        .parse::<u32>()
+        .map_err(|_| PlatformError::Invalid("AppX resume helper received an invalid PID".into()))?;
+    let thread_id = thread_id
+        .parse::<u32>()
+        .map_err(|_| PlatformError::Invalid("AppX resume helper received an invalid TID".into()))?;
+    let thread = unsafe {
+        OpenThread(
+            THREAD_QUERY_LIMITED_INFORMATION | THREAD_SUSPEND_RESUME,
+            false,
+            thread_id,
+        )
+    }
+    .map_err(|error| windows_error("cannot open the suspended AppX thread", error))?;
+    let thread = unsafe { Owned::new(thread) };
+    let owner_process_id = unsafe { GetProcessIdOfThread(*thread) };
+    if owner_process_id == 0 {
+        return Err(PlatformError::Io(io::Error::last_os_error()));
+    }
+    if owner_process_id != process_id {
+        return Err(PlatformError::Invalid(
+            "AppX resume helper received a thread owned by another process".into(),
+        ));
+    }
+    let previous_suspend_count = unsafe { ResumeThread(*thread) };
+    if previous_suspend_count == u32::MAX {
+        return Err(PlatformError::Io(io::Error::last_os_error()));
+    }
+    if previous_suspend_count == 0 {
+        return Err(PlatformError::Invalid(
+            "AppX resume helper received a thread that was not suspended".into(),
+        ));
+    }
+    Ok(())
+}
+
+fn wait_for_desktop_root(
+    activation_process_id: u32,
+    timeout: Duration,
+) -> Result<WindowsDesktopProcess, PlatformError> {
+    let started = Instant::now();
+    loop {
+        match desktop_root_process_ids()?.as_slice() {
+            [process_id] if *process_id == activation_process_id => {
+                return supervise_desktop(*process_id);
+            }
+            [] if started.elapsed() < timeout => thread::sleep(Duration::from_millis(20)),
+            [] => {
+                return Err(PlatformError::NotFound(
+                    "Codex Desktop AppX activation did not create a root process before timeout"
+                        .into(),
+                ));
+            }
+            roots => {
+                return Err(PlatformError::Invalid(format!(
+                    "Codex Desktop AppX activation did not own the observed root processes: {}",
+                    roots
+                        .iter()
+                        .map(u32::to_string)
+                        .collect::<Vec<_>>()
+                        .join(", ")
+                )));
+            }
+        }
+    }
+}
+
+pub fn activate_packaged_desktop(
+    package_full_name: &str,
+    app_user_model_id: &str,
+    arguments: &[OsString],
+    environment: &[(OsString, OsString)],
+) -> Result<WindowsDesktopProcess, PlatformError> {
+    let _apartment = ComApartment::initialize()?;
+    let environment = windows_environment_block(environment)?;
+    let mut package_environment = PackageEnvironment::enable(package_full_name, &environment)?;
+    let manager: IApplicationActivationManager =
+        unsafe { CoCreateInstance(&ApplicationActivationManager, None, CLSCTX_LOCAL_SERVER) }
+            .map_err(|error| windows_error("cannot initialize AppX activation manager", error))?;
+    let activation_process_id = unsafe {
+        manager.ActivateApplication(
+            &HSTRING::from(app_user_model_id),
+            &HSTRING::from(windows_command_line(arguments).to_string_lossy().as_ref()),
+            ACTIVATEOPTIONS(0),
+        )
+    }
+    .map_err(|error| windows_error("cannot activate Codex Desktop AppX package", error))?;
+    let desktop = wait_for_desktop_root(activation_process_id, Duration::from_secs(5))?;
+    package_environment.disable()?;
+    Ok(desktop)
+}
+
+pub fn supervise_desktop(process_id: u32) -> Result<WindowsDesktopProcess, PlatformError> {
+    let process =
+        unsafe { OpenProcess(PROCESS_SYNCHRONIZE | PROCESS_TERMINATE, false, process_id) }
+            .map_err(|error| windows_error("cannot supervise activated Codex Desktop", error))?;
+    Ok(WindowsDesktopProcess {
+        process_id,
+        process: WindowsDesktopBacking::Activated(unsafe { Owned::new(process) }),
+        status: None,
+    })
+}
+
+pub fn activate_stock_desktop(
+    package_full_name: &str,
+    app_user_model_id: &str,
+) -> Result<WindowsDesktopProcess, PlatformError> {
+    let _apartment = ComApartment::initialize()?;
+    // Recover from a Launcher that was terminated after enabling package
+    // debugging but before its normal Drop cleanup ran.
+    if let Ok(settings) = unsafe {
+        CoCreateInstance::<_, IPackageDebugSettings>(
+            &PackageDebugSettings,
+            None,
+            CLSCTX_INPROC_SERVER,
+        )
+    } {
+        let _ = unsafe { settings.DisableDebugging(&HSTRING::from(package_full_name)) };
+    }
+    let manager: IApplicationActivationManager =
+        unsafe { CoCreateInstance(&ApplicationActivationManager, None, CLSCTX_LOCAL_SERVER) }
+            .map_err(|error| windows_error("cannot initialize AppX activation manager", error))?;
+    let activation_process_id = unsafe {
+        manager.ActivateApplication(
+            &HSTRING::from(app_user_model_id),
+            &HSTRING::new(),
+            ACTIVATEOPTIONS(0),
+        )
+    }
+    .map_err(|error| windows_error("cannot activate stock Codex Desktop", error))?;
+    wait_for_desktop_root(activation_process_id, Duration::from_secs(5))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::ffi::{OsStr, OsString};
+
+    use super::{
+        quote_windows_argument, resume_packaged_application, windows_command_line,
+        windows_environment_block,
+    };
+
+    #[test]
+    fn quotes_packaged_activation_arguments() {
+        assert_eq!(quote_windows_argument(OsStr::new("plain")), "plain");
+        assert_eq!(
+            quote_windows_argument(OsStr::new("two words")),
+            "\"two words\""
+        );
+        assert_eq!(
+            windows_command_line(&[
+                OsString::from("--inspect=127.0.0.1:43123"),
+                OsString::from("two words"),
+            ]),
+            "--inspect=127.0.0.1:43123 \"two words\""
+        );
+    }
+
+    #[test]
+    fn rejects_invalid_appx_resume_arguments_before_opening_a_thread() {
+        assert!(resume_packaged_application(&[]).is_err());
+        assert!(
+            resume_packaged_application(&[
+                "-p".into(),
+                "not-a-pid".into(),
+                "-tid".into(),
+                "42".into(),
+            ])
+            .is_err()
+        );
+        assert!(
+            resume_packaged_application(&["--pid".into(), "1".into(), "-tid".into(), "2".into(),])
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn builds_a_sorted_double_nul_environment_block() {
+        let block = windows_environment_block(&[
+            (OsString::from("z"), OsString::from("last")),
+            (OsString::from("A"), OsString::from("first")),
+        ])
+        .expect("valid environment");
+        let expected = "A=first\0z=last\0\0".encode_utf16().collect::<Vec<_>>();
+        assert_eq!(block, expected);
+        assert_eq!(
+            windows_environment_block(&[]).expect("empty environment"),
+            [0, 0]
+        );
+        assert!(
+            windows_environment_block(&[(OsString::from("bad=name"), OsString::new())]).is_err()
+        );
+    }
+}

--- a/packages/adapters/claude-code/src/command.ts
+++ b/packages/adapters/claude-code/src/command.ts
@@ -41,17 +41,21 @@ function isExecutable(candidate: string, platform: NodeJS.Platform): boolean {
   }
 }
 
-function runnableCandidate(candidate: string, platform: NodeJS.Platform): string {
+function claudeNpmNativeExecutable(npmDirectory: string): string {
+  return path.join(
+    npmDirectory,
+    "node_modules",
+    "@anthropic-ai",
+    "claude-code",
+    "bin",
+    "claude.exe",
+  );
+}
+
+function runnableCandidate(candidate: string, platform: NodeJS.Platform): string | undefined {
   if (platform === "win32" && path.basename(candidate).toLowerCase() === "claude.cmd") {
-    const nativeExecutable = path.join(
-      path.dirname(candidate),
-      "node_modules",
-      "@anthropic-ai",
-      "claude-code",
-      "bin",
-      "claude.exe",
-    );
-    if (isExecutable(nativeExecutable, platform)) return nativeExecutable;
+    const nativeExecutable = claudeNpmNativeExecutable(path.dirname(candidate));
+    return isExecutable(nativeExecutable, platform) ? nativeExecutable : undefined;
   }
   return candidate;
 }
@@ -78,15 +82,7 @@ function userInstallCandidates(
   if (platform === "win32") {
     const appData = environment.APPDATA ?? path.join(homeDirectory, "AppData", "Roaming");
     return [
-      path.join(
-        appData,
-        "npm",
-        "node_modules",
-        "@anthropic-ai",
-        "claude-code",
-        "bin",
-        "claude.exe",
-      ),
+      claudeNpmNativeExecutable(path.join(appData, "npm")),
       path.join(appData, "npm", "claude.cmd"),
       path.join(homeDirectory, ".local", "bin", "claude.exe"),
       path.join(homeDirectory, ".local", "bin", "claude.cmd"),
@@ -122,7 +118,10 @@ export function resolveClaudeCodeExecutable(
   ];
   const executable = resolutionCandidates
     .map((candidate) => runnableCandidate(candidate, platform))
-    .find((candidate) => isExecutable(candidate, platform));
+    .find(
+      (candidate): candidate is string =>
+        candidate !== undefined && isExecutable(candidate, platform),
+    );
   if (!executable) throw new ClaudeCodeExecutableError("Claude Code is not installed");
   return path.resolve(executable);
 }

--- a/packages/adapters/claude-code/src/command.ts
+++ b/packages/adapters/claude-code/src/command.ts
@@ -41,6 +41,21 @@ function isExecutable(candidate: string, platform: NodeJS.Platform): boolean {
   }
 }
 
+function runnableCandidate(candidate: string, platform: NodeJS.Platform): string {
+  if (platform === "win32" && path.basename(candidate).toLowerCase() === "claude.cmd") {
+    const nativeExecutable = path.join(
+      path.dirname(candidate),
+      "node_modules",
+      "@anthropic-ai",
+      "claude-code",
+      "bin",
+      "claude.exe",
+    );
+    if (isExecutable(nativeExecutable, platform)) return nativeExecutable;
+  }
+  return candidate;
+}
+
 function nvmCandidates(homeDirectory: string): string[] {
   const versionsDirectory = path.join(homeDirectory, ".nvm", "versions", "node");
   try {
@@ -63,6 +78,15 @@ function userInstallCandidates(
   if (platform === "win32") {
     const appData = environment.APPDATA ?? path.join(homeDirectory, "AppData", "Roaming");
     return [
+      path.join(
+        appData,
+        "npm",
+        "node_modules",
+        "@anthropic-ai",
+        "claude-code",
+        "bin",
+        "claude.exe",
+      ),
       path.join(appData, "npm", "claude.cmd"),
       path.join(homeDirectory, ".local", "bin", "claude.exe"),
       path.join(homeDirectory, ".local", "bin", "claude.cmd"),
@@ -96,7 +120,9 @@ export function resolveClaudeCodeExecutable(
     ...candidates(command, platform, environment),
     ...(configuredCommand ? [] : userInstallCandidates(platform, environment, homeDirectory)),
   ];
-  const executable = resolutionCandidates.find((candidate) => isExecutable(candidate, platform));
+  const executable = resolutionCandidates
+    .map((candidate) => runnableCandidate(candidate, platform))
+    .find((candidate) => isExecutable(candidate, platform));
   if (!executable) throw new ClaudeCodeExecutableError("Claude Code is not installed");
   return path.resolve(executable);
 }

--- a/packages/adapters/claude-code/test/command.test.ts
+++ b/packages/adapters/claude-code/test/command.test.ts
@@ -38,6 +38,33 @@ describe("Claude Code executable resolution", () => {
     ).toBe(executable);
   });
 
+  it("resolves the Windows npm shim to Claude Code's native executable", () => {
+    const homeDirectory = fs.mkdtempSync(path.join(os.tmpdir(), "codexhost-claude-home-"));
+    directories.push(homeDirectory);
+    const appData = path.join(homeDirectory, "AppData", "Roaming");
+    const npmDirectory = path.join(appData, "npm");
+    const shim = path.join(npmDirectory, "claude.cmd");
+    const nativeExecutable = path.join(
+      npmDirectory,
+      "node_modules",
+      "@anthropic-ai",
+      "claude-code",
+      "bin",
+      "claude.exe",
+    );
+    fs.mkdirSync(path.dirname(nativeExecutable), { recursive: true });
+    fs.writeFileSync(shim, "@echo off\r\n", { mode: 0o700 });
+    fs.writeFileSync(nativeExecutable, "native Claude Code", { mode: 0o700 });
+
+    expect(
+      resolveClaudeCodeExecutable({
+        environment: { APPDATA: appData, PATH: npmDirectory, PATHEXT: ".CMD" },
+        homeDirectory,
+        platform: "win32",
+      }),
+    ).toBe(nativeExecutable);
+  });
+
   it("finds a user npm installation when a Finder-style PATH omits it", () => {
     const homeDirectory = fs.mkdtempSync(path.join(os.tmpdir(), "codexhost-claude-home-"));
     directories.push(homeDirectory);

--- a/packages/adapters/claude-code/test/command.test.ts
+++ b/packages/adapters/claude-code/test/command.test.ts
@@ -65,6 +65,21 @@ describe("Claude Code executable resolution", () => {
     ).toBe(nativeExecutable);
   });
 
+  it("rejects a Windows npm shim without a native executable", () => {
+    const directory = fs.mkdtempSync(path.join(os.tmpdir(), "codexhost-claude-npm-"));
+    directories.push(directory);
+    const shim = path.join(directory, "claude.cmd");
+    fs.writeFileSync(shim, "@echo off\r\n", { mode: 0o700 });
+
+    expect(() =>
+      resolveClaudeCodeExecutable({
+        command: shim,
+        environment: {},
+        platform: "win32",
+      }),
+    ).toThrow("not installed");
+  });
+
   it("finds a user npm installation when a Finder-style PATH omits it", () => {
     const homeDirectory = fs.mkdtempSync(path.join(os.tmpdir(), "codexhost-claude-home-"));
     directories.push(homeDirectory);

--- a/tools/gate-a/run.mjs
+++ b/tools/gate-a/run.mjs
@@ -82,21 +82,28 @@ $package = Get-AppxPackage -Name 'OpenAI.Codex' | Sort-Object Version -Descendin
 if ($null -eq $package) { throw 'OpenAI.Codex AppX package is not installed' }
 $package.Name
 $package.PackageFamilyName
+$package.PackageFullName
+$manifest = Get-AppxPackageManifest -Package $package.PackageFullName
+$applications = @($manifest.Package.Applications.Application)
+if ($applications.Count -ne 1 -or [string]::IsNullOrWhiteSpace($applications[0].Id)) { throw 'Codex AppX package must expose exactly one application identity' }
+"$($package.PackageFamilyName)!$($applications[0].Id)"
 $package.Version.ToString()
 $package.InstallLocation
 `;
   const result = run("powershell.exe", ["-NoProfile", "-NonInteractive", "-Command", script]);
   if (result.status !== 0) throw new Error(`AppX discovery failed: ${result.stderr.trim()}`);
   const values = result.stdout.replaceAll("\r", "").trim().split("\n");
-  if (values.length !== 4 || values.some((value) => value.length === 0)) {
+  if (values.length !== 6 || values.some((value) => value.length === 0)) {
     throw new Error("AppX discovery returned an unexpected result");
   }
   cachedLauncherEnvironment = {
     ...process.env,
     CODEXHOST_PROBE_PACKAGE_NAME: values[0],
     CODEXHOST_PROBE_PACKAGE_FAMILY: values[1],
-    CODEXHOST_PROBE_DESKTOP_VERSION: values[2],
-    CODEXHOST_PROBE_INSTALL_ROOT: values[3],
+    CODEXHOST_PROBE_PACKAGE_FULL_NAME: values[2],
+    CODEXHOST_PROBE_APP_USER_MODEL_ID: values[3],
+    CODEXHOST_PROBE_DESKTOP_VERSION: values[4],
+    CODEXHOST_PROBE_INSTALL_ROOT: values[5],
   };
   return cachedLauncherEnvironment;
 }


### PR DESCRIPTION
## Purpose

Fix two Windows failures observed with a Microsoft Store Codex installation on Windows 10 IoT Enterprise LTSC 2021:

- Codex Desktop failed at startup with `Access is denied (os error 5)` because the Launcher executed the protected `WindowsApps` binary directly.
- Claude Code was reported as unavailable because Node 24 could not directly spawn the global npm `claude.cmd` shim (`spawn EINVAL`).

## Changes

- Discover the AppX package full name and AppUserModelId alongside the existing Windows package metadata.
- Activate installed Store builds through `IApplicationActivationManager` while preserving direct execution for portable/unpacked builds.
- Inject the managed Desktop environment with `IPackageDebugSettings`.
- Supply an internal debugger/resume helper for Windows 10, which rejects a non-empty AppX debug environment unless a debugger command is present.
- Validate the AppX PID/TID relationship before resuming the suspended application thread.
- Clean stale package debug registrations and supervise the activated Desktop by PID.
- Resolve the Windows npm `claude.cmd` shim to the package's native `claude.exe` before starting Claude Code.

## Validation

- End-to-end launch on Windows 10 build 19044 with Microsoft Store Codex: Desktop launched, Controller ready, Host chain ready.
- `cargo test --locked --package codexhost-platform` — 20 passed.
- `cargo test --locked --package codexhost-launcher --test cli` — 4 passed.
- `cargo clippy --locked --package codexhost-platform --package codexhost-launcher --all-targets -- -D warnings -A unused-imports` — passed (allowance is for a pre-existing Windows-only unused import).
- `npm run build:typescript` — passed.
- Claude command resolver Vitest — 6 passed.
- Real Claude Adapter inspection returned `status: ready` and published its model/permission catalogs.
