### PR TITLE
fix: migrate version-one runtime owners

### DIFF
--- a/crates/launcher/src/active_update.rs
+++ b/crates/launcher/src/active_update.rs
@@ -333,8 +333,8 @@ mod tests {
     use super::{ACTIVE_UPDATE_LOCK_FILE, PendingUpdate, waiting_for_launcher_exit_at};
     #[cfg(target_os = "macos")]
     use super::{
-        pending_startable_update_at, pending_update_at, transfer_lock_to_updater,
-        wait_for_updater_ready,
+        atomic_replace_file, pending_startable_update_at, pending_update_at,
+        transfer_lock_to_updater, wait_for_updater_ready,
     };
 
     fn fixture_directory(label: &str) -> PathBuf {
@@ -450,8 +450,10 @@ mod tests {
         let ready_status_path = status_path.clone();
         let writer = std::thread::spawn(move || {
             std::thread::sleep(std::time::Duration::from_millis(50));
+            let temporary_status_path = ready_status_path
+                .with_file_name(format!(".{STATUS_FILE}.{}.tmp", std::process::id()));
             fs::write(
-                ready_status_path,
+                &temporary_status_path,
                 format!(
                     "{}\n",
                     json!({
@@ -464,6 +466,8 @@ mod tests {
                 ),
             )
             .expect("write waiting status fixture");
+            atomic_replace_file(&temporary_status_path, &ready_status_path)
+                .expect("publish waiting status fixture");
         });
         let started = std::time::Instant::now();
         wait_for_updater_ready(&mut child, &status_path).expect("wait for updater readiness");

--- a/crates/launcher/src/desktop_attachment.rs
+++ b/crates/launcher/src/desktop_attachment.rs
@@ -2,7 +2,7 @@
 use std::env;
 use std::error::Error;
 use std::ffi::OsString;
-use std::io::{BufRead, BufReader, Write};
+use std::io::{self, BufRead, BufReader, Write};
 use std::net::{TcpListener, TcpStream};
 use std::path::Path;
 use std::thread;
@@ -178,7 +178,13 @@ fn send_controlled_attachment(
     stream.set_write_timeout(Some(Duration::from_secs(2)))?;
     writeln!(stream, "ATTACH {}", descriptor.nonce)?;
     let mut response = String::new();
-    BufReader::new(stream).read_line(&mut response)?;
+    match BufReader::new(stream).read_line(&mut response) {
+        Ok(_) => {}
+        // An orderly Controller close is an empty response, but Winsock may surface the same
+        // close as WSAECONNRESET. Both mean the controlled Desktop is not attachable yet.
+        Err(error) if error.kind() == io::ErrorKind::ConnectionReset => return Ok(false),
+        Err(error) => return Err(error.into()),
+    }
     match response.trim_end() {
         "ready" => Ok(true),
         "rejected" => Err("Desktop Controller rejected the attachment nonce".into()),

--- a/crates/launcher/src/main.rs
+++ b/crates/launcher/src/main.rs
@@ -1773,14 +1773,20 @@ mod tests {
 
     #[test]
     fn npm_update_runtime_environment_forwards_only_absolute_paths() {
+        let fixture_root = std::env::current_dir()
+            .expect("resolve current directory")
+            .join("npm-runtime-fixture");
+        let node_path = fixture_root.join("node");
+        let cli_path = fixture_root.join("npm/bin/npm-cli.js");
+        let package_root = fixture_root.join("@codexhost/cli-platform");
         let forwarded = npm_update_runtime_environment([
             (
                 OsString::from(NPM_NODE_PATH_ENV),
-                OsString::from("/usr/bin/node"),
+                node_path.clone().into_os_string(),
             ),
             (
                 OsString::from(NPM_CLI_PATH_ENV),
-                OsString::from("/usr/lib/node_modules/npm/bin/npm-cli.js"),
+                cli_path.clone().into_os_string(),
             ),
             (
                 OsString::from(NPM_LAUNCHER_PATH_ENV),
@@ -1788,11 +1794,11 @@ mod tests {
             ),
             (
                 OsString::from(NPM_PACKAGE_ROOT_ENV),
-                OsString::from("/usr/lib/node_modules/@codexhost/cli-darwin-arm64"),
+                package_root.clone().into_os_string(),
             ),
             (
                 OsString::from("UNRELATED"),
-                OsString::from("/tmp/unrelated"),
+                fixture_root.join("unrelated").into_os_string(),
             ),
         ]);
 
@@ -1801,15 +1807,12 @@ mod tests {
             [
                 (
                     OsString::from(NPM_NODE_PATH_ENV),
-                    OsString::from("/usr/bin/node"),
+                    node_path.into_os_string(),
                 ),
-                (
-                    OsString::from(NPM_CLI_PATH_ENV),
-                    OsString::from("/usr/lib/node_modules/npm/bin/npm-cli.js"),
-                ),
+                (OsString::from(NPM_CLI_PATH_ENV), cli_path.into_os_string(),),
                 (
                     OsString::from(NPM_PACKAGE_ROOT_ENV),
-                    OsString::from("/usr/lib/node_modules/@codexhost/cli-darwin-arm64"),
+                    package_root.into_os_string(),
                 ),
             ]
         );

--- a/crates/platform/src/process.rs
+++ b/crates/platform/src/process.rs
@@ -124,13 +124,30 @@ pub fn process_snapshot(process_id: u32) -> Result<ProcessSnapshot, PlatformErro
 
 #[cfg(target_os = "windows")]
 pub fn process_snapshot(process_id: u32) -> Result<ProcessSnapshot, PlatformError> {
-    let parent_id = windows_process::process_entries()?
+    let parent_id = windows_process::process_entries()
+        .map_err(|error| {
+            PlatformError::Io(std::io::Error::new(
+                error.kind(),
+                format!("enumerate processes while inspecting PID {process_id}: {error}"),
+            ))
+        })?
         .into_iter()
         .find(|process| process.id == process_id)
         .ok_or_else(|| PlatformError::NotFound(format!("cannot inspect PID {process_id}")))?
         .parent_id;
-    let executable = windows_process::process_image_path(process_id)?;
-    let started_at_micros = windows_process::process_started_at_micros(process_id)?;
+    let executable = windows_process::process_image_path(process_id).map_err(|error| {
+        PlatformError::Io(std::io::Error::new(
+            error.kind(),
+            format!("read executable while inspecting PID {process_id}: {error}"),
+        ))
+    })?;
+    let started_at_micros =
+        windows_process::process_started_at_micros(process_id).map_err(|error| {
+            PlatformError::Io(std::io::Error::new(
+                error.kind(),
+                format!("read start time while inspecting PID {process_id}: {error}"),
+            ))
+        })?;
     Ok(ProcessSnapshot {
         id: process_id,
         parent_id,

--- a/crates/platform/src/process.rs
+++ b/crates/platform/src/process.rs
@@ -242,11 +242,18 @@ pub fn desktop_process_tree(
 }
 
 #[cfg(any(target_os = "macos", target_os = "linux"))]
+enum RootExecutablePolicy {
+    Fixed,
+    FollowSameProcess,
+}
+
+#[cfg(any(target_os = "macos", target_os = "linux"))]
 pub(crate) struct ObservedProcessTree {
     pub(crate) root: ProcessSnapshot,
     known: Vec<ProcessSnapshot>,
     process_group_id: Option<u32>,
     process_group_started_at_micros: u64,
+    root_executable_policy: RootExecutablePolicy,
 }
 
 #[cfg(any(target_os = "macos", target_os = "linux"))]
@@ -254,6 +261,12 @@ impl ObservedProcessTree {
     pub(crate) fn new(root: ProcessSnapshot) -> Self {
         let process_group_id = (root.process_group_id == root.id).then_some(root.process_group_id);
         Self::new_with_process_group(root, process_group_id, None)
+    }
+
+    pub(crate) fn new_following_root_exec(root: ProcessSnapshot) -> Self {
+        let mut tree = Self::new(root);
+        tree.root_executable_policy = RootExecutablePolicy::FollowSameProcess;
+        tree
     }
 
     pub(crate) fn new_with_process_group(
@@ -287,6 +300,7 @@ impl ObservedProcessTree {
                 .unwrap_or(root.started_at_micros),
             known,
             root,
+            root_executable_policy: RootExecutablePolicy::Fixed,
         }
     }
 
@@ -305,10 +319,16 @@ impl ObservedProcessTree {
                     )));
                 }
                 if expected.id == self.root.id && current.executable != self.root.executable {
-                    return Err(PlatformError::Invalid(format!(
-                        "Desktop root PID {} changed executable identity",
-                        expected.id
-                    )));
+                    if matches!(self.root_executable_policy, RootExecutablePolicy::Fixed) {
+                        return Err(PlatformError::Invalid(format!(
+                            "Desktop root PID {} changed executable identity",
+                            expected.id
+                        )));
+                    }
+                    // A supervised root may legitimately exec into another executable while
+                    // retaining the same PID and start identity. Preserve the strict
+                    // process-instance check above, then follow that exact root across exec.
+                    self.root.executable = current.executable.clone();
                 }
                 *expected = current.clone();
             }

--- a/crates/platform/src/process_supervision.rs
+++ b/crates/platform/src/process_supervision.rs
@@ -297,7 +297,7 @@ pub fn spawn_supervised(command: &mut Command) -> Result<SupervisedChild, Platfo
     Ok(SupervisedChild {
         child,
         guard: Some(ChildProcessGuard {
-            tree: std::sync::Mutex::new(ObservedProcessTree::new(root)),
+            tree: std::sync::Mutex::new(ObservedProcessTree::new_following_root_exec(root)),
             armed: true,
         }),
     })
@@ -305,14 +305,14 @@ pub fn spawn_supervised(command: &mut Command) -> Result<SupervisedChild, Platfo
 
 #[cfg(all(test, any(target_os = "macos", target_os = "linux")))]
 mod tests {
-    use super::spawn_supervised;
+    use super::{spawn_supervised, unix_process_snapshot};
     use std::fs;
     use std::os::unix::fs::PermissionsExt;
     use std::process::Command;
-    use std::time::{SystemTime, UNIX_EPOCH};
+    use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
     #[test]
-    fn accepts_a_shebang_script_that_runs_under_an_interpreter() {
+    fn tracks_a_shebang_root_across_an_exec_transition() {
         let unique = SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .expect("system clock is before the Unix epoch")
@@ -323,8 +323,12 @@ mod tests {
         ));
         fs::create_dir(&directory).expect("create temporary directory");
         let script = directory.join("codex.js");
-        fs::write(&script, "#!/bin/sh\ntrap 'exit 0' TERM INT\nsleep 30\n")
-            .expect("write shebang script");
+        let exec_ready = directory.join("exec-ready");
+        fs::write(
+            &script,
+            "#!/bin/sh\nwhile [ ! -e \"$CODEXHOST_EXEC_READY\" ]; do /bin/sleep 0.01; done\nexec /bin/sleep 30\n",
+        )
+        .expect("write shebang script");
         let mut permissions = fs::metadata(&script)
             .expect("stat shebang script")
             .permissions();
@@ -332,8 +336,29 @@ mod tests {
         fs::set_permissions(&script, permissions).expect("make shebang script executable");
 
         let mut command = Command::new(&script);
+        command.env("CODEXHOST_EXEC_READY", &exec_ready);
         let mut child =
             spawn_supervised(&mut command).expect("supervise an interpreter-backed executable");
+        fs::write(&exec_ready, b"ready").expect("release the shebang exec transition");
+        let expected_executable = fs::canonicalize("/bin/sleep").expect("resolve /bin/sleep");
+        let deadline = Instant::now() + Duration::from_secs(5);
+        loop {
+            let snapshot = unix_process_snapshot(child.id()).expect("observe shebang root process");
+            if snapshot.executable == expected_executable {
+                break;
+            }
+            if Instant::now() >= deadline {
+                let _ = child.force_terminate();
+                let _ = child.wait();
+                let _ = fs::remove_dir_all(&directory);
+                panic!(
+                    "shebang root did not exec {} (observed {})",
+                    expected_executable.display(),
+                    snapshot.executable.display()
+                );
+            }
+            std::thread::sleep(Duration::from_millis(10));
+        }
         child
             .force_terminate()
             .expect("terminate supervised script");

--- a/crates/platform/src/process_supervision.rs
+++ b/crates/platform/src/process_supervision.rs
@@ -196,7 +196,15 @@ pub fn spawn_supervised(command: &mut Command) -> Result<SupervisedChild, Platfo
     let guard = match windows_process::guard_child(&child) {
         Ok(job) => Some(ChildProcessGuard { job }),
         Err(_) if child.try_wait()?.is_some() => None,
-        Err(error) => return Err(PlatformError::Io(error)),
+        Err(error) => {
+            return Err(PlatformError::Io(io::Error::new(
+                error.kind(),
+                format!(
+                    "assign supervised child PID {} to its cleanup Job: {error}",
+                    child.id()
+                ),
+            )));
+        }
     };
     Ok(SupervisedChild { child, guard })
 }

--- a/crates/platform/src/windows_process.rs
+++ b/crates/platform/src/windows_process.rs
@@ -6,6 +6,8 @@ use std::os::windows::io::AsRawHandle;
 use std::path::PathBuf;
 use std::process::Child;
 use std::ptr::null;
+use std::thread;
+use std::time::{Duration, Instant};
 
 type Handle = *mut c_void;
 
@@ -17,6 +19,8 @@ const JOB_OBJECT_EXTENDED_LIMIT_INFORMATION_CLASS: i32 = 9;
 const JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE: u32 = 0x0000_2000;
 const MOVE_FILE_REPLACE_EXISTING: u32 = 0x0000_0001;
 const MOVE_FILE_WRITE_THROUGH: u32 = 0x0000_0008;
+const ATOMIC_REPLACE_RETRY_TIMEOUT: Duration = Duration::from_secs(2);
+const ATOMIC_REPLACE_RETRY_INTERVAL: Duration = Duration::from_millis(10);
 
 #[repr(C)]
 struct NativeProcessEntry {
@@ -279,17 +283,24 @@ pub fn atomic_replace_file(source: &std::path::Path, target: &std::path::Path) -
         .encode_wide()
         .chain([0])
         .collect::<Vec<_>>();
-    let result = unsafe {
-        MoveFileExW(
-            source.as_ptr(),
-            target.as_ptr(),
-            MOVE_FILE_REPLACE_EXISTING | MOVE_FILE_WRITE_THROUGH,
-        )
-    };
-    if result == 0 {
-        Err(io::Error::last_os_error())
-    } else {
-        Ok(())
+    let started = Instant::now();
+    loop {
+        let result = unsafe {
+            MoveFileExW(
+                source.as_ptr(),
+                target.as_ptr(),
+                MOVE_FILE_REPLACE_EXISTING | MOVE_FILE_WRITE_THROUGH,
+            )
+        };
+        if result != 0 {
+            return Ok(());
+        }
+        let error = io::Error::last_os_error();
+        let transient_conflict = matches!(error.raw_os_error(), Some(5 | 32 | 33));
+        if !transient_conflict || started.elapsed() >= ATOMIC_REPLACE_RETRY_TIMEOUT {
+            return Err(error);
+        }
+        thread::sleep(ATOMIC_REPLACE_RETRY_INTERVAL);
     }
 }
 
@@ -318,5 +329,58 @@ pub fn guard_child(child: &Child) -> io::Result<ChildJob> {
             return Err(error);
         }
         Ok(ChildJob(job))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs::{self, OpenOptions};
+    use std::os::windows::fs::OpenOptionsExt;
+    use std::thread;
+    use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+    use super::atomic_replace_file;
+
+    const FILE_SHARE_READ: u32 = 0x0000_0001;
+    const FILE_SHARE_WRITE: u32 = 0x0000_0002;
+
+    #[test]
+    fn retries_atomic_replace_while_a_transient_reader_blocks_deletion() {
+        let unique = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system clock is before the Unix epoch")
+            .as_nanos();
+        let directory = std::env::temp_dir().join(format!(
+            "codexhost-atomic-replace-{}-{unique}",
+            std::process::id()
+        ));
+        fs::create_dir(&directory).expect("create atomic replacement fixture");
+        let source = directory.join("owner.next");
+        let target = directory.join("owner");
+        fs::write(&source, b"replacement").expect("write replacement source");
+        fs::write(&target, b"original").expect("write replacement target");
+
+        // Readers outside codexhost, including real-time scanners, may briefly omit FILE_SHARE_DELETE.
+        // The publication remains safe to retry because MoveFileExW has not consumed the source when
+        // it reports a sharing/access violation.
+        let blocker = OpenOptions::new()
+            .read(true)
+            .share_mode(FILE_SHARE_READ | FILE_SHARE_WRITE)
+            .open(&target)
+            .expect("open target without delete sharing");
+        let release = thread::spawn(move || {
+            thread::sleep(Duration::from_millis(100));
+            drop(blocker);
+        });
+
+        let result = atomic_replace_file(&source, &target);
+        release.join().expect("release replacement blocker");
+        result.expect("retry transient atomic replacement conflict");
+        assert_eq!(
+            fs::read(&target).expect("read replaced target"),
+            b"replacement"
+        );
+        assert!(!source.exists(), "atomic replacement retained its source");
+        fs::remove_dir_all(directory).expect("remove atomic replacement fixture");
     }
 }

--- a/crates/shim/src/local_runtime_lease.rs
+++ b/crates/shim/src/local_runtime_lease.rs
@@ -441,10 +441,11 @@ fn terminate_recorded_process(
     Ok(())
 }
 
-// This in-process contender is meaningful only with Windows handle-scoped locks. Unix flock locks
-// are process-scoped, so `replacement_waits_for_the_local_runtime_owner_mutation_lock` provides
-// the cross-process integration coverage there.
-#[cfg(all(test, target_os = "windows"))]
+// Separate Windows handles and Linux open file descriptions contend even within one process, so
+// this focused unit test covers both platforms. macOS treats these flock acquisitions as
+// process-scoped; `replacement_waits_for_the_local_runtime_owner_mutation_lock` provides the
+// cross-process integration coverage there.
+#[cfg(all(test, any(target_os = "windows", target_os = "linux")))]
 mod tests {
     use super::*;
 

--- a/crates/shim/src/local_runtime_lease.rs
+++ b/crates/shim/src/local_runtime_lease.rs
@@ -31,10 +31,23 @@ struct OwnerRecord {
     child_process_started_at_micros: Option<u64>,
 }
 
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct VersionOneOwnerRecord {
+    process_id: u32,
+    desktop_process_id: u32,
+    child_process_id: Option<u32>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+enum StoredOwnerRecord {
+    Exact(OwnerRecord),
+    VersionOne(VersionOneOwnerRecord),
+}
+
 impl OwnerRecord {
     fn encode(&self) -> String {
         format!(
-            "version=1\nprocess_id={}\nprocess_started_at_micros={}\ndesktop_process_id={}\nchild_process_id={}\nchild_process_started_at_micros={}\n",
+            "version=2\nprocess_id={}\nprocess_started_at_micros={}\ndesktop_process_id={}\nchild_process_id={}\nchild_process_started_at_micros={}\n",
             self.process_id,
             self.process_started_at_micros,
             self.desktop_process_id,
@@ -45,28 +58,40 @@ impl OwnerRecord {
         )
     }
 
-    fn decode(value: &str) -> Option<Self> {
+    fn decode(value: &str) -> Option<StoredOwnerRecord> {
         let field = |name: &str| {
             value
                 .lines()
                 .find_map(|line| line.strip_prefix(&format!("{name}=")))
         };
-        if field("version")? != "1" {
+        let version = field("version")?;
+        let process_id = field("process_id")?.parse().ok()?;
+        let desktop_process_id = field("desktop_process_id")?.parse().ok()?;
+        let child_process_id = field("child_process_id").and_then(|value| value.parse().ok());
+        // The released v1 shape has no start identities. Development builds of this follow-up
+        // briefly emitted start identities under v1, so accept those as exact records too.
+        if version == "1" && field("process_started_at_micros").is_none() {
+            return Some(StoredOwnerRecord::VersionOne(VersionOneOwnerRecord {
+                process_id,
+                desktop_process_id,
+                child_process_id,
+            }));
+        }
+        if version != "2" && version != "1" {
             return None;
         }
-        let child_process_id = field("child_process_id").and_then(|value| value.parse().ok());
         let child_process_started_at_micros =
             field("child_process_started_at_micros").and_then(|value| value.parse().ok());
         if child_process_id.is_some() != child_process_started_at_micros.is_some() {
             return None;
         }
-        Some(Self {
-            process_id: field("process_id")?.parse().ok()?,
+        Some(StoredOwnerRecord::Exact(Self {
+            process_id,
             process_started_at_micros: field("process_started_at_micros")?.parse().ok()?,
-            desktop_process_id: field("desktop_process_id")?.parse().ok()?,
+            desktop_process_id,
             child_process_id,
             child_process_started_at_micros,
-        })
+        }))
     }
 }
 
@@ -167,9 +192,20 @@ impl LocalRuntimeLease {
                 Err(error) => return Err(error.into()),
             }
 
-            let Some(owner) = read_owner_with_grace(&directory)? else {
+            let Some(stored_owner) = read_stored_owner_with_grace(&directory)? else {
                 fs::remove_dir_all(&directory)?;
                 continue;
+            };
+            let owner = match &stored_owner {
+                StoredOwnerRecord::Exact(owner) => owner.clone(),
+                StoredOwnerRecord::VersionOne(owner) => {
+                    let Some(owner) = migrate_version_one_owner(&mutation_lock, &directory, owner)?
+                    else {
+                        remove_stored_owner_if_matches(&mutation_lock, &directory, &stored_owner)?;
+                        continue;
+                    };
+                    owner
+                }
             };
             if owner.process_id == process_id {
                 return Err("current codexhost Shim already owns the local Host Runtime".into());
@@ -211,15 +247,8 @@ impl LocalRuntimeLease {
         Ok(())
     }
 
-    fn write_record(&self, _mutation_lock: &OwnerMutationLock) -> Result<(), Box<dyn Error>> {
-        let target = self.directory.join(OWNER_RECORD_NAME);
-        let temporary = self.directory.join(format!(
-            "{OWNER_RECORD_NAME}.tmp-{}",
-            self.record.process_id
-        ));
-        fs::write(&temporary, self.record.encode())?;
-        atomic_replace_file(&temporary, &target)?;
-        Ok(())
+    fn write_record(&self, mutation_lock: &OwnerMutationLock) -> Result<(), Box<dyn Error>> {
+        write_owner_record(mutation_lock, &self.directory, &self.record)
     }
 }
 
@@ -242,15 +271,24 @@ impl Drop for LocalRuntimeLease {
 }
 
 fn read_owner(directory: &Path) -> Option<OwnerRecord> {
+    match read_stored_owner(directory)? {
+        StoredOwnerRecord::Exact(owner) => Some(owner),
+        StoredOwnerRecord::VersionOne(_) => None,
+    }
+}
+
+fn read_stored_owner(directory: &Path) -> Option<StoredOwnerRecord> {
     fs::read_to_string(directory.join(OWNER_RECORD_NAME))
         .ok()
         .and_then(|value| OwnerRecord::decode(&value))
 }
 
-fn read_owner_with_grace(directory: &Path) -> Result<Option<OwnerRecord>, Box<dyn Error>> {
+fn read_stored_owner_with_grace(
+    directory: &Path,
+) -> Result<Option<StoredOwnerRecord>, Box<dyn Error>> {
     let deadline = Instant::now() + OWNER_READ_GRACE;
     loop {
-        if let Some(owner) = read_owner(directory) {
+        if let Some(owner) = read_stored_owner(directory) {
             return Ok(Some(owner));
         }
         if Instant::now() >= deadline {
@@ -265,10 +303,79 @@ fn remove_owner_if_matches(
     directory: &Path,
     expected: &OwnerRecord,
 ) -> io::Result<()> {
-    if read_owner(directory).as_ref() == Some(expected) {
+    if read_stored_owner(directory).as_ref() == Some(&StoredOwnerRecord::Exact(expected.clone())) {
         fs::remove_dir_all(directory)?;
     }
     Ok(())
+}
+
+fn remove_stored_owner_if_matches(
+    _mutation_lock: &OwnerMutationLock,
+    directory: &Path,
+    expected: &StoredOwnerRecord,
+) -> io::Result<()> {
+    if read_stored_owner(directory).as_ref() == Some(expected) {
+        fs::remove_dir_all(directory)?;
+    }
+    Ok(())
+}
+
+fn write_owner_record(
+    _mutation_lock: &OwnerMutationLock,
+    directory: &Path,
+    record: &OwnerRecord,
+) -> Result<(), Box<dyn Error>> {
+    let target = directory.join(OWNER_RECORD_NAME);
+    let temporary = directory.join(format!("{OWNER_RECORD_NAME}.tmp-{}", record.process_id));
+    fs::write(&temporary, record.encode())?;
+    atomic_replace_file(&temporary, &target)?;
+    Ok(())
+}
+
+fn migrate_version_one_owner(
+    mutation_lock: &OwnerMutationLock,
+    directory: &Path,
+    legacy: &VersionOneOwnerRecord,
+) -> Result<Option<OwnerRecord>, Box<dyn Error>> {
+    // v1 cannot itself distinguish PID reuse. While the mutation is serialized, validate the
+    // live Shim and its lineage, snapshot exact process instances, and publish v2 before sending
+    // any signal. An ambiguous live Shim is never treated as stale ownership.
+    let Some(shim_snapshot) = current_process_snapshot(legacy.process_id)? else {
+        return Ok(None);
+    };
+    let current_executable = env::current_exe()?;
+    if shim_snapshot.executable.file_name() != current_executable.file_name() {
+        return Ok(None);
+    }
+    if shim_snapshot.parent_id != legacy.desktop_process_id && shim_snapshot.parent_id != 1 {
+        return Err(format!(
+            "live version-one local Host Runtime owner PID {} no longer belongs to its recorded Desktop PID {}; refusing unsafe takeover",
+            legacy.process_id, legacy.desktop_process_id,
+        )
+        .into());
+    }
+
+    let child_snapshot = match legacy.child_process_id {
+        Some(child_process_id) => current_process_snapshot(child_process_id)?
+            .filter(|snapshot| snapshot.parent_id == legacy.process_id),
+        None => None,
+    };
+    let migrated = OwnerRecord {
+        process_id: legacy.process_id,
+        process_started_at_micros: shim_snapshot.started_at_micros,
+        desktop_process_id: legacy.desktop_process_id,
+        child_process_id: child_snapshot.as_ref().map(|snapshot| snapshot.id),
+        child_process_started_at_micros: child_snapshot
+            .as_ref()
+            .map(|snapshot| snapshot.started_at_micros),
+    };
+
+    let expected = StoredOwnerRecord::VersionOne(legacy.clone());
+    if read_stored_owner(directory).as_ref() != Some(&expected) {
+        return Ok(None);
+    }
+    write_owner_record(mutation_lock, directory, &migrated)?;
+    Ok(Some(migrated))
 }
 
 fn owner_is_codexhost_shim(owner: &OwnerRecord) -> Result<bool, Box<dyn Error>> {
@@ -415,6 +522,15 @@ fn wait_for_owner_exit(owner: &OwnerRecord, timeout: Duration) -> Result<bool, B
             return Ok(false);
         }
         thread::sleep(POLL_INTERVAL);
+    }
+}
+
+fn current_process_snapshot(process_id: u32) -> Result<Option<ProcessSnapshot>, Box<dyn Error>> {
+    match process_snapshot(process_id) {
+        Ok(snapshot) => Ok(Some(snapshot)),
+        Err(PlatformError::NotFound(_)) => Ok(None),
+        Err(_) if !process_exists(process_id) => Ok(None),
+        Err(error) => Err(error.into()),
     }
 }
 

--- a/crates/shim/src/local_runtime_lease.rs
+++ b/crates/shim/src/local_runtime_lease.rs
@@ -108,6 +108,14 @@ impl OwnerMutationLock {
     }
 }
 
+impl Drop for OwnerMutationLock {
+    fn drop(&mut self) {
+        // Child publication is the ownership handoff boundary. Release it explicitly instead of
+        // relying on platform-specific file-close timing before a contender observes that boundary.
+        let _ = FileExt::unlock(&self._file);
+    }
+}
+
 impl LocalRuntimeLease {
     pub(crate) fn acquire(data_directory: &Path) -> Result<Self, Box<dyn Error>> {
         fs::create_dir_all(data_directory)?;

--- a/crates/shim/src/local_runtime_lease.rs
+++ b/crates/shim/src/local_runtime_lease.rs
@@ -442,12 +442,23 @@ fn terminate_recorded_process(
 }
 
 // Separate Windows handles and Linux open file descriptions contend even within one process, so
-// this focused unit test covers both platforms. macOS treats these flock acquisitions as
-// process-scoped; `replacement_waits_for_the_local_runtime_owner_mutation_lock` provides the
-// cross-process integration coverage there.
+// this focused unit test covers both platforms. Each boundary observation uses a freshly opened
+// contender, matching separate replacement processes and avoiding reuse of a failed flock attempt.
+// macOS treats these flock acquisitions as process-scoped;
+// `replacement_waits_for_the_local_runtime_owner_mutation_lock` provides the cross-process
+// integration coverage there.
 #[cfg(all(test, any(target_os = "windows", target_os = "linux")))]
 mod tests {
     use super::*;
+
+    fn contender_can_acquire(data_directory: &Path) -> bool {
+        let contender = OwnerMutationLock::open(data_directory).expect("open contender owner lock");
+        let acquired = contender.try_lock_exclusive().is_ok();
+        if acquired {
+            FileExt::unlock(&contender).expect("release contender owner lock");
+        }
+        acquired
+    }
 
     fn temporary_data_directory() -> PathBuf {
         static NEXT_DIRECTORY: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
@@ -462,26 +473,13 @@ mod tests {
     fn holds_the_mutation_lock_until_child_identity_is_published() {
         let data_directory = temporary_data_directory();
         let mut lease = LocalRuntimeLease::acquire(&data_directory).expect("acquire owner lease");
-        let contender = OpenOptions::new()
-            .read(true)
-            .write(true)
-            .open(data_directory.join(OWNER_LOCK_NAME))
-            .expect("open contender owner lock");
-
-        let contender_acquired_before_publish = contender.try_lock_exclusive().is_ok();
-        if contender_acquired_before_publish {
-            FileExt::unlock(&contender).expect("release unexpected contender lock");
-        }
+        let contender_acquired_before_publish = contender_can_acquire(&data_directory);
 
         lease
             .set_child_process_id(process::id())
             .expect("publish child identity");
-        let contender_acquired_after_publish = contender.try_lock_exclusive().is_ok();
-        if contender_acquired_after_publish {
-            FileExt::unlock(&contender).expect("release contender owner lock");
-        }
+        let contender_acquired_after_publish = contender_can_acquire(&data_directory);
 
-        drop(contender);
         drop(lease);
         fs::remove_dir_all(&data_directory).expect("remove owner lease fixture");
 

--- a/crates/shim/src/local_runtime_lease.rs
+++ b/crates/shim/src/local_runtime_lease.rs
@@ -50,6 +50,13 @@ enum StoredOwnerRecord {
     VersionOne(VersionOneOwnerRecord),
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum OwnerShimState {
+    Valid,
+    Missing,
+    Mismatched,
+}
+
 impl OwnerRecord {
     fn encode(&self) -> String {
         format!(
@@ -224,9 +231,29 @@ impl LocalRuntimeLease {
             if owner.process_id == process_id {
                 return Err("current codexhost Shim already owns the local Host Runtime".into());
             }
-            if !owner_is_codexhost_shim(&owner)? {
-                remove_owner_if_matches(&mutation_lock, &directory, &owner)?;
-                continue;
+            match owner_shim_state(&owner)? {
+                OwnerShimState::Valid => {}
+                OwnerShimState::Missing => {
+                    // A migrated exact record remains authoritative for its child after its Shim
+                    // exits. Retire that exact child before admitting a replacement; otherwise a
+                    // post-migration Shim exit can leave two Host Runtimes running concurrently.
+                    if is_live_other_desktop(owner.desktop_process_id, desktop_process_id) {
+                        return Err(format!(
+                            "another Codex Desktop process owns the orphaned local Host Runtime (former Shim PID {}, Desktop PID {})",
+                            owner.process_id, owner.desktop_process_id,
+                        )
+                        .into());
+                    }
+                    stop_orphaned_owner_child(&owner)?;
+                    remove_owner_if_matches(&mutation_lock, &directory, &owner)?;
+                    continue;
+                }
+                OwnerShimState::Mismatched => {
+                    // The recorded Shim instance is live but is not codexhost. Treat the record as
+                    // corrupt and never signal either that process or its claimed child.
+                    remove_owner_if_matches(&mutation_lock, &directory, &owner)?;
+                    continue;
+                }
             }
 
             if is_live_other_desktop(owner.desktop_process_id, desktop_process_id) {
@@ -539,20 +566,24 @@ fn migrated_owner_record(
     }
 }
 
-fn owner_is_codexhost_shim(owner: &OwnerRecord) -> Result<bool, Box<dyn Error>> {
-    let Some(owner_snapshot) =
-        recorded_process_snapshot(owner.process_id, owner.process_started_at_micros)?
-    else {
-        return Ok(false);
+fn owner_shim_state(owner: &OwnerRecord) -> Result<OwnerShimState, Box<dyn Error>> {
+    let Some(owner_snapshot) = current_process_snapshot(owner.process_id)? else {
+        return Ok(OwnerShimState::Missing);
     };
+    if owner_snapshot.started_at_micros != owner.process_started_at_micros {
+        return Ok(OwnerShimState::Mismatched);
+    }
     let current_executable = env::current_exe()?;
     // npm upgrades and candidate packages can move the same Shim to another absolute path.
     // PID plus start time is the process-instance identity. The basename additionally rejects a
     // corrupt lease without making an in-place npm upgrade impossible.
-    Ok(executable_file_name_matches(
-        &owner_snapshot.executable,
-        &current_executable,
-    ))
+    Ok(
+        if executable_file_name_matches(&owner_snapshot.executable, &current_executable) {
+            OwnerShimState::Valid
+        } else {
+            OwnerShimState::Mismatched
+        },
+    )
 }
 
 fn retire_legacy_mapping_store_owner(
@@ -660,6 +691,25 @@ fn stop_owner(owner: &OwnerRecord) -> Result<(), Box<dyn Error>> {
     }
     Err(format!(
         "previous local Host Runtime did not exit (Shim PID {}, child PID {:?})",
+        owner.process_id, owner.child_process_id,
+    )
+    .into())
+}
+
+fn stop_orphaned_owner_child(owner: &OwnerRecord) -> Result<(), Box<dyn Error>> {
+    if let (Some(child_process_id), Some(child_process_started_at_micros)) = (
+        owner.child_process_id,
+        owner.child_process_started_at_micros,
+    ) && let Some(child_snapshot) =
+        recorded_process_snapshot(child_process_id, child_process_started_at_micros)?
+    {
+        terminate_process_group_instance(&child_snapshot, true)?;
+    }
+    if wait_for_owner_exit(owner, FORCE_GRACE)? {
+        return Ok(());
+    }
+    Err(format!(
+        "orphaned local Host Runtime child did not exit (former Shim PID {}, child PID {:?})",
         owner.process_id, owner.child_process_id,
     )
     .into())

--- a/crates/shim/src/local_runtime_lease.rs
+++ b/crates/shim/src/local_runtime_lease.rs
@@ -18,6 +18,7 @@ const OWNER_LOCK_NAME: &str = "local-host-runtime-owner.lock";
 const OWNER_RECORD_NAME: &str = "owner";
 const MAPPING_STORE_LOCK_PATH: [&str; 2] = ["mapping-store", "store.lock"];
 const OWNER_READ_GRACE: Duration = Duration::from_millis(500);
+const VERSION_ONE_STARTUP_GRACE: Duration = Duration::from_secs(4);
 const HANDOFF_GRACE: Duration = Duration::from_secs(4);
 const FORCE_GRACE: Duration = Duration::from_secs(2);
 const POLL_INTERVAL: Duration = Duration::from_millis(20);
@@ -332,11 +333,52 @@ fn write_owner_record(
     Ok(())
 }
 
+fn stabilize_version_one_owner(
+    directory: &Path,
+    initial: &VersionOneOwnerRecord,
+) -> Result<Option<VersionOneOwnerRecord>, Box<dyn Error>> {
+    if initial.child_process_id.is_some() {
+        return Ok(Some(initial.clone()));
+    }
+
+    // Released Shims publish an empty owner record, spawn the child, and then replace the record
+    // without taking OWNER_LOCK_NAME. Do not overwrite that startup write with a child-less exact
+    // record: wait for its final publication or fail closed while the released owner remains live.
+    let deadline = Instant::now() + VERSION_ONE_STARTUP_GRACE;
+    loop {
+        let Some(StoredOwnerRecord::VersionOne(current)) = read_stored_owner(directory) else {
+            return Ok(None);
+        };
+        if current.process_id != initial.process_id
+            || current.desktop_process_id != initial.desktop_process_id
+        {
+            return Ok(None);
+        }
+        if current.child_process_id.is_some() {
+            return Ok(Some(current));
+        }
+        if current_process_snapshot(initial.process_id)?.is_none() {
+            return Ok(None);
+        }
+        if Instant::now() >= deadline {
+            return Err(format!(
+                "live version-one local Host Runtime owner PID {} did not publish its child process identity; refusing unsafe takeover",
+                initial.process_id,
+            )
+            .into());
+        }
+        thread::sleep(POLL_INTERVAL);
+    }
+}
+
 fn migrate_version_one_owner(
     mutation_lock: &OwnerMutationLock,
     directory: &Path,
     legacy: &VersionOneOwnerRecord,
 ) -> Result<Option<OwnerRecord>, Box<dyn Error>> {
+    let Some(legacy) = stabilize_version_one_owner(directory, legacy)? else {
+        return Ok(None);
+    };
     // v1 cannot itself distinguish PID reuse. While the mutation is serialized, validate the
     // live Shim and its lineage, snapshot exact process instances, and publish them before sending
     // any signal. An ambiguous live Shim is never treated as stale ownership.
@@ -360,9 +402,9 @@ fn migrate_version_one_owner(
             .filter(|snapshot| snapshot.parent_id == legacy.process_id),
         None => None,
     };
-    let migrated = migrated_owner_record(legacy, &shim_snapshot, child_snapshot.as_ref());
+    let migrated = migrated_owner_record(&legacy, &shim_snapshot, child_snapshot.as_ref());
 
-    let expected = StoredOwnerRecord::VersionOne(legacy.clone());
+    let expected = StoredOwnerRecord::VersionOne(legacy);
     if read_stored_owner(directory).as_ref() != Some(&expected) {
         return Ok(None);
     }

--- a/crates/shim/src/local_runtime_lease.rs
+++ b/crates/shim/src/local_runtime_lease.rs
@@ -47,7 +47,7 @@ enum StoredOwnerRecord {
 impl OwnerRecord {
     fn encode(&self) -> String {
         format!(
-            "version=2\nprocess_id={}\nprocess_started_at_micros={}\ndesktop_process_id={}\nchild_process_id={}\nchild_process_started_at_micros={}\n",
+            "version=1\nprocess_id={}\nprocess_started_at_micros={}\ndesktop_process_id={}\nchild_process_id={}\nchild_process_started_at_micros={}\n",
             self.process_id,
             self.process_started_at_micros,
             self.desktop_process_id,
@@ -338,7 +338,7 @@ fn migrate_version_one_owner(
     legacy: &VersionOneOwnerRecord,
 ) -> Result<Option<OwnerRecord>, Box<dyn Error>> {
     // v1 cannot itself distinguish PID reuse. While the mutation is serialized, validate the
-    // live Shim and its lineage, snapshot exact process instances, and publish v2 before sending
+    // live Shim and its lineage, snapshot exact process instances, and publish them before sending
     // any signal. An ambiguous live Shim is never treated as stale ownership.
     let Some(shim_snapshot) = current_process_snapshot(legacy.process_id)? else {
         return Ok(None);
@@ -561,6 +561,22 @@ fn terminate_recorded_process(
 mod tests {
     use super::*;
 
+    fn decode_released_version_one_owner(value: &str) -> Option<VersionOneOwnerRecord> {
+        let field = |name: &str| {
+            value
+                .lines()
+                .find_map(|line| line.strip_prefix(&format!("{name}=")))
+        };
+        if field("version")? != "1" {
+            return None;
+        }
+        Some(VersionOneOwnerRecord {
+            process_id: field("process_id")?.parse().ok()?,
+            desktop_process_id: field("desktop_process_id")?.parse().ok()?,
+            child_process_id: field("child_process_id").and_then(|value| value.parse().ok()),
+        })
+    }
+
     fn temporary_data_directory() -> PathBuf {
         static NEXT_DIRECTORY: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
         let sequence = NEXT_DIRECTORY.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
@@ -604,6 +620,29 @@ mod tests {
         assert!(
             contender_acquired_after_publish,
             "ownership mutation lock remained held after child identity publication"
+        );
+    }
+
+    #[test]
+    fn exact_owner_records_remain_readable_by_released_version_one_shims() {
+        let record = OwnerRecord {
+            process_id: 101,
+            process_started_at_micros: 202,
+            desktop_process_id: 303,
+            child_process_id: Some(404),
+            child_process_started_at_micros: Some(505),
+        };
+
+        let decoded = decode_released_version_one_owner(&record.encode())
+            .expect("released v1 Shim should accept an exact owner record");
+
+        assert_eq!(
+            decoded,
+            VersionOneOwnerRecord {
+                process_id: record.process_id,
+                desktop_process_id: record.desktop_process_id,
+                child_process_id: record.child_process_id,
+            }
         );
     }
 }

--- a/crates/shim/src/local_runtime_lease.rs
+++ b/crates/shim/src/local_runtime_lease.rs
@@ -39,6 +39,11 @@ struct VersionOneOwnerRecord {
     child_process_id: Option<u32>,
 }
 
+struct VersionOneMigrationCandidate {
+    record: VersionOneOwnerRecord,
+    shim_snapshot: ProcessSnapshot,
+}
+
 #[derive(Clone, Debug, PartialEq, Eq)]
 enum StoredOwnerRecord {
     Exact(OwnerRecord),
@@ -257,7 +262,8 @@ impl LocalRuntimeLease {
     }
 
     fn write_record(&self, mutation_lock: &OwnerMutationLock) -> Result<(), Box<dyn Error>> {
-        write_owner_record(mutation_lock, &self.directory, &self.record)
+        write_owner_record(mutation_lock, &self.directory, &self.record)?;
+        Ok(())
     }
 }
 
@@ -333,25 +339,104 @@ fn write_owner_record(
     _mutation_lock: &OwnerMutationLock,
     directory: &Path,
     record: &OwnerRecord,
-) -> Result<(), Box<dyn Error>> {
+) -> io::Result<()> {
     let target = directory.join(OWNER_RECORD_NAME);
     let temporary = directory.join(format!("{OWNER_RECORD_NAME}.tmp-{}", record.process_id));
     fs::write(&temporary, record.encode())?;
-    atomic_replace_file(&temporary, &target)?;
+    atomic_replace_file(&temporary, &target).map_err(|error| match error {
+        PlatformError::Io(error) => error,
+        PlatformError::NotFound(message) => io::Error::new(io::ErrorKind::NotFound, message),
+        error => io::Error::other(error),
+    })?;
     Ok(())
+}
+
+fn write_migrated_owner_record(
+    mutation_lock: &OwnerMutationLock,
+    directory: &Path,
+    record: &OwnerRecord,
+) -> Result<bool, Box<dyn Error>> {
+    match write_owner_record(mutation_lock, directory, record) {
+        Ok(()) => Ok(true),
+        // A released v1 Shim does not use the mutation lock. Its Drop may remove the verified
+        // directory between the equality check and publication; let acquisition observe again.
+        Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(false),
+        Err(error) => Err(error.into()),
+    }
+}
+
+fn executable_file_name_matches(observed: &Path, expected: &Path) -> bool {
+    let (Some(observed), Some(expected)) = (observed.file_name(), expected.file_name()) else {
+        return false;
+    };
+    if observed == expected {
+        return true;
+    }
+    #[cfg(target_os = "linux")]
+    {
+        use std::os::unix::ffi::OsStrExt;
+
+        return observed.as_bytes().strip_suffix(b" (deleted)") == Some(expected.as_bytes());
+    }
+    #[cfg(not(target_os = "linux"))]
+    false
+}
+
+fn ensure_no_live_version_one_child(owner: &VersionOneOwnerRecord) -> Result<(), Box<dyn Error>> {
+    let Some(child_process_id) = owner.child_process_id else {
+        return Ok(());
+    };
+    if current_process_snapshot(child_process_id)?.is_some() {
+        return Err(format!(
+            "version-one local Host Runtime child PID {child_process_id} remains live without a verified Shim process instance; refusing unsafe takeover",
+        )
+        .into());
+    }
+    Ok(())
+}
+
+fn validate_version_one_shim_snapshot(
+    owner: &VersionOneOwnerRecord,
+    snapshot: &ProcessSnapshot,
+    current_executable: &Path,
+) -> Result<bool, Box<dyn Error>> {
+    if !executable_file_name_matches(&snapshot.executable, current_executable) {
+        return Ok(false);
+    }
+    if snapshot.parent_id != owner.desktop_process_id && snapshot.parent_id != 1 {
+        return Err(format!(
+            "live version-one local Host Runtime owner PID {} no longer belongs to its recorded Desktop PID {}; refusing unsafe takeover",
+            owner.process_id, owner.desktop_process_id,
+        )
+        .into());
+    }
+    Ok(true)
 }
 
 fn stabilize_version_one_owner(
     directory: &Path,
     initial: &VersionOneOwnerRecord,
-) -> Result<Option<VersionOneOwnerRecord>, Box<dyn Error>> {
+) -> Result<Option<VersionOneMigrationCandidate>, Box<dyn Error>> {
+    let current_executable = env::current_exe()?;
+    let Some(initial_snapshot) = current_process_snapshot(initial.process_id)? else {
+        ensure_no_live_version_one_child(initial)?;
+        return Ok(None);
+    };
+    if !validate_version_one_shim_snapshot(initial, &initial_snapshot, &current_executable)? {
+        ensure_no_live_version_one_child(initial)?;
+        return Ok(None);
+    }
     if initial.child_process_id.is_some() {
-        return Ok(Some(initial.clone()));
+        return Ok(Some(VersionOneMigrationCandidate {
+            record: initial.clone(),
+            shim_snapshot: initial_snapshot,
+        }));
     }
 
     // Released Shims publish an empty owner record, spawn the child, and then replace the record
     // without taking OWNER_LOCK_NAME. Do not overwrite that startup write with a child-less exact
-    // record: wait for its final publication or fail closed while the released owner remains live.
+    // record. Pin the live Shim instance before waiting and keep validating that exact PID/start
+    // identity until its final publication, or fail closed while the released owner remains live.
     let deadline = Instant::now() + VERSION_ONE_STARTUP_GRACE;
     loop {
         let Some(StoredOwnerRecord::VersionOne(current)) = read_stored_owner(directory) else {
@@ -362,11 +447,21 @@ fn stabilize_version_one_owner(
         {
             return Ok(None);
         }
-        if current.child_process_id.is_some() {
-            return Ok(Some(current));
-        }
-        if current_process_snapshot(initial.process_id)?.is_none() {
+        let Some(shim_snapshot) =
+            recorded_process_snapshot(initial_snapshot.id, initial_snapshot.started_at_micros)?
+        else {
+            ensure_no_live_version_one_child(&current)?;
             return Ok(None);
+        };
+        if !validate_version_one_shim_snapshot(&current, &shim_snapshot, &current_executable)? {
+            ensure_no_live_version_one_child(&current)?;
+            return Ok(None);
+        }
+        if current.child_process_id.is_some() {
+            return Ok(Some(VersionOneMigrationCandidate {
+                record: current,
+                shim_snapshot,
+            }));
         }
         if Instant::now() >= deadline {
             return Err(format!(
@@ -384,39 +479,38 @@ fn migrate_version_one_owner(
     directory: &Path,
     legacy: &VersionOneOwnerRecord,
 ) -> Result<Option<OwnerRecord>, Box<dyn Error>> {
-    let Some(legacy) = stabilize_version_one_owner(directory, legacy)? else {
+    let Some(candidate) = stabilize_version_one_owner(directory, legacy)? else {
         return Ok(None);
     };
+    let legacy = candidate.record;
     // v1 cannot itself distinguish PID reuse. While the mutation is serialized, validate the
-    // live Shim and its lineage, snapshot exact process instances, and publish them before sending
-    // any signal. An ambiguous live Shim is never treated as stale ownership.
-    let Some(shim_snapshot) = current_process_snapshot(legacy.process_id)? else {
-        return Ok(None);
-    };
-    let current_executable = env::current_exe()?;
-    if shim_snapshot.executable.file_name() != current_executable.file_name() {
-        return Ok(None);
-    }
-    if shim_snapshot.parent_id != legacy.desktop_process_id && shim_snapshot.parent_id != 1 {
-        return Err(format!(
-            "live version-one local Host Runtime owner PID {} no longer belongs to its recorded Desktop PID {}; refusing unsafe takeover",
-            legacy.process_id, legacy.desktop_process_id,
-        )
-        .into());
-    }
-
+    // live Shim and its lineage before waiting, snapshot the recorded child while its lineage is
+    // still provable, and publish both exact instances before sending any signal. Once captured,
+    // the child snapshot remains authoritative if the Shim exits and the child is reparented.
     let child_snapshot = match legacy.child_process_id {
-        Some(child_process_id) => current_process_snapshot(child_process_id)?
-            .filter(|snapshot| snapshot.parent_id == legacy.process_id),
+        Some(child_process_id) => match current_process_snapshot(child_process_id)? {
+            Some(snapshot) if snapshot.parent_id == legacy.process_id => Some(snapshot),
+            Some(_) => {
+                return Err(format!(
+                    "live version-one local Host Runtime child PID {child_process_id} no longer belongs to Shim PID {}; refusing unsafe takeover",
+                    legacy.process_id,
+                )
+                .into());
+            }
+            None => None,
+        },
         None => None,
     };
-    let migrated = migrated_owner_record(&legacy, &shim_snapshot, child_snapshot.as_ref());
+    let migrated =
+        migrated_owner_record(&legacy, &candidate.shim_snapshot, child_snapshot.as_ref());
 
-    let expected = StoredOwnerRecord::VersionOne(legacy);
+    let expected = StoredOwnerRecord::VersionOne(legacy.clone());
     if read_stored_owner(directory).as_ref() != Some(&expected) {
         return Ok(None);
     }
-    write_owner_record(mutation_lock, directory, &migrated)?;
+    if !write_migrated_owner_record(mutation_lock, directory, &migrated)? {
+        return Ok(None);
+    }
     Ok(Some(migrated))
 }
 
@@ -446,7 +540,10 @@ fn owner_is_codexhost_shim(owner: &OwnerRecord) -> Result<bool, Box<dyn Error>> 
     // npm upgrades and candidate packages can move the same Shim to another absolute path.
     // PID plus start time is the process-instance identity. The basename additionally rejects a
     // corrupt lease without making an in-place npm upgrade impossible.
-    Ok(owner_snapshot.executable.file_name() == current_executable.file_name())
+    Ok(executable_file_name_matches(
+        &owner_snapshot.executable,
+        &current_executable,
+    ))
 }
 
 fn retire_legacy_mapping_store_owner(
@@ -481,7 +578,7 @@ fn retire_legacy_mapping_store_owner(
         Err(error) => return Err(error.into()),
     };
     let current_executable = env::current_exe()?;
-    if shim_snapshot.executable.file_name() != current_executable.file_name() {
+    if !executable_file_name_matches(&shim_snapshot.executable, &current_executable) {
         return Ok(());
     }
     let legacy_desktop_process_id = shim_snapshot.parent_id;
@@ -621,7 +718,7 @@ fn terminate_recorded_process(
 // macOS treats these flock acquisitions as process-scoped;
 // `replacement_waits_for_the_local_runtime_owner_mutation_lock` provides the cross-process
 // integration coverage there.
-#[cfg(all(test, any(target_os = "windows", target_os = "linux")))]
+#[cfg(test)]
 mod tests {
     use super::*;
 
@@ -641,6 +738,7 @@ mod tests {
         })
     }
 
+    #[cfg(any(target_os = "windows", target_os = "linux"))]
     fn contender_can_acquire(data_directory: &Path) -> bool {
         let contender = OwnerMutationLock::open(data_directory).expect("open contender owner lock");
         let acquired = contender.try_lock_exclusive().is_ok();
@@ -659,6 +757,7 @@ mod tests {
         ))
     }
 
+    #[cfg(any(target_os = "windows", target_os = "linux"))]
     #[test]
     fn holds_the_mutation_lock_until_child_identity_is_published() {
         let data_directory = temporary_data_directory();
@@ -724,5 +823,41 @@ mod tests {
         let migrated = migrated_owner_record(&legacy, &shim_snapshot, None);
 
         assert_eq!(migrated.desktop_process_id, 1);
+    }
+
+    #[test]
+    fn a_missing_owner_directory_retries_version_one_migration() {
+        let data_directory = temporary_data_directory();
+        fs::create_dir(&data_directory).expect("create owner lock fixture");
+        let mutation_lock =
+            OwnerMutationLock::acquire(&data_directory).expect("acquire owner mutation lock");
+        let missing_owner_directory = data_directory.join(OWNER_DIRECTORY_NAME);
+        let migrated = OwnerRecord {
+            process_id: 101,
+            process_started_at_micros: 202,
+            desktop_process_id: 303,
+            child_process_id: Some(404),
+            child_process_started_at_micros: Some(505),
+        };
+
+        let result =
+            write_migrated_owner_record(&mutation_lock, &missing_owner_directory, &migrated);
+
+        drop(mutation_lock);
+        fs::remove_dir_all(&data_directory).expect("remove owner lock fixture");
+        assert!(!result.expect("missing owner directory should request another acquisition pass"));
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn matches_an_unlinked_linux_shim_executable() {
+        assert!(executable_file_name_matches(
+            Path::new("/tmp/codexhost-shim (deleted)"),
+            Path::new("/opt/codexhost-shim"),
+        ));
+        assert!(!executable_file_name_matches(
+            Path::new("/tmp/not-codexhost-shim (deleted)"),
+            Path::new("/opt/codexhost-shim"),
+        ));
     }
 }

--- a/crates/shim/src/local_runtime_lease.rs
+++ b/crates/shim/src/local_runtime_lease.rs
@@ -238,13 +238,8 @@ impl LocalRuntimeLease {
                     // A migrated exact record remains authoritative for its child after its Shim
                     // exits, even if the Shim PID has since been reused. Retire that exact child
                     // before admitting a replacement; never signal the absent or reused Shim PID.
-                    if is_live_other_desktop(owner.desktop_process_id, desktop_process_id) {
-                        return Err(format!(
-                            "another Codex Desktop process owns the orphaned local Host Runtime (former Shim PID {}, Desktop PID {})",
-                            owner.process_id, owner.desktop_process_id,
-                        )
-                        .into());
-                    }
+                    // The record has no Desktop start identity. Once the verified Shim is gone,
+                    // its PID-only parent can be stale or reused and must not block orphan cleanup.
                     stop_orphaned_owner_child(&owner)?;
                     remove_owner_if_matches(&mutation_lock, &directory, &owner)?;
                     continue;

--- a/crates/shim/src/local_runtime_lease.rs
+++ b/crates/shim/src/local_runtime_lease.rs
@@ -343,10 +343,19 @@ fn write_owner_record(
     let target = directory.join(OWNER_RECORD_NAME);
     let temporary = directory.join(format!("{OWNER_RECORD_NAME}.tmp-{}", record.process_id));
     fs::write(&temporary, record.encode())?;
-    atomic_replace_file(&temporary, &target).map_err(|error| match error {
-        PlatformError::Io(error) => error,
-        PlatformError::NotFound(message) => io::Error::new(io::ErrorKind::NotFound, message),
-        error => io::Error::other(error),
+    atomic_replace_file(&temporary, &target).map_err(|error| {
+        let error = match error {
+            PlatformError::Io(error) => error,
+            PlatformError::NotFound(message) => io::Error::new(io::ErrorKind::NotFound, message),
+            error => io::Error::other(error),
+        };
+        io::Error::new(
+            error.kind(),
+            format!(
+                "publish local Host Runtime owner record {}: {error}",
+                target.display()
+            ),
+        )
     })?;
     Ok(())
 }

--- a/crates/shim/src/local_runtime_lease.rs
+++ b/crates/shim/src/local_runtime_lease.rs
@@ -54,7 +54,8 @@ enum StoredOwnerRecord {
 enum OwnerShimState {
     Valid,
     Missing,
-    Mismatched,
+    Reused,
+    MismatchedExecutable,
 }
 
 impl OwnerRecord {
@@ -233,10 +234,10 @@ impl LocalRuntimeLease {
             }
             match owner_shim_state(&owner)? {
                 OwnerShimState::Valid => {}
-                OwnerShimState::Missing => {
+                OwnerShimState::Missing | OwnerShimState::Reused => {
                     // A migrated exact record remains authoritative for its child after its Shim
-                    // exits. Retire that exact child before admitting a replacement; otherwise a
-                    // post-migration Shim exit can leave two Host Runtimes running concurrently.
+                    // exits, even if the Shim PID has since been reused. Retire that exact child
+                    // before admitting a replacement; never signal the absent or reused Shim PID.
                     if is_live_other_desktop(owner.desktop_process_id, desktop_process_id) {
                         return Err(format!(
                             "another Codex Desktop process owns the orphaned local Host Runtime (former Shim PID {}, Desktop PID {})",
@@ -248,7 +249,7 @@ impl LocalRuntimeLease {
                     remove_owner_if_matches(&mutation_lock, &directory, &owner)?;
                     continue;
                 }
-                OwnerShimState::Mismatched => {
+                OwnerShimState::MismatchedExecutable => {
                     // The recorded Shim instance is live but is not codexhost. Treat the record as
                     // corrupt and never signal either that process or its claimed child.
                     remove_owner_if_matches(&mutation_lock, &directory, &owner)?;
@@ -571,7 +572,7 @@ fn owner_shim_state(owner: &OwnerRecord) -> Result<OwnerShimState, Box<dyn Error
         return Ok(OwnerShimState::Missing);
     };
     if owner_snapshot.started_at_micros != owner.process_started_at_micros {
-        return Ok(OwnerShimState::Mismatched);
+        return Ok(OwnerShimState::Reused);
     }
     let current_executable = env::current_exe()?;
     // npm upgrades and candidate packages can move the same Shim to another absolute path.
@@ -581,7 +582,7 @@ fn owner_shim_state(owner: &OwnerRecord) -> Result<OwnerShimState, Box<dyn Error
         if executable_file_name_matches(&owner_snapshot.executable, &current_executable) {
             OwnerShimState::Valid
         } else {
-            OwnerShimState::Mismatched
+            OwnerShimState::MismatchedExecutable
         },
     )
 }

--- a/crates/shim/src/local_runtime_lease.rs
+++ b/crates/shim/src/local_runtime_lease.rs
@@ -376,7 +376,7 @@ fn executable_file_name_matches(observed: &Path, expected: &Path) -> bool {
     {
         use std::os::unix::ffi::OsStrExt;
 
-        return observed.as_bytes().strip_suffix(b" (deleted)") == Some(expected.as_bytes());
+        observed.as_bytes().strip_suffix(b" (deleted)") == Some(expected.as_bytes())
     }
     #[cfg(not(target_os = "linux"))]
     false

--- a/crates/shim/src/local_runtime_lease.rs
+++ b/crates/shim/src/local_runtime_lease.rs
@@ -220,6 +220,15 @@ impl LocalRuntimeLease {
             };
             let owner = match &stored_owner {
                 StoredOwnerRecord::Exact(owner) => owner.clone(),
+                StoredOwnerRecord::VersionOne(owner)
+                    if owner.process_id == process_id && owner.child_process_id.is_none() =>
+                {
+                    // A released childless record cannot belong to this acquiring Shim: it has not
+                    // returned from acquire or spawned its child yet. The PID was reused after the
+                    // released Shim exited, so do not wait on our own startup as a legacy owner.
+                    remove_stored_owner_if_matches(&mutation_lock, &directory, &stored_owner)?;
+                    continue;
+                }
                 StoredOwnerRecord::VersionOne(owner) => {
                     let Some(owner) = migrate_version_one_owner(&mutation_lock, &directory, owner)?
                     else {

--- a/crates/shim/src/local_runtime_lease.rs
+++ b/crates/shim/src/local_runtime_lease.rs
@@ -441,7 +441,10 @@ fn terminate_recorded_process(
     Ok(())
 }
 
-#[cfg(test)]
+// This in-process contender is meaningful only with Windows handle-scoped locks. Unix flock locks
+// are process-scoped, so `replacement_waits_for_the_local_runtime_owner_mutation_lock` provides
+// the cross-process integration coverage there.
+#[cfg(all(test, target_os = "windows"))]
 mod tests {
     use super::*;
 

--- a/crates/shim/src/local_runtime_lease.rs
+++ b/crates/shim/src/local_runtime_lease.rs
@@ -423,6 +423,16 @@ fn executable_file_name_matches(observed: &Path, expected: &Path) -> bool {
     false
 }
 
+#[cfg(target_os = "windows")]
+fn ensure_no_live_version_one_child(_owner: &VersionOneOwnerRecord) -> Result<(), Box<dyn Error>> {
+    // Released Windows Shims spawn the Host Runtime only after assigning it to their
+    // JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE Job. Once the Shim process is gone, that child cannot
+    // legitimately remain alive; a live process at the PID-only v1 child ID is therefore PID
+    // reuse. Never wait on or signal that unrelated process.
+    Ok(())
+}
+
+#[cfg(not(target_os = "windows"))]
 fn ensure_no_live_version_one_child(owner: &VersionOneOwnerRecord) -> Result<(), Box<dyn Error>> {
     let Some(child_process_id) = owner.child_process_id else {
         return Ok(());

--- a/crates/shim/src/local_runtime_lease.rs
+++ b/crates/shim/src/local_runtime_lease.rs
@@ -360,15 +360,7 @@ fn migrate_version_one_owner(
             .filter(|snapshot| snapshot.parent_id == legacy.process_id),
         None => None,
     };
-    let migrated = OwnerRecord {
-        process_id: legacy.process_id,
-        process_started_at_micros: shim_snapshot.started_at_micros,
-        desktop_process_id: legacy.desktop_process_id,
-        child_process_id: child_snapshot.as_ref().map(|snapshot| snapshot.id),
-        child_process_started_at_micros: child_snapshot
-            .as_ref()
-            .map(|snapshot| snapshot.started_at_micros),
-    };
+    let migrated = migrated_owner_record(legacy, &shim_snapshot, child_snapshot.as_ref());
 
     let expected = StoredOwnerRecord::VersionOne(legacy.clone());
     if read_stored_owner(directory).as_ref() != Some(&expected) {
@@ -376,6 +368,22 @@ fn migrate_version_one_owner(
     }
     write_owner_record(mutation_lock, directory, &migrated)?;
     Ok(Some(migrated))
+}
+
+fn migrated_owner_record(
+    legacy: &VersionOneOwnerRecord,
+    shim_snapshot: &ProcessSnapshot,
+    child_snapshot: Option<&ProcessSnapshot>,
+) -> OwnerRecord {
+    OwnerRecord {
+        process_id: legacy.process_id,
+        process_started_at_micros: shim_snapshot.started_at_micros,
+        desktop_process_id: shim_snapshot.parent_id,
+        child_process_id: child_snapshot.as_ref().map(|snapshot| snapshot.id),
+        child_process_started_at_micros: child_snapshot
+            .as_ref()
+            .map(|snapshot| snapshot.started_at_micros),
+    }
 }
 
 fn owner_is_codexhost_shim(owner: &OwnerRecord) -> Result<bool, Box<dyn Error>> {
@@ -644,5 +652,25 @@ mod tests {
                 child_process_id: record.child_process_id,
             }
         );
+    }
+
+    #[test]
+    fn migrated_owner_records_preserve_observed_reparenting() {
+        let legacy = VersionOneOwnerRecord {
+            process_id: 101,
+            desktop_process_id: 303,
+            child_process_id: None,
+        };
+        let shim_snapshot = ProcessSnapshot {
+            id: legacy.process_id,
+            parent_id: 1,
+            process_group_id: legacy.process_id,
+            executable: PathBuf::from("codexhost-shim"),
+            started_at_micros: 202,
+        };
+
+        let migrated = migrated_owner_record(&legacy, &shim_snapshot, None);
+
+        assert_eq!(migrated.desktop_process_id, 1);
     }
 }

--- a/crates/shim/tests/proxy.rs
+++ b/crates/shim/tests/proxy.rs
@@ -1203,6 +1203,12 @@ fn replacement_does_not_signal_a_reused_owner_process_id() {
 
     let owner_record = directory.join("local-host-runtime-owner-v1").join("owner");
     let contents = wait_for_complete_owner_record(&mut owner, &directory, Duration::from_secs(10));
+    let old_exact_child_started_at_micros = contents
+        .lines()
+        .find_map(|line| line.strip_prefix("child_process_started_at_micros="))
+        .expect("recorded child start identity")
+        .parse::<u64>()
+        .expect("recorded child start identity micros");
     let recycled = contents
         .lines()
         .map(|line| {
@@ -1229,7 +1235,11 @@ fn replacement_does_not_signal_a_reused_owner_process_id() {
         .try_wait()
         .expect("poll reused owner PID fixture")
         .is_none();
-    let old_exact_child_was_retired = !process_exists(owner_root);
+    // Linux keeps a killed child PID visible to kill(2) while its parent is about to reap the
+    // zombie, even though /proc/<pid>/exe is already gone. Match the production lease's exact
+    // process-instance semantics instead of treating that transient zombie as a live runtime.
+    let old_exact_child_was_retired = !process_snapshot(owner_root)
+        .is_ok_and(|snapshot| snapshot.started_at_micros == old_exact_child_started_at_micros);
 
     drop(owner_stdin);
     if !wait_for_process_exit(&mut owner, Duration::from_secs(5)) {

--- a/crates/shim/tests/proxy.rs
+++ b/crates/shim/tests/proxy.rs
@@ -667,7 +667,21 @@ fn migrates_a_live_version_one_owner_before_starting_a_replacement() {
     );
 
     let owner_record = directory.join("local-host-runtime-owner-v1").join("owner");
-    let contents = wait_for_file(&owner_record, Duration::from_secs(5));
+    let deadline = Instant::now() + Duration::from_secs(5);
+    let contents = loop {
+        let contents = fs::read_to_string(&owner_record).expect("read local Host Runtime owner");
+        if contents.lines().any(|line| {
+            line.strip_prefix("child_process_started_at_micros=")
+                .is_some_and(|value| !value.is_empty())
+        }) {
+            break contents;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "timed out waiting for the complete local Host Runtime owner record"
+        );
+        thread::sleep(Duration::from_millis(20));
+    };
     let field = |name: &str| {
         contents
             .lines()
@@ -713,6 +727,138 @@ fn migrates_a_live_version_one_owner_before_starting_a_replacement() {
     assert!(
         owner_was_retired && !process_exists(owner_root),
         "replacement started without retiring the live version-one owner"
+    );
+}
+
+#[cfg(any(target_os = "windows", target_os = "macos", target_os = "linux"))]
+#[test]
+fn waits_for_a_version_one_owner_to_publish_its_child_before_migration() {
+    let directory = temporary_directory();
+    let owner_ready = directory.join("owner-ready");
+    let replacement_ready = directory.join("replacement-ready");
+    let mut owner = host_runtime_shim(&directory, &owner_ready);
+    let owner_stdin = owner.stdin.take().expect("owner Host Runtime stdin");
+    let owner_root = process_id_from_ready(
+        &wait_for_file(&owner_ready, Duration::from_secs(5)),
+        "root=",
+    );
+
+    let owner_record = directory.join("local-host-runtime-owner-v1").join("owner");
+    let owner_record_deadline = Instant::now() + Duration::from_secs(5);
+    let contents = loop {
+        let contents = fs::read_to_string(&owner_record).expect("read local Host Runtime owner");
+        if contents.lines().any(|line| {
+            line.strip_prefix("child_process_started_at_micros=")
+                .is_some_and(|value| !value.is_empty())
+        }) {
+            break contents;
+        }
+        assert!(
+            Instant::now() < owner_record_deadline,
+            "timed out waiting for the complete local Host Runtime owner record"
+        );
+        thread::sleep(Duration::from_millis(20));
+    };
+    let field = |name: &str| {
+        contents
+            .lines()
+            .find_map(|line| line.strip_prefix(&format!("{name}=")))
+            .unwrap_or_else(|| panic!("owner record omitted {name}"))
+    };
+    let version_one_without_child = format!(
+        "version=1\nprocess_id={}\ndesktop_process_id={}\nchild_process_id=\n",
+        field("process_id"),
+        field("desktop_process_id"),
+    );
+    fs::write(&owner_record, &version_one_without_child)
+        .expect("publish starting version-one owner record");
+
+    let mut replacement = host_runtime_shim(&directory, &replacement_ready);
+    let replacement_stdin = replacement
+        .stdin
+        .take()
+        .expect("replacement Host Runtime stdin");
+    let owner_lock = OpenOptions::new()
+        .read(true)
+        .write(true)
+        .create(true)
+        .truncate(false)
+        .open(directory.join("local-host-runtime-owner.lock"))
+        .expect("open local Host Runtime owner mutation lock");
+    let deadline = Instant::now() + Duration::from_secs(5);
+    let replacement_holds_lock = loop {
+        match owner_lock.try_lock_exclusive() {
+            Ok(()) => {
+                FileExt::unlock(&owner_lock).expect("release owner mutation lock probe");
+            }
+            Err(error)
+                if error.kind() == std::io::ErrorKind::WouldBlock
+                    || (cfg!(target_os = "windows") && error.raw_os_error() == Some(33)) =>
+            {
+                break true;
+            }
+            Err(error) => panic!("probe local Host Runtime owner mutation lock: {error}"),
+        }
+        if Instant::now() >= deadline {
+            break false;
+        }
+        thread::sleep(Duration::from_millis(20));
+    };
+    thread::sleep(Duration::from_millis(100));
+    let observed_record = fs::read_to_string(&owner_record).ok();
+    let owner_is_live = process_exists(owner.id());
+    let owner_child_is_live = process_exists(owner_root);
+    let replacement_is_ready = replacement_ready.exists();
+    let replacement_waited_for_child = observed_record.as_deref()
+        == Some(version_one_without_child.as_str())
+        && owner_is_live
+        && owner_child_is_live
+        && !replacement_is_ready;
+    if replacement_waited_for_child {
+        fs::write(
+            &owner_record,
+            format!(
+                "version=1\nprocess_id={}\ndesktop_process_id={}\nchild_process_id={owner_root}\n",
+                field("process_id"),
+                field("desktop_process_id"),
+            ),
+        )
+        .expect("publish completed version-one owner record");
+    }
+
+    let replacement_identity = wait_for_optional_file(&replacement_ready, Duration::from_secs(5));
+    let replacement_root = replacement_identity
+        .as_deref()
+        .map(|identity| process_id_from_ready(identity, "root="));
+    let owner_was_retired = wait_for_process_exit(&mut owner, Duration::from_secs(2));
+
+    drop(owner_stdin);
+    if !owner_was_retired {
+        force_stop_test_process(owner.id());
+        force_stop_test_process(owner_root);
+        let _ = owner.wait();
+    }
+    drop(replacement_stdin);
+    if !wait_for_process_exit(&mut replacement, Duration::from_secs(5)) {
+        force_stop_test_process(replacement.id());
+        if let Some(replacement_root) = replacement_root {
+            force_stop_test_process(replacement_root);
+        }
+        let _ = replacement.wait();
+    }
+    let _ = fs::remove_dir_all(&directory);
+
+    assert!(
+        replacement_holds_lock,
+        "replacement did not acquire the local Host Runtime owner mutation lock"
+    );
+    assert!(
+        replacement_waited_for_child,
+        "replacement migrated or signalled a version-one owner before its child identity was published: record={observed_record:?}, owner_live={owner_is_live}, child_live={owner_child_is_live}, replacement_ready={replacement_is_ready}"
+    );
+    assert!(
+        replacement_identity.is_some() && owner_was_retired && !process_exists(owner_root),
+        "replacement did not retire the completed version-one owner and its child"
     );
 }
 

--- a/crates/shim/tests/proxy.rs
+++ b/crates/shim/tests/proxy.rs
@@ -1095,6 +1095,13 @@ fn retires_an_exact_owner_child_after_its_shim_exits() {
         .find_map(|line| line.strip_prefix("child_process_started_at_micros="))
         .filter(|value| !value.is_empty())
         .expect("fixture child start identity");
+    let mut reused_desktop_process = Command::new(fake_codex_path())
+        .env("FAKE_CODEX_DELAY_MS", "60000")
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("spawn reused Desktop PID fixture");
 
     force_stop_test_process(owner.id());
     assert!(
@@ -1111,6 +1118,8 @@ fn retires_an_exact_owner_child_after_its_shim_exits() {
                 format!("child_process_id={fixture_root}")
             } else if line.starts_with("child_process_started_at_micros=") {
                 format!("child_process_started_at_micros={fixture_child_started_at_micros}")
+            } else if line.starts_with("desktop_process_id=") {
+                format!("desktop_process_id={}", reused_desktop_process.id())
             } else {
                 line.to_owned()
             }
@@ -1129,14 +1138,22 @@ fn retires_an_exact_owner_child_after_its_shim_exits() {
         .stdin
         .take()
         .expect("replacement Host Runtime stdin");
-    let replacement_identity = wait_for_file(&replacement_ready, Duration::from_secs(10));
-    let replacement_root = process_id_from_ready(&replacement_identity, "root=");
+    let replacement_identity = wait_for_optional_file(&replacement_ready, Duration::from_secs(2));
+    let replacement_root = replacement_identity
+        .as_deref()
+        .map(|identity| process_id_from_ready(identity, "root="));
     let orphaned_child_was_retired = !process_exists(fixture_root);
+    let reused_desktop_was_not_signalled = reused_desktop_process
+        .try_wait()
+        .expect("poll reused Desktop PID fixture")
+        .is_none();
 
     drop(replacement_stdin);
     if !wait_for_process_exit(&mut replacement, Duration::from_secs(5)) {
         force_stop_test_process(replacement.id());
-        force_stop_test_process(replacement_root);
+        if let Some(replacement_root) = replacement_root {
+            force_stop_test_process(replacement_root);
+        }
         let _ = replacement.wait();
     }
     drop(fixture_stdin);
@@ -1145,9 +1162,19 @@ fn retires_an_exact_owner_child_after_its_shim_exits() {
         force_stop_test_process(fixture_root);
         let _ = fixture.wait();
     }
+    force_stop_test_process(reused_desktop_process.id());
+    let _ = reused_desktop_process.wait();
     let _ = fs::remove_dir_all(&directory);
     let _ = fs::remove_dir_all(&fixture_directory);
 
+    assert!(
+        replacement_identity.is_some(),
+        "replacement trusted a stale PID-only Desktop identity after the exact owner Shim exited"
+    );
+    assert!(
+        reused_desktop_was_not_signalled,
+        "replacement signalled the unrelated process that reused the recorded Desktop PID"
+    );
     assert!(
         orphaned_child_was_retired,
         "replacement started without retiring the exact child whose recorded Shim had exited"

--- a/crates/shim/tests/proxy.rs
+++ b/crates/shim/tests/proxy.rs
@@ -1067,6 +1067,95 @@ fn refuses_version_one_takeover_when_the_recorded_child_outlives_its_shim() {
 
 #[cfg(any(target_os = "windows", target_os = "macos", target_os = "linux"))]
 #[test]
+fn retires_an_exact_owner_child_after_its_shim_exits() {
+    let directory = temporary_directory();
+    let fixture_directory = temporary_directory();
+    let owner_ready = directory.join("owner-ready");
+    let fixture_ready = fixture_directory.join("fixture-ready");
+    let replacement_ready = directory.join("replacement-ready");
+
+    let mut owner = host_runtime_shim(&directory, &owner_ready);
+    let owner_stdin = owner.stdin.take().expect("owner Host Runtime stdin");
+    wait_for_file(&owner_ready, Duration::from_secs(5));
+    let owner_contents =
+        wait_for_complete_owner_record(&mut owner, &directory, Duration::from_secs(10));
+
+    // Keep an independently owned Host Runtime alive so this exact-child fixture also works on
+    // Windows, where killing a Shim normally closes its Job and retires its own process tree.
+    let mut fixture = host_runtime_shim(&fixture_directory, &fixture_ready);
+    let fixture_stdin = fixture.stdin.take().expect("fixture Host Runtime stdin");
+    let fixture_root = process_id_from_ready(
+        &wait_for_file(&fixture_ready, Duration::from_secs(5)),
+        "root=",
+    );
+    let fixture_contents =
+        wait_for_complete_owner_record(&mut fixture, &fixture_directory, Duration::from_secs(10));
+    let fixture_child_started_at_micros = fixture_contents
+        .lines()
+        .find_map(|line| line.strip_prefix("child_process_started_at_micros="))
+        .filter(|value| !value.is_empty())
+        .expect("fixture child start identity");
+
+    force_stop_test_process(owner.id());
+    assert!(
+        wait_for_process_exit(&mut owner, Duration::from_secs(5)),
+        "exact owner Shim did not exit"
+    );
+    drop(owner_stdin);
+
+    let owner_record = directory.join("local-host-runtime-owner-v1").join("owner");
+    let orphaned_exact_owner = owner_contents
+        .lines()
+        .map(|line| {
+            if line.starts_with("child_process_id=") {
+                format!("child_process_id={fixture_root}")
+            } else if line.starts_with("child_process_started_at_micros=") {
+                format!("child_process_started_at_micros={fixture_child_started_at_micros}")
+            } else {
+                line.to_owned()
+            }
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+    fs::write(&owner_record, format!("{orphaned_exact_owner}\n"))
+        .expect("publish orphaned exact owner record");
+    assert!(
+        process_exists(fixture_root),
+        "exact child fixture exited before replacement"
+    );
+
+    let mut replacement = host_runtime_shim(&directory, &replacement_ready);
+    let replacement_stdin = replacement
+        .stdin
+        .take()
+        .expect("replacement Host Runtime stdin");
+    let replacement_identity = wait_for_file(&replacement_ready, Duration::from_secs(10));
+    let replacement_root = process_id_from_ready(&replacement_identity, "root=");
+    let orphaned_child_was_retired = !process_exists(fixture_root);
+
+    drop(replacement_stdin);
+    if !wait_for_process_exit(&mut replacement, Duration::from_secs(5)) {
+        force_stop_test_process(replacement.id());
+        force_stop_test_process(replacement_root);
+        let _ = replacement.wait();
+    }
+    drop(fixture_stdin);
+    if !wait_for_process_exit(&mut fixture, Duration::from_secs(5)) {
+        force_stop_test_process(fixture.id());
+        force_stop_test_process(fixture_root);
+        let _ = fixture.wait();
+    }
+    let _ = fs::remove_dir_all(&directory);
+    let _ = fs::remove_dir_all(&fixture_directory);
+
+    assert!(
+        orphaned_child_was_retired,
+        "replacement started without retiring the exact child whose recorded Shim had exited"
+    );
+}
+
+#[cfg(any(target_os = "windows", target_os = "macos", target_os = "linux"))]
+#[test]
 fn replacement_does_not_signal_a_reused_owner_process_id() {
     let directory = temporary_directory();
     let owner_ready = directory.join("owner-ready");

--- a/crates/shim/tests/proxy.rs
+++ b/crates/shim/tests/proxy.rs
@@ -15,9 +15,9 @@ use std::time::Instant;
 
 #[cfg(any(target_os = "macos", target_os = "linux"))]
 use codexhost_platform::parent_process_id;
-#[cfg(any(target_os = "windows", target_os = "macos", target_os = "linux"))]
-use codexhost_platform::process_exists;
 use codexhost_platform::{CODEX_CLI_PATH_ENV, STOCK_CODEX_PATH_ENV};
+#[cfg(any(target_os = "windows", target_os = "macos", target_os = "linux"))]
+use codexhost_platform::{process_exists, process_snapshot};
 use codexhost_shim::{HOST_NODE_PATH_ENV, HOST_RUNTIME_PATH_ENV, REMOTE_SSH_MANAGED_ENV};
 #[cfg(any(target_os = "windows", target_os = "macos", target_os = "linux"))]
 use fs2::FileExt;
@@ -1166,24 +1166,28 @@ fn replacement_does_not_signal_a_reused_owner_process_id() {
         &wait_for_file(&owner_ready, Duration::from_secs(5)),
         "root=",
     );
+    let mut reused_owner_process = Command::new(fake_codex_path())
+        .env("FAKE_CODEX_DELAY_MS", "60000")
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("spawn reused owner PID fixture");
 
     let owner_record = directory.join("local-host-runtime-owner-v1").join("owner");
     let contents = wait_for_complete_owner_record(&mut owner, &directory, Duration::from_secs(10));
-    let mut replaced_start_time = false;
-    let mut recycled = contents
+    let recycled = contents
         .lines()
         .map(|line| {
-            if line.starts_with("process_started_at_micros=") {
-                replaced_start_time = true;
+            if line.starts_with("process_id=") {
+                format!("process_id={}", reused_owner_process.id())
+            } else if line.starts_with("process_started_at_micros=") {
                 "process_started_at_micros=18446744073709551615".to_owned()
             } else {
                 line.to_owned()
             }
         })
         .collect::<Vec<_>>();
-    if !replaced_start_time {
-        recycled.push("process_started_at_micros=18446744073709551615".to_owned());
-    }
     fs::write(&owner_record, format!("{}\n", recycled.join("\n")))
         .expect("publish recycled owner process identity");
 
@@ -1194,10 +1198,11 @@ fn replacement_does_not_signal_a_reused_owner_process_id() {
         .expect("replacement Host Runtime stdin");
     let replacement_identity = wait_for_file(&replacement_ready, Duration::from_secs(5));
     let replacement_root = process_id_from_ready(&replacement_identity, "root=");
-    let owner_was_not_signalled = owner
+    let reused_process_was_not_signalled = reused_owner_process
         .try_wait()
-        .expect("poll recycled owner Shim")
+        .expect("poll reused owner PID fixture")
         .is_none();
+    let old_exact_child_was_retired = !process_exists(owner_root);
 
     drop(owner_stdin);
     if !wait_for_process_exit(&mut owner, Duration::from_secs(5)) {
@@ -1213,11 +1218,102 @@ fn replacement_does_not_signal_a_reused_owner_process_id() {
         let _ = fs::remove_dir_all(&directory);
         panic!("replacement Host Runtime did not converge after recycled owner recovery");
     }
+    force_stop_test_process(reused_owner_process.id());
+    let _ = reused_owner_process.wait();
     fs::remove_dir_all(directory).expect("remove recycled owner fixture");
 
     assert!(
-        owner_was_not_signalled,
+        reused_process_was_not_signalled,
         "replacement signalled a live process whose PID no longer matched the recorded owner instance"
+    );
+    assert!(
+        old_exact_child_was_retired,
+        "replacement started without retiring the exact child after its Shim PID was reused"
+    );
+}
+
+#[cfg(any(target_os = "windows", target_os = "macos", target_os = "linux"))]
+#[test]
+fn replacement_does_not_signal_an_exact_owner_with_a_mismatched_executable() {
+    let directory = temporary_directory();
+    let owner_ready = directory.join("owner-ready");
+    let replacement_ready = directory.join("replacement-ready");
+    let mut owner = host_runtime_shim(&directory, &owner_ready);
+    let owner_stdin = owner.stdin.take().expect("owner Host Runtime stdin");
+    let owner_root = process_id_from_ready(
+        &wait_for_file(&owner_ready, Duration::from_secs(5)),
+        "root=",
+    );
+    let owner_contents =
+        wait_for_complete_owner_record(&mut owner, &directory, Duration::from_secs(10));
+
+    let mut mismatched_process = Command::new(fake_codex_path())
+        .env("FAKE_CODEX_DELAY_MS", "60000")
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("spawn mismatched owner executable fixture");
+    let mismatched_snapshot =
+        process_snapshot(mismatched_process.id()).expect("snapshot mismatched owner executable");
+    let mismatched_owner = owner_contents
+        .lines()
+        .map(|line| {
+            if line.starts_with("process_id=") {
+                format!("process_id={}", mismatched_process.id())
+            } else if line.starts_with("process_started_at_micros=") {
+                format!(
+                    "process_started_at_micros={}",
+                    mismatched_snapshot.started_at_micros
+                )
+            } else {
+                line.to_owned()
+            }
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+    fs::write(
+        directory.join("local-host-runtime-owner-v1").join("owner"),
+        format!("{mismatched_owner}\n"),
+    )
+    .expect("publish mismatched owner executable record");
+
+    let mut replacement = host_runtime_shim(&directory, &replacement_ready);
+    let replacement_stdin = replacement
+        .stdin
+        .take()
+        .expect("replacement Host Runtime stdin");
+    let replacement_identity = wait_for_file(&replacement_ready, Duration::from_secs(5));
+    let replacement_root = process_id_from_ready(&replacement_identity, "root=");
+    let mismatched_process_was_not_signalled = mismatched_process
+        .try_wait()
+        .expect("poll mismatched owner executable")
+        .is_none();
+    let claimed_child_was_not_signalled = process_exists(owner_root);
+
+    drop(owner_stdin);
+    if !wait_for_process_exit(&mut owner, Duration::from_secs(5)) {
+        force_stop_test_process(owner.id());
+        force_stop_test_process(owner_root);
+        let _ = owner.wait();
+    }
+    drop(replacement_stdin);
+    if !wait_for_process_exit(&mut replacement, Duration::from_secs(5)) {
+        force_stop_test_process(replacement.id());
+        force_stop_test_process(replacement_root);
+        let _ = replacement.wait();
+    }
+    force_stop_test_process(mismatched_process.id());
+    let _ = mismatched_process.wait();
+    fs::remove_dir_all(directory).expect("remove mismatched executable fixture");
+
+    assert!(
+        mismatched_process_was_not_signalled,
+        "replacement signalled a live exact owner whose executable was not codexhost"
+    );
+    assert!(
+        claimed_child_was_not_signalled,
+        "replacement trusted and signalled the child claimed by a mismatched executable"
     );
 }
 

--- a/crates/shim/tests/proxy.rs
+++ b/crates/shim/tests/proxy.rs
@@ -1049,6 +1049,65 @@ fn discards_a_childless_version_one_owner_that_names_the_current_shim() {
     );
 }
 
+#[cfg(target_os = "windows")]
+#[test]
+fn ignores_a_reused_version_one_child_pid_after_its_shim_exits() {
+    let directory = temporary_directory();
+    let owner_directory = directory.join("local-host-runtime-owner-v1");
+    let replacement_ready = directory.join("replacement-ready");
+    fs::create_dir(&owner_directory).expect("create stale version-one owner directory");
+
+    let mut unrelated = Command::new(fake_codex_path())
+        .env("FAKE_CODEX_DELAY_MS", "60000")
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("spawn unrelated reused-child-PID fixture");
+    fs::write(
+        owner_directory.join("owner"),
+        format!(
+            "version=1\nprocess_id={}\ndesktop_process_id={}\nchild_process_id={}\n",
+            u32::MAX,
+            process::id(),
+            unrelated.id(),
+        ),
+    )
+    .expect("publish stale version-one owner record with a reused child PID");
+
+    let mut replacement = host_runtime_shim(&directory, &replacement_ready);
+    let replacement_stdin = replacement
+        .stdin
+        .take()
+        .expect("replacement Host Runtime stdin");
+    let replacement_identity = wait_for_optional_file(&replacement_ready, Duration::from_secs(2));
+    let unrelated_was_not_signalled = unrelated
+        .try_wait()
+        .expect("poll unrelated reused-child-PID fixture")
+        .is_none();
+
+    force_stop_test_process(unrelated.id());
+    let _ = unrelated.wait();
+    drop(replacement_stdin);
+    if !wait_for_process_exit(&mut replacement, Duration::from_secs(5)) {
+        force_stop_test_process(replacement.id());
+        if let Some(identity) = replacement_identity.as_deref() {
+            force_stop_test_process(process_id_from_ready(identity, "root="));
+        }
+        let _ = replacement.wait();
+    }
+    let _ = fs::remove_dir_all(&directory);
+
+    assert!(
+        replacement_identity.is_some(),
+        "replacement trusted a live process that reused a dead Windows v1 child PID"
+    );
+    assert!(
+        unrelated_was_not_signalled,
+        "replacement signalled an unrelated process that reused a dead Windows v1 child PID"
+    );
+}
+
 #[cfg(any(target_os = "macos", target_os = "linux"))]
 #[test]
 fn refuses_version_one_takeover_when_the_recorded_child_outlives_its_shim() {

--- a/crates/shim/tests/proxy.rs
+++ b/crates/shim/tests/proxy.rs
@@ -871,6 +871,140 @@ fn waits_for_a_version_one_owner_to_publish_its_child_before_migration() {
 
 #[cfg(any(target_os = "windows", target_os = "macos", target_os = "linux"))]
 #[test]
+fn rejects_a_childless_version_one_owner_whose_process_id_was_reused() {
+    let directory = temporary_directory();
+    let owner_directory = directory.join("local-host-runtime-owner-v1");
+    let replacement_ready = directory.join("replacement-ready");
+    fs::create_dir(&owner_directory).expect("create version-one owner directory");
+
+    let mut unrelated = Command::new(fake_codex_path())
+        .env("FAKE_CODEX_DELAY_MS", "60000")
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("spawn unrelated reused-PID fixture");
+    fs::write(
+        owner_directory.join("owner"),
+        format!(
+            "version=1\nprocess_id={}\ndesktop_process_id={}\nchild_process_id=\n",
+            unrelated.id(),
+            process::id(),
+        ),
+    )
+    .expect("publish childless version-one owner record");
+
+    let mut replacement = host_runtime_shim(&directory, &replacement_ready);
+    let replacement_stdin = replacement
+        .stdin
+        .take()
+        .expect("replacement Host Runtime stdin");
+    let replacement_identity = wait_for_optional_file(&replacement_ready, Duration::from_secs(2));
+    let unrelated_was_not_signalled = unrelated
+        .try_wait()
+        .expect("poll unrelated reused-PID fixture")
+        .is_none();
+
+    force_stop_test_process(unrelated.id());
+    let _ = unrelated.wait();
+    drop(replacement_stdin);
+    if !wait_for_process_exit(&mut replacement, Duration::from_secs(5)) {
+        force_stop_test_process(replacement.id());
+        if let Some(identity) = replacement_identity.as_deref() {
+            force_stop_test_process(process_id_from_ready(identity, "root="));
+        }
+        let _ = replacement.wait();
+    }
+    let _ = fs::remove_dir_all(&directory);
+
+    assert!(
+        replacement_identity.is_some(),
+        "replacement waited on an unrelated process that reused a childless version-one owner PID"
+    );
+    assert!(
+        unrelated_was_not_signalled,
+        "replacement signalled an unrelated process that reused a version-one owner PID"
+    );
+}
+
+#[cfg(any(target_os = "macos", target_os = "linux"))]
+#[test]
+fn refuses_version_one_takeover_when_the_recorded_child_outlives_its_shim() {
+    let directory = temporary_directory();
+    let owner_ready = directory.join("owner-ready");
+    let replacement_ready = directory.join("replacement-ready");
+    let mut owner = host_runtime_shim(&directory, &owner_ready);
+    let owner_stdin = owner.stdin.take().expect("owner Host Runtime stdin");
+    let owner_root = process_id_from_ready(
+        &wait_for_file(&owner_ready, Duration::from_secs(5)),
+        "root=",
+    );
+    let owner_record = directory.join("local-host-runtime-owner-v1").join("owner");
+    let contents = wait_for_file(&owner_record, Duration::from_secs(5));
+    let field = |name: &str| {
+        contents
+            .lines()
+            .find_map(|line| line.strip_prefix(&format!("{name}=")))
+            .unwrap_or_else(|| panic!("owner record omitted {name}"))
+    };
+    fs::write(
+        &owner_record,
+        format!(
+            "version=1\nprocess_id={}\ndesktop_process_id={}\nchild_process_id={owner_root}\n",
+            field("process_id"),
+            field("desktop_process_id"),
+        ),
+    )
+    .expect("publish version-one owner record");
+
+    force_stop_test_process(owner.id());
+    assert!(
+        wait_for_process_exit(&mut owner, Duration::from_secs(5)),
+        "version-one owner Shim did not exit"
+    );
+    drop(owner_stdin);
+    let reparent_deadline = Instant::now() + Duration::from_secs(5);
+    while parent_process_id(owner_root).ok().flatten() == Some(owner.id())
+        && Instant::now() < reparent_deadline
+    {
+        thread::sleep(Duration::from_millis(20));
+    }
+    assert!(
+        process_exists(owner_root),
+        "recorded Host Runtime child exited"
+    );
+
+    let mut replacement = host_runtime_shim(&directory, &replacement_ready);
+    let replacement_stdin = replacement
+        .stdin
+        .take()
+        .expect("replacement Host Runtime stdin");
+    let replacement_identity = wait_for_optional_file(&replacement_ready, Duration::from_secs(2));
+    let recorded_child_survived = process_exists(owner_root);
+
+    drop(replacement_stdin);
+    if !wait_for_process_exit(&mut replacement, Duration::from_secs(2)) {
+        force_stop_test_process(replacement.id());
+        if let Some(identity) = replacement_identity.as_deref() {
+            force_stop_test_process(process_id_from_ready(identity, "root="));
+        }
+        let _ = replacement.wait();
+    }
+    force_stop_test_process(owner_root);
+    let _ = fs::remove_dir_all(&directory);
+
+    assert!(
+        replacement_identity.is_none(),
+        "replacement started while a version-one owner's reparented child remained live"
+    );
+    assert!(
+        recorded_child_survived,
+        "replacement signalled a version-one child without a verified process-instance identity"
+    );
+}
+
+#[cfg(any(target_os = "windows", target_os = "macos", target_os = "linux"))]
+#[test]
 fn replacement_does_not_signal_a_reused_owner_process_id() {
     let directory = temporary_directory();
     let owner_ready = directory.join("owner-ready");

--- a/crates/shim/tests/proxy.rs
+++ b/crates/shim/tests/proxy.rs
@@ -431,6 +431,83 @@ fn wait_for_optional_file(path: &std::path::Path, timeout: Duration) -> Option<S
 }
 
 #[cfg(any(target_os = "windows", target_os = "macos", target_os = "linux"))]
+fn wait_for_child_file_matching(
+    child: &mut process::Child,
+    path: &std::path::Path,
+    data_directory: &std::path::Path,
+    timeout: Duration,
+    description: &str,
+    matches: impl Fn(&str) -> bool,
+) -> String {
+    let started = Instant::now();
+    let mut last_contents = None;
+    loop {
+        if let Ok(contents) = fs::read_to_string(path) {
+            if matches(&contents) {
+                return contents;
+            }
+            last_contents = Some(contents);
+        }
+        if let Some(status) = child.try_wait().expect("poll Host Runtime Shim") {
+            let mut stderr = Vec::new();
+            if let Some(mut stream) = child.stderr.take() {
+                stream
+                    .read_to_end(&mut stderr)
+                    .expect("read exited Host Runtime Shim stderr");
+            }
+            let owner_record = fs::read_to_string(
+                data_directory
+                    .join("local-host-runtime-owner-v1")
+                    .join("owner"),
+            )
+            .ok();
+            panic!(
+                "{description}: Shim PID {} exited with {status}; stderr={}; owner_record={owner_record:?}; observed_file={last_contents:?}",
+                child.id(),
+                String::from_utf8_lossy(&stderr),
+            );
+        }
+        if started.elapsed() >= timeout {
+            let owner_record = fs::read_to_string(
+                data_directory
+                    .join("local-host-runtime-owner-v1")
+                    .join("owner"),
+            )
+            .ok();
+            panic!(
+                "{description}: timed out after {timeout:?} while Shim PID {} remained live; owner_record={owner_record:?}; observed_file={last_contents:?}",
+                child.id(),
+            );
+        }
+        thread::sleep(Duration::from_millis(20));
+    }
+}
+
+#[cfg(any(target_os = "windows", target_os = "macos", target_os = "linux"))]
+fn wait_for_complete_owner_record(
+    child: &mut process::Child,
+    data_directory: &std::path::Path,
+    timeout: Duration,
+) -> String {
+    let owner_record = data_directory
+        .join("local-host-runtime-owner-v1")
+        .join("owner");
+    wait_for_child_file_matching(
+        child,
+        &owner_record,
+        data_directory,
+        timeout,
+        "local Host Runtime owner publication failed",
+        |contents| {
+            contents.lines().any(|line| {
+                line.strip_prefix("child_process_started_at_micros=")
+                    .is_some_and(|value| !value.is_empty())
+            })
+        },
+    )
+}
+
+#[cfg(any(target_os = "windows", target_os = "macos", target_os = "linux"))]
 fn process_id_from_ready(contents: &str, label: &str) -> u32 {
     contents
         .lines()
@@ -546,6 +623,12 @@ fn hands_off_local_host_runtime_ownership_and_converges_on_stdin_eof() {
     let first_identity = wait_for_file(&first_ready, Duration::from_secs(5));
     let first_root = process_id_from_ready(&first_identity, "root=");
 
+    // Child readiness is written by the fake Host Runtime before the Shim atomically publishes
+    // that child's process-instance identity. Start the handoff clock only after publication has
+    // completed and the mutation lock is released; startup scheduling is not part of the bounded
+    // production handoff window tested below.
+    let _ = wait_for_complete_owner_record(&mut first, &directory, Duration::from_secs(10));
+
     let mut second = host_runtime_shim(&directory, &second_ready);
     let second_stdin = second.stdin.take().expect("second Host Runtime stdin");
     // Reap the old direct child before waiting for the replacement to publish readiness. Linux
@@ -580,7 +663,14 @@ fn hands_off_local_host_runtime_ownership_and_converges_on_stdin_eof() {
     );
     // A replacement can consume both the graceful and forced production handoff windows before
     // it launches its Host Runtime. Keep enough scheduling margin around that bounded takeover.
-    let second_identity = wait_for_file(&second_ready, Duration::from_secs(10));
+    let second_identity = wait_for_child_file_matching(
+        &mut second,
+        &second_ready,
+        &directory,
+        Duration::from_secs(10),
+        "replacement Host Runtime readiness failed",
+        |_| true,
+    );
     let second_root = process_id_from_ready(&second_identity, "root=");
 
     drop(second_stdin);
@@ -674,21 +764,7 @@ fn migrates_a_live_version_one_owner_before_starting_a_replacement() {
     );
 
     let owner_record = directory.join("local-host-runtime-owner-v1").join("owner");
-    let deadline = Instant::now() + Duration::from_secs(5);
-    let contents = loop {
-        let contents = fs::read_to_string(&owner_record).expect("read local Host Runtime owner");
-        if contents.lines().any(|line| {
-            line.strip_prefix("child_process_started_at_micros=")
-                .is_some_and(|value| !value.is_empty())
-        }) {
-            break contents;
-        }
-        assert!(
-            Instant::now() < deadline,
-            "timed out waiting for the complete local Host Runtime owner record"
-        );
-        thread::sleep(Duration::from_millis(20));
-    };
+    let contents = wait_for_complete_owner_record(&mut owner, &directory, Duration::from_secs(10));
     let field = |name: &str| {
         contents
             .lines()
@@ -751,21 +827,7 @@ fn waits_for_a_version_one_owner_to_publish_its_child_before_migration() {
     );
 
     let owner_record = directory.join("local-host-runtime-owner-v1").join("owner");
-    let owner_record_deadline = Instant::now() + Duration::from_secs(5);
-    let contents = loop {
-        let contents = fs::read_to_string(&owner_record).expect("read local Host Runtime owner");
-        if contents.lines().any(|line| {
-            line.strip_prefix("child_process_started_at_micros=")
-                .is_some_and(|value| !value.is_empty())
-        }) {
-            break contents;
-        }
-        assert!(
-            Instant::now() < owner_record_deadline,
-            "timed out waiting for the complete local Host Runtime owner record"
-        );
-        thread::sleep(Duration::from_millis(20));
-    };
+    let contents = wait_for_complete_owner_record(&mut owner, &directory, Duration::from_secs(10));
     let field = |name: &str| {
         contents
             .lines()
@@ -1017,21 +1079,7 @@ fn replacement_does_not_signal_a_reused_owner_process_id() {
     );
 
     let owner_record = directory.join("local-host-runtime-owner-v1").join("owner");
-    let deadline = Instant::now() + Duration::from_secs(5);
-    let contents = loop {
-        let contents = fs::read_to_string(&owner_record).expect("read local Host Runtime owner");
-        if contents.lines().any(|line| {
-            line.strip_prefix("child_process_started_at_micros=")
-                .is_some_and(|value| !value.is_empty())
-        }) {
-            break contents;
-        }
-        assert!(
-            Instant::now() < deadline,
-            "timed out waiting for the complete local Host Runtime owner record"
-        );
-        thread::sleep(Duration::from_millis(20));
-    };
+    let contents = wait_for_complete_owner_record(&mut owner, &directory, Duration::from_secs(10));
     let mut replaced_start_time = false;
     let mut recycled = contents
         .lines()

--- a/crates/shim/tests/proxy.rs
+++ b/crates/shim/tests/proxy.rs
@@ -655,6 +655,69 @@ fn replacement_waits_for_the_local_runtime_owner_mutation_lock() {
 
 #[cfg(any(target_os = "windows", target_os = "macos", target_os = "linux"))]
 #[test]
+fn migrates_a_live_version_one_owner_before_starting_a_replacement() {
+    let directory = temporary_directory();
+    let owner_ready = directory.join("owner-ready");
+    let replacement_ready = directory.join("replacement-ready");
+    let mut owner = host_runtime_shim(&directory, &owner_ready);
+    let owner_stdin = owner.stdin.take().expect("owner Host Runtime stdin");
+    let owner_root = process_id_from_ready(
+        &wait_for_file(&owner_ready, Duration::from_secs(5)),
+        "root=",
+    );
+
+    let owner_record = directory.join("local-host-runtime-owner-v1").join("owner");
+    let contents = wait_for_file(&owner_record, Duration::from_secs(5));
+    let field = |name: &str| {
+        contents
+            .lines()
+            .find_map(|line| line.strip_prefix(&format!("{name}=")))
+            .unwrap_or_else(|| panic!("owner record omitted {name}"))
+    };
+    fs::write(
+        &owner_record,
+        format!(
+            "version=1\nprocess_id={}\ndesktop_process_id={}\nchild_process_id={}\n",
+            field("process_id"),
+            field("desktop_process_id"),
+            field("child_process_id"),
+        ),
+    )
+    .expect("publish version-one owner record");
+
+    let mut replacement = host_runtime_shim(&directory, &replacement_ready);
+    let replacement_stdin = replacement
+        .stdin
+        .take()
+        .expect("replacement Host Runtime stdin");
+    let replacement_identity = wait_for_file(&replacement_ready, Duration::from_secs(5));
+    let replacement_root = process_id_from_ready(&replacement_identity, "root=");
+    let owner_was_retired = wait_for_process_exit(&mut owner, Duration::from_secs(2));
+
+    drop(owner_stdin);
+    if !owner_was_retired {
+        force_stop_test_process(owner.id());
+        force_stop_test_process(owner_root);
+        let _ = owner.wait();
+    }
+    drop(replacement_stdin);
+    if !wait_for_process_exit(&mut replacement, Duration::from_secs(5)) {
+        force_stop_test_process(replacement.id());
+        force_stop_test_process(replacement_root);
+        let _ = replacement.wait();
+        let _ = fs::remove_dir_all(&directory);
+        panic!("replacement Host Runtime did not converge after legacy owner migration");
+    }
+    let _ = fs::remove_dir_all(&directory);
+
+    assert!(
+        owner_was_retired && !process_exists(owner_root),
+        "replacement started without retiring the live version-one owner"
+    );
+}
+
+#[cfg(any(target_os = "windows", target_os = "macos", target_os = "linux"))]
+#[test]
 fn replacement_does_not_signal_a_reused_owner_process_id() {
     let directory = temporary_directory();
     let owner_ready = directory.join("owner-ready");

--- a/crates/shim/tests/proxy.rs
+++ b/crates/shim/tests/proxy.rs
@@ -404,7 +404,12 @@ fn reports_an_official_cli_crash_without_polluting_stdout() {
     let output = run_shim(b"", &[], &[("FAKE_CODEX_CRASH", "1")]);
     assert!(!output.status.success());
     assert!(output.stdout.is_empty());
-    assert!(String::from_utf8_lossy(&output.stderr).contains("terminated by signal"));
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("terminated by signal"),
+        "unexpected crash status {:?} with stderr: {stderr}",
+        output.status
+    );
 }
 
 fn wait_for_file(path: &std::path::Path, timeout: Duration) -> String {
@@ -570,7 +575,7 @@ fn hands_off_local_host_runtime_ownership_and_converges_on_stdin_eof() {
     }
     drop(first_stdin);
     assert!(
-        !process_exists(first_root),
+        wait_for_process_id_exit(first_root, Duration::from_secs(5)),
         "previous Host Runtime PID {first_root} survived ownership handoff"
     );
     let second_identity = wait_for_file(&second_ready, Duration::from_secs(5));
@@ -585,7 +590,7 @@ fn hands_off_local_host_runtime_ownership_and_converges_on_stdin_eof() {
         panic!("Host Runtime Shim did not converge after Desktop stdin EOF");
     }
     assert!(
-        !process_exists(second_root),
+        wait_for_process_id_exit(second_root, Duration::from_secs(5)),
         "Host Runtime PID {second_root} survived Desktop stdin EOF"
     );
     fs::remove_dir_all(directory).expect("remove Host Runtime handoff fixture");
@@ -823,7 +828,7 @@ fn retires_a_legacy_runtime_from_its_mapping_store_lock() {
     }
     drop(legacy_stdin);
     assert!(
-        !process_exists(legacy_root),
+        wait_for_process_id_exit(legacy_root, Duration::from_secs(5)),
         "legacy Host Runtime PID {legacy_root} survived ownership migration"
     );
     let replacement_identity = wait_for_file(&replacement_ready, Duration::from_secs(5));

--- a/crates/shim/tests/proxy.rs
+++ b/crates/shim/tests/proxy.rs
@@ -989,6 +989,57 @@ fn rejects_a_childless_version_one_owner_whose_process_id_was_reused() {
     );
 }
 
+#[cfg(any(target_os = "windows", target_os = "macos", target_os = "linux"))]
+#[test]
+fn discards_a_childless_version_one_owner_that_names_the_current_shim() {
+    let directory = temporary_directory();
+    let owner_directory = directory.join("local-host-runtime-owner-v1");
+    let replacement_ready = directory.join("replacement-ready");
+    let owner_lock = OpenOptions::new()
+        .read(true)
+        .write(true)
+        .create(true)
+        .truncate(false)
+        .open(directory.join("local-host-runtime-owner.lock"))
+        .expect("open local Host Runtime owner mutation lock");
+    owner_lock
+        .lock_exclusive()
+        .expect("hold local Host Runtime owner mutation lock");
+
+    let mut replacement = host_runtime_shim(&directory, &replacement_ready);
+    let replacement_stdin = replacement
+        .stdin
+        .take()
+        .expect("replacement Host Runtime stdin");
+    fs::create_dir(&owner_directory).expect("create stale version-one owner directory");
+    fs::write(
+        owner_directory.join("owner"),
+        format!(
+            "version=1\nprocess_id={}\ndesktop_process_id={}\nchild_process_id=\n",
+            replacement.id(),
+            process::id(),
+        ),
+    )
+    .expect("publish childless version-one self owner record");
+    FileExt::unlock(&owner_lock).expect("release local Host Runtime owner mutation lock");
+
+    let replacement_identity = wait_for_optional_file(&replacement_ready, Duration::from_secs(2));
+    drop(replacement_stdin);
+    if !wait_for_process_exit(&mut replacement, Duration::from_secs(1)) {
+        force_stop_test_process(replacement.id());
+        if let Some(identity) = replacement_identity.as_deref() {
+            force_stop_test_process(process_id_from_ready(identity, "root="));
+        }
+        let _ = replacement.wait();
+    }
+    let _ = fs::remove_dir_all(&directory);
+
+    assert!(
+        replacement_identity.is_some(),
+        "replacement waited on the childless version-one record that named its own Shim PID"
+    );
+}
+
 #[cfg(any(target_os = "macos", target_os = "linux"))]
 #[test]
 fn refuses_version_one_takeover_when_the_recorded_child_outlives_its_shim() {

--- a/crates/shim/tests/proxy.rs
+++ b/crates/shim/tests/proxy.rs
@@ -1565,7 +1565,17 @@ fn retires_a_legacy_runtime_from_its_mapping_store_lock() {
         wait_for_process_id_exit(legacy_root, Duration::from_secs(5)),
         "legacy Host Runtime PID {legacy_root} survived ownership migration"
     );
-    let replacement_identity = wait_for_file(&replacement_ready, Duration::from_secs(5));
+    // Legacy retirement can consume the four-second graceful window and the two-second forced
+    // window before the replacement publishes readiness. Keep the fixture outside that bounded
+    // production handoff and report an early Shim exit with its owner record and stderr.
+    let replacement_identity = wait_for_child_file_matching(
+        &mut replacement,
+        &replacement_ready,
+        &directory,
+        Duration::from_secs(10),
+        "replacement Host Runtime readiness failed after legacy retirement",
+        |_| true,
+    );
     let replacement_root = process_id_from_ready(&replacement_identity, "root=");
 
     drop(replacement_stdin);

--- a/crates/shim/tests/proxy.rs
+++ b/crates/shim/tests/proxy.rs
@@ -613,6 +613,15 @@ fn wait_for_process_id_exit(process_id: u32, timeout: Duration) -> bool {
 }
 
 #[cfg(any(target_os = "windows", target_os = "macos", target_os = "linux"))]
+fn exact_process_instance_is_executable(process_id: u32, started_at_micros: u64) -> bool {
+    // Linux keeps a killed child PID visible to kill(2) while its parent is about to reap the
+    // zombie, even though /proc/<pid>/exe is already gone. Match the production lease's exact
+    // process-instance semantics instead of treating that transient zombie as a live runtime.
+    process_snapshot(process_id)
+        .is_ok_and(|snapshot| snapshot.started_at_micros == started_at_micros)
+}
+
+#[cfg(any(target_os = "windows", target_os = "macos", target_os = "linux"))]
 #[test]
 fn hands_off_local_host_runtime_ownership_and_converges_on_stdin_eof() {
     let directory = temporary_directory();
@@ -1145,7 +1154,9 @@ fn retires_an_exact_owner_child_after_its_shim_exits() {
         .lines()
         .find_map(|line| line.strip_prefix("child_process_started_at_micros="))
         .filter(|value| !value.is_empty())
-        .expect("fixture child start identity");
+        .expect("fixture child start identity")
+        .parse::<u64>()
+        .expect("fixture child start identity micros");
     let mut reused_desktop_process = Command::new(fake_codex_path())
         .env("FAKE_CODEX_DELAY_MS", "60000")
         .stdin(Stdio::null())
@@ -1180,7 +1191,7 @@ fn retires_an_exact_owner_child_after_its_shim_exits() {
     fs::write(&owner_record, format!("{orphaned_exact_owner}\n"))
         .expect("publish orphaned exact owner record");
     assert!(
-        process_exists(fixture_root),
+        exact_process_instance_is_executable(fixture_root, fixture_child_started_at_micros),
         "exact child fixture exited before replacement"
     );
 
@@ -1193,7 +1204,8 @@ fn retires_an_exact_owner_child_after_its_shim_exits() {
     let replacement_root = replacement_identity
         .as_deref()
         .map(|identity| process_id_from_ready(identity, "root="));
-    let orphaned_child_was_retired = !process_exists(fixture_root);
+    let orphaned_child_was_retired =
+        !exact_process_instance_is_executable(fixture_root, fixture_child_started_at_micros);
     let reused_desktop_was_not_signalled = reused_desktop_process
         .try_wait()
         .expect("poll reused Desktop PID fixture")
@@ -1286,11 +1298,8 @@ fn replacement_does_not_signal_a_reused_owner_process_id() {
         .try_wait()
         .expect("poll reused owner PID fixture")
         .is_none();
-    // Linux keeps a killed child PID visible to kill(2) while its parent is about to reap the
-    // zombie, even though /proc/<pid>/exe is already gone. Match the production lease's exact
-    // process-instance semantics instead of treating that transient zombie as a live runtime.
-    let old_exact_child_was_retired = !process_snapshot(owner_root)
-        .is_ok_and(|snapshot| snapshot.started_at_micros == old_exact_child_started_at_micros);
+    let old_exact_child_was_retired =
+        !exact_process_instance_is_executable(owner_root, old_exact_child_started_at_micros);
 
     drop(owner_stdin);
     if !wait_for_process_exit(&mut owner, Duration::from_secs(5)) {

--- a/crates/shim/tests/proxy.rs
+++ b/crates/shim/tests/proxy.rs
@@ -578,7 +578,9 @@ fn hands_off_local_host_runtime_ownership_and_converges_on_stdin_eof() {
         wait_for_process_id_exit(first_root, Duration::from_secs(5)),
         "previous Host Runtime PID {first_root} survived ownership handoff"
     );
-    let second_identity = wait_for_file(&second_ready, Duration::from_secs(5));
+    // A replacement can consume both the graceful and forced production handoff windows before
+    // it launches its Host Runtime. Keep enough scheduling margin around that bounded takeover.
+    let second_identity = wait_for_file(&second_ready, Duration::from_secs(10));
     let second_root = process_id_from_ready(&second_identity, "root=");
 
     drop(second_stdin);


### PR DESCRIPTION
## Summary

- keep exact owner records encoded as `version=1` so released readers remain compatible
- recognize the released `version=1` record shape that has no process start identities
- validate a childless v1 Shim and pin its exact PID/start identity before waiting for child publication
- snapshot the verified Shim/child lineage under the owner mutation lock and publish exact identities before sending any signal
- preserve a verified child across migration-time reparenting, and fail closed if a still-live child has already escaped the recorded Shim lineage
- retire an exact recorded child when its migrated Shim exits, while distinguishing a missing Shim from PID reuse or an executable mismatch
- stop a stale PID-only Desktop identity from blocking exact-child cleanup after the verified Shim is missing or reused
- ignore a recycled PID-only v1 child identity on Windows after its supervising Shim is gone
- retry acquisition when a released v1 Shim removes its owner directory during migration publication
- discard a released childless v1 record that names the acquiring Shim before attempting migration or stabilization
- accept Linux's `/proc/<pid>/exe` ` (deleted)` suffix after an in-place npm upgrade
- retry bounded Windows atomic replacement conflicts caused by transient readers or real-time scanners
- cover released-v1 migration, rollback compatibility, startup publication, PID reuse, reparenting, directory disappearance, deleted Linux executables, and Windows sharing conflicts with regressions

## Why

This is a focused follow-up to #32 and addresses the compatibility gap identified in [the review discussion](https://github.com/BytePioneer-AI/codex-host/pull/32#discussion_r3838969510).

The owner records written by released builds contain PIDs but no process start identities. After #32, treating that released v1 shape as malformed could remove a still-live owner directory and allow a second local Host Runtime to start. This change migrates a verified live v1 owner to the exact start-identity representation under the same mutation lock before the existing handoff logic can signal it. Exact records keep `version=1`, because released readers ignore the additional fields and must continue honoring a newer live owner after a rollback or mixed-version launch.

A released v1 Shim can also be between its owner check and child publication while a newer launcher starts. The released writer does not take the new mutation lock. The migration now validates the candidate executable and Desktop lineage first, pins that exact Shim instance, and keeps revalidating it while the childless record stabilizes. Once the released owner publishes a child, migration snapshots the child only with proven parent lineage and preserves that exact snapshot if the Shim exits and the child is subsequently reparented. Ambiguous live processes fail closed instead of being signalled or discarded.

Windows may temporarily reject an otherwise safe `MoveFileExW(..., REPLACE_EXISTING | WRITE_THROUGH)` while a reader or real-time scanner holds the target without delete sharing. Owner publication previously treated that transient `ERROR_ACCESS_DENIED`, sharing violation, or lock violation as fatal, leaving the initial childless record behind. Atomic replacement now retries only those three transient conflicts for a bounded two-second window and preserves every other error immediately.

After migration publishes exact Shim and child identities, the Shim can still exit before the normal handoff validation. A missing exact Shim or a reused Shim PID now retires the exact recorded child before a replacement starts without signalling the absent or reused Shim process. Once that exact Shim identity is gone, the record's PID-only Desktop field can no longer prove a live Desktop instance and therefore cannot block orphan cleanup if the PID has been recycled. A live process with the recorded Shim PID/start identity but a non-codexhost executable remains an untrusted record and is removed without signalling either that process or its claimed child. While the exact Shim remains valid, a still-live different Desktop continues to block takeover.

A released childless v1 record cannot legitimately belong to the acquiring Shim: acquisition has not returned and that Shim has not spawned or published a Host Runtime child yet. If the stale record's PID has been recycled by the current Shim, the record is now removed before migration or child-publication stabilization can wait on the acquiring process itself. The exception is deliberately narrow: an exact same-PID record still errors, and any v1 record that already names a child still follows the strict migration and fail-closed path.

Released Windows Shims publish their Host Runtime child only after `spawn_supervised` has assigned it to a Job with `JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE`. Once that Shim is gone, its actual child cannot remain alive; a live process subsequently found at the record's PID-only v1 child ID is therefore PID reuse. The Windows acquisition path now removes that stale record without waiting on or signalling the unrelated process. This exception is Windows-only: macOS and Linux retain the strict live-child check because they do not have the same kill-on-close supervision invariant.

## Safety properties

- a stale or exited v1 Shim is removable
- a live v1 Shim is accepted only when its executable basename and Desktop lineage match
- a childless v1 owner is validated before waiting, and the same PID/start identity is revalidated throughout the startup grace period
- a released childless v1 record that names the acquiring Shim is discarded before stabilization, so the Shim never waits on itself
- an unrelated process that reused a stale childless owner PID is never waited on or signalled
- after a released Windows Shim exits, an unrelated process that reuses its PID-only child ID is never waited on or signalled
- a live childless v1 record is never committed as an exact owner merely because the released writer has not published its child yet
- an optional child is captured only while still parented by the verified Shim
- a captured child remains authoritative across later reparenting; an already-reparented live child fails closed
- a captured exact child is retired before replacement when its Shim has exited or its PID was reused, without signalling the absent or reused Shim process
- after an exact Shim is missing or reused, its PID-only Desktop field cannot block child retirement or cause an unrelated recycled Desktop PID to be signalled
- an exact owner whose live PID/start identity has a mismatched executable is discarded without signalling that process or its claimed child
- an orphaned live Shim records its verified PID 1 parent, so reuse of the old Desktop PID cannot block takeover
- disappearance of the released owner directory is treated as a stale-owner retry, not a launch failure
- Linux package replacement preserves recognition of the still-live `codexhost-shim (deleted)` process
- the exact record is published atomically before termination begins
- Windows atomic publication retries only errors 5, 32, and 33, remains bounded, and retains the source until replacement succeeds
- stock passthrough and managed remote SSH behavior remain unchanged

## Temporary branch dependency

The current head merges the exact nine commits from #34. They stabilize the cross-platform lifecycle checks that exercise this handoff path: portable npm runtime fixtures, platform-correct lock-test coverage, legitimate same-PID shebang `exec` transitions, bounded process-exit and readiness observation, atomic updater-readiness publication in the macOS fixture, explicit owner-lock release, and retry of the Windows reset form of a transient controlled-attachment response. Once #34 lands on `main`, GitHub will naturally de-duplicate those commits from this PR.

## Validation

### Exact PR head `5ac4372f1f696515a7d7cfab1876cdc07c70e550`

- local Windows `npm run check`: passed
- Prettier, ESLint/boundaries, TypeScript: passed
- Vitest: 145 files passed, 1 skipped; 1115 tests passed, 15 skipped
- Rust workspace formatting and Clippy with `-D warnings`: passed
- Rust workspace tests: passed
- Launcher: 33 tests passed
- Platform: 26 tests passed, including the new Windows atomic-replacement regression
- Shim: 8 unit tests and 24 Windows integration tests passed
- Updater: 7 tests passed
- the Windows sharing-conflict regression was observed red with `code 5 / PermissionDenied` before the fix, then passed 25 consecutive post-fix runs
- the complete 20-test Shim lifecycle suite passed 4 concurrent workers x 50 runs (200 full suites) after the fix
- the missing-Shim exact-child regression failed before the fix and now passes
- the reused-Shim-PID regression failed before its follow-up fix and now proves both child retirement and no signal to the reused process
- the mismatched-executable regression proves both the exact live process and its claimed child remain untouched
- the stale PID-only Desktop regression failed before the orphan-cleanup fix and now proves that the exact child is retired without signalling the unrelated process that recycled the Desktop PID
- the Linux CI regression exposed a transient zombie as a PID-only false positive; the assertion now uses the same exact PID/start/executable identity semantics as the lease and passes on Ubuntu
- the childless-current-Shim regression was deterministic red in 3.67 seconds before the fix and green in 0.18 seconds after the fix
- the shared exact-instance retirement assertion now treats a Linux zombie as retired in both orphan-retirement regressions while still detecting PID/start-identity reuse
- the Windows reused-child-PID regression was deterministic red in 2.64 seconds before the fix and green in 0.83 seconds after the fix; it proves that replacement starts and the unrelated reused-PID process remains unsignalled
- the complete 24-test Windows Shim integration suite passed 10 consecutive rounds (240 cases) after the reused-child-PID fix
- the first exact-head attempt exposed one existing Ubuntu orphan-child fixture jitter and a Windows fixture whose five-second readiness wait was shorter than the production retirement bound (four seconds graceful plus two seconds forced); the unchanged Unix behavior passed on the next exact-head run, and the Windows fixture now observes the documented bound with child stderr and owner-record diagnostics

### GitHub Actions — exact head `5ac4372f1f696515a7d7cfab1876cdc07c70e550`

- run https://github.com/BytePioneer-AI/codex-host/actions/runs/32667947567 passed
- `windows-latest`: passed, including all 24 Windows Shim integration tests, the Windows-only atomic-replacement regression, and the reused-child-PID regression
- `ubuntu-latest`: passed, including all 25 Linux Shim integration tests, the Linux npm package smoke test, deleted-executable coverage, and exact-instance zombie retirement assertions
- `macos-14`: passed, including migration-time reparenting coverage

### Focused migration regressions

- `rejects_a_childless_version_one_owner_whose_process_id_was_reused`
- `refuses_version_one_takeover_when_the_recorded_child_outlives_its_shim`
- `a_missing_owner_directory_retries_version_one_migration`
- `matches_an_unlinked_linux_shim_executable`
- `retries_atomic_replace_while_a_transient_reader_blocks_deletion`
- `hands_off_local_host_runtime_ownership_and_converges_on_stdin_eof`
- `retires_an_exact_owner_child_after_its_shim_exits`
- `replacement_does_not_signal_a_reused_owner_process_id`
- `replacement_does_not_signal_an_exact_owner_with_a_mismatched_executable`
- `discards_a_childless_version_one_owner_that_names_the_current_shim`
- `ignores_a_reused_version_one_child_pid_after_its_shim_exits`

## Review

The focused specification and standards reviews reported `PASS / APPROVE`. A fresh Codex review is requested for exact head `5ac4372f1f696515a7d7cfab1876cdc07c70e550` after all three CI jobs passed.
