### PR TITLE
feat: add Linux ARM64 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,3 +51,36 @@ jobs:
           node scripts/release/smoke-npm-package.mjs
           --target linux-x64
           --version 0.1.6-ci.0
+
+  check-linux-arm64:
+    name: Check Linux ARM64
+    runs-on: ubuntu-22.04-arm
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: .node-version
+          cache: npm
+
+      - name: Setup npm
+        run: npm install --global npm@11.8.0
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: 1.97.1
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Check
+        run: npm run check
+
+      - name: Smoke-test Linux ARM64 npm package
+        run: >
+          node scripts/release/smoke-npm-package.mjs
+          --target linux-arm64
+          --version 0.1.6-ci.0

--- a/.github/workflows/release-packages.yml
+++ b/.github/workflows/release-packages.yml
@@ -136,6 +136,9 @@ jobs:
           - target: linux-x64
             runner: ubuntu-22.04
             rustTarget: x86_64-unknown-linux-gnu
+          - target: linux-arm64
+            runner: ubuntu-22.04-arm
+            rustTarget: aarch64-unknown-linux-gnu
 
     steps:
       - name: Checkout release tag

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ https://github.com/user-attachments/assets/c48192d7-23ff-4f6e-b61a-6345a655bb76
 
 **使用 npm**
 
-> 支持 macOS、Windows 和 [x64 Linux](docs/linux.zh-CN.md)。
+> 支持 macOS、Windows 和 [x64/ARM64 Linux](docs/linux.zh-CN.md)。
 
 ```bash
 npm install -g @codexhost/cli

--- a/crates/platform/src/linux_installation.rs
+++ b/crates/platform/src/linux_installation.rs
@@ -13,6 +13,17 @@ const LINUX_PACKAGE_NAME: &str = "chatgpt";
 const ELF_MAGIC: [u8; 4] = [0x7f, b'E', b'L', b'F'];
 const ELF_CLASS_64: u8 = 2;
 const ELF_MACHINE_X86_64: u16 = 62;
+const ELF_MACHINE_AARCH64: u16 = 183;
+
+fn expected_elf_machine() -> Option<(u16, &'static str)> {
+    if cfg!(target_arch = "x86_64") {
+        Some((ELF_MACHINE_X86_64, "x86-64"))
+    } else if cfg!(target_arch = "aarch64") {
+        Some((ELF_MACHINE_AARCH64, "ARM64"))
+    } else {
+        None
+    }
+}
 
 #[derive(Deserialize)]
 #[serde(deny_unknown_fields)]
@@ -24,7 +35,12 @@ struct LinuxPackageMetadata {
     version: String,
 }
 
-fn canonical_linux_x64_elf(path: &Path, label: &str) -> Result<PathBuf, PlatformError> {
+fn canonical_linux_elf(path: &Path, label: &str) -> Result<PathBuf, PlatformError> {
+    let (expected_machine, architecture) = expected_elf_machine().ok_or_else(|| {
+        PlatformError::Unsupported(
+            "official ChatGPT Linux packages are unsupported on this architecture",
+        )
+    })?;
     let canonical = canonical_unix_executable(path, label)?;
     let mut header = [0_u8; 20];
     File::open(&canonical)?
@@ -39,10 +55,10 @@ fn canonical_linux_x64_elf(path: &Path, label: &str) -> Result<PathBuf, Platform
     if header[..4] != ELF_MAGIC
         || header[4] != ELF_CLASS_64
         || header[5] != 1
-        || machine != ELF_MACHINE_X86_64
+        || machine != expected_machine
     {
         return Err(PlatformError::Invalid(format!(
-            "{label} '{}' is not a little-endian x86-64 ELF executable",
+            "{label} '{}' is not a little-endian {architecture} ELF executable",
             path.display()
         )));
     }
@@ -102,11 +118,11 @@ fn linux_installation(
     }
 
     let desktop_executable =
-        canonical_linux_x64_elf(&install_root.join("ChatGPT"), "Desktop executable")?;
+        canonical_linux_elf(&install_root.join("ChatGPT"), "Desktop executable")?;
     let packaged_launcher =
         canonical_unix_executable(&install_root.join("codex-launcher"), "Desktop launcher")?;
     let packaged_codex_cli =
-        canonical_linux_x64_elf(&install_root.join("resources/codex"), "Codex CLI")?;
+        canonical_linux_elf(&install_root.join("resources/codex"), "Codex CLI")?;
     if !desktop_executable.starts_with(&install_root)
         || !packaged_launcher.starts_with(&install_root)
         || !packaged_codex_cli.starts_with(&install_root)
@@ -178,21 +194,27 @@ mod tests {
     use super::linux_installation;
     use crate::{DesktopIdentity, PlatformError, temporary_directory};
 
-    fn elf_x64() -> Vec<u8> {
+    fn elf(machine: u16) -> Vec<u8> {
         let mut header = vec![0_u8; 20];
         header[..4].copy_from_slice(&[0x7f, b'E', b'L', b'F']);
         header[4] = 2;
         header[5] = 1;
-        header[18..20].copy_from_slice(&62_u16.to_le_bytes());
+        header[18..20].copy_from_slice(&machine.to_le_bytes());
         header
+    }
+
+    fn native_elf() -> Vec<u8> {
+        elf(super::expected_elf_machine()
+            .expect("supported test architecture")
+            .0)
     }
 
     fn fixture(brand: &str, flavor: &str) -> std::path::PathBuf {
         let root = temporary_directory("codexhost-linux-installation");
         fs::create_dir_all(root.join("resources")).expect("create resources");
-        fs::write(root.join("ChatGPT"), elf_x64()).expect("write Desktop");
+        fs::write(root.join("ChatGPT"), native_elf()).expect("write Desktop");
         fs::write(root.join("codex-launcher"), b"launcher").expect("write Desktop launcher");
-        fs::write(root.join("resources/codex"), elf_x64()).expect("write CLI");
+        fs::write(root.join("resources/codex"), native_elf()).expect("write CLI");
         fs::write(root.join("resources/app.asar"), b"asar").expect("write app.asar");
         fs::write(
             root.join("resources/linux-package-metadata.json"),
@@ -286,9 +308,13 @@ mod tests {
 
         let wrong_architecture = fixture("chatgpt", "prod");
         let wrong_architecture_launcher = launcher(&wrong_architecture);
-        let mut arm64 = elf_x64();
-        arm64[18..20].copy_from_slice(&183_u16.to_le_bytes());
-        fs::write(wrong_architecture.join("ChatGPT"), arm64).expect("write ARM64 Desktop");
+        let wrong_machine = if cfg!(target_arch = "aarch64") {
+            62
+        } else {
+            183
+        };
+        fs::write(wrong_architecture.join("ChatGPT"), elf(wrong_machine))
+            .expect("write wrong-architecture Desktop");
         assert!(matches!(
             linux_installation(&wrong_architecture, &wrong_architecture_launcher),
             Err(PlatformError::Invalid(_))
@@ -296,10 +322,25 @@ mod tests {
         fs::remove_dir_all(wrong_architecture).expect("remove wrong architecture fixture");
         fs::remove_file(wrong_architecture_launcher).expect("remove wrong architecture launcher");
 
+        let wrong_cli_architecture = fixture("chatgpt", "prod");
+        let wrong_cli_architecture_launcher = launcher(&wrong_cli_architecture);
+        fs::write(
+            wrong_cli_architecture.join("resources/codex"),
+            elf(wrong_machine),
+        )
+        .expect("write wrong-architecture CLI");
+        assert!(matches!(
+            linux_installation(&wrong_cli_architecture, &wrong_cli_architecture_launcher),
+            Err(PlatformError::Invalid(_))
+        ));
+        fs::remove_dir_all(wrong_cli_architecture).expect("remove wrong CLI architecture fixture");
+        fs::remove_file(wrong_cli_architecture_launcher)
+            .expect("remove wrong CLI architecture launcher");
+
         let escaped = fixture("chatgpt", "prod");
         let escaped_launcher = launcher(&escaped);
         let external = escaped.parent().expect("parent").join("external-codex");
-        fs::write(&external, elf_x64()).expect("write external CLI");
+        fs::write(&external, native_elf()).expect("write external CLI");
         fs::set_permissions(&external, fs::Permissions::from_mode(0o755))
             .expect("make external executable");
         fs::remove_file(escaped.join("resources/codex")).expect("remove CLI");

--- a/crates/platform/src/linux_installation.rs
+++ b/crates/platform/src/linux_installation.rs
@@ -36,11 +36,10 @@ struct LinuxPackageMetadata {
 }
 
 fn canonical_linux_elf(path: &Path, label: &str) -> Result<PathBuf, PlatformError> {
-    let (expected_machine, architecture) = expected_elf_machine().ok_or_else(|| {
-        PlatformError::Unsupported(
+    let (expected_machine, architecture) =
+        expected_elf_machine().ok_or(PlatformError::Unsupported(
             "official ChatGPT Linux packages are unsupported on this architecture",
-        )
-    })?;
+        ))?;
     let canonical = canonical_unix_executable(path, label)?;
     let mut header = [0_u8; 20];
     File::open(&canonical)?

--- a/docs/README.en.md
+++ b/docs/README.en.md
@@ -46,7 +46,7 @@ https://github.com/user-attachments/assets/c48192d7-23ff-4f6e-b61a-6345a655bb76
 
 **Use npm**
 
-> Supports macOS, Windows, and [x64 Linux](linux.md).
+> Supports macOS, Windows, and [x64/ARM64 Linux](linux.md).
 
 ```bash
 npm install -g @codexhost/cli

--- a/docs/README.ko.md
+++ b/docs/README.ko.md
@@ -45,7 +45,7 @@ https://github.com/user-attachments/assets/c48192d7-23ff-4f6e-b61a-6345a655bb76
 
 **npm 사용**
 
-> macOS, Windows 및 [x64 Linux](linux.md)를 지원합니다.
+> macOS, Windows 및 [x64/ARM64 Linux](linux.md)를 지원합니다.
 
 ```bash
 npm install -g @codexhost/cli

--- a/docs/index.md
+++ b/docs/index.md
@@ -23,7 +23,7 @@
 
 | 文档 | 作用 |
 |---|---|
-| [`linux.zh-CN.md`](linux.zh-CN.md) | 说明 x64 Linux 上安装、兼容性、进程所有权和诊断方法。 |
+| [`linux.zh-CN.md`](linux.zh-CN.md) | 说明 x64/ARM64 Linux 上安装、兼容性、进程所有权和诊断方法。 |
 | [`linux.md`](linux.md) | 提供 Linux 安装与诊断说明的英文版本。 |
 | [`remote-ssh-host.zh-CN.md`](remote-ssh-host.zh-CN.md) | 说明通过 Codex Desktop 原生 SSH 工作流使用远程机器上的 Harness。 |
 | [`remote-ssh-host.md`](remote-ssh-host.md) | 提供 SSH 远程 Harness Host 使用说明的英文版本。 |

--- a/docs/linux.md
+++ b/docs/linux.md
@@ -1,6 +1,6 @@
 # Linux support
 
-codexhost supports x64 Linux through the npm package. Install the official ChatGPT App first, then install codexhost:
+codexhost supports x64 and ARM64 Linux through the npm package. Install the official ChatGPT App matching the current architecture first, then install codexhost:
 
 ```bash
 npm install -g @codexhost/cli
@@ -9,13 +9,13 @@ codexhost
 
 ## Supported environment
 
-The first Linux release intentionally supports the official ChatGPT `.deb` and `.rpm` packages on x86-64. The codexhost Linux x64 native binaries use glibc 2.35 as their release baseline and can load on systems with glibc 2.35 or newer; the official ChatGPT App's distribution support remains defined by OpenAI's documentation. codexhost verifies the production package metadata and these packaged entry points:
+The Linux release supports the official ChatGPT `.deb` and `.rpm` packages on x86-64 and ARM64. The codexhost Linux native binaries use glibc 2.35 as their release baseline and can load on systems with glibc 2.35 or newer; the official ChatGPT App's distribution support remains defined by OpenAI's documentation. codexhost verifies the production package metadata, native ELF architecture, and these packaged entry points:
 
 - launcher: `/usr/bin/chatgpt`
 - installation: `/usr/lib/chatgpt`
 - Desktop executable: `/usr/lib/chatgpt/ChatGPT`
 
-The runtime requires a mounted `/proc` and Linux `pidfd` support. Snap, Flatpak, AppImage, local or relocated installations, wrapper or `alternatives` launchers, ARM64, and Linux installer/self-update packages are not supported yet.
+The runtime requires a mounted `/proc` and Linux `pidfd` support. Snap, Flatpak, AppImage, local or relocated installations, wrapper or `alternatives` launchers, cross-architecture execution, and codexhost Linux installer packages are not supported. codexhost is installed and updated through npm on Linux.
 
 ## Renderer compatibility
 

--- a/docs/linux.zh-CN.md
+++ b/docs/linux.zh-CN.md
@@ -1,6 +1,6 @@
 # Linux 支持
 
-codexhost 通过 npm 包支持 x64 Linux。请先安装官方 ChatGPT App，再安装 codexhost：
+codexhost 通过 npm 包支持 x64 和 ARM64 Linux。请先安装与当前架构匹配的官方 ChatGPT App，再安装 codexhost：
 
 ```bash
 npm install -g @codexhost/cli
@@ -9,13 +9,13 @@ codexhost
 
 ## 支持范围
 
-首个 Linux 版本有意只支持 x86-64 上的官方 ChatGPT `.deb` 和 `.rpm` 包。codexhost 的 Linux x64 原生二进制以 glibc 2.35 为发布基线，可在使用 glibc 2.35 或更新版本的系统上装载；官方 ChatGPT App 自身的发行版支持范围仍以 OpenAI 文档为准。codexhost 会验证生产包元数据和以下包内入口：
+Linux 版本支持 x86-64 和 ARM64 上的官方 ChatGPT `.deb` 和 `.rpm` 包。codexhost 的 Linux 原生二进制以 glibc 2.35 为发布基线，可在使用 glibc 2.35 或更新版本的系统上装载；官方 ChatGPT App 自身的发行版支持范围仍以 OpenAI 文档为准。codexhost 会验证生产包元数据、当前架构的 ELF 身份和以下包内入口：
 
 - 启动器：`/usr/bin/chatgpt`
 - 安装目录：`/usr/lib/chatgpt`
 - Desktop 可执行文件：`/usr/lib/chatgpt/ChatGPT`
 
-运行时要求 `/proc` 已挂载，并且 Linux 支持 `pidfd`。目前不支持 Snap、Flatpak、AppImage、本地或迁移后的安装、包装脚本或 `alternatives` 启动器、ARM64，以及 Linux installer/self-update 包。
+运行时要求 `/proc` 已挂载，并且 Linux 支持 `pidfd`。目前不支持 Snap、Flatpak、AppImage、本地或迁移后的安装、包装脚本或 `alternatives` 启动器、跨架构执行，以及 codexhost Linux installer 包。codexhost 在 Linux 上通过 npm 安装和更新。
 
 ## Renderer 兼容性
 

--- a/docs/remote-ssh-host.md
+++ b/docs/remote-ssh-host.md
@@ -7,7 +7,7 @@ This path keeps the native Codex Desktop UI and SSH transport. It does not turn 
 ## Prerequisites
 
 - Codex Desktop and codexhost on the client machine.
-- Codex CLI and the same codexhost version on a macOS or Linux SSH host.
+- Codex CLI and the same codexhost version on a macOS or x64/ARM64 Linux SSH host.
 - The desired Harness installed and authenticated on the SSH host. For Claude Code, run its normal login there; do not copy its account files to the client.
 - A working Codex Desktop SSH workspace before enabling codexhost.
 

--- a/docs/remote-ssh-host.zh-CN.md
+++ b/docs/remote-ssh-host.zh-CN.md
@@ -7,7 +7,7 @@ Codex Desktop 可以通过原生 SSH 工作流打开另一台机器上的项目�
 ## 前置条件
 
 - 客户端已安装 Codex Desktop 和 codexhost。
-- macOS 或 Linux SSH 开发机已安装 Codex CLI，以及与客户端相同版本的 codexhost。
+- macOS 或 x64/ARM64 Linux SSH 开发机已安装 Codex CLI，以及与客户端相同版本的 codexhost。
 - 目标 Harness 已在 SSH 开发机安装并登录。Claude Code 请在开发机完成正常登录，不要把账号文件复制到客户端。
 - 启用 codexhost 前，Codex Desktop 原生 SSH 工作区已经可以正常使用。
 

--- a/openspec/changes/add-linux-arm64-support/.openspec.yaml
+++ b/openspec/changes/add-linux-arm64-support/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-29

--- a/openspec/changes/add-linux-arm64-support/design.md
+++ b/openspec/changes/add-linux-arm64-support/design.md
@@ -1,0 +1,34 @@
+## Context
+
+Linux support currently assumes x86-64 at three boundaries: official Desktop ELF validation, the npm release target registry, and Linux Gate A evidence. The remaining Launcher, Shim, Host Runtime, Remote Host, `/proc`, pidfd, Unix socket, and process-supervision implementations are Linux-generic. OpenAI now publishes matching official ARM64 Desktop `.deb` and `.rpm` packages, so architecture support can be expressed as another native Linux target instead of a separate runtime path.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Treat `linux-arm64` as a first-class npm and distribution target.
+- Validate that official Linux Desktop and packaged Codex CLI ELF architectures match the codexhost build architecture.
+- Build, smoke-test, and publish the ARM64 package on a native GitHub Actions runner.
+- Allow Linux Gate A evidence to identify either supported native architecture.
+- Preserve npm-owned update behavior and Remote Host semantics on ARM64.
+
+**Non-Goals:**
+
+- Add `.deb`, `.rpm`, AppImage, or another codexhost Linux installer.
+- Support 32-bit ARM, cross-architecture Desktop execution, emulation, or non-official ChatGPT package layouts.
+- Change Harness, protocol, Renderer, or Mapping Store semantics.
+
+## Decisions
+
+- Add one `linux-arm64` target beside `linux-x64`, using Rust target `aarch64-unknown-linux-gnu` and npm CPU `arm64`. This reuses the current architecture-specific optional-package design and avoids a multi-architecture binary package.
+- Make Linux ELF validation compile-target-aware with `EM_X86_64` for `target_arch = "x86_64"` and `EM_AARCH64` for `target_arch = "aarch64"`. Desktop and bundled Codex CLI must both match the running codexhost architecture; accepting either architecture at runtime would weaken package identity checks.
+- Keep Linux updates npm-only. `linux-arm64` participates in distribution metadata and npm updates but remains excluded from installer asset selection.
+- Run package build and smoke tests on `ubuntu-22.04-arm`, rather than cross-building on x64, so Node optional dependencies, Rust binaries, npm CPU constraints, executable smoke checks, and the existing Linux glibc compatibility baseline are observed natively.
+- Generalize Linux Gate A schemas from literal `x64` to `x64 | arm64`, while retaining architecture-specific evidence and release-readiness wording.
+
+## Risks / Trade-offs
+
+- [Official ARM64 package layout may diverge from x64] → Preserve strict paths, metadata identity, ELF, and symlink checks; require native Gate A evidence before claiming release readiness.
+- [ARM64 hosted runner availability or queueing can delay releases] → Use the standard `ubuntu-22.04-arm` runner and keep target jobs independent with `fail-fast: false`.
+- [A dependency may install a different ARM64 native optional package] → Build and smoke-test on native ARM64 with `npm ci`, package installation, executable-mode checks, and `codexhost --version`.
+- [Broad string unions can accidentally enable Linux installer flow] → Keep installer targets separately typed and treat both Linux npm targets explicitly as non-installer distributions.

--- a/openspec/changes/add-linux-arm64-support/proposal.md
+++ b/openspec/changes/add-linux-arm64-support/proposal.md
@@ -1,0 +1,24 @@
+## Why
+
+OpenAI now publishes official ChatGPT Desktop `.deb` and `.rpm` packages for ARM64 Linux, but codexhost still rejects ARM64 Desktop executables and publishes only a Linux x64 npm package. Adding ARM64 support now lets local Desktop users and SSH Remote Hosts use the same codexhost capabilities on native ARM Linux without emulation.
+
+## What Changes
+
+- Add `linux-arm64` as a first-class npm release and distribution target using `aarch64-unknown-linux-gnu`.
+- Publish and select `@codexhost/cli-linux-arm64` on `linux/arm64` hosts.
+- Accept official little-endian ARM64 ChatGPT Desktop and packaged Codex CLI ELF executables while preserving same-architecture validation.
+- Extend update metadata, release publishing, CI, package smoke tests, and Linux Gate A contracts to cover ARM64.
+- Update Linux support documentation to describe official x64 and ARM64 `.deb`/`.rpm` support and the absence of a Linux installer package.
+
+## Capabilities
+
+### New Capabilities
+- `linux-arm64-runtime-support`: Native ARM64 Linux Desktop discovery, npm distribution, Remote Host operation, and release validation.
+
+### Modified Capabilities
+- `remote-ssh-harness-host`: ARM64 Linux SHALL be supported as a packaged SSH Remote Host architecture.
+- `github-release-background-update`: npm-installed ARM64 Linux distributions SHALL resolve and update through the matching architecture-specific platform package.
+
+## Impact
+
+Affected areas include Linux native installation discovery in `crates/platform`, npm release target registration and package publication under `scripts/release`, distribution/update target contracts, Linux Gate A evidence schemas, GitHub Actions matrices, release tests, and Linux/Remote Host documentation. No installer is added for Linux; both Linux architectures continue to use npm distribution and npm-managed updates.

--- a/openspec/changes/add-linux-arm64-support/specs/github-release-background-update/spec.md
+++ b/openspec/changes/add-linux-arm64-support/specs/github-release-background-update/spec.md
@@ -1,0 +1,10 @@
+## ADDED Requirements
+
+### Requirement: ARM64 Linux npm distributions SHALL use npm updates
+Strict distribution metadata SHALL accept `linux-arm64`, SHALL require it to match a running `linux/arm64` host, and SHALL resolve its installed update context through the existing npm update path. It MUST NOT select or require a GitHub Release installer asset for Linux.
+
+#### Scenario: ARM64 Linux npm installation checks for updates
+- **WHEN** packaged metadata identifies distribution `npm` and target `linux-arm64` on a `linux/arm64` host
+- **THEN** Host resolves the verified npm package paths and reports npm installation availability
+- **AND** update preparation uses exact-version npm installation
+- **AND** no DMG, EXE, `.deb`, or `.rpm` installer asset is selected

--- a/openspec/changes/add-linux-arm64-support/specs/linux-arm64-runtime-support/spec.md
+++ b/openspec/changes/add-linux-arm64-support/specs/linux-arm64-runtime-support/spec.md
@@ -1,0 +1,27 @@
+## ADDED Requirements
+
+### Requirement: ARM64 Linux SHALL be a native codexhost target
+The release system SHALL define `linux-arm64` as an npm distribution target using Rust target `aarch64-unknown-linux-gnu`, npm platform `linux`, and npm CPU `arm64`. The architecture-neutral CLI package SHALL select the matching ARM64 platform package when `process.platform` is `linux` and `process.arch` is `arm64`.
+
+#### Scenario: ARM64 user installs the npm CLI
+- **WHEN** an ARM64 Linux user installs `@codexhost/cli` with optional dependencies enabled
+- **THEN** npm installs `@codexhost/cli-linux-arm64`
+- **AND** the CLI resolves that package instead of the x64 package
+
+### Requirement: Linux Desktop discovery SHALL enforce the native architecture
+On supported Linux builds, codexhost SHALL accept official little-endian 64-bit ELF Desktop and packaged Codex CLI executables only when their ELF machine matches the codexhost build architecture. It SHALL accept `EM_X86_64` on x86-64 and `EM_AARCH64` on ARM64, and SHALL reject cross-architecture or unsupported ELF executables.
+
+#### Scenario: ARM64 official package is discovered
+- **WHEN** ARM64 codexhost inspects an official production ChatGPT package whose Desktop and packaged Codex CLI are little-endian `EM_AARCH64` ELF executables
+- **THEN** installation discovery succeeds with the existing official Linux package identity and paths
+
+#### Scenario: Package architecture does not match codexhost
+- **WHEN** the official package Desktop or packaged Codex CLI ELF machine differs from the codexhost build architecture
+- **THEN** installation discovery rejects the package before managed launch
+
+### Requirement: ARM64 Linux release validation SHALL run natively
+CI and release workflows SHALL build and smoke-test the `linux-arm64` npm package on a native ARM64 Linux runner. Linux Gate A contracts SHALL record either `x64` or `arm64` and SHALL not classify one architecture's evidence as proof for the other architecture.
+
+#### Scenario: ARM64 release package is prepared
+- **WHEN** the release workflow builds `linux-arm64`
+- **THEN** it compiles the ARM64 Rust binaries, builds browser and Host bundles, installs the platform and meta tarballs, verifies npm OS/CPU constraints and executable modes, and runs `codexhost --version` on ARM64

--- a/openspec/changes/add-linux-arm64-support/specs/remote-ssh-harness-host/spec.md
+++ b/openspec/changes/add-linux-arm64-support/specs/remote-ssh-harness-host/spec.md
@@ -1,0 +1,11 @@
+## ADDED Requirements
+
+### Requirement: Packaged Remote Host SHALL support native ARM64 Linux
+The npm distribution SHALL provide the same managed Remote Host installation, lifecycle, Unix socket transport, Harness execution, and reversible uninstall behavior on native ARM64 Linux as on x64 Linux.
+
+#### Scenario: ARM64 SSH host installs codexhost
+- **GIVEN** an ARM64 Linux SSH host has supported Node.js and an official ARM64 Codex CLI
+- **WHEN** the user installs `@codexhost/cli` and runs `codexhost remote install` followed by `codexhost remote start`
+- **THEN** the managed entrypoint uses ARM64 codexhost Launcher and Shim binaries
+- **AND** the Remote Host accepts the existing Codex WebSocket-over-Unix-socket transport
+- **AND** Harness processes remain local to the ARM64 SSH host

--- a/openspec/changes/add-linux-arm64-support/tasks.md
+++ b/openspec/changes/add-linux-arm64-support/tasks.md
@@ -1,0 +1,21 @@
+## 1. Native Linux Architecture
+
+- [x] 1.1 Make official Linux Desktop and packaged Codex CLI ELF validation target-architecture-aware for x86-64 and ARM64
+- [x] 1.2 Add focused Rust tests for accepted native and rejected cross-architecture Linux packages
+
+## 2. Distribution and Updates
+
+- [x] 2.1 Register `linux-arm64` in release targets, npm platform packages, distribution metadata, and Host update target resolution
+- [x] 2.2 Extend release, npm package, publish, and update-manager tests for `linux-arm64`
+
+## 3. CI and Compatibility Gates
+
+- [x] 3.1 Add native ARM64 Linux CI/release jobs and package smoke coverage
+- [x] 3.2 Generalize Linux Gate A architecture contracts and runtime reporting for x64 and ARM64
+
+## 4. Documentation and Validation
+
+- [x] 4.1 Update Linux and Remote Host documentation to include official ARM64 support and npm-only codexhost distribution
+- [x] 4.2 Run focused formatting, type, release, update, and Rust checks; document any native Desktop Gate not executable on the current host
+
+Validation note: the implementation host is macOS ARM64, so native Linux ARM64 npm smoke execution and the interactive Linux ARM64 Desktop Gate remain delegated to the `ubuntu-22.04-arm` CI/release jobs and a native ARM64 Linux Gate A run. Local `npm run check` reached a failure in unrelated uncommitted nvm-windows discovery work already present in the working tree; all ARM64-focused TypeScript tests, Rust checks, formatting, lint/type checks before that failure, and OpenSpec validation passed.

--- a/packages/host-runtime/src/update-coordinator.ts
+++ b/packages/host-runtime/src/update-coordinator.ts
@@ -95,7 +95,7 @@ export function createHostUpdateCoordinator(
   ): Promise<boolean> {
     if (context.installation.kind === "npm") return true;
     const target = context.metadata.target;
-    if (target === "linux-x64") return false;
+    if (target === "linux-x64" || target === "linux-arm64") return false;
     try {
       selectInstallerReleaseArtifact(release, target);
       return true;
@@ -216,7 +216,7 @@ export function createHostUpdateCoordinator(
               });
             } else {
               const target = context.metadata.target;
-              if (target === "linux-x64") {
+              if (target === "linux-x64" || target === "linux-arm64") {
                 throw new Error("Linux installer updates are unsupported");
               }
               const artifact = selectInstallerReleaseArtifact(release, target).source;

--- a/packages/renderer-extension/test/settings/release-notes.test.ts
+++ b/packages/renderer-extension/test/settings/release-notes.test.ts
@@ -143,7 +143,7 @@ describe("Release notes Markdown", () => {
   it("renders release-note blockquotes and does not create unsafe links", () => {
     const root = render(
       [
-        "> **Note / 提示**: Linux x64 users install via npm.",
+        "> **Note / 提示**: Linux x64/ARM64 users install via npm.",
         ">",
         "> See [the release](javascript:alert(1)).",
         "---",

--- a/packages/update-manager/src/distribution.ts
+++ b/packages/update-manager/src/distribution.ts
@@ -63,9 +63,14 @@ export function parseDistributionMetadata(value: unknown): DistributionMetadata 
   if (
     metadata.schemaVersion !== 1 ||
     (metadata.distribution !== "npm" && metadata.distribution !== "installer") ||
-    !["macos-arm64", "macos-x64", "windows-x64", "windows-arm64", "linux-x64"].includes(
-      String(metadata.target),
-    ) ||
+    ![
+      "macos-arm64",
+      "macos-x64",
+      "windows-x64",
+      "windows-arm64",
+      "linux-x64",
+      "linux-arm64",
+    ].includes(String(metadata.target)) ||
     typeof metadata.version !== "string"
   ) {
     throw new Error("distribution metadata is invalid");
@@ -96,6 +101,7 @@ function expectedTarget(platform: NodeJS.Platform, architecture: string): Releas
   if (platform === "win32" && architecture === "arm64") return "windows-arm64";
   if (platform === "win32" && architecture === "x64") return "windows-x64";
   if (platform === "linux" && architecture === "x64") return "linux-x64";
+  if (platform === "linux" && architecture === "arm64") return "linux-arm64";
   throw new Error(`unsupported update host ${platform}/${architecture}`);
 }
 

--- a/packages/update-manager/src/github-release.ts
+++ b/packages/update-manager/src/github-release.ts
@@ -10,7 +10,7 @@ const RELEASE_NOTES_URL_PATTERN =
 const DOWNLOAD_URL_PREFIX = "https://github.com/BytePioneer-AI/codex-host/releases/download/";
 
 export type InstallerReleaseTarget = "macos-arm64" | "macos-x64" | "windows-x64" | "windows-arm64";
-export type ReleaseTarget = InstallerReleaseTarget | "linux-x64";
+export type ReleaseTarget = InstallerReleaseTarget | "linux-x64" | "linux-arm64";
 
 export interface CodexhostLatestRelease {
   version: string;

--- a/packages/update-manager/test/distribution.test.ts
+++ b/packages/update-manager/test/distribution.test.ts
@@ -109,52 +109,58 @@ describe("installed update context", () => {
     ).resolves.toMatchObject({ installation: { kind: "npm", options: { packageRoot } } });
   });
 
-  it("resolves a Linux npm installation without enabling installer updates", async () => {
-    const root = await mkdtemp(path.join(os.tmpdir(), "codexhost-linux-npm-distribution-"));
-    roots.push(root);
-    const packageRoot = path.join(root, "platform-package");
-    const host = path.join(packageRoot, "app", "host-runtime.mjs");
-    const environment = runtimeEnvironment(root);
-    Object.assign(environment, {
-      [UPDATE_RUNTIME_ENV.npmNodePath]: path.join(root, "node"),
-      [UPDATE_RUNTIME_ENV.npmCliPath]: path.join(root, "npm-cli.js"),
-      [UPDATE_RUNTIME_ENV.npmLauncherPath]: path.join(root, "codexhost.js"),
-      [UPDATE_RUNTIME_ENV.npmPackageRoot]: packageRoot,
-    });
-    await Promise.all([
-      file(host),
-      file(path.join(packageRoot, "libexec", "codexhost-updater")),
-      file(path.join(root, "bin", "codexhost")),
-      file(path.join(root, "node")),
-      file(path.join(root, "npm-cli.js")),
-      file(path.join(root, "codexhost.js")),
-      file(
-        path.join(packageRoot, "app", "codexhost-distribution.json"),
-        JSON.stringify({
-          schemaVersion: 1,
-          version: "1.2.3",
-          distribution: "npm",
-          target: "linux-x64",
-        }),
-      ),
-    ]);
+  it.each([
+    ["linux-x64", "x64"],
+    ["linux-arm64", "arm64"],
+  ] as const)(
+    "resolves a %s npm installation without enabling installer updates",
+    async (target, architecture) => {
+      const root = await mkdtemp(path.join(os.tmpdir(), "codexhost-linux-npm-distribution-"));
+      roots.push(root);
+      const packageRoot = path.join(root, "platform-package");
+      const host = path.join(packageRoot, "app", "host-runtime.mjs");
+      const environment = runtimeEnvironment(root);
+      Object.assign(environment, {
+        [UPDATE_RUNTIME_ENV.npmNodePath]: path.join(root, "node"),
+        [UPDATE_RUNTIME_ENV.npmCliPath]: path.join(root, "npm-cli.js"),
+        [UPDATE_RUNTIME_ENV.npmLauncherPath]: path.join(root, "codexhost.js"),
+        [UPDATE_RUNTIME_ENV.npmPackageRoot]: packageRoot,
+      });
+      await Promise.all([
+        file(host),
+        file(path.join(packageRoot, "libexec", "codexhost-updater")),
+        file(path.join(root, "bin", "codexhost")),
+        file(path.join(root, "node")),
+        file(path.join(root, "npm-cli.js")),
+        file(path.join(root, "codexhost.js")),
+        file(
+          path.join(packageRoot, "app", "codexhost-distribution.json"),
+          JSON.stringify({
+            schemaVersion: 1,
+            version: "1.2.3",
+            distribution: "npm",
+            target,
+          }),
+        ),
+      ]);
 
-    await expect(
-      resolveInstalledUpdateContext({
-        hostRuntimePath: host,
-        environment,
-        platform: "linux",
-        architecture: "x64",
-        stateDirectory: path.join(root, "state"),
-      }),
-    ).resolves.toMatchObject({
-      metadata: { target: "linux-x64" },
-      common: {
-        runtimeDescriptorPath: environment[UPDATE_RUNTIME_ENV.runtimeDescriptorPath],
-      },
-      installation: { kind: "npm", options: { packageRoot } },
-    });
-  });
+      await expect(
+        resolveInstalledUpdateContext({
+          hostRuntimePath: host,
+          environment,
+          platform: "linux",
+          architecture,
+          stateDirectory: path.join(root, "state"),
+        }),
+      ).resolves.toMatchObject({
+        metadata: { target },
+        common: {
+          runtimeDescriptorPath: environment[UPDATE_RUNTIME_ENV.runtimeDescriptorPath],
+        },
+        installation: { kind: "npm", options: { packageRoot } },
+      });
+    },
+  );
 
   it("rejects unknown metadata and target mismatch", async () => {
     expect(() =>

--- a/scripts/release/distribution-metadata.mjs
+++ b/scripts/release/distribution-metadata.mjs
@@ -2,7 +2,7 @@ import { writeFile } from "node:fs/promises";
 
 const semverPattern =
   /^\d+\.\d+\.\d+(?:-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$/u;
-const targetPattern = /^(?:(?:macos|windows)-(?:arm64|x64)|linux-x64)$/u;
+const targetPattern = /^(?:macos|windows|linux)-(?:arm64|x64)$/u;
 
 export function createDistributionMetadata({ version, distribution, target }) {
   if (!semverPattern.test(version)) throw new Error("distribution version must be valid semver");

--- a/scripts/release/prepare-npm.mjs
+++ b/scripts/release/prepare-npm.mjs
@@ -25,6 +25,7 @@ export const NPM_PLATFORM_PACKAGE_NAMES = Object.freeze({
   "windows-x64": "@codexhost/cli-win32-x64",
   "windows-arm64": "@codexhost/cli-win32-arm64",
   "linux-x64": "@codexhost/cli-linux-x64",
+  "linux-arm64": "@codexhost/cli-linux-arm64",
 });
 export const NPM_RUNTIME_PLATFORM_PACKAGES = Object.freeze({
   "darwin-arm64": NPM_PLATFORM_PACKAGE_NAMES["macos-arm64"],
@@ -32,6 +33,7 @@ export const NPM_RUNTIME_PLATFORM_PACKAGES = Object.freeze({
   "win32-x64": NPM_PLATFORM_PACKAGE_NAMES["windows-x64"],
   "win32-arm64": NPM_PLATFORM_PACKAGE_NAMES["windows-arm64"],
   "linux-x64": NPM_PLATFORM_PACKAGE_NAMES["linux-x64"],
+  "linux-arm64": NPM_PLATFORM_PACKAGE_NAMES["linux-arm64"],
 });
 export const NPM_PACKAGE_DESCRIPTION =
   "Run Pi and Claude Code as first-class external harnesses inside Codex Desktop.";

--- a/scripts/release/targets.mjs
+++ b/scripts/release/targets.mjs
@@ -57,6 +57,13 @@ export const RELEASE_TARGETS = Object.freeze({
     packageArchitecture: "x64",
     executableSuffix: "",
   }),
+  "linux-arm64": Object.freeze({
+    id: "linux-arm64",
+    hostPlatform: "linux",
+    rustTarget: "aarch64-unknown-linux-gnu",
+    packageArchitecture: "arm64",
+    executableSuffix: "",
+  }),
 });
 
 export function supportedReleaseTargets() {
@@ -94,6 +101,7 @@ export function hostReleaseTargetId(platform = process.platform, arch = process.
   if (platform === "win32" && arch === "x64") return "windows-x64";
   if (platform === "win32" && arch === "arm64") return "windows-arm64";
   if (platform === "linux" && arch === "x64") return "linux-x64";
+  if (platform === "linux" && arch === "arm64") return "linux-arm64";
   throw new Error(`unsupported npm release host: ${platform}/${arch}`);
 }
 

--- a/tests/release/distribution-metadata.test.mjs
+++ b/tests/release/distribution-metadata.test.mjs
@@ -65,12 +65,12 @@ describe("release distribution metadata", () => {
         target: "linux-x64",
       }),
     ).toMatchObject({ target: "linux-x64" });
-    expect(() =>
+    expect(
       createDistributionMetadata({
         version: "1.2.3",
         distribution: "npm",
         target: "linux-arm64",
       }),
-    ).toThrow("target is invalid");
+    ).toMatchObject({ target: "linux-arm64" });
   });
 });

--- a/tests/release/npm-package.test.mjs
+++ b/tests/release/npm-package.test.mjs
@@ -256,7 +256,7 @@ describe("npm package release", () => {
     expect(hostReleaseTargetId("win32", "x64")).toBe("windows-x64");
     expect(hostReleaseTargetId("win32", "arm64")).toBe("windows-arm64");
     expect(hostReleaseTargetId("linux", "x64")).toBe("linux-x64");
-    expect(() => hostReleaseTargetId("linux", "arm64")).toThrow("unsupported npm release host");
+    expect(hostReleaseTargetId("linux", "arm64")).toBe("linux-arm64");
   });
 
   it("defaults the npm release target to the current host", () => {
@@ -353,6 +353,7 @@ describe("npm package release", () => {
     const source = createNpmBinLauncherSource({ version: "0.1.0" });
     expect(source).toContain('"darwin-arm64": "@codexhost/cli-darwin-arm64"');
     expect(source).toContain('"linux-x64": "@codexhost/cli-linux-x64"');
+    expect(source).toContain('"linux-arm64": "@codexhost/cli-linux-arm64"');
     expect(source).toContain("require.resolve");
     expect(source).toContain("--omit=optional");
     expect(source).toContain('launchArguments = ["launch"]');
@@ -517,6 +518,7 @@ describe("npm package release", () => {
       "@codexhost/cli-win32-x64",
       "@codexhost/cli-win32-arm64",
       "@codexhost/cli-linux-x64",
+      "@codexhost/cli-linux-arm64",
     ]);
     expect(source).toContain("publishConfig");
     expect(source).toContain('access: "public"');
@@ -531,6 +533,9 @@ describe("npm package release", () => {
     );
     expect(npmTarballFileName({ version: "0.1.0", target: releaseTarget("linux-x64") })).toBe(
       "codexhost-cli-0.1.0-linux-x64.tgz",
+    );
+    expect(npmTarballFileName({ version: "0.1.0", target: releaseTarget("linux-arm64") })).toBe(
+      "codexhost-cli-0.1.0-linux-arm64.tgz",
     );
   });
 });

--- a/tests/release/npm-publish.test.mjs
+++ b/tests/release/npm-publish.test.mjs
@@ -41,6 +41,7 @@ describe("npm registry publishing", () => {
       `codexhost-cli-${version}-windows-x64.tgz`,
       `codexhost-cli-${version}-windows-arm64.tgz`,
       `codexhost-cli-${version}-linux-x64.tgz`,
+      `codexhost-cli-${version}-linux-arm64.tgz`,
       `codexhost-cli-${version}.tgz`,
     ];
     try {
@@ -53,6 +54,7 @@ describe("npm registry publishing", () => {
         "@codexhost/cli-win32-x64",
         "@codexhost/cli-win32-arm64",
         "@codexhost/cli-linux-x64",
+        "@codexhost/cli-linux-arm64",
         "@codexhost/cli",
       ]);
       expect(plan.at(-1).kind).toBe("meta");

--- a/tests/release/packagers.test.mjs
+++ b/tests/release/packagers.test.mjs
@@ -70,6 +70,9 @@ describe("platform packagers", () => {
     expect(workflow).toContain("target: linux-x64");
     expect(workflow).toContain("runner: ubuntu-22.04");
     expect(workflow).toContain("rustTarget: x86_64-unknown-linux-gnu");
+    expect(workflow).toContain("target: linux-arm64");
+    expect(workflow).toContain("runner: ubuntu-22.04-arm");
+    expect(workflow).toContain("rustTarget: aarch64-unknown-linux-gnu");
     expect(workflow).toContain("Build npm package");
     expect(workflow).toContain("release:npm:meta");
     expect(workflow).toContain("release:npm:publish");

--- a/tests/release/targets.test.mjs
+++ b/tests/release/targets.test.mjs
@@ -11,13 +11,20 @@ import {
   supportedReleaseTargets,
 } from "../../scripts/release/targets.mjs";
 
-const expectedTargets = ["macos-arm64", "macos-x64", "windows-x64", "windows-arm64", "linux-x64"];
+const expectedTargets = [
+  "macos-arm64",
+  "macos-x64",
+  "windows-x64",
+  "windows-arm64",
+  "linux-x64",
+  "linux-arm64",
+];
 
 describe("release targets", () => {
   it("defines the complete release target matrix", () => {
     expect(supportedReleaseTargets()).toEqual(expectedTargets);
     expect(installerReleaseTargets()).toEqual(
-      expectedTargets.filter((target) => target !== "linux-x64"),
+      expectedTargets.filter((target) => !target.startsWith("linux-")),
     );
     expect(NODE_VERSION).toBe("24.13.1");
     expect(Object.values(RELEASE_TARGETS).map((target) => target.rustTarget)).toEqual([
@@ -26,6 +33,7 @@ describe("release targets", () => {
       "x86_64-pc-windows-msvc",
       "aarch64-pc-windows-msvc",
       "x86_64-unknown-linux-gnu",
+      "aarch64-unknown-linux-gnu",
     ]);
     expect(Object.values(RELEASE_TARGETS).map((target) => target.installerArchitecture)).toEqual([
       "arm64",
@@ -33,10 +41,11 @@ describe("release targets", () => {
       "x64",
       "arm64",
       undefined,
+      undefined,
     ]);
     for (const target of Object.values(RELEASE_TARGETS)) {
       if (target.packageArchitecture !== undefined) {
-        expect(target.packageArchitecture).toBe("x64");
+        expect(["x64", "arm64"]).toContain(target.packageArchitecture);
         expect(target.nodeArchive).toBeUndefined();
         expect(target.nodeArchiveSha256).toBeUndefined();
       } else {
@@ -78,6 +87,9 @@ describe("release targets", () => {
       "unknown release option",
     );
     expect(() => parseReleaseArguments(["--target", "linux-x64"], "linux")).toThrow(
+      "has no installer",
+    );
+    expect(() => parseReleaseArguments(["--target", "linux-arm64"], "linux")).toThrow(
       "has no installer",
     );
   });

--- a/tools/gate-a/capture.test.mjs
+++ b/tools/gate-a/capture.test.mjs
@@ -61,26 +61,29 @@ describe("Gate A raw capture", () => {
     });
   });
 
-  it("sanitizes a platform-discriminated Linux invocation", () => {
-    const record = invocationRecord({
-      platform: "linux",
-      architecture: "x64",
-      process_group_id: 42,
-      launch_mode: "direct-executable",
-      cwd: "/home/alice/project",
-      install_root: "/usr/lib/chatgpt",
-      stock_codex_path: "/usr/lib/chatgpt/resources/codex",
-    });
-    const capture = sanitizeCapture(record);
-    expect(capture).toMatchObject({
-      platform: "linux",
-      architecture: "x64",
-      processGroupId: 42,
-      launchMode: "direct-executable",
-      cwd: "<WORKING_DIRECTORY>",
-      stockCodexPath: "<STOCK_CODEX>",
-    });
-  });
+  it.each(["x64", "arm64"])(
+    "sanitizes a platform-discriminated Linux %s invocation",
+    (architecture) => {
+      const record = invocationRecord({
+        platform: "linux",
+        architecture,
+        process_group_id: 42,
+        launch_mode: "direct-executable",
+        cwd: "/home/alice/project",
+        install_root: "/usr/lib/chatgpt",
+        stock_codex_path: "/usr/lib/chatgpt/resources/codex",
+      });
+      const capture = sanitizeCapture(record);
+      expect(capture).toMatchObject({
+        platform: "linux",
+        architecture,
+        processGroupId: 42,
+        launchMode: "direct-executable",
+        cwd: "<WORKING_DIRECTORY>",
+        stockCodexPath: "<STOCK_CODEX>",
+      });
+    },
+  );
 
   it("redacts sensitive argument values", () => {
     const record = invocationRecord({

--- a/tools/gate-a/contracts.mjs
+++ b/tools/gate-a/contracts.mjs
@@ -28,7 +28,7 @@ export const probeInvocationSchema = z.discriminatedUnion("platform", [
   }),
   invocationBase.extend({
     platform: z.literal("linux"),
-    architecture: z.literal("x64"),
+    architecture: z.enum(["x64", "arm64"]),
     processGroupId: z.number().int().positive(),
     launchMode: z.literal("direct-executable"),
   }),
@@ -173,7 +173,7 @@ export const desktopInteractiveEvidenceSchema = z.discriminatedUnion("platform",
   interactiveBase.extend({
     platform: z.literal("linux"),
     linuxVersion: z.string(),
-    architecture: z.literal("x64"),
+    architecture: z.enum(["x64", "arm64"]),
     launchMode: z.literal("direct-executable"),
     scenarios: linuxInteractiveScenariosSchema,
   }),
@@ -209,6 +209,6 @@ export const gateReportSchema = z.discriminatedUnion("platform", [
     platform: z.literal("linux"),
     gate: z.literal("linux-codex-transparent-proxy"),
     linuxVersion: z.string(),
-    architecture: z.literal("x64"),
+    architecture: z.enum(["x64", "arm64"]),
   }),
 ]);

--- a/tools/gate-a/run.mjs
+++ b/tools/gate-a/run.mjs
@@ -20,8 +20,8 @@ const gatePlatform = process.platform === "win32" ? "windows" : process.platform
 if (!["windows", "darwin", "linux"].includes(gatePlatform)) {
   throw new Error("Gate A currently supports Windows, macOS, and Linux only");
 }
-if (gatePlatform === "linux" && process.arch !== "x64") {
-  throw new Error("Gate A Linux support currently requires x64");
+if (gatePlatform === "linux" && !["x64", "arm64"].includes(process.arch)) {
+  throw new Error("Gate A Linux support currently requires x64 or arm64");
 }
 const platformName = gatePlatform === "darwin" ? "macos" : gatePlatform;
 const launcherPath = path.join(repositoryRoot, "target", "debug", `codexhost${executableSuffix}`);
@@ -213,7 +213,7 @@ function writeGateReport({
             platform: "linux",
             gate: "linux-codex-transparent-proxy",
             linuxVersion: `${os.type()} ${os.release()}`,
-            architecture: "x64",
+            architecture: os.arch(),
           };
   const report = gateReportSchema.parse({
     schemaVersion: 1,
@@ -458,12 +458,18 @@ function finalize() {
   if (platformName === "linux" && interactive.linuxVersion !== expectedSystemVersion) {
     throw new Error("interactive evidence Linux version does not match the current host");
   }
+  if (platformName === "linux" && interactive.architecture !== os.arch()) {
+    throw new Error("interactive evidence Linux architecture does not match the current host");
+  }
   const invocationPath = invocationEvidencePath;
   const invocation = probeInvocationSchema.parse(
     JSON.parse(fs.readFileSync(invocationPath, "utf8")),
   );
   if (invocation.desktopVersion !== inspection.desktop_version) {
     throw new Error("reviewed Shim evidence Desktop version does not match the installed version");
+  }
+  if (platformName === "linux" && invocation.architecture !== os.arch()) {
+    throw new Error("reviewed Shim evidence Linux architecture does not match the current host");
   }
   const { report, outputPath } = writeGateReport({
     inspection,
@@ -481,7 +487,7 @@ function finalize() {
     impact: `${platformName === "linux" ? "Linux ChatGPT" : "Windows Codex"} Desktop transparent proxy launch, protocol forwarding, interaction, and lifecycle invariants passed for the recorded versions.`,
     nextDecision:
       platformName === "linux"
-        ? "The Linux Gate may be used as verified evidence for Linux x64 release readiness."
+        ? `The Linux Gate may be used as verified evidence for Linux ${interactive.architecture} release readiness.`
         : "Gate A may be used as the verified native boundary for a separately proposed Protocol Core change.",
   });
   console.log(JSON.stringify(report, null, 2));


### PR DESCRIPTION
## Purpose

Add first-class native Linux ARM64 support for codexhost Desktop and SSH Remote Host operation.

## Changes

- validate official ChatGPT Desktop and packaged Codex CLI against the native Linux ELF architecture
- add the `linux-arm64` / `aarch64-unknown-linux-gnu` release target and `@codexhost/cli-linux-arm64`
- preserve npm-only Linux update behavior and exclude Linux targets from installer assets
- add native `ubuntu-22.04-arm` CI and release package smoke coverage
- generalize Linux Gate A evidence to x64 and ARM64
- update Linux and Remote Host documentation
- add and complete OpenSpec change `add-linux-arm64-support`

## Validation

- OpenSpec strict validation
- Prettier, rustfmt, TypeScript typecheck
- focused release, npm, update-manager, Gate A, and renderer release-note tests
- Rust checks for `aarch64-unknown-linux-gnu` and `x86_64-unknown-linux-gnu`
- native host `codexhost-platform` tests

The implementation host is macOS ARM64, so native Linux ARM64 npm smoke execution is intentionally delegated to the new `ubuntu-22.04-arm` CI job. Interactive ChatGPT Desktop Gate A still requires a native ARM64 Linux desktop environment.
