### PR TITLE
fix: stabilize cross-platform lifecycle checks

### DIFF
--- a/crates/launcher/src/active_update.rs
+++ b/crates/launcher/src/active_update.rs
@@ -333,8 +333,8 @@ mod tests {
     use super::{ACTIVE_UPDATE_LOCK_FILE, PendingUpdate, waiting_for_launcher_exit_at};
     #[cfg(target_os = "macos")]
     use super::{
-        pending_startable_update_at, pending_update_at, transfer_lock_to_updater,
-        wait_for_updater_ready,
+        atomic_replace_file, pending_startable_update_at, pending_update_at,
+        transfer_lock_to_updater, wait_for_updater_ready,
     };
 
     fn fixture_directory(label: &str) -> PathBuf {
@@ -450,8 +450,10 @@ mod tests {
         let ready_status_path = status_path.clone();
         let writer = std::thread::spawn(move || {
             std::thread::sleep(std::time::Duration::from_millis(50));
+            let temporary_status_path = ready_status_path
+                .with_file_name(format!(".{STATUS_FILE}.{}.tmp", std::process::id()));
             fs::write(
-                ready_status_path,
+                &temporary_status_path,
                 format!(
                     "{}\n",
                     json!({
@@ -464,6 +466,8 @@ mod tests {
                 ),
             )
             .expect("write waiting status fixture");
+            atomic_replace_file(&temporary_status_path, &ready_status_path)
+                .expect("publish waiting status fixture");
         });
         let started = std::time::Instant::now();
         wait_for_updater_ready(&mut child, &status_path).expect("wait for updater readiness");

--- a/crates/launcher/src/desktop_attachment.rs
+++ b/crates/launcher/src/desktop_attachment.rs
@@ -2,7 +2,7 @@
 use std::env;
 use std::error::Error;
 use std::ffi::OsString;
-use std::io::{BufRead, BufReader, Write};
+use std::io::{self, BufRead, BufReader, Write};
 use std::net::{TcpListener, TcpStream};
 use std::path::Path;
 use std::thread;
@@ -178,7 +178,13 @@ fn send_controlled_attachment(
     stream.set_write_timeout(Some(Duration::from_secs(2)))?;
     writeln!(stream, "ATTACH {}", descriptor.nonce)?;
     let mut response = String::new();
-    BufReader::new(stream).read_line(&mut response)?;
+    match BufReader::new(stream).read_line(&mut response) {
+        Ok(_) => {}
+        // An orderly Controller close is an empty response, but Winsock may surface the same
+        // close as WSAECONNRESET. Both mean the controlled Desktop is not attachable yet.
+        Err(error) if error.kind() == io::ErrorKind::ConnectionReset => return Ok(false),
+        Err(error) => return Err(error.into()),
+    }
     match response.trim_end() {
         "ready" => Ok(true),
         "rejected" => Err("Desktop Controller rejected the attachment nonce".into()),

--- a/crates/launcher/src/main.rs
+++ b/crates/launcher/src/main.rs
@@ -1773,14 +1773,20 @@ mod tests {
 
     #[test]
     fn npm_update_runtime_environment_forwards_only_absolute_paths() {
+        let fixture_root = std::env::current_dir()
+            .expect("resolve current directory")
+            .join("npm-runtime-fixture");
+        let node_path = fixture_root.join("node");
+        let cli_path = fixture_root.join("npm/bin/npm-cli.js");
+        let package_root = fixture_root.join("@codexhost/cli-platform");
         let forwarded = npm_update_runtime_environment([
             (
                 OsString::from(NPM_NODE_PATH_ENV),
-                OsString::from("/usr/bin/node"),
+                node_path.clone().into_os_string(),
             ),
             (
                 OsString::from(NPM_CLI_PATH_ENV),
-                OsString::from("/usr/lib/node_modules/npm/bin/npm-cli.js"),
+                cli_path.clone().into_os_string(),
             ),
             (
                 OsString::from(NPM_LAUNCHER_PATH_ENV),
@@ -1788,11 +1794,11 @@ mod tests {
             ),
             (
                 OsString::from(NPM_PACKAGE_ROOT_ENV),
-                OsString::from("/usr/lib/node_modules/@codexhost/cli-darwin-arm64"),
+                package_root.clone().into_os_string(),
             ),
             (
                 OsString::from("UNRELATED"),
-                OsString::from("/tmp/unrelated"),
+                fixture_root.join("unrelated").into_os_string(),
             ),
         ]);
 
@@ -1801,15 +1807,12 @@ mod tests {
             [
                 (
                     OsString::from(NPM_NODE_PATH_ENV),
-                    OsString::from("/usr/bin/node"),
+                    node_path.into_os_string(),
                 ),
-                (
-                    OsString::from(NPM_CLI_PATH_ENV),
-                    OsString::from("/usr/lib/node_modules/npm/bin/npm-cli.js"),
-                ),
+                (OsString::from(NPM_CLI_PATH_ENV), cli_path.into_os_string(),),
                 (
                     OsString::from(NPM_PACKAGE_ROOT_ENV),
-                    OsString::from("/usr/lib/node_modules/@codexhost/cli-darwin-arm64"),
+                    package_root.into_os_string(),
                 ),
             ]
         );

--- a/crates/platform/src/process.rs
+++ b/crates/platform/src/process.rs
@@ -242,11 +242,18 @@ pub fn desktop_process_tree(
 }
 
 #[cfg(any(target_os = "macos", target_os = "linux"))]
+enum RootExecutablePolicy {
+    Fixed,
+    FollowSameProcess,
+}
+
+#[cfg(any(target_os = "macos", target_os = "linux"))]
 pub(crate) struct ObservedProcessTree {
     pub(crate) root: ProcessSnapshot,
     known: Vec<ProcessSnapshot>,
     process_group_id: Option<u32>,
     process_group_started_at_micros: u64,
+    root_executable_policy: RootExecutablePolicy,
 }
 
 #[cfg(any(target_os = "macos", target_os = "linux"))]
@@ -254,6 +261,12 @@ impl ObservedProcessTree {
     pub(crate) fn new(root: ProcessSnapshot) -> Self {
         let process_group_id = (root.process_group_id == root.id).then_some(root.process_group_id);
         Self::new_with_process_group(root, process_group_id, None)
+    }
+
+    pub(crate) fn new_following_root_exec(root: ProcessSnapshot) -> Self {
+        let mut tree = Self::new(root);
+        tree.root_executable_policy = RootExecutablePolicy::FollowSameProcess;
+        tree
     }
 
     pub(crate) fn new_with_process_group(
@@ -287,6 +300,7 @@ impl ObservedProcessTree {
                 .unwrap_or(root.started_at_micros),
             known,
             root,
+            root_executable_policy: RootExecutablePolicy::Fixed,
         }
     }
 
@@ -305,10 +319,16 @@ impl ObservedProcessTree {
                     )));
                 }
                 if expected.id == self.root.id && current.executable != self.root.executable {
-                    return Err(PlatformError::Invalid(format!(
-                        "Desktop root PID {} changed executable identity",
-                        expected.id
-                    )));
+                    if matches!(self.root_executable_policy, RootExecutablePolicy::Fixed) {
+                        return Err(PlatformError::Invalid(format!(
+                            "Desktop root PID {} changed executable identity",
+                            expected.id
+                        )));
+                    }
+                    // A supervised root may legitimately exec into another executable while
+                    // retaining the same PID and start identity. Preserve the strict
+                    // process-instance check above, then follow that exact root across exec.
+                    self.root.executable = current.executable.clone();
                 }
                 *expected = current.clone();
             }

--- a/crates/platform/src/process_supervision.rs
+++ b/crates/platform/src/process_supervision.rs
@@ -297,7 +297,7 @@ pub fn spawn_supervised(command: &mut Command) -> Result<SupervisedChild, Platfo
     Ok(SupervisedChild {
         child,
         guard: Some(ChildProcessGuard {
-            tree: std::sync::Mutex::new(ObservedProcessTree::new(root)),
+            tree: std::sync::Mutex::new(ObservedProcessTree::new_following_root_exec(root)),
             armed: true,
         }),
     })
@@ -305,14 +305,14 @@ pub fn spawn_supervised(command: &mut Command) -> Result<SupervisedChild, Platfo
 
 #[cfg(all(test, any(target_os = "macos", target_os = "linux")))]
 mod tests {
-    use super::spawn_supervised;
+    use super::{spawn_supervised, unix_process_snapshot};
     use std::fs;
     use std::os::unix::fs::PermissionsExt;
     use std::process::Command;
-    use std::time::{SystemTime, UNIX_EPOCH};
+    use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
     #[test]
-    fn accepts_a_shebang_script_that_runs_under_an_interpreter() {
+    fn tracks_a_shebang_root_across_an_exec_transition() {
         let unique = SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .expect("system clock is before the Unix epoch")
@@ -323,8 +323,12 @@ mod tests {
         ));
         fs::create_dir(&directory).expect("create temporary directory");
         let script = directory.join("codex.js");
-        fs::write(&script, "#!/bin/sh\ntrap 'exit 0' TERM INT\nsleep 30\n")
-            .expect("write shebang script");
+        let exec_ready = directory.join("exec-ready");
+        fs::write(
+            &script,
+            "#!/bin/sh\nwhile [ ! -e \"$CODEXHOST_EXEC_READY\" ]; do /bin/sleep 0.01; done\nexec /bin/sleep 30\n",
+        )
+        .expect("write shebang script");
         let mut permissions = fs::metadata(&script)
             .expect("stat shebang script")
             .permissions();
@@ -332,8 +336,29 @@ mod tests {
         fs::set_permissions(&script, permissions).expect("make shebang script executable");
 
         let mut command = Command::new(&script);
+        command.env("CODEXHOST_EXEC_READY", &exec_ready);
         let mut child =
             spawn_supervised(&mut command).expect("supervise an interpreter-backed executable");
+        fs::write(&exec_ready, b"ready").expect("release the shebang exec transition");
+        let expected_executable = fs::canonicalize("/bin/sleep").expect("resolve /bin/sleep");
+        let deadline = Instant::now() + Duration::from_secs(5);
+        loop {
+            let snapshot = unix_process_snapshot(child.id()).expect("observe shebang root process");
+            if snapshot.executable == expected_executable {
+                break;
+            }
+            if Instant::now() >= deadline {
+                let _ = child.force_terminate();
+                let _ = child.wait();
+                let _ = fs::remove_dir_all(&directory);
+                panic!(
+                    "shebang root did not exec {} (observed {})",
+                    expected_executable.display(),
+                    snapshot.executable.display()
+                );
+            }
+            std::thread::sleep(Duration::from_millis(10));
+        }
         child
             .force_terminate()
             .expect("terminate supervised script");

--- a/crates/shim/src/local_runtime_lease.rs
+++ b/crates/shim/src/local_runtime_lease.rs
@@ -441,10 +441,11 @@ fn terminate_recorded_process(
     Ok(())
 }
 
-// This in-process contender is meaningful only with Windows handle-scoped locks. Unix flock locks
-// are process-scoped, so `replacement_waits_for_the_local_runtime_owner_mutation_lock` provides
-// the cross-process integration coverage there.
-#[cfg(all(test, target_os = "windows"))]
+// Separate Windows handles and Linux open file descriptions contend even within one process, so
+// this focused unit test covers both platforms. macOS treats these flock acquisitions as
+// process-scoped; `replacement_waits_for_the_local_runtime_owner_mutation_lock` provides the
+// cross-process integration coverage there.
+#[cfg(all(test, any(target_os = "windows", target_os = "linux")))]
 mod tests {
     use super::*;
 

--- a/crates/shim/src/local_runtime_lease.rs
+++ b/crates/shim/src/local_runtime_lease.rs
@@ -108,6 +108,14 @@ impl OwnerMutationLock {
     }
 }
 
+impl Drop for OwnerMutationLock {
+    fn drop(&mut self) {
+        // Child publication is the ownership handoff boundary. Release it explicitly instead of
+        // relying on platform-specific file-close timing before a contender observes that boundary.
+        let _ = FileExt::unlock(&self._file);
+    }
+}
+
 impl LocalRuntimeLease {
     pub(crate) fn acquire(data_directory: &Path) -> Result<Self, Box<dyn Error>> {
         fs::create_dir_all(data_directory)?;

--- a/crates/shim/src/local_runtime_lease.rs
+++ b/crates/shim/src/local_runtime_lease.rs
@@ -442,12 +442,23 @@ fn terminate_recorded_process(
 }
 
 // Separate Windows handles and Linux open file descriptions contend even within one process, so
-// this focused unit test covers both platforms. macOS treats these flock acquisitions as
-// process-scoped; `replacement_waits_for_the_local_runtime_owner_mutation_lock` provides the
-// cross-process integration coverage there.
+// this focused unit test covers both platforms. Each boundary observation uses a freshly opened
+// contender, matching separate replacement processes and avoiding reuse of a failed flock attempt.
+// macOS treats these flock acquisitions as process-scoped;
+// `replacement_waits_for_the_local_runtime_owner_mutation_lock` provides the cross-process
+// integration coverage there.
 #[cfg(all(test, any(target_os = "windows", target_os = "linux")))]
 mod tests {
     use super::*;
+
+    fn contender_can_acquire(data_directory: &Path) -> bool {
+        let contender = OwnerMutationLock::open(data_directory).expect("open contender owner lock");
+        let acquired = contender.try_lock_exclusive().is_ok();
+        if acquired {
+            FileExt::unlock(&contender).expect("release contender owner lock");
+        }
+        acquired
+    }
 
     fn temporary_data_directory() -> PathBuf {
         static NEXT_DIRECTORY: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
@@ -462,26 +473,13 @@ mod tests {
     fn holds_the_mutation_lock_until_child_identity_is_published() {
         let data_directory = temporary_data_directory();
         let mut lease = LocalRuntimeLease::acquire(&data_directory).expect("acquire owner lease");
-        let contender = OpenOptions::new()
-            .read(true)
-            .write(true)
-            .open(data_directory.join(OWNER_LOCK_NAME))
-            .expect("open contender owner lock");
-
-        let contender_acquired_before_publish = contender.try_lock_exclusive().is_ok();
-        if contender_acquired_before_publish {
-            FileExt::unlock(&contender).expect("release unexpected contender lock");
-        }
+        let contender_acquired_before_publish = contender_can_acquire(&data_directory);
 
         lease
             .set_child_process_id(process::id())
             .expect("publish child identity");
-        let contender_acquired_after_publish = contender.try_lock_exclusive().is_ok();
-        if contender_acquired_after_publish {
-            FileExt::unlock(&contender).expect("release contender owner lock");
-        }
+        let contender_acquired_after_publish = contender_can_acquire(&data_directory);
 
-        drop(contender);
         drop(lease);
         fs::remove_dir_all(&data_directory).expect("remove owner lease fixture");
 

--- a/crates/shim/src/local_runtime_lease.rs
+++ b/crates/shim/src/local_runtime_lease.rs
@@ -441,7 +441,10 @@ fn terminate_recorded_process(
     Ok(())
 }
 
-#[cfg(test)]
+// This in-process contender is meaningful only with Windows handle-scoped locks. Unix flock locks
+// are process-scoped, so `replacement_waits_for_the_local_runtime_owner_mutation_lock` provides
+// the cross-process integration coverage there.
+#[cfg(all(test, target_os = "windows"))]
 mod tests {
     use super::*;
 

--- a/crates/shim/tests/proxy.rs
+++ b/crates/shim/tests/proxy.rs
@@ -404,7 +404,12 @@ fn reports_an_official_cli_crash_without_polluting_stdout() {
     let output = run_shim(b"", &[], &[("FAKE_CODEX_CRASH", "1")]);
     assert!(!output.status.success());
     assert!(output.stdout.is_empty());
-    assert!(String::from_utf8_lossy(&output.stderr).contains("terminated by signal"));
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("terminated by signal"),
+        "unexpected crash status {:?} with stderr: {stderr}",
+        output.status
+    );
 }
 
 fn wait_for_file(path: &std::path::Path, timeout: Duration) -> String {
@@ -570,7 +575,7 @@ fn hands_off_local_host_runtime_ownership_and_converges_on_stdin_eof() {
     }
     drop(first_stdin);
     assert!(
-        !process_exists(first_root),
+        wait_for_process_id_exit(first_root, Duration::from_secs(5)),
         "previous Host Runtime PID {first_root} survived ownership handoff"
     );
     let second_identity = wait_for_file(&second_ready, Duration::from_secs(5));
@@ -585,7 +590,7 @@ fn hands_off_local_host_runtime_ownership_and_converges_on_stdin_eof() {
         panic!("Host Runtime Shim did not converge after Desktop stdin EOF");
     }
     assert!(
-        !process_exists(second_root),
+        wait_for_process_id_exit(second_root, Duration::from_secs(5)),
         "Host Runtime PID {second_root} survived Desktop stdin EOF"
     );
     fs::remove_dir_all(directory).expect("remove Host Runtime handoff fixture");
@@ -823,7 +828,7 @@ fn retires_a_legacy_runtime_from_its_mapping_store_lock() {
     }
     drop(legacy_stdin);
     assert!(
-        !process_exists(legacy_root),
+        wait_for_process_id_exit(legacy_root, Duration::from_secs(5)),
         "legacy Host Runtime PID {legacy_root} survived ownership migration"
     );
     let replacement_identity = wait_for_file(&replacement_ready, Duration::from_secs(5));

--- a/crates/shim/tests/proxy.rs
+++ b/crates/shim/tests/proxy.rs
@@ -578,7 +578,9 @@ fn hands_off_local_host_runtime_ownership_and_converges_on_stdin_eof() {
         wait_for_process_id_exit(first_root, Duration::from_secs(5)),
         "previous Host Runtime PID {first_root} survived ownership handoff"
     );
-    let second_identity = wait_for_file(&second_ready, Duration::from_secs(5));
+    // A replacement can consume both the graceful and forced production handoff windows before
+    // it launches its Host Runtime. Keep enough scheduling margin around that bounded takeover.
+    let second_identity = wait_for_file(&second_ready, Duration::from_secs(10));
     let second_root = process_id_from_ready(&second_identity, "root=");
 
     drop(second_stdin);


### PR DESCRIPTION
## Summary

- use platform-native absolute paths in the npm runtime environment fixture
- keep the focused in-process owner-lock unit test on Windows and Linux, while using cross-process coverage on macOS
- explicitly unlock the owner mutation guard at the child-publication handoff boundary
- follow legitimate Unix supervised-root `exec` transitions without relaxing PID/start-time identity checks
- wait for asynchronous Host Runtime cleanup and the complete bounded handoff before asserting
- retry a controlled Desktop attachment when Winsock reports an empty response as a reset
- publish the updater-readiness test status with the same atomic protocol used in production

## Problems

### Windows npm fixture

`npm_update_runtime_environment_forwards_only_absolute_paths` exercises
`Path::is_absolute()`, but its accepted fixtures were hard-coded as `/usr/bin/...`.
Those paths are absolute on Unix and relative on Windows, so the Windows job
deterministically received an empty result.

### Platform owner-lock fixture

`holds_the_mutation_lock_until_child_identity_is_published` opened a second lock
handle in the same process and treated it as a competing owner. Separate Windows
handles and Linux open file descriptions contend for this lock, so the focused
publication-boundary test is valid on both platforms. macOS treats these `flock`
acquisitions as process-scoped, so the same-process fixture is invalid there even
though the separate cross-process integration test passes. Each side of the
publication boundary must use a fresh descriptor: a Linux descriptor whose first
nonblocking `flock` attempt failed is not a reliable post-release observation. The
fresh-descriptor form then proved that relying only on file-close semantics did not
make the release synchronously observable on the Linux runner.

### Unix supervised-root exec transitions

Unix process identity already treats an unchanged PID plus start time as the same
process across `exec`, but `ObservedProcessTree::observe` still rejected a changed
root executable path. A shebang root or the official CLI can legitimately `exec`
another executable. Depending on timing, supervision therefore failed with
`changed executable identity` instead of observing or terminating the same process.

### Windows asynchronous cleanup

The local-runtime handoff tests asserted that the Host Runtime PID disappeared
immediately after the Shim exited. Windows Job Object cleanup is asynchronous, so
the process could still be visible for a short interval even though teardown was
already in progress.

The replacement-readiness fixture also allowed five seconds, while production can
legitimately consume a four-second graceful handoff plus a two-second forced
handoff before launch overhead. A loaded Windows runner could therefore fail the
fixture even though takeover remained inside the bounded production contract.

### Windows controlled-attachment reset

An attachment Controller that closes without a response produces an orderly EOF
on some runs, but Winsock can report the same loopback close as
`WSAECONNRESET`. The acquisition loop already treats an empty response as
transient; propagating the equivalent reset made Desktop attachment fail instead
of retrying.

### macOS updater-readiness fixture

The updater-readiness test overwrote `status-v1.json` with `fs::write`. That
temporarily truncates the file before writing the replacement JSON, so the
Launcher polling thread could observe an empty file and correctly reject it as
invalid. The production Updater never exposes that state: it writes and syncs a
temporary file, then atomically replaces the published status.

These failures are visible in [`main@4d1af29` / v0.3.2](https://github.com/BytePioneer-AI/codex-host/actions/runs/32651408930),
the first [PR #34 run](https://github.com/BytePioneer-AI/codex-host/actions/runs/32652942119),
the second [PR #34 run](https://github.com/BytePioneer-AI/codex-host/actions/runs/32653669370),
and the updater fixture race in the [post-review run](https://github.com/BytePioneer-AI/codex-host/actions/runs/32656237475).
The subsequent [Linux-focused review run](https://github.com/BytePioneer-AI/codex-host/actions/runs/32656747332)
also exposed the invalid reuse of one failed contender descriptor.
The [explicit-unlock run](https://github.com/BytePioneer-AI/codex-host/actions/runs/32657380156)
validated Linux and macOS, then exposed the undersized Windows handoff fixture.

## Fix

The launcher test now derives node, npm CLI, package-root, and unrelated paths
from an absolute current-directory fixture root. Its `codexhost.js` input stays
relative, so the test still proves that only allowlisted absolute values are
forwarded.

The in-process lock test is compiled on Windows and Linux. It opens a fresh
independent contender before and after child publication, matching separate
replacement processes and documenting the differing platform semantics. macOS
behavior remains covered through the real cross-process
`replacement_waits_for_the_local_runtime_owner_mutation_lock` test.
`OwnerMutationLock` now explicitly unlocks in `Drop`, so child publication and all
other guard-release paths establish the handoff boundary before closing the file.

Unix `spawn_supervised` now constructs its process tree with an explicit
`FollowSameProcess` root-executable policy. The existing PID and start-time check
runs before that policy can accept an executable change, so PID reuse remains a
hard failure. Desktop and other process trees keep the default `Fixed` policy.
A deterministic test holds a shebang interpreter until supervision starts, then
execs `/bin/sleep` and proves that the same root remains terminable.

The handoff assertions use bounded process-exit waits instead of assuming
synchronous Job Object cleanup. Replacement readiness now allows ten seconds,
covering both production handoff windows plus scheduling and launch overhead.

Controlled attachment treats `ConnectionReset` while reading the response like
the equivalent empty response: the current attachment attempt returns unavailable
and the bounded acquisition loop retries. Other read errors still fail closed.

The updater-readiness fixture now writes its replacement status to a temporary
file and publishes it with `atomic_replace_file`, matching the production
Updater contract without weakening the Launcher's fail-closed status parser.

## Validation

Windows:

- portable npm fixture: red on the exact base, green after the change
- `npm run check:rust`: passed, including workspace Clippy with `-D warnings`
- Rust: 33 launcher, 25 platform, 5 Shim unit, 17 Shim integration, and 7 updater tests passed
- local-runtime handoff test: 30 consecutive passes on the explicit-unlock head
- transient controlled-attachment test: 50 consecutive passes after reset handling

GitHub Actions on exact head `029b871`:

- `windows-latest`: passed
- `ubuntu-latest`: passed, including the Linux npm package smoke test
- `macos-14`: passed
- run: https://github.com/BytePioneer-AI/codex-host/actions/runs/32657988159

macOS arm64:

- full Prettier, ESLint/boundaries, TypeScript, and Vitest suite passed
- Vitest: 145 files passed, 1 skipped; 1124 tests passed, 6 skipped
- workspace Clippy with `-D warnings`: passed
- Rust: 37 launcher, 30 platform, 7 Shim unit, 25 Shim integration, and 7 updater tests passed
- deterministic shebang exec test: red before the production fix, green after it
- official CLI crash test: 20 consecutive passes after the exec-tracking fix
- updater-readiness handshake test: CI reproduced the non-atomic fixture failure; the atomic fixture passed 100 consecutive runs
- fresh detached clone of `4cb9dbc`: full `npm run check` passed before the final
  platform-neutral lock release and Windows-only attachment follow-ups

The cross-process owner-lock integration test remains enabled on Windows, macOS,
and Linux.
