### PR TITLE
fix: make local runtime ownership atomic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -124,6 +124,7 @@ name = "codexhost-shim"
 version = "0.3.1"
 dependencies = [
  "codexhost-platform",
+ "fs2",
  "nix",
  "signal-hook",
 ]

--- a/crates/platform/src/lib.rs
+++ b/crates/platform/src/lib.rs
@@ -18,6 +18,7 @@ mod linux_installation;
 mod macos_ui;
 mod process;
 mod process_supervision;
+mod process_termination;
 mod proxy_environment;
 #[cfg(target_os = "macos")]
 mod system_proxy;
@@ -50,16 +51,16 @@ pub use process::force_stop_desktop;
 pub use process::{
     ProcessSnapshot, descendant_executable_exists, desktop_process_ids_for_installation,
     desktop_root_process_ids_for_installation, parent_process_id, process_executable_path,
-    process_exists, terminate_process_by_id,
+    process_exists, process_snapshot, terminate_process_by_id,
 };
 #[cfg(target_os = "windows")]
 pub use process::{desktop_process_ids, desktop_root_process_ids};
 #[cfg(any(target_os = "macos", target_os = "linux"))]
 pub use process::{
-    desktop_process_tree, desktop_root_snapshots_for_installation, process_snapshot,
-    process_snapshots,
+    desktop_process_tree, desktop_root_snapshots_for_installation, process_snapshots,
 };
 pub use process_supervision::{ChildProcessGuard, SupervisedChild, spawn_supervised};
+pub use process_termination::{terminate_process_group_instance, terminate_process_instance};
 pub use proxy_environment::proxy_environment;
 #[cfg(target_os = "macos")]
 pub use system_proxy::{SystemProxySettings, system_proxy_settings};

--- a/crates/platform/src/process.rs
+++ b/crates/platform/src/process.rs
@@ -122,6 +122,31 @@ pub fn process_snapshot(process_id: u32) -> Result<ProcessSnapshot, PlatformErro
     unix_process_snapshot(process_id)
 }
 
+#[cfg(target_os = "windows")]
+pub fn process_snapshot(process_id: u32) -> Result<ProcessSnapshot, PlatformError> {
+    let parent_id = windows_process::process_entries()?
+        .into_iter()
+        .find(|process| process.id == process_id)
+        .ok_or_else(|| PlatformError::NotFound(format!("cannot inspect PID {process_id}")))?
+        .parent_id;
+    let executable = windows_process::process_image_path(process_id)?;
+    let started_at_micros = windows_process::process_started_at_micros(process_id)?;
+    Ok(ProcessSnapshot {
+        id: process_id,
+        parent_id,
+        process_group_id: process_id,
+        executable,
+        started_at_micros,
+    })
+}
+
+#[cfg(not(any(target_os = "windows", target_os = "macos", target_os = "linux")))]
+pub fn process_snapshot(_process_id: u32) -> Result<ProcessSnapshot, PlatformError> {
+    Err(PlatformError::Unsupported(
+        "process snapshots require Windows, macOS, or Linux",
+    ))
+}
+
 #[cfg(target_os = "macos")]
 pub fn process_snapshots() -> Result<Vec<ProcessSnapshot>, PlatformError> {
     use libproc::processes::{ProcFilter, pids_by_type};
@@ -142,7 +167,6 @@ pub fn process_snapshots() -> Result<Vec<ProcessSnapshot>, PlatformError> {
         .collect())
 }
 
-#[cfg(any(target_os = "macos", target_os = "linux"))]
 pub(crate) fn same_process_instance(expected: &ProcessSnapshot, current: &ProcessSnapshot) -> bool {
     expected.id == current.id && expected.started_at_micros == current.started_at_micros
 }

--- a/crates/platform/src/process_termination.rs
+++ b/crates/platform/src/process_termination.rs
@@ -1,0 +1,106 @@
+use super::PlatformError;
+use super::process::{ProcessSnapshot, process_snapshot, same_process_instance};
+
+#[cfg(any(target_os = "macos", target_os = "linux"))]
+use super::process::{ObservedProcessTree, process_snapshots};
+#[cfg(target_os = "windows")]
+use super::windows_process;
+
+pub fn terminate_process_instance(
+    expected: &ProcessSnapshot,
+    _force: bool,
+) -> Result<(), PlatformError> {
+    #[cfg(target_os = "windows")]
+    {
+        let current = match process_snapshot(expected.id) {
+            Ok(current) => current,
+            Err(PlatformError::NotFound(_)) => return Ok(()),
+            Err(error) => return Err(error),
+        };
+        if !same_process_instance(expected, &current) {
+            return Ok(());
+        }
+        let _ = windows_process::terminate_process_instance(
+            expected.id,
+            expected.started_at_micros,
+            1,
+        )?;
+        Ok(())
+    }
+    #[cfg(any(target_os = "macos", target_os = "linux"))]
+    {
+        let signal = if _force {
+            nix::sys::signal::Signal::SIGKILL
+        } else {
+            nix::sys::signal::Signal::SIGTERM
+        };
+        ObservedProcessTree::new(expected.clone())
+            .signal_processes(std::slice::from_ref(expected), signal)
+    }
+    #[cfg(not(any(target_os = "windows", target_os = "macos", target_os = "linux")))]
+    {
+        let _ = (expected, _force);
+        Err(PlatformError::Unsupported(
+            "exact process termination requires Windows, macOS, or Linux",
+        ))
+    }
+}
+
+pub fn terminate_process_group_instance(
+    expected_root: &ProcessSnapshot,
+    force: bool,
+) -> Result<(), PlatformError> {
+    #[cfg(target_os = "windows")]
+    {
+        terminate_process_instance(expected_root, force)
+    }
+    #[cfg(any(target_os = "macos", target_os = "linux"))]
+    {
+        let current = match process_snapshot(expected_root.id) {
+            Ok(current) => current,
+            Err(PlatformError::NotFound(_)) => return Ok(()),
+            Err(error) => return Err(error),
+        };
+        if !same_process_instance(expected_root, &current) {
+            return Ok(());
+        }
+        let group_members = process_snapshots()?
+            .into_iter()
+            .filter(|process| {
+                process.process_group_id == current.process_group_id
+                    && process.started_at_micros >= current.started_at_micros
+            })
+            .collect::<Vec<_>>();
+        let signal = if force {
+            nix::sys::signal::Signal::SIGKILL
+        } else {
+            nix::sys::signal::Signal::SIGTERM
+        };
+        ObservedProcessTree::new_with_process_group(
+            current.clone(),
+            Some(current.process_group_id),
+            Some(current.started_at_micros),
+        )
+        .signal_processes(&group_members, signal)
+    }
+    #[cfg(not(any(target_os = "windows", target_os = "macos", target_os = "linux")))]
+    {
+        let _ = (expected_root, force);
+        Err(PlatformError::Unsupported(
+            "exact process-group termination requires Windows, macOS, or Linux",
+        ))
+    }
+}
+
+#[cfg(all(test, target_os = "windows"))]
+mod windows_tests {
+    use super::{process_snapshot, terminate_process_instance};
+
+    #[test]
+    fn refuses_to_terminate_a_reused_windows_process_id() {
+        let mut recycled = process_snapshot(std::process::id()).expect("current process snapshot");
+        recycled.started_at_micros = recycled.started_at_micros.saturating_add(1);
+        terminate_process_instance(&recycled, true).expect("reject recycled process instance");
+        assert!(process_snapshot(std::process::id()).is_ok());
+    }
+}

--- a/crates/platform/src/windows_process.rs
+++ b/crates/platform/src/windows_process.rs
@@ -56,6 +56,13 @@ struct IoCounters {
 }
 
 #[repr(C)]
+#[derive(Clone, Copy, Default)]
+struct FileTime {
+    low_date_time: u32,
+    high_date_time: u32,
+}
+
+#[repr(C)]
 struct ExtendedLimitInformation {
     basic_limit_information: BasicLimitInformation,
     io_info: IoCounters,
@@ -77,6 +84,13 @@ unsafe extern "system" {
         flags: u32,
         name: *mut u16,
         size: *mut u32,
+    ) -> i32;
+    fn GetProcessTimes(
+        process: Handle,
+        creation_time: *mut FileTime,
+        exit_time: *mut FileTime,
+        kernel_time: *mut FileTime,
+        user_time: *mut FileTime,
     ) -> i32;
     fn CreateJobObjectW(attributes: *const c_void, name: *const u16) -> Handle;
     fn SetInformationJobObject(
@@ -158,6 +172,79 @@ pub fn process_image_path(process_id: u32) -> io::Result<PathBuf> {
         }
         buffer.truncate(length as usize);
         Ok(PathBuf::from(String::from_utf16_lossy(&buffer)))
+    }
+}
+
+fn process_started_at_micros_from_handle(process: Handle) -> io::Result<u64> {
+    let mut creation_time = FileTime::default();
+    let mut exit_time = FileTime::default();
+    let mut kernel_time = FileTime::default();
+    let mut user_time = FileTime::default();
+    let result = unsafe {
+        GetProcessTimes(
+            process,
+            &mut creation_time,
+            &mut exit_time,
+            &mut kernel_time,
+            &mut user_time,
+        )
+    };
+    if result == 0 {
+        return Err(io::Error::last_os_error());
+    }
+    let ticks =
+        (u64::from(creation_time.high_date_time) << 32) | u64::from(creation_time.low_date_time);
+    Ok(ticks / 10)
+}
+
+pub fn process_started_at_micros(process_id: u32) -> io::Result<u64> {
+    unsafe {
+        let process = OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, 0, process_id);
+        if process.is_null() {
+            return Err(io::Error::last_os_error());
+        }
+        let result = process_started_at_micros_from_handle(process);
+        CloseHandle(process);
+        result
+    }
+}
+
+pub fn terminate_process_instance(
+    process_id: u32,
+    expected_started_at_micros: u64,
+    exit_code: u32,
+) -> io::Result<bool> {
+    unsafe {
+        let process = OpenProcess(
+            PROCESS_QUERY_LIMITED_INFORMATION | PROCESS_TERMINATE,
+            0,
+            process_id,
+        );
+        if process.is_null() {
+            return Ok(false);
+        }
+        let current_started_at_micros = match process_started_at_micros_from_handle(process) {
+            Ok(value) => value,
+            Err(error) => {
+                CloseHandle(process);
+                return Err(error);
+            }
+        };
+        if current_started_at_micros != expected_started_at_micros {
+            CloseHandle(process);
+            return Ok(false);
+        }
+        let result = TerminateProcess(process, exit_code);
+        let error = if result == 0 {
+            Some(io::Error::last_os_error())
+        } else {
+            None
+        };
+        CloseHandle(process);
+        match error {
+            Some(error) => Err(error),
+            None => Ok(true),
+        }
     }
 }
 

--- a/crates/shim/Cargo.toml
+++ b/crates/shim/Cargo.toml
@@ -19,6 +19,7 @@ required-features = ["test-utils"]
 
 [dependencies]
 codexhost-platform = { path = "../platform" }
+fs2 = "0.4.3"
 
 [target.'cfg(any(target_os = "macos", target_os = "linux"))'.dependencies]
 nix = { version = "0.31.3", features = ["process", "signal"] }

--- a/crates/shim/src/local_runtime_lease.rs
+++ b/crates/shim/src/local_runtime_lease.rs
@@ -1,19 +1,20 @@
 use std::env;
 use std::error::Error;
-use std::fs;
+use std::fs::{self, File, OpenOptions};
 use std::io;
 use std::path::{Path, PathBuf};
 use std::process;
 use std::thread;
 use std::time::{Duration, Instant};
 
-#[cfg(target_os = "windows")]
-use codexhost_platform::terminate_process_by_id;
 use codexhost_platform::{
-    atomic_replace_file, parent_process_id, process_executable_path, process_exists,
+    PlatformError, ProcessSnapshot, atomic_replace_file, process_exists, process_snapshot,
+    terminate_process_group_instance, terminate_process_instance,
 };
+use fs2::FileExt;
 
 const OWNER_DIRECTORY_NAME: &str = "local-host-runtime-owner-v1";
+const OWNER_LOCK_NAME: &str = "local-host-runtime-owner.lock";
 const OWNER_RECORD_NAME: &str = "owner";
 const MAPPING_STORE_LOCK_PATH: [&str; 2] = ["mapping-store", "store.lock"];
 const OWNER_READ_GRACE: Duration = Duration::from_millis(500);
@@ -24,17 +25,22 @@ const POLL_INTERVAL: Duration = Duration::from_millis(20);
 #[derive(Clone, Debug, PartialEq, Eq)]
 struct OwnerRecord {
     process_id: u32,
+    process_started_at_micros: u64,
     desktop_process_id: u32,
     child_process_id: Option<u32>,
+    child_process_started_at_micros: Option<u64>,
 }
 
 impl OwnerRecord {
     fn encode(&self) -> String {
         format!(
-            "version=1\nprocess_id={}\ndesktop_process_id={}\nchild_process_id={}\n",
+            "version=1\nprocess_id={}\nprocess_started_at_micros={}\ndesktop_process_id={}\nchild_process_id={}\nchild_process_started_at_micros={}\n",
             self.process_id,
+            self.process_started_at_micros,
             self.desktop_process_id,
             self.child_process_id
+                .map_or_else(String::new, |value| value.to_string()),
+            self.child_process_started_at_micros
                 .map_or_else(String::new, |value| value.to_string()),
         )
     }
@@ -48,38 +54,101 @@ impl OwnerRecord {
         if field("version")? != "1" {
             return None;
         }
+        let child_process_id = field("child_process_id").and_then(|value| value.parse().ok());
+        let child_process_started_at_micros =
+            field("child_process_started_at_micros").and_then(|value| value.parse().ok());
+        if child_process_id.is_some() != child_process_started_at_micros.is_some() {
+            return None;
+        }
         Some(Self {
             process_id: field("process_id")?.parse().ok()?,
+            process_started_at_micros: field("process_started_at_micros")?.parse().ok()?,
             desktop_process_id: field("desktop_process_id")?.parse().ok()?,
-            child_process_id: field("child_process_id").and_then(|value| value.parse().ok()),
+            child_process_id,
+            child_process_started_at_micros,
         })
     }
 }
 
 pub(crate) struct LocalRuntimeLease {
+    data_directory: PathBuf,
     directory: PathBuf,
     record: OwnerRecord,
+    mutation_lock: Option<OwnerMutationLock>,
+    active: bool,
+}
+
+struct OwnerMutationLock {
+    _file: File,
+}
+
+impl OwnerMutationLock {
+    fn open(data_directory: &Path) -> io::Result<File> {
+        OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(true)
+            .truncate(false)
+            .open(data_directory.join(OWNER_LOCK_NAME))
+    }
+
+    fn acquire(data_directory: &Path) -> io::Result<Self> {
+        let file = Self::open(data_directory)?;
+        file.lock_exclusive()?;
+        Ok(Self { _file: file })
+    }
+
+    fn try_acquire(data_directory: &Path) -> io::Result<Option<Self>> {
+        let file = Self::open(data_directory)?;
+        match file.try_lock_exclusive() {
+            Ok(()) => Ok(Some(Self { _file: file })),
+            Err(error) if error.kind() == io::ErrorKind::WouldBlock => Ok(None),
+            Err(error) => Err(error),
+        }
+    }
 }
 
 impl LocalRuntimeLease {
     pub(crate) fn acquire(data_directory: &Path) -> Result<Self, Box<dyn Error>> {
         fs::create_dir_all(data_directory)?;
+        // Serialize observation, retirement, removal, and publication as one cross-process
+        // mutation. Without this lock, a delayed contender can delete a newer contender's lease.
+        let mutation_lock = OwnerMutationLock::acquire(data_directory)?;
         let directory = data_directory.join(OWNER_DIRECTORY_NAME);
         let process_id = process::id();
-        let desktop_process_id = parent_process_id(process_id)?.ok_or_else(|| {
-            io::Error::other("codexhost Shim parent process identity is unavailable")
-        })?;
+        let process_snapshot = process_snapshot(process_id)?;
+        let desktop_process_id = process_snapshot.parent_id;
+        if desktop_process_id == 0 {
+            return Err(
+                io::Error::other("codexhost Shim parent process identity is unavailable").into(),
+            );
+        }
         let record = OwnerRecord {
             process_id,
+            process_started_at_micros: process_snapshot.started_at_micros,
             desktop_process_id,
             child_process_id: None,
+            child_process_started_at_micros: None,
         };
 
         loop {
             match fs::create_dir(&directory) {
                 Ok(()) => {
-                    let lease = Self { directory, record };
-                    if let Err(error) = lease.write_record() {
+                    let mut lease = Self {
+                        data_directory: data_directory.to_path_buf(),
+                        directory,
+                        record,
+                        // Keep the transaction closed to contenders until the caller has spawned
+                        // the Host Runtime and atomically published that exact child instance.
+                        mutation_lock: Some(mutation_lock),
+                        active: true,
+                    };
+                    let lease_lock = lease
+                        .mutation_lock
+                        .as_ref()
+                        .expect("new local Host Runtime lease owns the mutation lock");
+                    if let Err(error) = lease.write_record(lease_lock) {
+                        lease.active = false;
                         let _ = fs::remove_dir_all(&lease.directory);
                         return Err(error);
                     }
@@ -87,7 +156,9 @@ impl LocalRuntimeLease {
                         data_directory,
                         lease.record.desktop_process_id,
                     ) {
-                        drop(lease);
+                        let _ =
+                            remove_owner_if_matches(lease_lock, &lease.directory, &lease.record);
+                        lease.active = false;
                         return Err(error);
                     }
                     return Ok(lease);
@@ -104,7 +175,7 @@ impl LocalRuntimeLease {
                 return Err("current codexhost Shim already owns the local Host Runtime".into());
             }
             if !owner_is_codexhost_shim(&owner)? {
-                remove_owner_if_matches(&directory, &owner)?;
+                remove_owner_if_matches(&mutation_lock, &directory, &owner)?;
                 continue;
             }
 
@@ -117,7 +188,7 @@ impl LocalRuntimeLease {
             }
 
             stop_owner(&owner)?;
-            remove_owner_if_matches(&directory, &owner)?;
+            remove_owner_if_matches(&mutation_lock, &directory, &owner)?;
         }
     }
 
@@ -125,14 +196,22 @@ impl LocalRuntimeLease {
         &mut self,
         child_process_id: u32,
     ) -> Result<(), Box<dyn Error>> {
+        let mutation_lock = self
+            .mutation_lock
+            .as_ref()
+            .ok_or("local Host Runtime child identity was already published")?;
         if read_owner(&self.directory).as_ref() != Some(&self.record) {
             return Err("local Host Runtime ownership changed before child startup".into());
         }
+        let child_snapshot = process_snapshot(child_process_id)?;
         self.record.child_process_id = Some(child_process_id);
-        self.write_record()
+        self.record.child_process_started_at_micros = Some(child_snapshot.started_at_micros);
+        self.write_record(mutation_lock)?;
+        self.mutation_lock.take();
+        Ok(())
     }
 
-    fn write_record(&self) -> Result<(), Box<dyn Error>> {
+    fn write_record(&self, _mutation_lock: &OwnerMutationLock) -> Result<(), Box<dyn Error>> {
         let target = self.directory.join(OWNER_RECORD_NAME);
         let temporary = self.directory.join(format!(
             "{OWNER_RECORD_NAME}.tmp-{}",
@@ -146,7 +225,19 @@ impl LocalRuntimeLease {
 
 impl Drop for LocalRuntimeLease {
     fn drop(&mut self) {
-        let _ = remove_owner_if_matches(&self.directory, &self.record);
+        if !self.active {
+            return;
+        }
+        if let Some(mutation_lock) = self.mutation_lock.take() {
+            let _ = remove_owner_if_matches(&mutation_lock, &self.directory, &self.record);
+            return;
+        }
+        // A replacement owns this lock while it waits for us to exit. Blocking here would make
+        // its graceful handoff wait on our Drop while our Drop waits on the replacement.
+        let Ok(Some(mutation_lock)) = OwnerMutationLock::try_acquire(&self.data_directory) else {
+            return;
+        };
+        let _ = remove_owner_if_matches(&mutation_lock, &self.directory, &self.record);
     }
 }
 
@@ -169,7 +260,11 @@ fn read_owner_with_grace(directory: &Path) -> Result<Option<OwnerRecord>, Box<dy
     }
 }
 
-fn remove_owner_if_matches(directory: &Path, expected: &OwnerRecord) -> io::Result<()> {
+fn remove_owner_if_matches(
+    _mutation_lock: &OwnerMutationLock,
+    directory: &Path,
+    expected: &OwnerRecord,
+) -> io::Result<()> {
     if read_owner(directory).as_ref() == Some(expected) {
         fs::remove_dir_all(directory)?;
     }
@@ -177,15 +272,16 @@ fn remove_owner_if_matches(directory: &Path, expected: &OwnerRecord) -> io::Resu
 }
 
 fn owner_is_codexhost_shim(owner: &OwnerRecord) -> Result<bool, Box<dyn Error>> {
-    if !process_exists(owner.process_id) {
+    let Some(owner_snapshot) =
+        recorded_process_snapshot(owner.process_id, owner.process_started_at_micros)?
+    else {
         return Ok(false);
-    }
-    let owner_executable = process_executable_path(owner.process_id)?;
+    };
     let current_executable = env::current_exe()?;
     // npm upgrades and candidate packages can move the same Shim to another absolute path.
-    // The lease's PID and Desktop lineage are the trust boundary; the basename rejects PID reuse
-    // by an unrelated executable without making in-place upgrades impossible.
-    Ok(owner_executable.file_name() == current_executable.file_name())
+    // PID plus start time is the process-instance identity. The basename additionally rejects a
+    // corrupt lease without making an in-place npm upgrade impossible.
+    Ok(owner_snapshot.executable.file_name() == current_executable.file_name())
 }
 
 fn retire_legacy_mapping_store_owner(
@@ -200,36 +296,30 @@ fn retire_legacy_mapping_store_owner(
     let Some(runtime_process_id) = legacy_lock_process_id(&lock_path) else {
         return Ok(());
     };
-    if !process_exists(runtime_process_id) {
-        return Ok(());
-    }
-    let runtime_executable = match process_executable_path(runtime_process_id) {
-        Ok(path) => path,
+    let runtime_snapshot = match process_snapshot(runtime_process_id) {
+        Ok(snapshot) => snapshot,
         Err(_) if !process_exists(runtime_process_id) => return Ok(()),
         Err(error) => return Err(error.into()),
     };
-    if !runtime_executable
+    if !runtime_snapshot
+        .executable
         .file_name()
         .is_some_and(|name| is_node_executable_name(&name.to_string_lossy()))
     {
         return Ok(());
     }
 
-    let Some(shim_process_id) = parent_process_id(runtime_process_id)? else {
-        return Ok(());
-    };
-    let shim_executable = match process_executable_path(shim_process_id) {
-        Ok(path) => path,
+    let shim_process_id = runtime_snapshot.parent_id;
+    let shim_snapshot = match process_snapshot(shim_process_id) {
+        Ok(snapshot) => snapshot,
         Err(_) if !process_exists(shim_process_id) => return Ok(()),
         Err(error) => return Err(error.into()),
     };
     let current_executable = env::current_exe()?;
-    if shim_executable.file_name() != current_executable.file_name() {
+    if shim_snapshot.executable.file_name() != current_executable.file_name() {
         return Ok(());
     }
-    let Some(legacy_desktop_process_id) = parent_process_id(shim_process_id)? else {
-        return Ok(());
-    };
+    let legacy_desktop_process_id = shim_snapshot.parent_id;
     if is_live_other_desktop(legacy_desktop_process_id, current_desktop_process_id) {
         return Err(format!(
             "another Codex Desktop process owns the legacy local Host Runtime (Shim PID {shim_process_id}, Desktop PID {legacy_desktop_process_id})",
@@ -239,8 +329,10 @@ fn retire_legacy_mapping_store_owner(
 
     let legacy_owner = OwnerRecord {
         process_id: shim_process_id,
+        process_started_at_micros: shim_snapshot.started_at_micros,
         desktop_process_id: legacy_desktop_process_id,
         child_process_id: Some(runtime_process_id),
+        child_process_started_at_micros: Some(runtime_snapshot.started_at_micros),
     };
     eprintln!(
         "codexhost shim: retiring legacy local Host Runtime owned by Shim PID {shim_process_id}"
@@ -279,15 +371,20 @@ fn is_node_executable_name(name: &str) -> bool {
 }
 
 fn stop_owner(owner: &OwnerRecord) -> Result<(), Box<dyn Error>> {
-    terminate(owner.process_id, false)?;
-    if wait_for_owner_exit(owner, HANDOFF_GRACE) {
+    terminate_recorded_process(owner.process_id, owner.process_started_at_micros, false)?;
+    if wait_for_owner_exit(owner, HANDOFF_GRACE)? {
         return Ok(());
     }
-    terminate(owner.process_id, true)?;
-    if let Some(child_process_id) = owner.child_process_id {
-        terminate_child_group(child_process_id)?;
+    if let (Some(child_process_id), Some(child_process_started_at_micros)) = (
+        owner.child_process_id,
+        owner.child_process_started_at_micros,
+    ) && let Some(child_snapshot) =
+        recorded_process_snapshot(child_process_id, child_process_started_at_micros)?
+    {
+        terminate_process_group_instance(&child_snapshot, true)?;
     }
-    if wait_for_owner_exit(owner, FORCE_GRACE) {
+    terminate_recorded_process(owner.process_id, owner.process_started_at_micros, true)?;
+    if wait_for_owner_exit(owner, FORCE_GRACE)? {
         return Ok(());
     }
     Err(format!(
@@ -297,77 +394,100 @@ fn stop_owner(owner: &OwnerRecord) -> Result<(), Box<dyn Error>> {
     .into())
 }
 
-fn wait_for_owner_exit(owner: &OwnerRecord, timeout: Duration) -> bool {
+fn wait_for_owner_exit(owner: &OwnerRecord, timeout: Duration) -> Result<bool, Box<dyn Error>> {
     let deadline = Instant::now() + timeout;
     loop {
-        let owner_alive = process_exists(owner.process_id);
-        let child_alive = owner.child_process_id.is_some_and(process_exists);
+        let owner_alive =
+            recorded_process_snapshot(owner.process_id, owner.process_started_at_micros)?.is_some();
+        let child_alive = match (
+            owner.child_process_id,
+            owner.child_process_started_at_micros,
+        ) {
+            (Some(process_id), Some(started_at_micros)) => {
+                recorded_process_snapshot(process_id, started_at_micros)?.is_some()
+            }
+            _ => false,
+        };
         if !owner_alive && !child_alive {
-            return true;
+            return Ok(true);
         }
         if Instant::now() >= deadline {
-            return false;
+            return Ok(false);
         }
         thread::sleep(POLL_INTERVAL);
     }
 }
 
-#[cfg(any(target_os = "macos", target_os = "linux"))]
-fn terminate(process_id: u32, force: bool) -> Result<(), Box<dyn Error>> {
-    use nix::errno::Errno;
-    use nix::sys::signal::{Signal, kill};
-    use nix::unistd::Pid;
-
-    let process_id = i32::try_from(process_id)?;
-    let signal = if force {
-        Signal::SIGKILL
-    } else {
-        Signal::SIGTERM
-    };
-    match kill(Pid::from_raw(process_id), signal) {
-        Ok(()) | Err(Errno::ESRCH) => Ok(()),
+fn recorded_process_snapshot(
+    process_id: u32,
+    started_at_micros: u64,
+) -> Result<Option<ProcessSnapshot>, Box<dyn Error>> {
+    match process_snapshot(process_id) {
+        Ok(snapshot) if snapshot.started_at_micros == started_at_micros => Ok(Some(snapshot)),
+        Ok(_) | Err(PlatformError::NotFound(_)) => Ok(None),
+        Err(_) if !process_exists(process_id) => Ok(None),
         Err(error) => Err(error.into()),
     }
 }
 
-#[cfg(target_os = "windows")]
-fn terminate(process_id: u32, _force: bool) -> Result<(), Box<dyn Error>> {
-    if !process_exists(process_id) {
-        return Ok(());
+fn terminate_recorded_process(
+    process_id: u32,
+    started_at_micros: u64,
+    force: bool,
+) -> Result<(), Box<dyn Error>> {
+    if let Some(snapshot) = recorded_process_snapshot(process_id, started_at_micros)? {
+        terminate_process_instance(&snapshot, force)?;
     }
-    terminate_process_by_id(process_id)?;
     Ok(())
 }
 
-#[cfg(not(any(target_os = "windows", target_os = "macos", target_os = "linux")))]
-fn terminate(_process_id: u32, _force: bool) -> Result<(), Box<dyn Error>> {
-    Err("local Host Runtime ownership requires Windows, macOS, or Linux".into())
-}
+#[cfg(test)]
+mod tests {
+    use super::*;
 
-#[cfg(any(target_os = "macos", target_os = "linux"))]
-fn terminate_child_group(process_id: u32) -> Result<(), Box<dyn Error>> {
-    use nix::errno::Errno;
-    use nix::sys::signal::{Signal, kill, killpg};
-    use nix::unistd::Pid;
-
-    let process_id = i32::try_from(process_id)?;
-    let process_id = Pid::from_raw(process_id);
-    match killpg(process_id, Signal::SIGKILL) {
-        Ok(()) | Err(Errno::ESRCH) => {}
-        Err(error) => return Err(error.into()),
+    fn temporary_data_directory() -> PathBuf {
+        static NEXT_DIRECTORY: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+        let sequence = NEXT_DIRECTORY.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        env::temp_dir().join(format!(
+            "codexhost-local-runtime-lease-{}-{sequence}",
+            process::id()
+        ))
     }
-    match kill(process_id, Signal::SIGKILL) {
-        Ok(()) | Err(Errno::ESRCH) => Ok(()),
-        Err(error) => Err(error.into()),
+
+    #[test]
+    fn holds_the_mutation_lock_until_child_identity_is_published() {
+        let data_directory = temporary_data_directory();
+        let mut lease = LocalRuntimeLease::acquire(&data_directory).expect("acquire owner lease");
+        let contender = OpenOptions::new()
+            .read(true)
+            .write(true)
+            .open(data_directory.join(OWNER_LOCK_NAME))
+            .expect("open contender owner lock");
+
+        let contender_acquired_before_publish = contender.try_lock_exclusive().is_ok();
+        if contender_acquired_before_publish {
+            FileExt::unlock(&contender).expect("release unexpected contender lock");
+        }
+
+        lease
+            .set_child_process_id(process::id())
+            .expect("publish child identity");
+        let contender_acquired_after_publish = contender.try_lock_exclusive().is_ok();
+        if contender_acquired_after_publish {
+            FileExt::unlock(&contender).expect("release contender owner lock");
+        }
+
+        drop(contender);
+        drop(lease);
+        fs::remove_dir_all(&data_directory).expect("remove owner lease fixture");
+
+        assert!(
+            !contender_acquired_before_publish,
+            "a contender acquired ownership before the child identity was published"
+        );
+        assert!(
+            contender_acquired_after_publish,
+            "ownership mutation lock remained held after child identity publication"
+        );
     }
-}
-
-#[cfg(target_os = "windows")]
-fn terminate_child_group(process_id: u32) -> Result<(), Box<dyn Error>> {
-    terminate(process_id, true)
-}
-
-#[cfg(not(any(target_os = "windows", target_os = "macos", target_os = "linux")))]
-fn terminate_child_group(_process_id: u32) -> Result<(), Box<dyn Error>> {
-    Ok(())
 }

--- a/crates/shim/tests/proxy.rs
+++ b/crates/shim/tests/proxy.rs
@@ -1,4 +1,6 @@
 use std::fs;
+#[cfg(any(target_os = "windows", target_os = "macos", target_os = "linux"))]
+use std::fs::OpenOptions;
 #[cfg(target_os = "windows")]
 use std::io::{BufRead, BufReader};
 use std::io::{Read, Write};
@@ -17,6 +19,8 @@ use codexhost_platform::parent_process_id;
 use codexhost_platform::process_exists;
 use codexhost_platform::{CODEX_CLI_PATH_ENV, STOCK_CODEX_PATH_ENV};
 use codexhost_shim::{HOST_NODE_PATH_ENV, HOST_RUNTIME_PATH_ENV, REMOTE_SSH_MANAGED_ENV};
+#[cfg(any(target_os = "windows", target_os = "macos", target_os = "linux"))]
+use fs2::FileExt;
 
 fn shim_path() -> PathBuf {
     PathBuf::from(env!("CARGO_BIN_EXE_codexhost-shim"))
@@ -553,6 +557,17 @@ fn hands_off_local_host_runtime_ownership_and_converges_on_stdin_eof() {
         fs::remove_dir_all(&directory).expect("remove failed handoff fixture");
         panic!("replacement Host Runtime did not retire the previous Shim");
     }
+    #[cfg(any(target_os = "macos", target_os = "linux"))]
+    {
+        use std::os::unix::process::ExitStatusExt;
+
+        let status = first.wait().expect("read retired owner Shim status");
+        assert_ne!(
+            status.signal(),
+            Some(nix::sys::signal::Signal::SIGKILL as i32),
+            "ownership handoff forced the previous Shim instead of allowing graceful exit"
+        );
+    }
     drop(first_stdin);
     assert!(
         !process_exists(first_root),
@@ -574,6 +589,149 @@ fn hands_off_local_host_runtime_ownership_and_converges_on_stdin_eof() {
         "Host Runtime PID {second_root} survived Desktop stdin EOF"
     );
     fs::remove_dir_all(directory).expect("remove Host Runtime handoff fixture");
+}
+
+#[cfg(any(target_os = "windows", target_os = "macos", target_os = "linux"))]
+#[test]
+fn replacement_waits_for_the_local_runtime_owner_mutation_lock() {
+    let directory = temporary_directory();
+    let owner_ready = directory.join("owner-ready");
+    let replacement_ready = directory.join("replacement-ready");
+    let mut owner = host_runtime_shim(&directory, &owner_ready);
+    let owner_stdin = owner.stdin.take().expect("owner Host Runtime stdin");
+    let owner_root = process_id_from_ready(
+        &wait_for_file(&owner_ready, Duration::from_secs(5)),
+        "root=",
+    );
+
+    let owner_lock = OpenOptions::new()
+        .read(true)
+        .write(true)
+        .create(true)
+        .truncate(false)
+        .open(directory.join("local-host-runtime-owner.lock"))
+        .expect("open local Host Runtime owner mutation lock");
+    owner_lock
+        .lock_exclusive()
+        .expect("hold local Host Runtime owner mutation lock");
+
+    let mut replacement = host_runtime_shim(&directory, &replacement_ready);
+    let replacement_stdin = replacement
+        .stdin
+        .take()
+        .expect("replacement Host Runtime stdin");
+    thread::sleep(Duration::from_millis(300));
+    let owner_was_untouched =
+        process_exists(owner.id()) && process_exists(owner_root) && !replacement_ready.exists();
+    FileExt::unlock(&owner_lock).expect("release local Host Runtime owner mutation lock");
+
+    if !wait_for_process_exit(&mut owner, Duration::from_secs(5)) {
+        force_stop_test_process(owner.id());
+        force_stop_test_process(owner_root);
+        force_stop_test_process(replacement.id());
+        let _ = owner.wait();
+        let _ = replacement.wait();
+        let _ = fs::remove_dir_all(&directory);
+        panic!("replacement Host Runtime did not retire the owner after lock release");
+    }
+    drop(owner_stdin);
+    let replacement_identity = wait_for_file(&replacement_ready, Duration::from_secs(5));
+    let replacement_root = process_id_from_ready(&replacement_identity, "root=");
+    drop(replacement_stdin);
+    if !wait_for_process_exit(&mut replacement, Duration::from_secs(5)) {
+        force_stop_test_process(replacement.id());
+        force_stop_test_process(replacement_root);
+        let _ = replacement.wait();
+        let _ = fs::remove_dir_all(&directory);
+        panic!("replacement Host Runtime did not converge after Desktop stdin EOF");
+    }
+    fs::remove_dir_all(directory).expect("remove owner mutation lock fixture");
+
+    assert!(
+        owner_was_untouched,
+        "replacement observed or changed local Host Runtime ownership while the mutation lock was held"
+    );
+}
+
+#[cfg(any(target_os = "windows", target_os = "macos", target_os = "linux"))]
+#[test]
+fn replacement_does_not_signal_a_reused_owner_process_id() {
+    let directory = temporary_directory();
+    let owner_ready = directory.join("owner-ready");
+    let replacement_ready = directory.join("replacement-ready");
+    let mut owner = host_runtime_shim(&directory, &owner_ready);
+    let owner_stdin = owner.stdin.take().expect("owner Host Runtime stdin");
+    let owner_root = process_id_from_ready(
+        &wait_for_file(&owner_ready, Duration::from_secs(5)),
+        "root=",
+    );
+
+    let owner_record = directory.join("local-host-runtime-owner-v1").join("owner");
+    let deadline = Instant::now() + Duration::from_secs(5);
+    let contents = loop {
+        let contents = fs::read_to_string(&owner_record).expect("read local Host Runtime owner");
+        if contents.lines().any(|line| {
+            line.strip_prefix("child_process_started_at_micros=")
+                .is_some_and(|value| !value.is_empty())
+        }) {
+            break contents;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "timed out waiting for the complete local Host Runtime owner record"
+        );
+        thread::sleep(Duration::from_millis(20));
+    };
+    let mut replaced_start_time = false;
+    let mut recycled = contents
+        .lines()
+        .map(|line| {
+            if line.starts_with("process_started_at_micros=") {
+                replaced_start_time = true;
+                "process_started_at_micros=18446744073709551615".to_owned()
+            } else {
+                line.to_owned()
+            }
+        })
+        .collect::<Vec<_>>();
+    if !replaced_start_time {
+        recycled.push("process_started_at_micros=18446744073709551615".to_owned());
+    }
+    fs::write(&owner_record, format!("{}\n", recycled.join("\n")))
+        .expect("publish recycled owner process identity");
+
+    let mut replacement = host_runtime_shim(&directory, &replacement_ready);
+    let replacement_stdin = replacement
+        .stdin
+        .take()
+        .expect("replacement Host Runtime stdin");
+    let replacement_identity = wait_for_file(&replacement_ready, Duration::from_secs(5));
+    let replacement_root = process_id_from_ready(&replacement_identity, "root=");
+    let owner_was_not_signalled = owner
+        .try_wait()
+        .expect("poll recycled owner Shim")
+        .is_none();
+
+    drop(owner_stdin);
+    if !wait_for_process_exit(&mut owner, Duration::from_secs(5)) {
+        force_stop_test_process(owner.id());
+        force_stop_test_process(owner_root);
+        let _ = owner.wait();
+    }
+    drop(replacement_stdin);
+    if !wait_for_process_exit(&mut replacement, Duration::from_secs(5)) {
+        force_stop_test_process(replacement.id());
+        force_stop_test_process(replacement_root);
+        let _ = replacement.wait();
+        let _ = fs::remove_dir_all(&directory);
+        panic!("replacement Host Runtime did not converge after recycled owner recovery");
+    }
+    fs::remove_dir_all(directory).expect("remove recycled owner fixture");
+
+    assert!(
+        owner_was_not_signalled,
+        "replacement signalled a live process whose PID no longer matched the recorded owner instance"
+    );
 }
 
 #[cfg(any(target_os = "windows", target_os = "macos", target_os = "linux"))]


### PR DESCRIPTION
## Summary

Follow-up to #31. This closes the two post-merge ownership gaps identified in review:

- serialize every local runtime owner observe/retire/remove/publish mutation across processes
- bind every termination decision to an exact process instance, not a reusable PID

It also closes three adjacent handoff races found while reproducing the Desktop restart crash:

- retain the mutation lock until the spawned Host Runtime child PID and start time are durably published
- use a nonblocking cleanup lock in the retiring Shim so Unix handoff can finish gracefully instead of stalling into SIGKILL
- migrate released version-1 owner records to exact version-2 process identities before takeover

## Implementation

- add an `fs2`-backed cross-process owner mutation lock and exact-record deletion
- persist Shim and child process start identities and revalidate them immediately before termination
- decode released v1 records, validate the live Shim and lineage under the mutation lock, then atomically publish v2 before signaling; ambiguous live owners fail closed
- on Windows, query start time and terminate through the same validated process handle
- keep cohesive exact-termination logic in `process_termination.rs`
- preserve stock passthrough and managed remote SSH routing

Post-merge review context:

- atomic owner mutation: https://github.com/BytePioneer-AI/codex-host/pull/31#discussion_r3838839539
- PID reuse protection: https://github.com/BytePioneer-AI/codex-host/pull/31#discussion_r3838839541

## Validation

Windows 11:

- `cargo fmt --all`
- `cargo clippy -p codexhost-platform -p codexhost-shim --all-targets --locked --features codexhost-shim/test-utils -- -D warnings`
- `cargo test -p codexhost-platform --locked` — 25 passed
- `cargo test -p codexhost-shim --locked --features test-utils` — 5 unit + 18 integration passed

macOS 27 arm64, full `npm run check`:

- Prettier, ESLint/boundaries, and TypeScript checks passed
- Vitest: 145 files passed, 1 skipped; 1124 tests passed, 6 skipped
- Rust workspace Clippy with `-D warnings` passed
- platform: 30 passed
- shim: 8 unit + 26 integration passed