### PR TITLE
fix: hand off local host runtime ownership

### DIFF
--- a/crates/shim/src/lib.rs
+++ b/crates/shim/src/lib.rs
@@ -15,6 +15,10 @@ use codexhost_platform::{
     validate_proxy_target,
 };
 
+mod local_runtime_lease;
+
+use local_runtime_lease::LocalRuntimeLease;
+
 pub type ShimResult<T> = Result<T, Box<dyn Error>>;
 
 pub const HOST_NODE_PATH_ENV: &str = "CODEXHOST_HOST_NODE_PATH";
@@ -125,12 +129,14 @@ struct ChildOutcome {
     forwarded_signal: Option<i32>,
     forced: bool,
     terminated_descendants: bool,
+    desktop_input_closed: bool,
 }
 
 #[cfg(any(target_os = "macos", target_os = "linux"))]
 fn wait_for_child(
     child: &mut codexhost_platform::SupervisedChild,
     signals: &ShutdownSignals,
+    desktop_input: Option<&std::sync::mpsc::Receiver<io::Result<u64>>>,
 ) -> ShimResult<ChildOutcome> {
     const POLL_INTERVAL: Duration = Duration::from_millis(20);
     const TERMINATION_GRACE: Duration = Duration::from_secs(2);
@@ -140,6 +146,7 @@ fn wait_for_child(
     let mut deadline = None;
     let mut forced = false;
     let mut terminated_descendants = false;
+    let mut desktop_input_closed = false;
     loop {
         if root_status.is_none() {
             root_status = child.try_wait()?;
@@ -153,9 +160,17 @@ fn wait_for_child(
                 forwarded_signal,
                 forced,
                 terminated_descendants,
+                desktop_input_closed,
             });
         }
-        if let Some(signal) = signals.pending().filter(|_| forwarded_signal.is_none()) {
+        if !desktop_input_closed
+            && root_status.is_none()
+            && desktop_input.is_some_and(|input| input.try_recv().is_ok())
+        {
+            child.terminate()?;
+            desktop_input_closed = true;
+            deadline = Some(Instant::now() + TERMINATION_GRACE);
+        } else if let Some(signal) = signals.pending().filter(|_| forwarded_signal.is_none()) {
             child.forward_signal(signal)?;
             forwarded_signal = Some(signal);
             deadline = Some(Instant::now() + TERMINATION_GRACE);
@@ -176,16 +191,35 @@ fn wait_for_child(
 fn wait_for_child(
     child: &mut codexhost_platform::SupervisedChild,
     _signals: &ShutdownSignals,
+    desktop_input: Option<&std::sync::mpsc::Receiver<io::Result<u64>>>,
 ) -> ShimResult<ChildOutcome> {
-    child
-        .wait()
-        .map(|status| ChildOutcome {
-            status,
-            forwarded_signal: None,
-            forced: false,
-            terminated_descendants: false,
-        })
-        .map_err(Into::into)
+    const POLL_INTERVAL: Duration = Duration::from_millis(20);
+    const TERMINATION_GRACE: Duration = Duration::from_secs(2);
+
+    let mut desktop_input_closed = false;
+    let mut deadline = None;
+    let mut forced = false;
+    loop {
+        if let Some(status) = child.try_wait()? {
+            return Ok(ChildOutcome {
+                status,
+                forwarded_signal: None,
+                forced,
+                terminated_descendants: false,
+                desktop_input_closed,
+            });
+        }
+        if !desktop_input_closed && desktop_input.is_some_and(|input| input.try_recv().is_ok()) {
+            child.terminate()?;
+            desktop_input_closed = true;
+            deadline = Some(Instant::now() + TERMINATION_GRACE);
+        }
+        if !forced && deadline.is_some_and(|deadline| Instant::now() >= deadline) {
+            child.force_terminate()?;
+            forced = true;
+        }
+        thread::sleep(POLL_INTERVAL);
+    }
 }
 
 #[cfg(any(target_os = "macos", target_os = "linux"))]
@@ -494,6 +528,35 @@ fn select_host_paths(
     (configured_node, configured_runtime)
 }
 
+#[must_use]
+fn is_managed_remote_listener(arguments: &[OsString]) -> bool {
+    #[cfg(any(target_os = "macos", target_os = "linux"))]
+    {
+        env::var_os(REMOTE_SSH_MANAGED_ENV).as_deref() == Some(std::ffi::OsStr::new("1"))
+            && is_default_remote_unix_listener(arguments)
+    }
+    #[cfg(not(any(target_os = "macos", target_os = "linux")))]
+    {
+        let _ = arguments;
+        false
+    }
+}
+
+#[must_use]
+fn host_runtime_paths_are_configured() -> bool {
+    let launcher_managed = env::var_os(LAUNCHER_PID_ENV).is_some();
+    matches!(
+        select_host_paths(
+            env::var_os(HOST_NODE_PATH_ENV),
+            env::var_os(HOST_RUNTIME_PATH_ENV),
+            launcher_managed,
+            env::var_os(NPM_NODE_PATH_ENV),
+            env::var_os(NPM_PACKAGE_ROOT_ENV),
+        ),
+        (Some(_), Some(_))
+    )
+}
+
 fn child_command(
     arguments: &[OsString],
     current_executable: &Path,
@@ -575,6 +638,17 @@ pub fn run_proxy_with_observer(
 
     let started = Instant::now();
     let shutdown_signals = ShutdownSignals::install()?;
+    let local_host_runtime = should_start_host_runtime(arguments)
+        && host_runtime_paths_are_configured()
+        && !is_managed_remote_listener(arguments)
+        && env::var_os(DATA_DIRECTORY_ENV).is_some();
+    let mut local_runtime_lease = if local_host_runtime {
+        Some(LocalRuntimeLease::acquire(&PathBuf::from(
+            env::var_os(DATA_DIRECTORY_ENV).ok_or("CODEXHOST_DATA_DIR is unavailable")?,
+        ))?)
+    } else {
+        None
+    };
     let mut command = child_command(arguments, &current_executable, &stock_codex_path)?;
     command
         .stdin(Stdio::piped())
@@ -582,6 +656,13 @@ pub fn run_proxy_with_observer(
         .stderr(Stdio::piped());
     let mut child = spawn_supervised(&mut command)?;
     let child_id = child.id();
+    if let Some(lease) = &mut local_runtime_lease
+        && let Err(error) = lease.set_child_process_id(child_id)
+    {
+        let _ = child.force_terminate();
+        let _ = child.wait();
+        return Err(error);
+    }
 
     let child_stdin = child
         .take_stdin()
@@ -593,11 +674,18 @@ pub fn run_proxy_with_observer(
         .take_stderr()
         .ok_or("official CLI stderr is unavailable")?;
 
-    let _stdin_pump = thread::spawn(move || copy_stream(io::stdin().lock(), child_stdin));
+    let (stdin_sender, stdin_receiver) = std::sync::mpsc::sync_channel(1);
+    let _stdin_pump = thread::spawn(move || {
+        let _ = stdin_sender.send(copy_stream(io::stdin().lock(), child_stdin));
+    });
     let stdout_pump = thread::spawn(move || copy_stream(child_stdout, io::stdout().lock()));
     let stderr_pump = thread::spawn(move || copy_stream(child_stderr, io::stderr().lock()));
 
-    let outcome = wait_for_child(&mut child, &shutdown_signals)?;
+    let outcome = wait_for_child(
+        &mut child,
+        &shutdown_signals,
+        local_host_runtime.then_some(&stdin_receiver),
+    )?;
     stdout_pump
         .join()
         .map_err(|_| "official CLI stdout pump panicked")??;
@@ -612,13 +700,20 @@ pub fn run_proxy_with_observer(
     if outcome.terminated_descendants {
         eprintln!("codexhost shim: terminated official CLI descendants after root exit");
     }
+    if outcome.desktop_input_closed {
+        eprintln!("codexhost shim: closed the local Host Runtime after Desktop stdin EOF");
+    }
     if outcome.forced {
         eprintln!("codexhost shim: forced official CLI process-group termination after timeout");
     }
     if let Some(signal) = exit_signal(&outcome.status) {
         eprintln!("codexhost shim: official CLI terminated by signal {signal}");
     }
-    Ok(outcome.status.code().unwrap_or(1))
+    Ok(if outcome.desktop_input_closed {
+        0
+    } else {
+        outcome.status.code().unwrap_or(1)
+    })
 }
 
 pub fn run_proxy(arguments: &[OsString]) -> ShimResult<i32> {

--- a/crates/shim/src/local_runtime_lease.rs
+++ b/crates/shim/src/local_runtime_lease.rs
@@ -1,0 +1,373 @@
+use std::env;
+use std::error::Error;
+use std::fs;
+use std::io;
+use std::path::{Path, PathBuf};
+use std::process;
+use std::thread;
+use std::time::{Duration, Instant};
+
+#[cfg(target_os = "windows")]
+use codexhost_platform::terminate_process_by_id;
+use codexhost_platform::{
+    atomic_replace_file, parent_process_id, process_executable_path, process_exists,
+};
+
+const OWNER_DIRECTORY_NAME: &str = "local-host-runtime-owner-v1";
+const OWNER_RECORD_NAME: &str = "owner";
+const MAPPING_STORE_LOCK_PATH: [&str; 2] = ["mapping-store", "store.lock"];
+const OWNER_READ_GRACE: Duration = Duration::from_millis(500);
+const HANDOFF_GRACE: Duration = Duration::from_secs(4);
+const FORCE_GRACE: Duration = Duration::from_secs(2);
+const POLL_INTERVAL: Duration = Duration::from_millis(20);
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct OwnerRecord {
+    process_id: u32,
+    desktop_process_id: u32,
+    child_process_id: Option<u32>,
+}
+
+impl OwnerRecord {
+    fn encode(&self) -> String {
+        format!(
+            "version=1\nprocess_id={}\ndesktop_process_id={}\nchild_process_id={}\n",
+            self.process_id,
+            self.desktop_process_id,
+            self.child_process_id
+                .map_or_else(String::new, |value| value.to_string()),
+        )
+    }
+
+    fn decode(value: &str) -> Option<Self> {
+        let field = |name: &str| {
+            value
+                .lines()
+                .find_map(|line| line.strip_prefix(&format!("{name}=")))
+        };
+        if field("version")? != "1" {
+            return None;
+        }
+        Some(Self {
+            process_id: field("process_id")?.parse().ok()?,
+            desktop_process_id: field("desktop_process_id")?.parse().ok()?,
+            child_process_id: field("child_process_id").and_then(|value| value.parse().ok()),
+        })
+    }
+}
+
+pub(crate) struct LocalRuntimeLease {
+    directory: PathBuf,
+    record: OwnerRecord,
+}
+
+impl LocalRuntimeLease {
+    pub(crate) fn acquire(data_directory: &Path) -> Result<Self, Box<dyn Error>> {
+        fs::create_dir_all(data_directory)?;
+        let directory = data_directory.join(OWNER_DIRECTORY_NAME);
+        let process_id = process::id();
+        let desktop_process_id = parent_process_id(process_id)?.ok_or_else(|| {
+            io::Error::other("codexhost Shim parent process identity is unavailable")
+        })?;
+        let record = OwnerRecord {
+            process_id,
+            desktop_process_id,
+            child_process_id: None,
+        };
+
+        loop {
+            match fs::create_dir(&directory) {
+                Ok(()) => {
+                    let lease = Self { directory, record };
+                    if let Err(error) = lease.write_record() {
+                        let _ = fs::remove_dir_all(&lease.directory);
+                        return Err(error);
+                    }
+                    if let Err(error) = retire_legacy_mapping_store_owner(
+                        data_directory,
+                        lease.record.desktop_process_id,
+                    ) {
+                        drop(lease);
+                        return Err(error);
+                    }
+                    return Ok(lease);
+                }
+                Err(error) if error.kind() == io::ErrorKind::AlreadyExists => {}
+                Err(error) => return Err(error.into()),
+            }
+
+            let Some(owner) = read_owner_with_grace(&directory)? else {
+                fs::remove_dir_all(&directory)?;
+                continue;
+            };
+            if owner.process_id == process_id {
+                return Err("current codexhost Shim already owns the local Host Runtime".into());
+            }
+            if !owner_is_codexhost_shim(&owner)? {
+                remove_owner_if_matches(&directory, &owner)?;
+                continue;
+            }
+
+            if is_live_other_desktop(owner.desktop_process_id, desktop_process_id) {
+                return Err(format!(
+                    "another Codex Desktop process owns the local Host Runtime (Shim PID {}, Desktop PID {})",
+                    owner.process_id, owner.desktop_process_id,
+                )
+                .into());
+            }
+
+            stop_owner(&owner)?;
+            remove_owner_if_matches(&directory, &owner)?;
+        }
+    }
+
+    pub(crate) fn set_child_process_id(
+        &mut self,
+        child_process_id: u32,
+    ) -> Result<(), Box<dyn Error>> {
+        if read_owner(&self.directory).as_ref() != Some(&self.record) {
+            return Err("local Host Runtime ownership changed before child startup".into());
+        }
+        self.record.child_process_id = Some(child_process_id);
+        self.write_record()
+    }
+
+    fn write_record(&self) -> Result<(), Box<dyn Error>> {
+        let target = self.directory.join(OWNER_RECORD_NAME);
+        let temporary = self.directory.join(format!(
+            "{OWNER_RECORD_NAME}.tmp-{}",
+            self.record.process_id
+        ));
+        fs::write(&temporary, self.record.encode())?;
+        atomic_replace_file(&temporary, &target)?;
+        Ok(())
+    }
+}
+
+impl Drop for LocalRuntimeLease {
+    fn drop(&mut self) {
+        let _ = remove_owner_if_matches(&self.directory, &self.record);
+    }
+}
+
+fn read_owner(directory: &Path) -> Option<OwnerRecord> {
+    fs::read_to_string(directory.join(OWNER_RECORD_NAME))
+        .ok()
+        .and_then(|value| OwnerRecord::decode(&value))
+}
+
+fn read_owner_with_grace(directory: &Path) -> Result<Option<OwnerRecord>, Box<dyn Error>> {
+    let deadline = Instant::now() + OWNER_READ_GRACE;
+    loop {
+        if let Some(owner) = read_owner(directory) {
+            return Ok(Some(owner));
+        }
+        if Instant::now() >= deadline {
+            return Ok(None);
+        }
+        thread::sleep(POLL_INTERVAL);
+    }
+}
+
+fn remove_owner_if_matches(directory: &Path, expected: &OwnerRecord) -> io::Result<()> {
+    if read_owner(directory).as_ref() == Some(expected) {
+        fs::remove_dir_all(directory)?;
+    }
+    Ok(())
+}
+
+fn owner_is_codexhost_shim(owner: &OwnerRecord) -> Result<bool, Box<dyn Error>> {
+    if !process_exists(owner.process_id) {
+        return Ok(false);
+    }
+    let owner_executable = process_executable_path(owner.process_id)?;
+    let current_executable = env::current_exe()?;
+    // npm upgrades and candidate packages can move the same Shim to another absolute path.
+    // The lease's PID and Desktop lineage are the trust boundary; the basename rejects PID reuse
+    // by an unrelated executable without making in-place upgrades impossible.
+    Ok(owner_executable.file_name() == current_executable.file_name())
+}
+
+fn retire_legacy_mapping_store_owner(
+    data_directory: &Path,
+    current_desktop_process_id: u32,
+) -> Result<(), Box<dyn Error>> {
+    let lock_path = MAPPING_STORE_LOCK_PATH
+        .iter()
+        .fold(data_directory.to_path_buf(), |path, segment| {
+            path.join(segment)
+        });
+    let Some(runtime_process_id) = legacy_lock_process_id(&lock_path) else {
+        return Ok(());
+    };
+    if !process_exists(runtime_process_id) {
+        return Ok(());
+    }
+    let runtime_executable = match process_executable_path(runtime_process_id) {
+        Ok(path) => path,
+        Err(_) if !process_exists(runtime_process_id) => return Ok(()),
+        Err(error) => return Err(error.into()),
+    };
+    if !runtime_executable
+        .file_name()
+        .is_some_and(|name| is_node_executable_name(&name.to_string_lossy()))
+    {
+        return Ok(());
+    }
+
+    let Some(shim_process_id) = parent_process_id(runtime_process_id)? else {
+        return Ok(());
+    };
+    let shim_executable = match process_executable_path(shim_process_id) {
+        Ok(path) => path,
+        Err(_) if !process_exists(shim_process_id) => return Ok(()),
+        Err(error) => return Err(error.into()),
+    };
+    let current_executable = env::current_exe()?;
+    if shim_executable.file_name() != current_executable.file_name() {
+        return Ok(());
+    }
+    let Some(legacy_desktop_process_id) = parent_process_id(shim_process_id)? else {
+        return Ok(());
+    };
+    if is_live_other_desktop(legacy_desktop_process_id, current_desktop_process_id) {
+        return Err(format!(
+            "another Codex Desktop process owns the legacy local Host Runtime (Shim PID {shim_process_id}, Desktop PID {legacy_desktop_process_id})",
+        )
+        .into());
+    }
+
+    let legacy_owner = OwnerRecord {
+        process_id: shim_process_id,
+        desktop_process_id: legacy_desktop_process_id,
+        child_process_id: Some(runtime_process_id),
+    };
+    eprintln!(
+        "codexhost shim: retiring legacy local Host Runtime owned by Shim PID {shim_process_id}"
+    );
+    stop_owner(&legacy_owner)
+}
+
+fn is_live_other_desktop(process_id: u32, current_desktop_process_id: u32) -> bool {
+    if process_id == current_desktop_process_id {
+        return false;
+    }
+    #[cfg(any(target_os = "macos", target_os = "linux"))]
+    if process_id == 1 {
+        // A surviving legacy Shim is reparented to launchd/systemd after its Desktop exits.
+        // PID 1 is not another Codex Desktop.
+        return false;
+    }
+    // Refuse takeover whenever the recorded/observed parent is still alive. Executable-name
+    // matching is not sufficient: another Desktop channel or build may use a different basename.
+    process_exists(process_id)
+}
+
+fn legacy_lock_process_id(path: &Path) -> Option<u32> {
+    let contents = fs::read_to_string(path).ok()?;
+    let after_key = contents.split_once("\"pid\"")?.1;
+    let after_colon = after_key.split_once(':')?.1.trim_start();
+    let digits = after_colon
+        .chars()
+        .take_while(char::is_ascii_digit)
+        .collect::<String>();
+    (!digits.is_empty()).then(|| digits.parse().ok()).flatten()
+}
+
+fn is_node_executable_name(name: &str) -> bool {
+    name.eq_ignore_ascii_case("node") || name.eq_ignore_ascii_case("node.exe")
+}
+
+fn stop_owner(owner: &OwnerRecord) -> Result<(), Box<dyn Error>> {
+    terminate(owner.process_id, false)?;
+    if wait_for_owner_exit(owner, HANDOFF_GRACE) {
+        return Ok(());
+    }
+    terminate(owner.process_id, true)?;
+    if let Some(child_process_id) = owner.child_process_id {
+        terminate_child_group(child_process_id)?;
+    }
+    if wait_for_owner_exit(owner, FORCE_GRACE) {
+        return Ok(());
+    }
+    Err(format!(
+        "previous local Host Runtime did not exit (Shim PID {}, child PID {:?})",
+        owner.process_id, owner.child_process_id,
+    )
+    .into())
+}
+
+fn wait_for_owner_exit(owner: &OwnerRecord, timeout: Duration) -> bool {
+    let deadline = Instant::now() + timeout;
+    loop {
+        let owner_alive = process_exists(owner.process_id);
+        let child_alive = owner.child_process_id.is_some_and(process_exists);
+        if !owner_alive && !child_alive {
+            return true;
+        }
+        if Instant::now() >= deadline {
+            return false;
+        }
+        thread::sleep(POLL_INTERVAL);
+    }
+}
+
+#[cfg(any(target_os = "macos", target_os = "linux"))]
+fn terminate(process_id: u32, force: bool) -> Result<(), Box<dyn Error>> {
+    use nix::errno::Errno;
+    use nix::sys::signal::{Signal, kill};
+    use nix::unistd::Pid;
+
+    let process_id = i32::try_from(process_id)?;
+    let signal = if force {
+        Signal::SIGKILL
+    } else {
+        Signal::SIGTERM
+    };
+    match kill(Pid::from_raw(process_id), signal) {
+        Ok(()) | Err(Errno::ESRCH) => Ok(()),
+        Err(error) => Err(error.into()),
+    }
+}
+
+#[cfg(target_os = "windows")]
+fn terminate(process_id: u32, _force: bool) -> Result<(), Box<dyn Error>> {
+    if !process_exists(process_id) {
+        return Ok(());
+    }
+    terminate_process_by_id(process_id)?;
+    Ok(())
+}
+
+#[cfg(not(any(target_os = "windows", target_os = "macos", target_os = "linux")))]
+fn terminate(_process_id: u32, _force: bool) -> Result<(), Box<dyn Error>> {
+    Err("local Host Runtime ownership requires Windows, macOS, or Linux".into())
+}
+
+#[cfg(any(target_os = "macos", target_os = "linux"))]
+fn terminate_child_group(process_id: u32) -> Result<(), Box<dyn Error>> {
+    use nix::errno::Errno;
+    use nix::sys::signal::{Signal, kill, killpg};
+    use nix::unistd::Pid;
+
+    let process_id = i32::try_from(process_id)?;
+    let process_id = Pid::from_raw(process_id);
+    match killpg(process_id, Signal::SIGKILL) {
+        Ok(()) | Err(Errno::ESRCH) => {}
+        Err(error) => return Err(error.into()),
+    }
+    match kill(process_id, Signal::SIGKILL) {
+        Ok(()) | Err(Errno::ESRCH) => Ok(()),
+        Err(error) => Err(error.into()),
+    }
+}
+
+#[cfg(target_os = "windows")]
+fn terminate_child_group(process_id: u32) -> Result<(), Box<dyn Error>> {
+    terminate(process_id, true)
+}
+
+#[cfg(not(any(target_os = "windows", target_os = "macos", target_os = "linux")))]
+fn terminate_child_group(_process_id: u32) -> Result<(), Box<dyn Error>> {
+    Ok(())
+}

--- a/crates/shim/tests/fixtures/fake-codex-cli.rs
+++ b/crates/shim/tests/fixtures/fake-codex-cli.rs
@@ -11,7 +11,8 @@ use std::time::Duration;
 #[cfg(any(target_os = "macos", target_os = "linux"))]
 use std::os::unix::net::UnixListener;
 
-use codexhost_platform::CODEX_CLI_PATH_ENV;
+use codexhost_platform::{CODEX_CLI_PATH_ENV, STOCK_CODEX_PATH_ENV};
+use codexhost_shim::{HOST_NODE_PATH_ENV, HOST_RUNTIME_PATH_ENV};
 
 fn environment_u64(name: &str, default: u64) -> u64 {
     env::var(name)
@@ -97,6 +98,98 @@ fn run_signal_observer() -> bool {
     false
 }
 
+#[cfg(any(target_os = "windows", target_os = "macos", target_os = "linux"))]
+#[allow(clippy::zombie_processes)]
+fn run_orphan_shim_launcher() -> bool {
+    let Some(shim_path) = env::var_os("FAKE_CODEX_ORPHAN_SHIM") else {
+        return false;
+    };
+    let runtime_path =
+        env::var_os("FAKE_CODEX_ORPHAN_RUNTIME").expect("orphan launcher fake runtime path");
+    let data_directory =
+        env::var_os("FAKE_CODEX_ORPHAN_DATA_DIR").expect("orphan launcher data directory");
+    let runtime_ready =
+        env::var_os("FAKE_CODEX_ORPHAN_RUNTIME_READY").expect("orphan launcher runtime ready path");
+    let launcher_ready =
+        env::var_os("FAKE_CODEX_ORPHAN_LAUNCHER_READY").expect("orphan launcher ready path");
+
+    let keep_desktop_alive = env::var_os("FAKE_CODEX_ORPHAN_KEEP_DESKTOP").is_some();
+    let configured_host_runtime = env::var_os("FAKE_CODEX_ORPHAN_USE_HOST_RUNTIME").is_some();
+    let mut command = Command::new(shim_path);
+    command
+        .args(["app-server", "--stdio"])
+        .env_remove("FAKE_CODEX_ORPHAN_SHIM")
+        .env_remove("FAKE_CODEX_ORPHAN_RUNTIME")
+        .env_remove("FAKE_CODEX_ORPHAN_DATA_DIR")
+        .env_remove("FAKE_CODEX_ORPHAN_RUNTIME_READY")
+        .env_remove("FAKE_CODEX_ORPHAN_LAUNCHER_READY")
+        .env_remove("FAKE_CODEX_ORPHAN_KEEP_DESKTOP")
+        .env_remove("FAKE_CODEX_ORPHAN_USE_HOST_RUNTIME")
+        .env(STOCK_CODEX_PATH_ENV, &runtime_path)
+        .env("CODEXHOST_DATA_DIR", data_directory)
+        .env("FAKE_CODEX_HOST_RUNTIME_READY", runtime_ready)
+        .stdin(if keep_desktop_alive {
+            Stdio::piped()
+        } else {
+            Stdio::null()
+        })
+        .stdout(Stdio::null())
+        .stderr(Stdio::null());
+    if configured_host_runtime {
+        command
+            .env(HOST_NODE_PATH_ENV, &runtime_path)
+            .env(HOST_RUNTIME_PATH_ENV, &runtime_path);
+    } else {
+        command
+            .env_remove(HOST_NODE_PATH_ENV)
+            .env_remove(HOST_RUNTIME_PATH_ENV);
+    }
+    let mut child = command
+        .spawn()
+        .expect("spawn orphaned fake Host Runtime Shim");
+    write_ready_file(
+        &std::path::PathBuf::from(launcher_ready),
+        &format!("shim={}\n", child.id()),
+    );
+    if keep_desktop_alive {
+        // A real Desktop reaps a rejected Shim while the Desktop itself stays open. Poll both
+        // lifetimes so Linux does not retain the exited child as a zombie until Desktop EOF.
+        let (desktop_eof_sender, desktop_eof_receiver) = std::sync::mpsc::sync_channel(1);
+        thread::spawn(move || {
+            let result = io::stdin().read_to_end(&mut Vec::new());
+            let _ = desktop_eof_sender.send(result);
+        });
+        let mut child_exited = false;
+        loop {
+            if !child_exited {
+                child_exited = child.try_wait().expect("poll fake Desktop child").is_some();
+            }
+            match desktop_eof_receiver.try_recv() {
+                Ok(result) => {
+                    result.expect("wait for fake Desktop stdin EOF");
+                    break;
+                }
+                Err(std::sync::mpsc::TryRecvError::Empty) => {
+                    thread::sleep(Duration::from_millis(10));
+                }
+                Err(std::sync::mpsc::TryRecvError::Disconnected) => {
+                    panic!("fake Desktop stdin reader disconnected")
+                }
+            }
+        }
+        if !child_exited {
+            drop(child.stdin.take());
+            child.wait().expect("reap fake Desktop child");
+        }
+    }
+    true
+}
+
+#[cfg(not(any(target_os = "windows", target_os = "macos", target_os = "linux")))]
+fn run_orphan_shim_launcher() -> bool {
+    false
+}
+
 // The root-exit test mode intentionally drops a live child to verify orphan cleanup.
 #[allow(clippy::zombie_processes)]
 fn main() {
@@ -112,6 +205,20 @@ fn main() {
         return;
     }
     if run_signal_observer() {
+        return;
+    }
+    if run_orphan_shim_launcher() {
+        return;
+    }
+    if let Some(ready_path) = env::var_os("FAKE_CODEX_HOST_RUNTIME_READY") {
+        write_ready_file(Path::new(&ready_path), &format!("root={}\n", process::id()));
+        io::stdin()
+            .read_to_end(&mut Vec::new())
+            .expect("wait for fake Host Runtime stdin EOF");
+        thread::sleep(Duration::from_millis(environment_u64(
+            "FAKE_CODEX_HOST_RUNTIME_EOF_DELAY_MS",
+            60_000,
+        )));
         return;
     }
     if arguments

--- a/crates/shim/tests/proxy.rs
+++ b/crates/shim/tests/proxy.rs
@@ -11,6 +11,8 @@ use std::time::Duration;
 #[cfg(any(target_os = "windows", target_os = "macos", target_os = "linux"))]
 use std::time::Instant;
 
+#[cfg(any(target_os = "macos", target_os = "linux"))]
+use codexhost_platform::parent_process_id;
 #[cfg(any(target_os = "windows", target_os = "macos", target_os = "linux"))]
 use codexhost_platform::process_exists;
 use codexhost_platform::{CODEX_CLI_PATH_ENV, STOCK_CODEX_PATH_ENV};
@@ -401,20 +403,458 @@ fn reports_an_official_cli_crash_without_polluting_stdout() {
     assert!(String::from_utf8_lossy(&output.stderr).contains("terminated by signal"));
 }
 
-#[cfg(target_os = "macos")]
 fn wait_for_file(path: &std::path::Path, timeout: Duration) -> String {
+    wait_for_optional_file(path, timeout)
+        .unwrap_or_else(|| panic!("timed out waiting for {}", path.display()))
+}
+
+fn wait_for_optional_file(path: &std::path::Path, timeout: Duration) -> Option<String> {
     let started = Instant::now();
     loop {
         if let Ok(contents) = fs::read_to_string(path) {
-            return contents;
+            return Some(contents);
         }
-        assert!(
-            started.elapsed() < timeout,
-            "timed out waiting for {}",
-            path.display()
-        );
+        if started.elapsed() >= timeout {
+            return None;
+        }
         thread::sleep(Duration::from_millis(20));
     }
+}
+
+#[cfg(any(target_os = "windows", target_os = "macos", target_os = "linux"))]
+fn process_id_from_ready(contents: &str, label: &str) -> u32 {
+    contents
+        .lines()
+        .find_map(|line| line.strip_prefix(label))
+        .expect("ready process identity field")
+        .parse::<u32>()
+        .expect("ready process identity PID")
+}
+
+#[cfg(any(target_os = "windows", target_os = "macos", target_os = "linux"))]
+fn host_runtime_shim(directory: &std::path::Path, ready: &std::path::Path) -> process::Child {
+    Command::new(shim_path())
+        .args(["app-server", "--stdio"])
+        .env(STOCK_CODEX_PATH_ENV, fake_codex_path())
+        .env(HOST_NODE_PATH_ENV, fake_codex_path())
+        .env(HOST_RUNTIME_PATH_ENV, fake_codex_path())
+        .env("CODEXHOST_DATA_DIR", directory)
+        .env("FAKE_CODEX_HOST_RUNTIME_READY", ready)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn fake Host Runtime Shim")
+}
+
+#[cfg(any(target_os = "windows", target_os = "macos", target_os = "linux"))]
+fn legacy_host_runtime_shim(
+    directory: &std::path::Path,
+    ready: &std::path::Path,
+    runtime: &std::path::Path,
+) -> process::Child {
+    Command::new(shim_path())
+        .args(["app-server", "--stdio"])
+        .env_remove(HOST_NODE_PATH_ENV)
+        .env_remove(HOST_RUNTIME_PATH_ENV)
+        .env(STOCK_CODEX_PATH_ENV, runtime)
+        .env("CODEXHOST_DATA_DIR", directory)
+        .env("FAKE_CODEX_HOST_RUNTIME_READY", ready)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn legacy fake Host Runtime Shim")
+}
+
+#[cfg(any(target_os = "windows", target_os = "macos", target_os = "linux"))]
+fn desktop_owned_shim(
+    directory: &std::path::Path,
+    launcher_ready: &std::path::Path,
+    runtime_ready: &std::path::Path,
+    runtime: &std::path::Path,
+    configured_host_runtime: bool,
+) -> process::Child {
+    let mut command = Command::new(fake_codex_path());
+    command
+        .env("FAKE_CODEX_ORPHAN_SHIM", shim_path())
+        .env("FAKE_CODEX_ORPHAN_RUNTIME", runtime)
+        .env("FAKE_CODEX_ORPHAN_DATA_DIR", directory)
+        .env("FAKE_CODEX_ORPHAN_RUNTIME_READY", runtime_ready)
+        .env("FAKE_CODEX_ORPHAN_LAUNCHER_READY", launcher_ready)
+        .env("FAKE_CODEX_ORPHAN_KEEP_DESKTOP", "1")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::null())
+        .stderr(Stdio::piped());
+    if configured_host_runtime {
+        command.env("FAKE_CODEX_ORPHAN_USE_HOST_RUNTIME", "1");
+    }
+    command.spawn().expect("start fake live Desktop")
+}
+
+#[cfg(any(target_os = "windows", target_os = "macos", target_os = "linux"))]
+fn force_stop_test_process(process_id: u32) {
+    #[cfg(target_os = "windows")]
+    let _ = Command::new("taskkill.exe")
+        .args(["/PID", &process_id.to_string(), "/T", "/F"])
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status();
+    #[cfg(any(target_os = "macos", target_os = "linux"))]
+    let _ = Command::new("/bin/kill")
+        .args(["-KILL", &process_id.to_string()])
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status();
+}
+
+#[cfg(any(target_os = "windows", target_os = "macos", target_os = "linux"))]
+fn wait_for_process_exit(child: &mut process::Child, timeout: Duration) -> bool {
+    let deadline = Instant::now() + timeout;
+    while child.try_wait().expect("poll test process").is_none() && Instant::now() < deadline {
+        thread::sleep(Duration::from_millis(20));
+    }
+    child.try_wait().expect("final test process poll").is_some()
+}
+
+#[cfg(any(target_os = "windows", target_os = "macos", target_os = "linux"))]
+fn wait_for_process_id_exit(process_id: u32, timeout: Duration) -> bool {
+    let deadline = Instant::now() + timeout;
+    while process_exists(process_id) && Instant::now() < deadline {
+        thread::sleep(Duration::from_millis(20));
+    }
+    !process_exists(process_id)
+}
+
+#[cfg(any(target_os = "windows", target_os = "macos", target_os = "linux"))]
+#[test]
+fn hands_off_local_host_runtime_ownership_and_converges_on_stdin_eof() {
+    let directory = temporary_directory();
+    let first_ready = directory.join("first-ready");
+    let second_ready = directory.join("second-ready");
+    let mut first = host_runtime_shim(&directory, &first_ready);
+    let first_stdin = first.stdin.take().expect("first Host Runtime stdin");
+    let first_identity = wait_for_file(&first_ready, Duration::from_secs(5));
+    let first_root = process_id_from_ready(&first_identity, "root=");
+
+    let mut second = host_runtime_shim(&directory, &second_ready);
+    let second_stdin = second.stdin.take().expect("second Host Runtime stdin");
+    // Reap the old direct child before waiting for the replacement to publish readiness. Linux
+    // reports an unreaped child as an existing PID, so reversing these waits deadlocks the fixture.
+    if !wait_for_process_exit(&mut first, Duration::from_secs(5)) {
+        force_stop_test_process(first.id());
+        force_stop_test_process(first_root);
+        force_stop_test_process(second.id());
+        if let Some(identity) = wait_for_optional_file(&second_ready, Duration::from_secs(1)) {
+            force_stop_test_process(process_id_from_ready(&identity, "root="));
+        }
+        let _ = first.wait();
+        let _ = second.wait();
+        fs::remove_dir_all(&directory).expect("remove failed handoff fixture");
+        panic!("replacement Host Runtime did not retire the previous Shim");
+    }
+    drop(first_stdin);
+    assert!(
+        !process_exists(first_root),
+        "previous Host Runtime PID {first_root} survived ownership handoff"
+    );
+    let second_identity = wait_for_file(&second_ready, Duration::from_secs(5));
+    let second_root = process_id_from_ready(&second_identity, "root=");
+
+    drop(second_stdin);
+    if !wait_for_process_exit(&mut second, Duration::from_secs(5)) {
+        force_stop_test_process(second.id());
+        force_stop_test_process(second_root);
+        let _ = second.wait();
+        fs::remove_dir_all(&directory).expect("remove failed EOF fixture");
+        panic!("Host Runtime Shim did not converge after Desktop stdin EOF");
+    }
+    assert!(
+        !process_exists(second_root),
+        "Host Runtime PID {second_root} survived Desktop stdin EOF"
+    );
+    fs::remove_dir_all(directory).expect("remove Host Runtime handoff fixture");
+}
+
+#[cfg(any(target_os = "windows", target_os = "macos", target_os = "linux"))]
+#[test]
+fn refuses_handoff_from_another_live_desktop() {
+    let directory = temporary_directory();
+    let owner_ready = directory.join("owner-ready");
+    let launcher_ready = directory.join("launcher-ready");
+    let replacement_ready = directory.join("replacement-ready");
+    let mut owner = host_runtime_shim(&directory, &owner_ready);
+    let owner_stdin = owner.stdin.take().expect("owner Host Runtime stdin");
+    let owner_root = process_id_from_ready(
+        &wait_for_file(&owner_ready, Duration::from_secs(5)),
+        "root=",
+    );
+
+    let mut desktop = desktop_owned_shim(
+        &directory,
+        &launcher_ready,
+        &replacement_ready,
+        &fake_codex_path(),
+        true,
+    );
+    let desktop_stdin = desktop.stdin.take().expect("fake Desktop stdin");
+    let replacement_shim = process_id_from_ready(
+        &wait_for_file(&launcher_ready, Duration::from_secs(5)),
+        "shim=",
+    );
+    assert!(
+        wait_for_process_id_exit(replacement_shim, Duration::from_secs(5)),
+        "replacement Shim did not refuse another live Desktop owner"
+    );
+    assert!(!replacement_ready.exists());
+    assert!(
+        process_exists(owner.id()) && process_exists(owner_root),
+        "another live Desktop's Shim or Host Runtime was terminated"
+    );
+
+    drop(owner_stdin);
+    assert!(wait_for_process_exit(&mut owner, Duration::from_secs(5)));
+    drop(desktop_stdin);
+    assert!(wait_for_process_exit(&mut desktop, Duration::from_secs(5)));
+    fs::remove_dir_all(directory).expect("remove live Desktop owner fixture");
+}
+
+#[cfg(any(target_os = "windows", target_os = "macos", target_os = "linux"))]
+#[test]
+fn retires_a_legacy_runtime_from_its_mapping_store_lock() {
+    let directory = temporary_directory();
+    let legacy_ready = directory.join("legacy-ready");
+    let replacement_ready = directory.join("replacement-ready");
+    let legacy_runtime = directory.join(if cfg!(target_os = "windows") {
+        "node.exe"
+    } else {
+        "node"
+    });
+    fs::copy(fake_codex_path(), &legacy_runtime).expect("copy legacy fake Node runtime");
+
+    let mut legacy = legacy_host_runtime_shim(&directory, &legacy_ready, &legacy_runtime);
+    let legacy_stdin = legacy.stdin.take().expect("legacy Host Runtime stdin");
+    let legacy_identity = wait_for_file(&legacy_ready, Duration::from_secs(5));
+    let legacy_root = process_id_from_ready(&legacy_identity, "root=");
+    let mapping_store = directory.join("mapping-store");
+    fs::create_dir(&mapping_store).expect("create legacy Mapping Store directory");
+    fs::write(
+        mapping_store.join("store.lock"),
+        format!("{{\"pid\":{legacy_root},\"instanceId\":\"legacy\"}}\n"),
+    )
+    .expect("write legacy Mapping Store lock");
+
+    let mut replacement = host_runtime_shim(&directory, &replacement_ready);
+    let replacement_stdin = replacement
+        .stdin
+        .take()
+        .expect("replacement Host Runtime stdin");
+    // See the local-owner handoff above: the fixture parent must reap its old direct child before
+    // the replacement can finish validating that the legacy owner has disappeared on Linux.
+    if !wait_for_process_exit(&mut legacy, Duration::from_secs(5)) {
+        force_stop_test_process(legacy.id());
+        force_stop_test_process(legacy_root);
+        force_stop_test_process(replacement.id());
+        if let Some(identity) = wait_for_optional_file(&replacement_ready, Duration::from_secs(1)) {
+            force_stop_test_process(process_id_from_ready(&identity, "root="));
+        }
+        let _ = legacy.wait();
+        let _ = replacement.wait();
+        fs::remove_dir_all(&directory).expect("remove failed legacy handoff fixture");
+        panic!("replacement Host Runtime did not retire the legacy Shim");
+    }
+    drop(legacy_stdin);
+    assert!(
+        !process_exists(legacy_root),
+        "legacy Host Runtime PID {legacy_root} survived ownership migration"
+    );
+    let replacement_identity = wait_for_file(&replacement_ready, Duration::from_secs(5));
+    let replacement_root = process_id_from_ready(&replacement_identity, "root=");
+
+    drop(replacement_stdin);
+    if !wait_for_process_exit(&mut replacement, Duration::from_secs(5)) {
+        force_stop_test_process(replacement.id());
+        force_stop_test_process(replacement_root);
+        let _ = replacement.wait();
+        fs::remove_dir_all(&directory).expect("remove failed legacy replacement fixture");
+        panic!("replacement Host Runtime did not converge after Desktop stdin EOF");
+    }
+    fs::remove_dir_all(directory).expect("remove legacy Host Runtime fixture");
+}
+
+#[cfg(any(target_os = "windows", target_os = "macos", target_os = "linux"))]
+#[test]
+fn refuses_legacy_migration_from_another_live_desktop() {
+    let directory = temporary_directory();
+    let launcher_ready = directory.join("launcher-ready");
+    let legacy_ready = directory.join("legacy-ready");
+    let replacement_ready = directory.join("replacement-ready");
+    let legacy_runtime = directory.join(if cfg!(target_os = "windows") {
+        "node.exe"
+    } else {
+        "node"
+    });
+    fs::copy(fake_codex_path(), &legacy_runtime).expect("copy live legacy fake Node runtime");
+
+    let mut desktop = desktop_owned_shim(
+        &directory,
+        &launcher_ready,
+        &legacy_ready,
+        &legacy_runtime,
+        false,
+    );
+    let desktop_stdin = desktop.stdin.take().expect("fake Desktop stdin");
+    let legacy_shim = process_id_from_ready(
+        &wait_for_file(&launcher_ready, Duration::from_secs(5)),
+        "shim=",
+    );
+    let legacy_root = process_id_from_ready(
+        &wait_for_file(&legacy_ready, Duration::from_secs(5)),
+        "root=",
+    );
+    let mapping_store = directory.join("mapping-store");
+    fs::create_dir(&mapping_store).expect("create live legacy Mapping Store directory");
+    fs::write(
+        mapping_store.join("store.lock"),
+        format!("{{\"pid\":{legacy_root},\"instanceId\":\"live-other\"}}\n"),
+    )
+    .expect("write live legacy Mapping Store lock");
+
+    let mut replacement = host_runtime_shim(&directory, &replacement_ready);
+    if !wait_for_process_exit(&mut replacement, Duration::from_secs(5)) {
+        force_stop_test_process(replacement.id());
+        if let Some(identity) = wait_for_optional_file(&replacement_ready, Duration::from_secs(1)) {
+            force_stop_test_process(process_id_from_ready(&identity, "root="));
+        }
+        force_stop_test_process(legacy_shim);
+        force_stop_test_process(legacy_root);
+        drop(desktop_stdin);
+        let _ = desktop.wait();
+        let _ = replacement.wait();
+        fs::remove_dir_all(&directory).expect("remove unsafe legacy migration fixture");
+        panic!("replacement Shim retired a Host Runtime owned by another live Desktop");
+    }
+    let mut replacement_error = String::new();
+    replacement
+        .stderr
+        .take()
+        .expect("replacement Shim stderr")
+        .read_to_string(&mut replacement_error)
+        .expect("read replacement Shim error");
+    assert!(
+        replacement_error.contains("another Codex Desktop process owns the legacy"),
+        "unexpected replacement error: {replacement_error}"
+    );
+    assert!(!replacement_ready.exists());
+    assert!(
+        process_exists(legacy_shim) && process_exists(legacy_root),
+        "legacy Shim or Host Runtime owned by another live Desktop was terminated"
+    );
+
+    force_stop_test_process(legacy_shim);
+    force_stop_test_process(legacy_root);
+    drop(desktop_stdin);
+    assert!(wait_for_process_exit(&mut desktop, Duration::from_secs(5)));
+    fs::remove_dir_all(directory).expect("remove live legacy Desktop fixture");
+}
+
+#[cfg(any(target_os = "macos", target_os = "linux"))]
+#[test]
+fn retires_an_orphaned_legacy_runtime_after_desktop_exit() {
+    let directory = temporary_directory();
+    let launcher_ready = directory.join("launcher-ready");
+    let legacy_ready = directory.join("legacy-ready");
+    let replacement_ready = directory.join("replacement-ready");
+    let legacy_runtime = directory.join("node");
+    fs::copy(fake_codex_path(), &legacy_runtime).expect("copy orphaned fake Node runtime");
+
+    let launcher = Command::new(fake_codex_path())
+        .env("FAKE_CODEX_ORPHAN_SHIM", shim_path())
+        .env("FAKE_CODEX_ORPHAN_RUNTIME", &legacy_runtime)
+        .env("FAKE_CODEX_ORPHAN_DATA_DIR", &directory)
+        .env("FAKE_CODEX_ORPHAN_RUNTIME_READY", &legacy_ready)
+        .env("FAKE_CODEX_ORPHAN_LAUNCHER_READY", &launcher_ready)
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("start fake Desktop launcher");
+    let launcher_process_id = launcher.id();
+    let launcher = launcher
+        .wait_with_output()
+        .expect("run fake Desktop launcher");
+    assert!(
+        launcher.status.success(),
+        "{}",
+        String::from_utf8_lossy(&launcher.stderr)
+    );
+    let legacy_shim = process_id_from_ready(
+        &wait_for_file(&launcher_ready, Duration::from_secs(5)),
+        "shim=",
+    );
+    let legacy_root = process_id_from_ready(
+        &wait_for_file(&legacy_ready, Duration::from_secs(5)),
+        "root=",
+    );
+    let deadline = Instant::now() + Duration::from_secs(5);
+    while parent_process_id(legacy_shim)
+        .expect("read orphaned Shim parent")
+        .is_some_and(|parent| parent == launcher_process_id)
+        && Instant::now() < deadline
+    {
+        thread::sleep(Duration::from_millis(20));
+    }
+    assert_ne!(
+        parent_process_id(legacy_shim).expect("read reparented Shim parent"),
+        Some(launcher_process_id),
+        "legacy Shim was not reparented after its fake Desktop exited"
+    );
+
+    let mapping_store = directory.join("mapping-store");
+    fs::create_dir(&mapping_store).expect("create orphaned Mapping Store directory");
+    fs::write(
+        mapping_store.join("store.lock"),
+        format!("{{\"pid\":{legacy_root},\"instanceId\":\"orphaned\"}}\n"),
+    )
+    .expect("write orphaned Mapping Store lock");
+
+    let mut replacement = host_runtime_shim(&directory, &replacement_ready);
+    let replacement_stdin = replacement
+        .stdin
+        .take()
+        .expect("replacement Host Runtime stdin");
+    let Some(replacement_identity) =
+        wait_for_optional_file(&replacement_ready, Duration::from_secs(5))
+    else {
+        drop(replacement_stdin);
+        force_stop_test_process(legacy_shim);
+        force_stop_test_process(legacy_root);
+        force_stop_test_process(replacement.id());
+        let _ = replacement.wait();
+        let mut replacement_error = String::new();
+        if let Some(mut stderr) = replacement.stderr.take() {
+            let _ = stderr.read_to_string(&mut replacement_error);
+        }
+        let _ = fs::remove_dir_all(&directory);
+        panic!(
+            "replacement Host Runtime did not recover the orphaned legacy owner: {replacement_error}"
+        );
+    };
+    let replacement_root = process_id_from_ready(&replacement_identity, "root=");
+    assert!(
+        !process_exists(legacy_shim) && !process_exists(legacy_root),
+        "orphaned legacy Shim or Host Runtime survived ownership migration"
+    );
+
+    drop(replacement_stdin);
+    if !wait_for_process_exit(&mut replacement, Duration::from_secs(5)) {
+        force_stop_test_process(replacement.id());
+        force_stop_test_process(replacement_root);
+        let _ = replacement.wait();
+        fs::remove_dir_all(&directory).expect("remove failed orphan replacement fixture");
+        panic!("replacement Host Runtime did not converge after orphan recovery");
+    }
+    fs::remove_dir_all(directory).expect("remove orphaned Host Runtime fixture");
 }
 
 #[cfg(target_os = "macos")]


### PR DESCRIPTION
## Summary  - tie a locally configured Host Runtime to the owning Codex Desktop session instead of leaving it alive after Desktop stdin closes - serialize local Host Runtime ownership with a PID-validated lease, same-Desktop handoff, and orphan recovery - migrate the legacy Mapping Store owner without terminating a runtime owned by another live Codex Desktop - keep stock Codex passthrough and the managed remote SSH listener on their existing lifetime paths  ## Problem  CodexHost can start a local Host Runtime through the shim. When Codex Desktop exits or restarts, the shim currently keeps waiting for the Host Runtime even after Desktop stdin reaches EOF. The old shim/runtime pair remains alive and continues to own the Mapping Store, so a subsequent CodexHost launch can fail with:  ``` codexhost Host Runtime: Mapping Store initialization failed: Another codexhost process owns Mapping Store ```  A black-box reproduction against `v0.3.0-test.3` observed both the shim and fake Host Runtime still alive four seconds after closing Desktop stdin. The branch is now rebased onto `main@dd22b4f`; the upstream changes through that commit do not add local Host Runtime EOF ownership convergence.  ## Implementation  - Observe Desktop stdin completion alongside child exit and platform shutdown signals. - For a configured local Host Runtime, treat stdin EOF as ownership termination and stop the supervised child tree. - Store the shim, Desktop, and Host Runtime PIDs in an atomic directory lease under the CodexHost data directory. - Allow a replacement shim from the same Desktop to hand off ownership safely. - Recover an owner whose Desktop is gone, including a legacy Mapping Store lock after validating the expected `node -> shim` lineage. - Refuse takeover whenever a different recorded or observed Desktop PID is still alive. This is intentionally conservative and does not depend on executable basenames, because different Desktop channels and builds may use different names. - Do not apply this lifetime policy to stock passthrough or the managed remote SSH listener.  ## Regression coverage  - local Host Runtime ownership handoff and stdin-EOF convergence - refusal to replace a v1 lease owned by another live Desktop - safe migration of a legacy Mapping Store owner - refusal to migrate a legacy owner belonging to another live Desktop - Unix orphan recovery after the original Desktop exits - stock passthrough and managed remote-listener process behavior remain covered by the existing suite  ## Verification  Windows:  - `cargo fmt --all --check` - `git diff --check origin/main...HEAD` - `cargo test -p codexhost-shim --locked --features test-utils`   - 4 shim unit tests passed   - 15 shim integration tests passed - targeted upstream-sensitive Vitest coverage after the final rebase   - `remote-app-server.test.ts` and `app-server-host.test.ts`   - 96 tests passed and 8 skipped  macOS:  - `npm run check`   - Prettier, ESLint, boundary checks, and TypeScript checks passed   - 145 Vitest files passed; 1123 tests passed and 6 skipped   - Rust workspace clippy passed with `-D warnings`   - Rust workspace tests passed   - shim-specific result: 7 unit tests and 23 integration tests passed  ## CI status and upstream baseline  This branch is based on `main@dd22b4f`, including the upstream remote socket shutdown serialization and Windows process-supervision warning fix. Those changes are complementary and do not overlap the four files changed by this PR.  - [PR head `1f723df` CI](https://github.com/BytePioneer-AI/codex-host/actions/runs/32647306884): macOS passed; Ubuntu reached the upstream Rust suite and failed only the same pre-existing `process_supervision::tests::accepts_a_shebang_script_that_runs_under_an_interpreter` identity check as the base; Windows reached the upstream TypeScript suite with exactly one failure: `packages/adapters/claude-code/test/command.test.ts > resolves from PATH` (`CLAUDE_NOT_FOUND`). All shim lifecycle tests passed on the CI platforms that completed them. - [Upstream `main@dd22b4f` CI](https://github.com/BytePioneer-AI/codex-host/actions/runs/32646578928): the same Windows Claude PATH test fails independently of this PR; upstream Ubuntu also fails its process-supervision shebang identity test, while macOS passes. - Relative to the exact base SHA, this PR introduces no additional CI failure. Its Ubuntu and Windows failures are the same pre-existing upstream failures, and a prior run of the identical PR tree also demonstrated the new shim lifecycle tests passing on Ubuntu.