### PR TITLE
feat: add Codex Desktop contract audit

### DIFF
--- a/openspec/changes/archive/2026-08-29-add-codex-desktop-contract-audit/.openspec.yaml
+++ b/openspec/changes/archive/2026-08-29-add-codex-desktop-contract-audit/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-29

--- a/openspec/changes/archive/2026-08-29-add-codex-desktop-contract-audit/design.md
+++ b/openspec/changes/archive/2026-08-29-add-codex-desktop-contract-audit/design.md
@@ -1,0 +1,95 @@
+## Context
+
+codexhost binds to private Codex Desktop surfaces across `packages/renderer-extension` and `packages/desktop-control`. The existing `tools/renderer-binding/run.mjs` exercises the core Agent-routing chain in a controlled lifecycle, while `inspectRendererDom()` provides a small generic DOM summary. Neither provides one default-read-only audit covering every consumed GUI surface, a reviewed-baseline comparison, or a per-surface verdict suitable for deciding whether an upstream Desktop update affects codexhost.
+
+The audit must remain developer tooling. Production startup deliberately treats Renderer integration failures as recoverable and must not regain a compatibility modal or blocking version gate. The tool must also avoid persisting user content or entire upstream applications.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Provide one local command that audits the installed or already-running Codex Desktop against the semantic contracts consumed by codexhost.
+- Make read-only live inspection the default and controlled installation/reload an explicit opt-in tier.
+- Keep contract discovery local to the owning production modules and expose sanitized inspection summaries instead of duplicating selectors or private structure knowledge in the runner.
+- Produce schema-validated JSON and human-readable Markdown with per-surface evidence and verdicts.
+- Persist a bounded reviewed baseline that can be compared with a later Desktop update.
+- Cover the MVP surfaces: Composer, Model, Permission, request/prewarm, title, Settings, Sidebar, Usage/Credits, and Fork.
+
+**Non-Goals:**
+
+- Do not run from Launcher, Controller startup, Host runtime, Renderer production entry, or Settings update flows.
+- Do not block or downgrade the user's Desktop based on audit output.
+- Do not automatically download Codex Desktop builds or retain complete applications, `app.asar`, full bundles, full DOM, screenshots, prompts, transcripts, payloads, credentials, IDs, Model values, or user paths.
+- Do not claim end-to-end routing, title creation, Fork execution, or visual behavior unless an explicit controlled check exercises that boundary.
+- Do not build a generic crawler for all Codex GUI code.
+
+## Decisions
+
+### 1. Add one deep audit module with a small CLI seam
+
+The external interface will be a local CLI under `tools/codex-desktop-contract-audit/`, invoked through a root npm script. Internally it will compose installation metadata, CDP inspection, Electron Inspector inspection, optional production-control status, baseline loading, classification, and report writing.
+
+The command will support two explicit modes:
+
+- `read-only`: attach to caller-provided loopback CDP and Inspector endpoints and evaluate only side-effect-free expressions.
+- `controlled`: delegate installation/reload and binding verification to the existing Renderer Control Session or controlled Renderer probe after an explicit flag.
+
+Alternative: add many surface-specific scripts. Rejected because callers would need to understand ordering, sanitization, and verdict aggregation, creating a shallow interface and inconsistent reports.
+
+### 2. Keep contract discovery in owning production modules
+
+`renderer-extension` will expose bounded inspection functions for the semantic relationships it already owns. These functions may return cardinality, state, ownership, visibility, and stable reason codes, but never raw Fiber objects, function source, Thread IDs, Model values, text content, or arbitrary attributes. `desktop-control` will validate the returned schema and handle CDP/Inspector transport.
+
+The audit runner will own orchestration and cross-version comparison, not private selectors.
+
+Alternative: duplicate all production selectors in the audit tool. Rejected because production and audit assumptions would drift and either create false failures or false passes.
+
+### 3. Separate observation levels in the report
+
+Each surface records independent evidence levels:
+
+- `static`: installed metadata and optional bounded marker inventory;
+- `liveStructure`: read-only candidate, relationship, state, and ownership inspection;
+- `installation`: production binding/policy readiness when observable;
+- `behavior`: only present for an explicitly exercised controlled boundary.
+
+The aggregate verdict is:
+
+- `no-impact`: required observed contracts pass and no material baseline difference remains unexplained;
+- `confirmed-impact`: an expected active contract or explicitly exercised behavior fails;
+- `possible-impact`: material shape/relationship evidence changed but the decisive live boundary was unavailable;
+- `unverified`: the current Renderer state did not expose the conditional surface and no failure was observed.
+
+An absent state-conditional control does not become `confirmed-impact` without evidence that its precondition was active.
+
+Alternative: one boolean compatible flag. Rejected because it hides unexercised states and encourages unsafe conclusions.
+
+### 4. Make the reviewed baseline explicit and bounded
+
+Reports are stored under `.codexhost/update-impact/<version-or-build>/`. A baseline manifest contains only schema version, Desktop version/build, Chromium/protocol identity, app.asar integrity, relevant bounded marker counts or hashes, per-surface normalized results, checks run, timestamp, and verdict. The command accepts an explicit baseline path and never silently substitutes an arbitrary older report.
+
+The first MVP will compare normalized reports rather than performing broad minified-source diffs. Source extraction can be added later only for contracts that cannot be localized from live and metadata evidence.
+
+Alternative: save every `app.asar` and diff all generated JavaScript. Rejected due to storage, noise, upstream-code retention, and poor correlation with actual impact.
+
+### 5. Reuse the controlled Renderer probe for behavioral escalation
+
+The existing `tools/renderer-binding/run.mjs` remains the owner of controlled Agent switching, prewarm clearing, title-policy installation, and sanitized submission observation. The new audit command may invoke shared operations or consume its normalized output in controlled mode; it will not create a second implementation of those flows.
+
+Read-only mode must not reload the Renderer, install policies, inject the Renderer bundle, switch Agent state, submit, create Threads, or alter Settings.
+
+Alternative: always run the existing probe. Rejected because its reload and injection behavior is inappropriate for default inspection of an active user Renderer.
+
+### 6. Classify command exit status separately from surface verdicts
+
+The command exits non-zero for invalid arguments, inaccessible endpoints, invalid report schemas, write failures, or `confirmed-impact`. It exits zero for `no-impact`, `possible-impact`, and `unverified` while making the verdict explicit in JSON/Markdown. This keeps scripting useful without treating a state-dependent unverified surface as a technical execution failure.
+
+## Risks / Trade-offs
+
+- **[The audit and production code share the same faulty discovery assumption]** → Include independent cardinality, DOM relationship, visibility, and ownership observations instead of trusting a single success boolean; use controlled behavior checks for decisive routing boundaries.
+- **[Conditional UI creates false failures]** → Record explicit preconditions and classify unavailable states as `unverified` unless the precondition is known active.
+- **[Read-only inspection cannot prove all behavior]** → Separate structure, installation, and behavior evidence and prohibit behavior claims when the boundary was not exercised.
+- **[Private Renderer changes expand inspection code]** → Keep each contract owned by its production module and expose one normalized aggregate interface to the runner.
+- **[Evidence leaks user data]** → Validate report schemas, use stable reason codes and counts only, sanitize URLs to scheme/path, and reject unknown fields before writing.
+- **[Baseline becomes stale or misleading]** → Require an explicit reviewed baseline, record which checks ran, and never auto-promote a current report to reviewed.
+- **[MVP scope grows into full upstream bundle analysis]** → Limit the first implementation to normalized metadata and live semantic contracts; defer source extraction unless a concrete audit gap requires it.

--- a/openspec/changes/archive/2026-08-29-add-codex-desktop-contract-audit/proposal.md
+++ b/openspec/changes/archive/2026-08-29-add-codex-desktop-contract-audit/proposal.md
@@ -1,0 +1,30 @@
+## Why
+
+Codex Desktop updates can change private DOM, React/Fiber state, Electron main-process objects, or request-manager shapes without breaking codexhost compilation or startup. Maintainers need one local, developer-only audit entrypoint that checks every Codex GUI contract consumed by codexhost and produces bounded evidence before deciding whether an upstream update is safe.
+
+## What Changes
+
+- Add a local Codex Desktop contract-audit command that is never invoked by the production Launcher, Controller readiness, Host runtime, or user-facing update path.
+- Inventory the semantic Renderer and main-process contracts consumed by Composer, Model, Permission, request/prewarm, title, Settings, Sidebar, Usage/Credits, and Fork integration.
+- Run read-only inspection by default against an existing loopback CDP and Electron Inspector endpoint; require an explicit controlled mode before reload, policy installation, or Renderer injection.
+- Reuse production discovery and validation logic rather than maintaining a second set of private selectors or Fiber-shape assumptions.
+- Emit per-surface `no-impact`, `confirmed-impact`, `possible-impact`, or `unverified` verdicts with sanitized JSON and Markdown reports under ignored `.codexhost/update-impact/` storage.
+- Record installed Desktop version/build, Chromium/protocol identity, app.asar integrity, checks that actually ran, and an optional reviewed-baseline comparison without retaining a complete Codex application or full DOM snapshot.
+- Extend the existing controlled Renderer binding probe only as the opt-in behavioral tier; do not replace it or weaken production fail-closed behavior.
+
+## Capabilities
+
+### New Capabilities
+
+- `codex-desktop-contract-audit`: Defines the local audit command, semantic contract inventory, read-only and controlled inspection modes, sanitized evidence, baseline comparison, and verdict semantics.
+
+### Modified Capabilities
+
+- `versioned-renderer-agent-routing`: Requires audit-facing inspection to reuse the owning production discovery logic for version-locked Renderer and main-process contracts without changing production routing behavior.
+
+## Impact
+
+- New tooling under `tools/` and a root npm audit command.
+- Focused additions to `packages/desktop-control` and `packages/renderer-extension` for reusable, read-only inspection summaries at existing ownership seams.
+- Focused tests for argument parsing, schema validation, sanitization, contract classification, and report generation.
+- No production startup integration, no user-facing compatibility dialog, no automatic Codex download, no modification of the installed `app.asar`, and no persistence of prompts, transcripts, credentials, IDs, payloads, user paths, or full DOM/source snapshots.

--- a/openspec/changes/archive/2026-08-29-add-codex-desktop-contract-audit/specs/codex-desktop-contract-audit/spec.md
+++ b/openspec/changes/archive/2026-08-29-add-codex-desktop-contract-audit/specs/codex-desktop-contract-audit/spec.md
@@ -1,0 +1,108 @@
+## ADDED Requirements
+
+### Requirement: Contract audit SHALL be local developer tooling only
+The repository SHALL provide a local Codex Desktop contract-audit command that is not invoked by production Launcher startup, Controller readiness, Host runtime composition, Renderer production entry, or user-facing update operations. Audit findings MUST NOT display compatibility dialogs, write compatibility acknowledgements, or block normal managed Desktop startup.
+
+#### Scenario: User starts codexhost normally
+- **WHEN** the production Launcher starts or attaches to a managed Desktop
+- **THEN** the contract-audit command SHALL NOT run
+- **AND** no audit report or baseline SHALL be required for startup
+
+#### Scenario: Maintainer invokes the audit command
+- **WHEN** a maintainer explicitly runs the local audit command
+- **THEN** the command SHALL inspect the requested local Desktop endpoints and write only local ignored evidence
+- **AND** it SHALL NOT modify production readiness or user compatibility policy
+
+### Requirement: Read-only inspection SHALL be the default mode
+The audit command SHALL default to read-only inspection of caller-provided loopback CDP and Electron Inspector endpoints. In read-only mode it MUST NOT reload a Renderer, install production policies, inject the Renderer bundle, switch Agent state, submit a Composer, create or delete a Thread, open Settings, or modify the installed application.
+
+#### Scenario: Audit runs without a controlled flag
+- **WHEN** the maintainer supplies reachable loopback CDP and Inspector endpoints without enabling controlled mode
+- **THEN** the audit SHALL evaluate only side-effect-free metadata and Renderer inspection expressions
+- **AND** the report SHALL identify every behavior boundary that was not exercised
+
+#### Scenario: Endpoint is not loopback
+- **WHEN** either endpoint resolves to a non-loopback HTTP host or an invalid port
+- **THEN** the command SHALL reject the request before opening a connection
+
+### Requirement: Audit SHALL inventory every codexhost-consumed GUI surface
+The MVP audit SHALL classify semantic contracts for Composer identity and actions, Model target, Permission control, request/prewarm ownership, title policy, Settings insertion, Sidebar decoration, Usage/Credits placement, and Fork discovery. Each surface result SHALL include stable contract identifiers, observed state, bounded cardinality or ownership evidence, checks that ran, and a stable reason code.
+
+#### Scenario: Active Composer exposes all core routing contracts
+- **WHEN** the primary Renderer contains one active supported Composer and the required request and title ownership objects are observable
+- **THEN** the report SHALL include Composer, Model, Permission, request/prewarm, and title results
+- **AND** each result SHALL distinguish unique, missing, ambiguous, unsupported, and state-inactive outcomes
+
+#### Scenario: Conditional surface is not active
+- **WHEN** Fork, Permission, Usage, Credits, Sidebar, or Settings evidence is unavailable because its documented UI precondition is not active
+- **THEN** the surface SHALL be `unverified` rather than `confirmed-impact`
+- **AND** the report SHALL identify the unavailable precondition without recording user content
+
+### Requirement: Audit discovery SHALL reuse owning production contracts
+Private selectors, React/Fiber shape discovery, request-manager shape validation, and main-process ownership checks used by the audit SHALL remain owned by the production module that consumes that contract. The audit runner MUST NOT maintain a parallel copy of those assumptions.
+
+#### Scenario: Production Settings anchor changes
+- **WHEN** the owning Settings module changes its reviewed header-surface discovery contract
+- **THEN** read-only audit inspection SHALL consume the same owning discovery logic or normalized inspector
+- **AND** the CLI runner SHALL not require a second selector edit
+
+#### Scenario: Audit reads a private object
+- **WHEN** inspection traverses a Fiber, request manager, or main-process service
+- **THEN** the owning inspector SHALL return only normalized state, cardinality, API-shape, and ownership evidence
+- **AND** it SHALL omit object values, function source, IDs, payloads, and text content
+
+### Requirement: Audit SHALL report evidence levels and per-surface verdicts
+Each surface SHALL report applicable `static`, `liveStructure`, `installation`, and `behavior` evidence separately. The audit SHALL use only `no-impact`, `confirmed-impact`, `possible-impact`, or `unverified` as compatibility verdicts and MUST NOT infer behavior success from static markers or installation status alone.
+
+#### Scenario: Structure and observed installation agree
+- **WHEN** a required active surface has unchanged normalized baseline evidence, unique live ownership, and a successful applicable installation check
+- **THEN** that surface MAY be `no-impact`
+- **AND** the report SHALL still identify any behavior boundary that was not exercised
+
+#### Scenario: Expected active ownership is ambiguous
+- **WHEN** a required active contract resolves to multiple candidate owners or an explicitly controlled behavior fails
+- **THEN** the affected surface SHALL be `confirmed-impact`
+- **AND** the command SHALL exit non-zero after writing the sanitized report
+
+#### Scenario: Material evidence changed without a decisive live state
+- **WHEN** normalized baseline evidence changes materially but the required UI state or controlled boundary is unavailable
+- **THEN** the affected surface SHALL be `possible-impact`
+- **AND** the report SHALL state what evidence is needed to resolve the verdict
+
+### Requirement: Audit evidence SHALL be bounded and sanitized
+The audit SHALL write schema-validated JSON and Markdown under ignored `.codexhost/update-impact/` storage. Persisted evidence MUST NOT include prompts, transcripts, input text, rendered text content, Model values, Thread or Request IDs, credentials, tokens, RPC payloads, complete URLs, function source, full DOM snapshots, screenshots, complete bundles, complete `app.asar`, or user-specific absolute paths.
+
+#### Scenario: Audit records installed Desktop identity
+- **WHEN** installation metadata and browser protocol information are available
+- **THEN** the report SHALL record bounded version/build, Chromium/protocol identity, and app.asar integrity
+- **AND** executable or profile paths SHALL be omitted or reduced to a non-user-specific platform identity
+
+#### Scenario: Inspector returns an unknown field
+- **WHEN** a live inspector or baseline document contains data outside the declared audit schema
+- **THEN** the audit SHALL reject that input rather than persisting it
+
+### Requirement: Baseline comparison SHALL use an explicit reviewed baseline
+The audit SHALL accept an optional explicit reviewed-baseline report and compare normalized contract evidence by contract identifier. It MUST NOT silently select an arbitrary prior report, infer reviewed status from recency, or require a complete historical application.
+
+#### Scenario: Explicit reviewed baseline is supplied
+- **WHEN** the baseline schema is valid and identifies a previously reviewed Desktop build
+- **THEN** the audit SHALL compare each current contract with the matching baseline contract
+- **AND** the report SHALL classify unchanged evidence, material shape changes, and previously unverified surfaces separately
+
+#### Scenario: No baseline is supplied
+- **WHEN** the maintainer runs a first audit without a reviewed baseline
+- **THEN** the command SHALL still produce current live results
+- **AND** it SHALL mark baseline-dependent conclusions as `unverified` rather than choosing another local report
+
+### Requirement: Controlled audit SHALL reuse existing Renderer behavior probes
+Controlled mode SHALL use the existing Renderer Control Session and Renderer binding probe for reload, policy installation, Agent switching, prewarm, title, or submission observation. It MUST NOT implement a second production binding or routing flow.
+
+#### Scenario: Maintainer requests controlled installation verification
+- **WHEN** controlled mode is enabled for an isolated Desktop lifecycle
+- **THEN** the audit SHALL reuse the existing production Renderer source and control-session installation path
+- **AND** it SHALL record installation evidence separately from behavior evidence
+
+#### Scenario: Behavior boundary is not requested
+- **WHEN** controlled mode installs the binding but does not exercise submission, routing, Fork, or title creation
+- **THEN** those behavior boundaries SHALL remain `unverified`
+- **AND** the report SHALL NOT claim end-to-end compatibility for them

--- a/openspec/changes/archive/2026-08-29-add-codex-desktop-contract-audit/specs/versioned-renderer-agent-routing/spec.md
+++ b/openspec/changes/archive/2026-08-29-add-codex-desktop-contract-audit/specs/versioned-renderer-agent-routing/spec.md
@@ -1,0 +1,19 @@
+## ADDED Requirements
+
+### Requirement: Versioned Renderer contracts SHALL expose sanitized audit inspection
+The modules that own version-locked Composer Model targeting, request/prewarm ownership, title ownership, Settings insertion, Sidebar decoration, Usage/Credits placement, Permission control, and Fork discovery SHALL expose reusable read-only inspection that reports only normalized contract state. Adding audit inspection MUST NOT change production binding, routing, recovery timing, or fail-closed behavior.
+
+#### Scenario: Audit inspects the active Composer
+- **WHEN** a local audit requests the Composer and Model contract summary
+- **THEN** the Renderer Extension SHALL apply the same supported identity, candidate uniqueness, and ownership rules used by production binding
+- **AND** it SHALL return stable state and reason codes without returning the Composer target value, Thread identity, Model value, Fiber object, or rendered content
+
+#### Scenario: Audit inspects request and title ownership
+- **WHEN** a local audit requests request/prewarm or title contract status
+- **THEN** Desktop Control SHALL apply the existing Host ownership and `webContents` ownership checks
+- **AND** inspection SHALL not install, reload, or mutate those policies in read-only mode
+
+#### Scenario: Audit support is absent from production entry
+- **WHEN** the production Renderer entry installs codexhost binding
+- **THEN** it SHALL continue using the existing production installation and status interfaces
+- **AND** it SHALL NOT automatically execute or persist the local contract audit

--- a/openspec/changes/archive/2026-08-29-add-codex-desktop-contract-audit/tasks.md
+++ b/openspec/changes/archive/2026-08-29-add-codex-desktop-contract-audit/tasks.md
@@ -1,0 +1,27 @@
+## 1. Audit contracts and report model
+
+- [x] 1.1 Define the schema-validated audit report, per-surface evidence levels, verdicts, stable reason codes, and explicit reviewed-baseline comparison.
+- [x] 1.2 Add focused tests for report validation, unknown-field rejection, verdict aggregation, state-conditional `unverified` handling, and sanitization.
+
+## 2. Read-only production contract inspection
+
+- [x] 2.1 Add a bounded Renderer inspection owned by `renderer-extension` for Composer, Model, Permission, Settings, Sidebar, Usage/Credits, and Fork contracts without returning content, IDs, Model values, or raw Fiber objects.
+- [x] 2.2 Extend `desktop-control` with read-only CDP and Electron Inspector orchestration for primary Renderer selection, request/prewarm ownership, title ownership/readiness observation, and strict inspection-schema validation.
+- [x] 2.3 Add focused fixtures and tests proving unique, missing, ambiguous, state-inactive, and unsupported outcomes while preserving production binding behavior.
+
+## 3. Local audit command
+
+- [x] 3.1 Implement `tools/codex-desktop-contract-audit/` argument parsing with loopback-only endpoints, explicit `read-only`/`controlled` modes, optional reviewed baseline, and bounded output paths.
+- [x] 3.2 Compose installed Desktop metadata, browser identity, live contract inspection, baseline comparison, verdict aggregation, and sanitized JSON/Markdown report writing behind one command.
+- [x] 3.3 Add a root `audit:codex-desktop` npm script and user-facing local tooling documentation with privacy and mode guarantees.
+
+## 4. Controlled escalation
+
+- [x] 4.1 Reuse the existing Renderer Control Session and Renderer binding probe for explicitly requested installation evidence without duplicating production binding logic.
+- [x] 4.2 Keep unexercised submission, routing, title creation, Settings interaction, and Fork behavior marked `unverified`, with tests covering the distinction between installation and behavior evidence.
+
+## 5. Validation
+
+- [x] 5.1 Run focused TypeScript tests, typecheck, lint, Renderer build, report-schema fixtures, and `git diff --check`.
+- [x] 5.2 Run a read-only local audit against an existing controlled Desktop when available and verify that no reload, injection, submission, or user-data persistence occurs.
+- [x] 5.3 Run an isolated controlled audit when the local Desktop permits, record which behavior boundaries were and were not exercised, and validate the OpenSpec change.

--- a/openspec/specs/codex-desktop-contract-audit/spec.md
+++ b/openspec/specs/codex-desktop-contract-audit/spec.md
@@ -1,0 +1,114 @@
+# codex-desktop-contract-audit Specification
+
+## Purpose
+
+Define the local, privacy-preserving Codex Desktop contract audit used by maintainers to assess whether upstream GUI and Renderer changes affect codexhost without entering production startup.
+
+## Requirements
+
+### Requirement: Contract audit SHALL be local developer tooling only
+The repository SHALL provide a local Codex Desktop contract-audit command that is not invoked by production Launcher startup, Controller readiness, Host runtime composition, Renderer production entry, or user-facing update operations. Audit findings MUST NOT display compatibility dialogs, write compatibility acknowledgements, or block normal managed Desktop startup.
+
+#### Scenario: User starts codexhost normally
+- **WHEN** the production Launcher starts or attaches to a managed Desktop
+- **THEN** the contract-audit command SHALL NOT run
+- **AND** no audit report or baseline SHALL be required for startup
+
+#### Scenario: Maintainer invokes the audit command
+- **WHEN** a maintainer explicitly runs the local audit command
+- **THEN** the command SHALL inspect the requested local Desktop endpoints and write only local ignored evidence
+- **AND** it SHALL NOT modify production readiness or user compatibility policy
+
+### Requirement: Read-only inspection SHALL be the default mode
+The audit command SHALL default to read-only inspection of caller-provided loopback CDP and Electron Inspector endpoints. In read-only mode it MUST NOT reload a Renderer, install production policies, inject the Renderer bundle, switch Agent state, submit a Composer, create or delete a Thread, open Settings, or modify the installed application.
+
+#### Scenario: Audit runs without a controlled flag
+- **WHEN** the maintainer supplies reachable loopback CDP and Inspector endpoints without enabling controlled mode
+- **THEN** the audit SHALL evaluate only side-effect-free metadata and Renderer inspection expressions
+- **AND** the report SHALL identify every behavior boundary that was not exercised
+
+#### Scenario: Endpoint is not loopback
+- **WHEN** either endpoint resolves to a non-loopback HTTP host or an invalid port
+- **THEN** the command SHALL reject the request before opening a connection
+
+### Requirement: Audit SHALL inventory every codexhost-consumed GUI surface
+The MVP audit SHALL classify semantic contracts for Composer identity and actions, Model target, Permission control, request/prewarm ownership, title policy, Settings insertion, Sidebar decoration, Usage/Credits placement, and Fork discovery. Each surface result SHALL include stable contract identifiers, observed state, bounded cardinality or ownership evidence, checks that ran, and a stable reason code.
+
+#### Scenario: Active Composer exposes all core routing contracts
+- **WHEN** the primary Renderer contains one active supported Composer and the required request and title ownership objects are observable
+- **THEN** the report SHALL include Composer, Model, Permission, request/prewarm, and title results
+- **AND** each result SHALL distinguish unique, missing, ambiguous, unsupported, and state-inactive outcomes
+
+#### Scenario: Conditional surface is not active
+- **WHEN** Fork, Permission, Usage, Credits, Sidebar, or Settings evidence is unavailable because its documented UI precondition is not active
+- **THEN** the surface SHALL be `unverified` rather than `confirmed-impact`
+- **AND** the report SHALL identify the unavailable precondition without recording user content
+
+### Requirement: Audit discovery SHALL reuse owning production contracts
+Private selectors, React/Fiber shape discovery, request-manager shape validation, and main-process ownership checks used by the audit SHALL remain owned by the production module that consumes that contract. The audit runner MUST NOT maintain a parallel copy of those assumptions.
+
+#### Scenario: Production Settings anchor changes
+- **WHEN** the owning Settings module changes its reviewed header-surface discovery contract
+- **THEN** read-only audit inspection SHALL consume the same owning discovery logic or normalized inspector
+- **AND** the CLI runner SHALL not require a second selector edit
+
+#### Scenario: Audit reads a private object
+- **WHEN** inspection traverses a Fiber, request manager, or main-process service
+- **THEN** the owning inspector SHALL return only normalized state, cardinality, API-shape, and ownership evidence
+- **AND** it SHALL omit object values, function source, IDs, payloads, and text content
+
+### Requirement: Audit SHALL report evidence levels and per-surface verdicts
+Each surface SHALL report applicable `static`, `liveStructure`, `installation`, and `behavior` evidence separately. The audit SHALL use only `no-impact`, `confirmed-impact`, `possible-impact`, or `unverified` as compatibility verdicts and MUST NOT infer behavior success from static markers or installation status alone.
+
+#### Scenario: Structure and observed installation agree
+- **WHEN** a required active surface has unchanged normalized baseline evidence, unique live ownership, and a successful applicable installation check
+- **THEN** that surface MAY be `no-impact`
+- **AND** the report SHALL still identify any behavior boundary that was not exercised
+
+#### Scenario: Expected active ownership is ambiguous
+- **WHEN** a required active contract resolves to multiple candidate owners or an explicitly controlled behavior fails
+- **THEN** the affected surface SHALL be `confirmed-impact`
+- **AND** the command SHALL exit non-zero after writing the sanitized report
+
+#### Scenario: Material evidence changed without a decisive live state
+- **WHEN** normalized baseline evidence changes materially but the required UI state or controlled boundary is unavailable
+- **THEN** the affected surface SHALL be `possible-impact`
+- **AND** the report SHALL state what evidence is needed to resolve the verdict
+
+### Requirement: Audit evidence SHALL be bounded and sanitized
+The audit SHALL write schema-validated JSON and Markdown under ignored `.codexhost/update-impact/` storage. Persisted evidence MUST NOT include prompts, transcripts, input text, rendered text content, Model values, Thread or Request IDs, credentials, tokens, RPC payloads, complete URLs, function source, full DOM snapshots, screenshots, complete bundles, complete `app.asar`, or user-specific absolute paths.
+
+#### Scenario: Audit records installed Desktop identity
+- **WHEN** installation metadata and browser protocol information are available
+- **THEN** the report SHALL record bounded version/build, Chromium/protocol identity, and app.asar integrity
+- **AND** executable or profile paths SHALL be omitted or reduced to a non-user-specific platform identity
+
+#### Scenario: Inspector returns an unknown field
+- **WHEN** a live inspector or baseline document contains data outside the declared audit schema
+- **THEN** the audit SHALL reject that input rather than persisting it
+
+### Requirement: Baseline comparison SHALL use an explicit reviewed baseline
+The audit SHALL accept an optional explicit reviewed-baseline report and compare normalized contract evidence by contract identifier. It MUST NOT silently select an arbitrary prior report, infer reviewed status from recency, or require a complete historical application.
+
+#### Scenario: Explicit reviewed baseline is supplied
+- **WHEN** the baseline schema is valid and identifies a previously reviewed Desktop build
+- **THEN** the audit SHALL compare each current contract with the matching baseline contract
+- **AND** the report SHALL classify unchanged evidence, material shape changes, and previously unverified surfaces separately
+
+#### Scenario: No baseline is supplied
+- **WHEN** the maintainer runs a first audit without a reviewed baseline
+- **THEN** the command SHALL still produce current live results
+- **AND** it SHALL mark baseline-dependent conclusions as `unverified` rather than choosing another local report
+
+### Requirement: Controlled audit SHALL reuse existing Renderer behavior probes
+Controlled mode SHALL use the existing Renderer Control Session and Renderer binding probe for reload, policy installation, Agent switching, prewarm, title, or submission observation. It MUST NOT implement a second production binding or routing flow.
+
+#### Scenario: Maintainer requests controlled installation verification
+- **WHEN** controlled mode is enabled for an isolated Desktop lifecycle
+- **THEN** the audit SHALL reuse the existing production Renderer source and control-session installation path
+- **AND** it SHALL record installation evidence separately from behavior evidence
+
+#### Scenario: Behavior boundary is not requested
+- **WHEN** controlled mode installs the binding but does not exercise submission, routing, Fork, or title creation
+- **THEN** those behavior boundaries SHALL remain `unverified`
+- **AND** the report SHALL NOT claim end-to-end compatibility for them

--- a/openspec/specs/versioned-renderer-agent-routing/spec.md
+++ b/openspec/specs/versioned-renderer-agent-routing/spec.md
@@ -670,3 +670,20 @@ The versioned Renderer Adapter SHALL bind Agent selection and draft prewarm rout
 - **THEN** that conversation ID becomes the authoritative model target
 - **AND** a retained draft settings wrapper does not make the bound Composer ambiguous
 
+### Requirement: Versioned Renderer contracts SHALL expose sanitized audit inspection
+The modules that own version-locked Composer Model targeting, request/prewarm ownership, title ownership, Settings insertion, Sidebar decoration, Usage/Credits placement, Permission control, and Fork discovery SHALL expose reusable read-only inspection that reports only normalized contract state. Adding audit inspection MUST NOT change production binding, routing, recovery timing, or fail-closed behavior.
+
+#### Scenario: Audit inspects the active Composer
+- **WHEN** a local audit requests the Composer and Model contract summary
+- **THEN** the Renderer Extension SHALL apply the same supported identity, candidate uniqueness, and ownership rules used by production binding
+- **AND** it SHALL return stable state and reason codes without returning the Composer target value, Thread identity, Model value, Fiber object, or rendered content
+
+#### Scenario: Audit inspects request and title ownership
+- **WHEN** a local audit requests request/prewarm or title contract status
+- **THEN** Desktop Control SHALL apply the existing Host ownership and `webContents` ownership checks
+- **AND** inspection SHALL not install, reload, or mutate those policies in read-only mode
+
+#### Scenario: Audit support is absent from production entry
+- **WHEN** the production Renderer entry installs codexhost binding
+- **THEN** it SHALL continue using the existing production installation and status interfaces
+- **AND** it SHALL NOT automatically execute or persist the local contract audit

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "gate:claude:live": "node tools/gate-claude-code/run.mjs live",
     "gate:claude": "node tools/gate-claude-code/run.mjs gate",
     "probe:renderer-binding": "npm run build:typescript && npm run build:renderer && node tools/renderer-binding/run.mjs",
+    "audit:codex-desktop": "npm run build:typescript && npm run build:renderer && node tools/codex-desktop-contract-audit/run.mjs",
     "check:rust": "cargo fmt --all --check && cargo clippy --workspace --all-targets --locked --features codexhost-shim/test-utils,codexhost-gate-a-native/gate-tools -- -D warnings && cargo test --workspace --locked --features codexhost-shim/test-utils,codexhost-gate-a-native/gate-tools",
     "check": "npm run format:check && npm run lint && npm run typecheck && npm run test:typescript && npm run check:rust",
     "clean": "node tools/clean.mjs"

--- a/packages/desktop-control/src/contract-audit.ts
+++ b/packages/desktop-control/src/contract-audit.ts
@@ -1,0 +1,264 @@
+import { CdpClient, getCdpBrowserVersion, type CdpBrowserVersion } from "./cdp-client.js";
+import {
+  inspectElectronWebContents,
+  selectRendererWebContents,
+  waitForInspectorTarget,
+  type ElectronRendererSummary,
+} from "./renderer-control-session.js";
+
+export const DESKTOP_CONTRACT_AUDIT_SCHEMA_VERSION = 1 as const;
+
+export type ContractAuditCardinalityState = "unique" | "missing" | "ambiguous" | "inactive";
+
+export interface RendererContractAuditInspection {
+  schemaVersion: 1;
+  composer: {
+    composerCount: number;
+    visibleComposerCount: number;
+    activeComposerCount: number;
+    modelCandidateCount: number;
+    verifiedModelCandidateCount: number;
+    permissionCandidateCount: number;
+    verifiedPermissionCandidateCount: number;
+    contextUsageCandidateCount: number;
+    verifiedContextUsageCandidateCount: number;
+    sendButtonCount: number;
+    trailingActionOwnerCount: number;
+  };
+  model: {
+    draftCount: number;
+    conversationCount: number;
+    missingCount: number;
+    ambiguousCount: number;
+  };
+  settings: {
+    headerCount: number;
+    visibleHeaderCount: number;
+    insertionPointCount: number;
+  };
+  sidebar: {
+    rowCount: number;
+    titleOwnerCount: number;
+    resolvedThreadCount: number;
+    ambiguousThreadCount: number;
+  };
+  fork: {
+    annotatedResponseCount: number;
+    candidateButtonCount: number;
+    verifiedButtonCount: number;
+  };
+  production: {
+    bindingPresent: boolean;
+    adapterState: "installing" | "ready" | "unsupported" | "absent";
+    adapterReason: string;
+    titlePolicyState: "ready" | "absent" | "unknown";
+    draftPrewarmPolicyState: "ready" | "absent" | "unknown";
+  };
+}
+
+export interface DesktopContractAuditObservation {
+  schemaVersion: typeof DESKTOP_CONTRACT_AUDIT_SCHEMA_VERSION;
+  browser: {
+    browser: string;
+    protocolVersion: string;
+  };
+  renderer: ElectronRendererSummary;
+  contracts: RendererContractAuditInspection;
+}
+
+export interface InspectDesktopContractsOptions {
+  endpoint: string;
+  inspectorEndpoint: string;
+  rendererAuditSource: string;
+  timeoutMs?: number;
+}
+
+interface RecordValue {
+  [key: string]: unknown;
+}
+
+function isRecord(value: unknown): value is RecordValue {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function strictKeys(value: RecordValue, expected: readonly string[], label: string): void {
+  const keys = Object.keys(value).toSorted();
+  const sortedExpected = [...expected].toSorted();
+  if (
+    keys.length !== sortedExpected.length ||
+    keys.some((key, index) => key !== sortedExpected[index])
+  ) {
+    throw new Error(`${label} contains unknown or missing fields`);
+  }
+}
+
+function integer(value: unknown, label: string): number {
+  if (!Number.isInteger(value) || (value as number) < 0) {
+    throw new Error(`${label} must be a non-negative integer`);
+  }
+  return value as number;
+}
+
+function integerRecord<T extends readonly string[]>(
+  value: unknown,
+  keys: T,
+  label: string,
+): { [K in T[number]]: number } {
+  if (!isRecord(value)) throw new Error(`${label} must be an object`);
+  strictKeys(value, keys, label);
+  return Object.fromEntries(keys.map((key) => [key, integer(value[key], `${label}.${key}`)])) as {
+    [K in T[number]]: number;
+  };
+}
+
+export function validateRendererContractAuditInspection(
+  value: unknown,
+): RendererContractAuditInspection {
+  if (!isRecord(value)) throw new Error("Renderer contract audit must be an object");
+  strictKeys(
+    value,
+    ["schemaVersion", "composer", "model", "settings", "sidebar", "fork", "production"],
+    "Renderer contract audit",
+  );
+  if (value.schemaVersion !== 1) throw new Error("Renderer contract audit schema is unsupported");
+  const production = value.production;
+  if (!isRecord(production)) throw new Error("Renderer contract audit production state is invalid");
+  strictKeys(
+    production,
+    [
+      "bindingPresent",
+      "adapterState",
+      "adapterReason",
+      "titlePolicyState",
+      "draftPrewarmPolicyState",
+    ],
+    "Renderer contract audit production state",
+  );
+  if (
+    typeof production.bindingPresent !== "boolean" ||
+    !["installing", "ready", "unsupported", "absent"].includes(String(production.adapterState)) ||
+    typeof production.adapterReason !== "string" ||
+    production.adapterReason.length > 64 ||
+    !["ready", "absent", "unknown"].includes(String(production.titlePolicyState)) ||
+    !["ready", "absent", "unknown"].includes(String(production.draftPrewarmPolicyState))
+  ) {
+    throw new Error("Renderer contract audit production state is invalid");
+  }
+  return {
+    schemaVersion: 1,
+    composer: integerRecord(
+      value.composer,
+      [
+        "composerCount",
+        "visibleComposerCount",
+        "activeComposerCount",
+        "modelCandidateCount",
+        "verifiedModelCandidateCount",
+        "permissionCandidateCount",
+        "verifiedPermissionCandidateCount",
+        "contextUsageCandidateCount",
+        "verifiedContextUsageCandidateCount",
+        "sendButtonCount",
+        "trailingActionOwnerCount",
+      ] as const,
+      "Renderer composer contract",
+    ),
+    model: integerRecord(
+      value.model,
+      ["draftCount", "conversationCount", "missingCount", "ambiguousCount"] as const,
+      "Renderer model contract",
+    ),
+    settings: integerRecord(
+      value.settings,
+      ["headerCount", "visibleHeaderCount", "insertionPointCount"] as const,
+      "Renderer settings contract",
+    ),
+    sidebar: integerRecord(
+      value.sidebar,
+      ["rowCount", "titleOwnerCount", "resolvedThreadCount", "ambiguousThreadCount"] as const,
+      "Renderer sidebar contract",
+    ),
+    fork: integerRecord(
+      value.fork,
+      ["annotatedResponseCount", "candidateButtonCount", "verifiedButtonCount"] as const,
+      "Renderer fork contract",
+    ),
+    production: {
+      bindingPresent: production.bindingPresent,
+      adapterState:
+        production.adapterState as RendererContractAuditInspection["production"]["adapterState"],
+      adapterReason: production.adapterReason,
+      titlePolicyState:
+        production.titlePolicyState as RendererContractAuditInspection["production"]["titlePolicyState"],
+      draftPrewarmPolicyState:
+        production.draftPrewarmPolicyState as RendererContractAuditInspection["production"]["draftPrewarmPolicyState"],
+    },
+  };
+}
+
+const electronModuleExpression = `(() => {
+  const mainModule = process.mainModule;
+  if (mainModule != null && typeof mainModule.require === 'function') {
+    return mainModule.require('electron');
+  }
+  const { createRequire } = process.getBuiltinModule('module');
+  return createRequire(process.execPath)('electron');
+})()`;
+
+async function executeReadOnlyAudit(
+  inspector: Pick<CdpClient, "evaluate">,
+  rendererWebContentsId: number,
+  source: string,
+): Promise<unknown> {
+  return inspector.evaluate<unknown>(`(async () => {
+    const { webContents } = ${electronModuleExpression};
+    const contents = webContents.fromId(${rendererWebContentsId});
+    if (contents == null || contents.isDestroyed()) throw new Error('Renderer webContents is unavailable');
+    return contents.executeJavaScript(${JSON.stringify(`(() => {
+      const previous = window.__codexhostContractAuditV1;
+      ${source}
+      try {
+        const audit = window.__codexhostContractAuditV1;
+        if (audit == null || typeof audit.inspect !== 'function') {
+          throw new Error('Renderer contract audit entry is unavailable');
+        }
+        return audit.inspect();
+      } finally {
+        if (previous === undefined) delete window.__codexhostContractAuditV1;
+        else window.__codexhostContractAuditV1 = previous;
+      }
+    })()`)}, true);
+  })()`);
+}
+
+function browserIdentity(version: CdpBrowserVersion): DesktopContractAuditObservation["browser"] {
+  return { browser: version.browser, protocolVersion: version.protocolVersion };
+}
+
+export async function inspectDesktopContracts(
+  options: InspectDesktopContractsOptions,
+): Promise<DesktopContractAuditObservation> {
+  const timeoutMs = options.timeoutMs ?? 30_000;
+  const [browser, inspectorTarget] = await Promise.all([
+    getCdpBrowserVersion(options.endpoint),
+    waitForInspectorTarget(options.inspectorEndpoint, { timeoutMs }),
+  ]);
+  const inspector = await CdpClient.connect(inspectorTarget.webSocketDebuggerUrl);
+  try {
+    await inspector.command("Runtime.enable");
+    const inventory = await inspectElectronWebContents(inspector);
+    const renderer = selectRendererWebContents(inventory);
+    if (!renderer) throw new Error("Contract audit did not find a primary Renderer");
+    const contracts = validateRendererContractAuditInspection(
+      await executeReadOnlyAudit(inspector, renderer.id, options.rendererAuditSource),
+    );
+    return {
+      schemaVersion: DESKTOP_CONTRACT_AUDIT_SCHEMA_VERSION,
+      browser: browserIdentity(browser),
+      renderer,
+      contracts,
+    };
+  } finally {
+    inspector.close();
+  }
+}

--- a/packages/desktop-control/src/index.ts
+++ b/packages/desktop-control/src/index.ts
@@ -15,6 +15,16 @@ export type {
   CdpSocketFactory,
   CdpTarget,
 } from "./cdp-client.js";
+export {
+  DESKTOP_CONTRACT_AUDIT_SCHEMA_VERSION,
+  inspectDesktopContracts,
+  validateRendererContractAuditInspection,
+} from "./contract-audit.js";
+export type {
+  DesktopContractAuditObservation,
+  InspectDesktopContractsOptions,
+  RendererContractAuditInspection,
+} from "./contract-audit.js";
 export { inspectRendererDom, validateRendererDomInspection } from "./renderer-dom.js";
 export {
   activateElectronDesktop,

--- a/packages/desktop-control/test/contract-audit.test.ts
+++ b/packages/desktop-control/test/contract-audit.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+
+import { validateRendererContractAuditInspection } from "../src/index.js";
+
+const validInspection = {
+  schemaVersion: 1,
+  composer: {
+    composerCount: 1,
+    visibleComposerCount: 1,
+    activeComposerCount: 1,
+    modelCandidateCount: 1,
+    verifiedModelCandidateCount: 1,
+    permissionCandidateCount: 0,
+    verifiedPermissionCandidateCount: 0,
+    contextUsageCandidateCount: 0,
+    verifiedContextUsageCandidateCount: 0,
+    sendButtonCount: 1,
+    trailingActionOwnerCount: 1,
+  },
+  model: { draftCount: 1, conversationCount: 0, missingCount: 0, ambiguousCount: 0 },
+  settings: { headerCount: 1, visibleHeaderCount: 1, insertionPointCount: 1 },
+  sidebar: { rowCount: 0, titleOwnerCount: 0, resolvedThreadCount: 0, ambiguousThreadCount: 0 },
+  fork: { annotatedResponseCount: 0, candidateButtonCount: 0, verifiedButtonCount: 0 },
+  production: {
+    bindingPresent: false,
+    adapterState: "absent",
+    adapterReason: "absent",
+    titlePolicyState: "absent",
+    draftPrewarmPolicyState: "absent",
+  },
+};
+
+describe("Desktop contract audit inspection", () => {
+  it("accepts the bounded Renderer schema", () => {
+    expect(validateRendererContractAuditInspection(validInspection)).toEqual(validInspection);
+  });
+
+  it("rejects unknown fields and private values", () => {
+    expect(() =>
+      validateRendererContractAuditInspection({ ...validInspection, prompt: "private" }),
+    ).toThrow("unknown or missing fields");
+    expect(() =>
+      validateRendererContractAuditInspection({
+        ...validInspection,
+        production: { ...validInspection.production, source: "function source" },
+      }),
+    ).toThrow("unknown or missing fields");
+  });
+});

--- a/packages/renderer-extension/package.json
+++ b/packages/renderer-extension/package.json
@@ -13,7 +13,7 @@
     }
   },
   "scripts": {
-    "build": "esbuild src/index.ts --bundle --platform=browser --format=esm --target=es2024 --loader:.png=dataurl --loader:.svg=dataurl --loader:.css=text --outfile=dist/index.js && esbuild src/production-entry.ts --bundle --platform=browser --format=iife --target=es2024 --loader:.png=dataurl --loader:.svg=dataurl --loader:.css=text --outfile=dist/production.js && esbuild src/probe-entry.ts --bundle --platform=browser --format=iife --target=es2024 --loader:.png=dataurl --loader:.svg=dataurl --loader:.css=text --outfile=dist/renderer-binding-probe.js"
+    "build": "esbuild src/index.ts --bundle --platform=browser --format=esm --target=es2024 --loader:.png=dataurl --loader:.svg=dataurl --loader:.css=text --outfile=dist/index.js && esbuild src/production-entry.ts --bundle --platform=browser --format=iife --target=es2024 --loader:.png=dataurl --loader:.svg=dataurl --loader:.css=text --outfile=dist/production.js && esbuild src/probe-entry.ts --bundle --platform=browser --format=iife --target=es2024 --loader:.png=dataurl --loader:.svg=dataurl --loader:.css=text --outfile=dist/renderer-binding-probe.js && esbuild src/audit-entry.ts --bundle --platform=browser --format=iife --target=es2024 --loader:.png=dataurl --loader:.svg=dataurl --loader:.css=text --outfile=dist/contract-audit.js"
   },
   "dependencies": {
     "@codexhost/shared-contracts": "0.0.0",

--- a/packages/renderer-extension/src/audit-entry.ts
+++ b/packages/renderer-extension/src/audit-entry.ts
@@ -1,0 +1,5 @@
+import { inspectRendererContracts } from "./contract-audit.js";
+
+window.__codexhostContractAuditV1 = Object.freeze({
+  inspect: () => inspectRendererContracts(window),
+});

--- a/packages/renderer-extension/src/contract-audit.ts
+++ b/packages/renderer-extension/src/contract-audit.ts
@@ -1,0 +1,96 @@
+import {
+  CODEX_COMPOSER_SELECTOR,
+  inspectRendererComposerContract,
+  type RendererComposerContractInspection,
+} from "./renderer-composer-dom.js";
+import {
+  inspectRendererForkContract,
+  type RendererForkContractInspection,
+} from "./renderer-fork-control.js";
+import {
+  inspectRendererSidebarContract,
+  type RendererSidebarContractInspection,
+} from "./renderer-sidebar-agent-icons.js";
+import {
+  inspectRendererSettingsContract,
+  type RendererSettingsContractInspection,
+} from "./settings/trigger.js";
+import {
+  inspectComposerModelContract,
+  type RendererComposerModelContractState,
+} from "./versioned-renderer-adapter.js";
+
+export const RENDERER_CONTRACT_AUDIT_SCHEMA_VERSION = 1 as const;
+
+export interface RendererContractAuditApi {
+  inspect(): RendererContractAuditInspection;
+}
+
+export interface RendererContractAuditInspection {
+  schemaVersion: typeof RENDERER_CONTRACT_AUDIT_SCHEMA_VERSION;
+  composer: RendererComposerContractInspection;
+  model: {
+    draftCount: number;
+    conversationCount: number;
+    missingCount: number;
+    ambiguousCount: number;
+  };
+  settings: RendererSettingsContractInspection;
+  sidebar: RendererSidebarContractInspection;
+  fork: RendererForkContractInspection;
+  production: {
+    bindingPresent: boolean;
+    adapterState: "installing" | "ready" | "unsupported" | "absent";
+    adapterReason: string;
+    titlePolicyState: "ready" | "absent" | "unknown";
+    draftPrewarmPolicyState: "ready" | "absent" | "unknown";
+  };
+}
+
+declare global {
+  interface Window {
+    __codexhostContractAuditV1?: RendererContractAuditApi;
+  }
+}
+
+function modelCounts(states: readonly RendererComposerModelContractState[]): {
+  draftCount: number;
+  conversationCount: number;
+  missingCount: number;
+  ambiguousCount: number;
+} {
+  return {
+    draftCount: states.filter((state) => state === "draft").length,
+    conversationCount: states.filter((state) => state === "conversation").length,
+    missingCount: states.filter((state) => state === "missing").length,
+    ambiguousCount: states.filter((state) => state === "ambiguous").length,
+  };
+}
+
+export function inspectRendererContracts(
+  ownerWindow: Window = window,
+): RendererContractAuditInspection {
+  const composers = [...ownerWindow.document.querySelectorAll<Element>(CODEX_COMPOSER_SELECTOR)];
+  const binding = ownerWindow.__codexhostRendererBindingProbeV1;
+  const status = binding?.status();
+  const adapterState = status?.adapter.state ?? "absent";
+  const titlePolicy = ownerWindow.__codexhostMainProcessTitlePolicyV1;
+  const draftPolicy = ownerWindow.__codexhostDraftPrewarmPolicyV1;
+  return {
+    schemaVersion: RENDERER_CONTRACT_AUDIT_SCHEMA_VERSION,
+    composer: inspectRendererComposerContract(ownerWindow.document),
+    model: modelCounts(composers.map(inspectComposerModelContract)),
+    settings: inspectRendererSettingsContract(ownerWindow.document),
+    sidebar: inspectRendererSidebarContract(ownerWindow.document),
+    fork: inspectRendererForkContract(ownerWindow.document),
+    production: {
+      bindingPresent: binding !== undefined,
+      adapterState,
+      adapterReason: status?.adapter.state ?? "absent",
+      titlePolicyState:
+        titlePolicy === undefined ? "absent" : titlePolicy.state === "ready" ? "ready" : "unknown",
+      draftPrewarmPolicyState:
+        draftPolicy === undefined ? "absent" : draftPolicy.state === "ready" ? "ready" : "unknown",
+    },
+  };
+}

--- a/packages/renderer-extension/src/index.ts
+++ b/packages/renderer-extension/src/index.ts
@@ -44,9 +44,11 @@ export {
 } from "./renderer-model-client.js";
 export type { RendererModelClient } from "./renderer-model-client.js";
 export {
+  inspectRendererComposerContract,
   isNativeContextUsageControlCandidate,
   nativeContextUsageControlForComposer,
 } from "./renderer-composer-dom.js";
+export type { RendererComposerContractInspection } from "./renderer-composer-dom.js";
 export { mountRendererHarnessCommandControl } from "./renderer-harness-command-control.js";
 export type { RendererHarnessCommandControl } from "./renderer-harness-command-control.js";
 export {
@@ -61,10 +63,12 @@ export {
   formatRendererTokenCount,
 } from "./renderer-usage-control.js";
 export {
+  inspectRendererForkContract,
   installRendererForkControl,
   rendererForkTargetFromButton,
 } from "./renderer-fork-control.js";
 export type {
+  RendererForkContractInspection,
   RendererForkControl,
   RendererForkDom,
   RendererForkTarget,
@@ -97,6 +101,7 @@ export {
   decodePiTransportModelId,
   findActivePrewarmTargets,
   findComposerModelTarget,
+  inspectComposerModelContract,
   installCurrentRendererAdapter,
   isClaudeTransportModelId,
   isDeepSeekHarnessTransportModelId,
@@ -119,12 +124,28 @@ export type {
   RendererDraftPrewarmPolicy,
   RendererAdapterState,
   RendererAdapterStatus,
+  RendererComposerModelContractState,
 } from "./versioned-renderer-adapter.js";
+export {
+  inspectRendererSidebarContract,
+  SIDEBAR_AGENT_ICON_ATTRIBUTE,
+  SIDEBAR_THREAD_ROW_ATTRIBUTE,
+  SIDEBAR_THREAD_ROW_SELECTOR,
+} from "./renderer-sidebar-agent-icons.js";
+export type { RendererSidebarContractInspection } from "./renderer-sidebar-agent-icons.js";
 export type {
   ExternalModelControlView,
   ExternalPermissionModeControlView,
   PiModelControlView,
 } from "./renderer-composer-dom.js";
+export {
+  RENDERER_CONTRACT_AUDIT_SCHEMA_VERSION,
+  inspectRendererContracts,
+} from "./contract-audit.js";
+export type {
+  RendererContractAuditApi,
+  RendererContractAuditInspection,
+} from "./contract-audit.js";
 export {
   CLAUDE_PERMISSION_MODE_PREFERENCE_KEY,
   readClaudePermissionModePreference,
@@ -191,12 +212,14 @@ export type { RendererSettingsShell } from "./settings/shell.js";
 export {
   SETTINGS_HEADER_SURFACE_SELECTOR,
   SETTINGS_TRIGGER_ATTRIBUTE,
+  inspectRendererSettingsContract,
   installRendererSettingsHeaderTrigger,
   mountRendererSettingsTrigger,
   selectRendererSettingsHeaderSlot,
 } from "./settings/trigger.js";
 export type {
   RendererSettingsBounds,
+  RendererSettingsContractInspection,
   RendererSettingsHeaderSlotCandidate,
   RendererSettingsHeaderTriggerControl,
   RendererSettingsTriggerControl,

--- a/packages/renderer-extension/src/renderer-composer-dom.ts
+++ b/packages/renderer-extension/src/renderer-composer-dom.ts
@@ -63,6 +63,20 @@ interface NativeControlState {
 type NativeModelControlState = NativeControlState;
 type NativePermissionModeControlState = NativeControlState;
 
+export interface RendererComposerContractInspection {
+  composerCount: number;
+  visibleComposerCount: number;
+  activeComposerCount: number;
+  modelCandidateCount: number;
+  verifiedModelCandidateCount: number;
+  permissionCandidateCount: number;
+  verifiedPermissionCandidateCount: number;
+  contextUsageCandidateCount: number;
+  verifiedContextUsageCandidateCount: number;
+  sendButtonCount: number;
+  trailingActionOwnerCount: number;
+}
+
 export interface ComposerAgentControl {
   composer: Element;
   root: HTMLElement;
@@ -336,6 +350,74 @@ export function nativeContextUsageControlForComposer(composer: Element): HTMLEle
     ...composer.querySelectorAll<HTMLElement>('span[role="img"][aria-label]'),
   ].filter(isNativeContextUsageControlCandidate);
   return candidates.length === 1 ? (candidates[0] ?? null) : null;
+}
+
+function contractElementVisible(element: Element): boolean {
+  const typed = element as HTMLElement;
+  const bounds = typed.getBoundingClientRect?.();
+  if (!bounds || bounds.width <= 0 || bounds.height <= 0) return false;
+  if (typed.hidden || typed.getAttribute?.("aria-hidden") === "true") return false;
+  const view = element.ownerDocument?.defaultView;
+  const style = view?.getComputedStyle?.(typed);
+  return !style || (style.display !== "none" && style.visibility !== "hidden");
+}
+
+export function inspectRendererComposerContract(
+  root: ParentNode = document,
+): RendererComposerContractInspection {
+  const composers = [...root.querySelectorAll<Element>(CODEX_COMPOSER_SELECTOR)];
+  const result: RendererComposerContractInspection = {
+    composerCount: composers.length,
+    visibleComposerCount: 0,
+    activeComposerCount: 0,
+    modelCandidateCount: 0,
+    verifiedModelCandidateCount: 0,
+    permissionCandidateCount: 0,
+    verifiedPermissionCandidateCount: 0,
+    contextUsageCandidateCount: 0,
+    verifiedContextUsageCandidateCount: 0,
+    sendButtonCount: 0,
+    trailingActionOwnerCount: 0,
+  };
+  for (const composer of composers) {
+    if (contractElementVisible(composer)) result.visibleComposerCount += 1;
+    const editors = [...composer.querySelectorAll<HTMLElement>(EDITOR_SELECTOR)].filter(
+      contractElementVisible,
+    );
+    const allButtons = [...composer.querySelectorAll<HTMLButtonElement>("button")];
+    const sendButton = sendButtonWithin(composer) ?? allButtons.at(-1) ?? null;
+    if (editors.length === 1 && sendButton !== null) result.activeComposerCount += 1;
+    if (sendButton) {
+      result.sendButtonCount += 1;
+      if (trailingActionAnchor(sendButton).parentElement !== null) {
+        result.trailingActionOwnerCount += 1;
+      }
+    }
+    const modelCandidates = [
+      ...composer.querySelectorAll<HTMLElement>('button[aria-haspopup="menu"]'),
+    ].filter((element) => !isOwnedRendererControl(element));
+    result.modelCandidateCount += modelCandidates.length;
+    result.verifiedModelCandidateCount += modelCandidates.filter(
+      isNativeModelControlCandidate,
+    ).length;
+    const permissionCandidates = [
+      ...composer.querySelectorAll<HTMLElement>(
+        'button[aria-haspopup="menu"][data-composer-navigation-target="permissions"]',
+      ),
+    ].filter((element) => !element.hasAttribute("data-codexhost-permission-mode-control"));
+    result.permissionCandidateCount += permissionCandidates.length;
+    result.verifiedPermissionCandidateCount += permissionCandidates.filter(
+      isNativePermissionModeControlCandidate,
+    ).length;
+    const contextCandidates = [
+      ...composer.querySelectorAll<HTMLElement>('span[role="img"][aria-label]'),
+    ].filter((element) => !isOwnedRendererControl(element));
+    result.contextUsageCandidateCount += contextCandidates.length;
+    result.verifiedContextUsageCandidateCount += contextCandidates.filter(
+      isNativeContextUsageControlCandidate,
+    ).length;
+  }
+  return result;
 }
 
 function captureNativeControl(element: HTMLElement | null): NativeControlState | null {

--- a/packages/renderer-extension/src/renderer-fork-control.ts
+++ b/packages/renderer-extension/src/renderer-fork-control.ts
@@ -32,6 +32,12 @@ export interface RendererForkControl {
   dispose(): void;
 }
 
+export interface RendererForkContractInspection {
+  annotatedResponseCount: number;
+  candidateButtonCount: number;
+  verifiedButtonCount: number;
+}
+
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
@@ -93,6 +99,24 @@ export function rendererForkTargetFromButton(button: HTMLButtonElement): Rendere
     isProjectlessConversation: projectlessStates.has(true),
     threadId: threadId.data,
     turnId: turnId.data,
+  };
+}
+
+export function inspectRendererForkContract(
+  root: ParentNode = document,
+): RendererForkContractInspection {
+  const annotatedResponses = [
+    ...root.querySelectorAll<HTMLElement>(`[${RESPONSE_CONVERSATION_ATTRIBUTE}]`),
+  ];
+  const candidateButtons = annotatedResponses.flatMap((annotation) => [
+    ...annotation.querySelectorAll<HTMLButtonElement>("button"),
+  ]);
+  return {
+    annotatedResponseCount: annotatedResponses.length,
+    candidateButtonCount: candidateButtons.length,
+    verifiedButtonCount: candidateButtons.filter(
+      (button) => rendererForkTargetFromButton(button) !== null,
+    ).length,
   };
 }
 

--- a/packages/renderer-extension/src/renderer-sidebar-agent-icons.ts
+++ b/packages/renderer-extension/src/renderer-sidebar-agent-icons.ts
@@ -14,6 +14,13 @@ export const SIDEBAR_THREAD_ID_ATTRIBUTE = "data-app-action-sidebar-thread-id";
 export const SIDEBAR_THREAD_HOST_ID_ATTRIBUTE = "data-app-action-sidebar-thread-host-id";
 export const SIDEBAR_AGENT_ICON_ATTRIBUTE = "data-codexhost-sidebar-agent-icon";
 
+export interface RendererSidebarContractInspection {
+  rowCount: number;
+  titleOwnerCount: number;
+  resolvedThreadCount: number;
+  ambiguousThreadCount: number;
+}
+
 const OWNERSHIP_RETRY_DELAYS_MS = [100, 300, 800, 1_500, 3_000] as const;
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -74,6 +81,30 @@ export function threadIdFromSidebarRowElement(element: HTMLElement): string | nu
     fiber = isRecord(fiber.return) ? fiber.return : null;
   }
   return candidates.size === 1 ? (candidates.values().next().value ?? null) : null;
+}
+
+export function inspectRendererSidebarContract(
+  root: ParentNode = document,
+): RendererSidebarContractInspection {
+  const rows = [...root.querySelectorAll<HTMLElement>(SIDEBAR_THREAD_ROW_SELECTOR)];
+  let titleOwnerCount = 0;
+  let resolvedThreadCount = 0;
+  let ambiguousThreadCount = 0;
+  for (const row of rows) {
+    const titleTrigger = row.querySelector<HTMLElement>("[data-thread-title-trigger]");
+    const title = titleTrigger?.querySelector<HTMLElement>("[data-thread-title]");
+    if (titleTrigger && title) titleOwnerCount += 1;
+    const attributes = sidebarThreadAttributes(row);
+    if (!attributes || attributes.taskKey.startsWith("client-new-thread:")) continue;
+    if (threadIdFromSidebarRowElement(row) === null) ambiguousThreadCount += 1;
+    else resolvedThreadCount += 1;
+  }
+  return {
+    rowCount: rows.length,
+    titleOwnerCount,
+    resolvedThreadCount,
+    ambiguousThreadCount,
+  };
 }
 
 export interface SidebarAgentIconRow {

--- a/packages/renderer-extension/src/settings/trigger.ts
+++ b/packages/renderer-extension/src/settings/trigger.ts
@@ -46,6 +46,12 @@ interface RendererSettingsHeaderInsertionPoint {
   before: ChildNode | null;
 }
 
+export interface RendererSettingsContractInspection {
+  headerCount: number;
+  visibleHeaderCount: number;
+  insertionPointCount: number;
+}
+
 function measuredBounds(element: Element): RendererSettingsBounds {
   const bounds = element.getBoundingClientRect();
   return {
@@ -82,6 +88,29 @@ export function selectRendererSettingsHeaderSlot<T>(
       left.bounds.left - right.bounds.left,
   );
   return eligible[0]?.value ?? null;
+}
+
+export function inspectRendererSettingsContract(
+  ownerDocument: Document = document,
+): RendererSettingsContractInspection {
+  const headers = [
+    ...ownerDocument.querySelectorAll<HTMLElement>(SETTINGS_APPLICATION_HEADER_SELECTOR),
+  ];
+  const visibleHeaders = headers.filter((header) => {
+    const bounds = measuredBounds(header);
+    return bounds.width > 0 && bounds.height > 0;
+  });
+  const insertionPointCount = visibleHeaders.filter((header) =>
+    [...header.querySelectorAll<HTMLElement>(SETTINGS_HEADER_SLOT_SELECTOR)].some((slot) => {
+      const bounds = measuredBounds(slot);
+      return bounds.width > 0 && bounds.height > 0;
+    }),
+  ).length;
+  return {
+    headerCount: headers.length,
+    visibleHeaderCount: visibleHeaders.length,
+    insertionPointCount,
+  };
 }
 
 function findRendererSettingsHeaderInsertionPoint(

--- a/packages/renderer-extension/src/versioned-renderer-adapter.ts
+++ b/packages/renderer-extension/src/versioned-renderer-adapter.ts
@@ -577,6 +577,19 @@ export function findComposerModelTarget(composer: Element): readonly unknown[] |
   return ["default", draftIds.values().next().value];
 }
 
+export type RendererComposerModelContractState = "draft" | "conversation" | "missing" | "ambiguous";
+
+export function inspectComposerModelContract(
+  composer: Element,
+): RendererComposerModelContractState {
+  const target = findComposerModelTarget(composer);
+  if (target?.[0] === "default") return "draft";
+  if (target?.[0] === "conversation") return "conversation";
+  const domIdentity = findComposerDomIdentity(composer);
+  if (domIdentity.kind === "ambiguous") return "ambiguous";
+  return "missing";
+}
+
 export function isMainProcessTitlePolicyReady(value: unknown): boolean {
   return isRecord(value) && value.state === "ready";
 }

--- a/packages/renderer-extension/test/contract-audit.test.ts
+++ b/packages/renderer-extension/test/contract-audit.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  inspectRendererComposerContract,
+  inspectRendererForkContract,
+  inspectRendererSettingsContract,
+  inspectRendererSidebarContract,
+} from "../src/index.js";
+
+function list<T>(values: T[]): NodeListOf<T & Node> {
+  return values as unknown as NodeListOf<T & Node>;
+}
+
+describe("Renderer contract audit inspectors", () => {
+  it("classifies a semantic Composer without reading content", () => {
+    const editor = {
+      hidden: false,
+      getAttribute: () => null,
+      getBoundingClientRect: () => ({ width: 100, height: 24 }),
+      ownerDocument: { defaultView: null },
+    } as unknown as HTMLElement;
+    const send = {
+      type: "submit",
+      parentElement: { children: [], parentElement: null },
+      hasAttribute: () => false,
+      getAttribute: () => null,
+      querySelectorAll: () => list([]),
+    } as unknown as HTMLButtonElement;
+    const composer = {
+      hidden: false,
+      getAttribute: () => null,
+      getBoundingClientRect: () => ({ width: 600, height: 120 }),
+      ownerDocument: { defaultView: null },
+      querySelectorAll: (selector: string) => {
+        if (selector.includes("textarea")) return list([editor]);
+        if (selector === "button") return list([send]);
+        return list([]);
+      },
+    } as unknown as Element;
+    const root = {
+      querySelectorAll: () => list([composer]),
+    } as unknown as ParentNode;
+
+    expect(inspectRendererComposerContract(root)).toMatchObject({
+      composerCount: 1,
+      visibleComposerCount: 1,
+      activeComposerCount: 1,
+      sendButtonCount: 1,
+    });
+  });
+
+  it("reports inactive Settings, Sidebar, and Fork surfaces with zero counts", () => {
+    const root = { querySelectorAll: () => list([]) } as unknown as Document;
+    expect(inspectRendererSettingsContract(root)).toEqual({
+      headerCount: 0,
+      visibleHeaderCount: 0,
+      insertionPointCount: 0,
+    });
+    expect(inspectRendererSidebarContract(root)).toEqual({
+      rowCount: 0,
+      titleOwnerCount: 0,
+      resolvedThreadCount: 0,
+      ambiguousThreadCount: 0,
+    });
+    expect(inspectRendererForkContract(root)).toEqual({
+      annotatedResponseCount: 0,
+      candidateButtonCount: 0,
+      verifiedButtonCount: 0,
+    });
+  });
+});

--- a/tests/release/production-renderer.test.mjs
+++ b/tests/release/production-renderer.test.mjs
@@ -52,6 +52,19 @@ describe("production Renderer release chain", () => {
     ).toThrow("invalid selection");
   });
 
+  it("builds the local audit entry without packaging it in production", async () => {
+    const [rendererManifest, auditEntry, releaseBuilder] = await Promise.all([
+      source("packages/renderer-extension/package.json"),
+      source("packages/renderer-extension/src/audit-entry.ts"),
+      source("scripts/release/prepare-payload.mjs"),
+    ]);
+
+    expect(rendererManifest).toContain("src/audit-entry.ts");
+    expect(rendererManifest).toContain("dist/contract-audit.js");
+    expect(auditEntry).toContain("__codexhostContractAuditV1");
+    expect(releaseBuilder).not.toContain("contract-audit.js");
+  });
+
   it("builds and packages executable production entries", async () => {
     const [rendererManifest, releaseBuilder] = await Promise.all([
       source("packages/renderer-extension/package.json"),

--- a/tools/codex-desktop-contract-audit/README.md
+++ b/tools/codex-desktop-contract-audit/README.md
@@ -1,0 +1,62 @@
+# Codex Desktop contract audit
+
+This local maintainer tool checks the semantic Codex Desktop GUI contracts consumed by codexhost. It is not part of Launcher startup, Controller readiness, the Host runtime, the Renderer production entry, or Settings updates.
+
+## Build and run
+
+Start or attach to a controlled Codex Desktop with loopback CDP and Electron Inspector endpoints, then run:
+
+```bash
+npm run audit:codex-desktop -- \
+  --endpoint http://127.0.0.1:9222 \
+  --inspector-endpoint http://127.0.0.1:9223
+```
+
+The default `read-only` mode evaluates a standalone audit bundle in the selected Renderer. It does not reload the page, install codexhost production policies, switch Agent state, submit a Composer, create or delete a Thread, open Settings, Fork, or alter the installed application.
+
+To compare against a report that has already been reviewed:
+
+```bash
+npm run audit:codex-desktop -- --baseline .codexhost/update-impact/26.1/audit-report.json
+```
+
+The tool never chooses a baseline automatically. A first run without a baseline still records current evidence, while baseline-dependent conclusions remain explicit.
+
+## Controlled installation check
+
+Use controlled mode only with an isolated Desktop lifecycle:
+
+```bash
+npm run audit:codex-desktop -- --mode controlled
+```
+
+Controlled mode reuses the existing production `RendererControlSession`. It can reload the Renderer and install Title, Draft/Prewarm, and Renderer binding policies. It still does not automatically submit, create a Thread, open Settings, execute Fork, or exercise title creation, so those behavior checks remain `unverified`.
+
+## Evidence
+
+Reports are written under ignored `.codexhost/update-impact/<desktop-version>/` as:
+
+```text
+audit-report.json
+audit-report.md
+```
+
+The report contains bounded version/build, app.asar integrity, Chromium/protocol identity, checks that ran, normalized counts and ownership results, and per-surface verdicts:
+
+- `no-impact`
+- `confirmed-impact`
+- `possible-impact`
+- `unverified`
+
+The tool does not retain prompts, transcripts, input or rendered text, Model values, Thread/Request IDs, credentials, tokens, RPC payloads, complete URLs, user paths, function source, full DOM snapshots, screenshots, complete bundles, or complete `app.asar` files.
+
+## Supplying Desktop identity
+
+By default the command uses a built `target/debug/codexhost inspect`. A different Launcher may be provided with `--launcher`. For fixture or remote endpoint audits, all three bounded values may be supplied directly:
+
+```bash
+npm run audit:codex-desktop -- \
+  --desktop-version 26.1 \
+  --desktop-build 100 \
+  --asar-integrity sha256:<64-lowercase-hex>
+```

--- a/tools/codex-desktop-contract-audit/report.mjs
+++ b/tools/codex-desktop-contract-audit/report.mjs
@@ -1,0 +1,415 @@
+export const AUDIT_REPORT_SCHEMA_VERSION = 1;
+export const AUDIT_VERDICTS = Object.freeze([
+  "no-impact",
+  "confirmed-impact",
+  "possible-impact",
+  "unverified",
+]);
+
+export const AUDIT_SURFACE_IDS = Object.freeze([
+  "composer",
+  "model",
+  "permission",
+  "request-prewarm",
+  "title",
+  "settings",
+  "sidebar",
+  "usage-credits",
+  "fork",
+]);
+
+const verdictRank = Object.freeze({
+  "no-impact": 0,
+  unverified: 1,
+  "possible-impact": 2,
+  "confirmed-impact": 3,
+});
+
+function isRecord(value) {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function exactKeys(value, expected, label) {
+  if (!isRecord(value)) throw new Error(`${label} must be an object`);
+  const actual = Object.keys(value).sort();
+  const sorted = [...expected].sort();
+  if (actual.length !== sorted.length || actual.some((key, index) => key !== sorted[index])) {
+    throw new Error(`${label} contains unknown or missing fields`);
+  }
+}
+
+function boundedText(value, label, maximum = 128) {
+  if (typeof value !== "string" || value.length === 0 || value.length > maximum) {
+    throw new Error(`${label} must be bounded text`);
+  }
+  return value;
+}
+
+function optionalBoundedText(value, label, maximum = 128) {
+  if (value === null) return null;
+  return boundedText(value, label, maximum);
+}
+
+function integer(value, label) {
+  if (!Number.isInteger(value) || value < 0)
+    throw new Error(`${label} must be a non-negative integer`);
+  return value;
+}
+
+function validateEvidence(value, label) {
+  exactKeys(value, ["static", "liveStructure", "installation", "behavior"], label);
+  const allowed = ["pass", "fail", "changed", "not-run", "inactive"];
+  const result = {};
+  for (const key of ["static", "liveStructure", "installation", "behavior"]) {
+    if (!allowed.includes(value[key])) throw new Error(`${label}.${key} is invalid`);
+    result[key] = value[key];
+  }
+  return result;
+}
+
+function validateSurface(value, index) {
+  exactKeys(
+    value,
+    ["id", "verdict", "reason", "evidence", "observed", "baselineChanged"],
+    `surface ${index}`,
+  );
+  const id = boundedText(value.id, `surface ${index}.id`, 64);
+  if (!AUDIT_SURFACE_IDS.includes(id)) throw new Error(`surface ${index}.id is unknown`);
+  if (!AUDIT_VERDICTS.includes(value.verdict))
+    throw new Error(`surface ${index}.verdict is invalid`);
+  if (typeof value.baselineChanged !== "boolean")
+    throw new Error(`surface ${index}.baselineChanged is invalid`);
+  if (!isRecord(value.observed)) throw new Error(`surface ${index}.observed must be an object`);
+  const observed = {};
+  for (const [key, observedValue] of Object.entries(value.observed)) {
+    if (!/^[a-z][a-zA-Z0-9]{0,63}$/.test(key))
+      throw new Error(`surface ${index}.observed key is invalid`);
+    if (typeof observedValue === "boolean") observed[key] = observedValue;
+    else observed[key] = integer(observedValue, `surface ${index}.observed.${key}`);
+  }
+  return {
+    id,
+    verdict: value.verdict,
+    reason: boundedText(value.reason, `surface ${index}.reason`, 96),
+    evidence: validateEvidence(value.evidence, `surface ${index}.evidence`),
+    observed,
+    baselineChanged: value.baselineChanged,
+  };
+}
+
+export function validateAuditReport(value) {
+  exactKeys(
+    value,
+    [
+      "schemaVersion",
+      "recordedAt",
+      "mode",
+      "verdict",
+      "desktop",
+      "browser",
+      "checksRun",
+      "baseline",
+      "surfaces",
+    ],
+    "audit report",
+  );
+  if (value.schemaVersion !== AUDIT_REPORT_SCHEMA_VERSION)
+    throw new Error("audit report schema is unsupported");
+  if (!Number.isFinite(Date.parse(value.recordedAt)))
+    throw new Error("audit report timestamp is invalid");
+  if (!["read-only", "controlled"].includes(value.mode))
+    throw new Error("audit report mode is invalid");
+  if (!AUDIT_VERDICTS.includes(value.verdict)) throw new Error("audit report verdict is invalid");
+  exactKeys(value.desktop, ["version", "build", "asarIntegrity"], "audit report desktop");
+  exactKeys(value.browser, ["browser", "protocolVersion"], "audit report browser");
+  exactKeys(value.baseline, ["supplied", "version", "build"], "audit report baseline");
+  if (typeof value.baseline.supplied !== "boolean")
+    throw new Error("audit report baseline flag is invalid");
+  if (
+    !Array.isArray(value.checksRun) ||
+    value.checksRun.some((item) => typeof item !== "string" || item.length > 64)
+  ) {
+    throw new Error("audit report checksRun is invalid");
+  }
+  if (!Array.isArray(value.surfaces) || value.surfaces.length !== AUDIT_SURFACE_IDS.length) {
+    throw new Error("audit report surfaces are incomplete");
+  }
+  const surfaces = value.surfaces.map(validateSurface);
+  if (new Set(surfaces.map(({ id }) => id)).size !== AUDIT_SURFACE_IDS.length) {
+    throw new Error("audit report surfaces must be unique");
+  }
+  const report = {
+    schemaVersion: AUDIT_REPORT_SCHEMA_VERSION,
+    recordedAt: new Date(value.recordedAt).toISOString(),
+    mode: value.mode,
+    verdict: value.verdict,
+    desktop: {
+      version: boundedText(value.desktop.version, "audit report desktop.version", 64),
+      build: boundedText(value.desktop.build, "audit report desktop.build", 64),
+      asarIntegrity: boundedText(
+        value.desktop.asarIntegrity,
+        "audit report desktop.asarIntegrity",
+        80,
+      ),
+    },
+    browser: {
+      browser: boundedText(value.browser.browser, "audit report browser.browser", 96),
+      protocolVersion: boundedText(
+        value.browser.protocolVersion,
+        "audit report browser.protocolVersion",
+        32,
+      ),
+    },
+    checksRun: [...new Set(value.checksRun)],
+    baseline: {
+      supplied: value.baseline.supplied,
+      version: optionalBoundedText(value.baseline.version, "audit report baseline.version", 64),
+      build: optionalBoundedText(value.baseline.build, "audit report baseline.build", 64),
+    },
+    surfaces,
+  };
+  if (aggregateVerdict(surfaces) !== report.verdict)
+    throw new Error("audit report aggregate verdict is inconsistent");
+  return report;
+}
+
+export function aggregateVerdict(surfaces) {
+  return surfaces.reduce(
+    (current, surface) =>
+      verdictRank[surface.verdict] > verdictRank[current] ? surface.verdict : current,
+    "no-impact",
+  );
+}
+
+function stateForUnique(count, active) {
+  if (!active) return "inactive";
+  if (count === 1) return "pass";
+  return "fail";
+}
+
+function baselineSurface(baseline, id) {
+  return baseline?.surfaces?.find((surface) => surface.id === id) ?? null;
+}
+
+function compareObserved(baseline, id, observed) {
+  const previous = baselineSurface(baseline, id);
+  return previous !== null && JSON.stringify(previous.observed) !== JSON.stringify(observed);
+}
+
+function classifySurface({
+  id,
+  observed,
+  live,
+  installation = "not-run",
+  behavior = "not-run",
+  active = true,
+  reason,
+  baseline,
+}) {
+  const baselineChanged = compareObserved(baseline, id, observed);
+  let verdict;
+  let finalReason = reason;
+  if (!active) {
+    verdict = baselineChanged ? "possible-impact" : "unverified";
+    finalReason = baselineChanged ? "baseline-changed-without-active-state" : reason;
+  } else if (live === "fail" || installation === "fail" || behavior === "fail") {
+    verdict = "confirmed-impact";
+  } else if (baselineChanged) {
+    verdict = "possible-impact";
+    finalReason = "normalized-contract-changed";
+  } else {
+    verdict = "no-impact";
+  }
+  return {
+    id,
+    verdict,
+    reason: finalReason,
+    evidence: {
+      static: baseline ? (baselineChanged ? "changed" : "pass") : "not-run",
+      liveStructure: live,
+      installation,
+      behavior,
+    },
+    observed,
+    baselineChanged,
+  };
+}
+
+export function buildSurfaceResults(contracts, baseline = null, controlled = null) {
+  const activeComposer = contracts.composer.activeComposerCount === 1;
+  const composer = classifySurface({
+    id: "composer",
+    observed: {
+      composerCount: contracts.composer.composerCount,
+      visibleComposerCount: contracts.composer.visibleComposerCount,
+      activeComposerCount: contracts.composer.activeComposerCount,
+      sendButtonCount: contracts.composer.sendButtonCount,
+      trailingActionOwnerCount: contracts.composer.trailingActionOwnerCount,
+    },
+    live: stateForUnique(
+      contracts.composer.activeComposerCount,
+      contracts.composer.visibleComposerCount > 0,
+    ),
+    active: contracts.composer.visibleComposerCount > 0,
+    reason:
+      contracts.composer.visibleComposerCount > 0
+        ? "active-composer-cardinality"
+        : "composer-state-not-visible",
+    baseline,
+  });
+  const modelResolved = contracts.model.draftCount + contracts.model.conversationCount;
+  const model = classifySurface({
+    id: "model",
+    observed: {
+      resolvedTargetCount: modelResolved,
+      missingCount: contracts.model.missingCount,
+      ambiguousCount: contracts.model.ambiguousCount,
+      verifiedTriggerCount: contracts.composer.verifiedModelCandidateCount,
+    },
+    live:
+      activeComposer && modelResolved === 1 && contracts.model.ambiguousCount === 0
+        ? "pass"
+        : activeComposer
+          ? "fail"
+          : "inactive",
+    active: activeComposer,
+    reason: activeComposer ? "composer-model-target" : "composer-state-not-active",
+    baseline,
+  });
+  const permissionActive = contracts.composer.permissionCandidateCount > 0;
+  const permission = classifySurface({
+    id: "permission",
+    observed: {
+      candidateCount: contracts.composer.permissionCandidateCount,
+      verifiedCount: contracts.composer.verifiedPermissionCandidateCount,
+    },
+    live: stateForUnique(contracts.composer.verifiedPermissionCandidateCount, permissionActive),
+    active: permissionActive,
+    reason: permissionActive ? "permission-owner-cardinality" : "permission-control-state-inactive",
+    baseline,
+  });
+  const installationRequested = controlled !== null;
+  const requestInstallation = installationRequested
+    ? controlled.draftPrewarmPolicyState === "ready" && controlled.adapterState === "ready"
+      ? "pass"
+      : "fail"
+    : contracts.production.bindingPresent
+      ? contracts.production.draftPrewarmPolicyState === "ready" &&
+        contracts.production.adapterState === "ready"
+        ? "pass"
+        : "fail"
+      : "not-run";
+  const request = classifySurface({
+    id: "request-prewarm",
+    observed: {
+      bindingPresent: contracts.production.bindingPresent,
+      adapterReady: contracts.production.adapterState === "ready",
+      draftPrewarmReady: contracts.production.draftPrewarmPolicyState === "ready",
+    },
+    live: activeComposer ? "pass" : "inactive",
+    installation: requestInstallation,
+    active: activeComposer,
+    reason: activeComposer ? "request-prewarm-observation" : "composer-state-not-active",
+    baseline,
+  });
+  const titleInstallation = installationRequested
+    ? controlled.titlePolicyState === "ready"
+      ? "pass"
+      : "fail"
+    : contracts.production.bindingPresent
+      ? contracts.production.titlePolicyState === "ready"
+        ? "pass"
+        : "fail"
+      : "not-run";
+  const effectiveTitleReady =
+    controlled?.titlePolicyState === "ready" || contracts.production.titlePolicyState === "ready";
+  const title = classifySurface({
+    id: "title",
+    observed: { titlePolicyReady: effectiveTitleReady },
+    live: effectiveTitleReady ? "pass" : "inactive",
+    installation: titleInstallation,
+    behavior: controlled?.titleBehavior ?? "not-run",
+    active: contracts.production.bindingPresent || installationRequested,
+    reason:
+      contracts.production.bindingPresent || installationRequested
+        ? "title-policy-observation"
+        : "title-policy-not-installed",
+    baseline,
+  });
+  const settingsActive = contracts.settings.visibleHeaderCount > 0;
+  const settings = classifySurface({
+    id: "settings",
+    observed: contracts.settings,
+    live: stateForUnique(contracts.settings.insertionPointCount, settingsActive),
+    behavior: controlled?.settingsBehavior ?? "not-run",
+    active: settingsActive,
+    reason: settingsActive ? "settings-insertion-cardinality" : "application-header-state-inactive",
+    baseline,
+  });
+  const sidebarActive = contracts.sidebar.rowCount > 0;
+  const sidebar = classifySurface({
+    id: "sidebar",
+    observed: contracts.sidebar,
+    live:
+      sidebarActive &&
+      contracts.sidebar.ambiguousThreadCount === 0 &&
+      contracts.sidebar.titleOwnerCount === contracts.sidebar.rowCount
+        ? "pass"
+        : sidebarActive
+          ? "fail"
+          : "inactive",
+    active: sidebarActive,
+    reason: sidebarActive ? "sidebar-row-ownership" : "sidebar-thread-state-inactive",
+    baseline,
+  });
+  const usageActive = contracts.composer.contextUsageCandidateCount > 0;
+  const usageCredits = classifySurface({
+    id: "usage-credits",
+    observed: {
+      candidateCount: contracts.composer.contextUsageCandidateCount,
+      verifiedCount: contracts.composer.verifiedContextUsageCandidateCount,
+    },
+    live: stateForUnique(contracts.composer.verifiedContextUsageCandidateCount, usageActive),
+    active: usageActive,
+    reason: usageActive ? "context-usage-owner-cardinality" : "usage-control-state-inactive",
+    baseline,
+  });
+  const forkActive = contracts.fork.annotatedResponseCount > 0;
+  const fork = classifySurface({
+    id: "fork",
+    observed: contracts.fork,
+    live:
+      forkActive && contracts.fork.verifiedButtonCount > 0
+        ? "pass"
+        : forkActive
+          ? "fail"
+          : "inactive",
+    behavior: controlled?.forkBehavior ?? "not-run",
+    active: forkActive,
+    reason: forkActive ? "fork-owner-cardinality" : "fork-surface-state-inactive",
+    baseline,
+  });
+  return [composer, model, permission, request, title, settings, sidebar, usageCredits, fork];
+}
+
+export function auditReportMarkdown(report) {
+  const lines = [
+    `# Codex Desktop contract audit`,
+    "",
+    `**Verdict:** ${report.verdict}`,
+    `**Mode:** ${report.mode}`,
+    `**Desktop:** ${report.desktop.version} (${report.desktop.build})`,
+    `**Browser:** ${report.browser.browser}; protocol ${report.browser.protocolVersion}`,
+    `**Reviewed baseline:** ${report.baseline.supplied ? `${report.baseline.version} (${report.baseline.build})` : "not supplied"}`,
+    "",
+    "| Surface | Verdict | Reason | Structure | Installation | Behavior |",
+    "| --- | --- | --- | --- | --- | --- |",
+  ];
+  for (const surface of report.surfaces) {
+    lines.push(
+      `| ${surface.id} | ${surface.verdict} | ${surface.reason} | ${surface.evidence.liveStructure} | ${surface.evidence.installation} | ${surface.evidence.behavior} |`,
+    );
+  }
+  lines.push("", `Checks run: ${report.checksRun.join(", ") || "none"}`, "");
+  return `${lines.join("\n")}\n`;
+}

--- a/tools/codex-desktop-contract-audit/report.test.mjs
+++ b/tools/codex-desktop-contract-audit/report.test.mjs
@@ -1,0 +1,96 @@
+import { describe, expect, it } from "vitest";
+
+import { aggregateVerdict, buildSurfaceResults, validateAuditReport } from "./report.mjs";
+
+const contracts = {
+  composer: {
+    composerCount: 1,
+    visibleComposerCount: 1,
+    activeComposerCount: 1,
+    modelCandidateCount: 1,
+    verifiedModelCandidateCount: 1,
+    permissionCandidateCount: 0,
+    verifiedPermissionCandidateCount: 0,
+    contextUsageCandidateCount: 0,
+    verifiedContextUsageCandidateCount: 0,
+    sendButtonCount: 1,
+    trailingActionOwnerCount: 1,
+  },
+  model: { draftCount: 1, conversationCount: 0, missingCount: 0, ambiguousCount: 0 },
+  settings: { headerCount: 1, visibleHeaderCount: 1, insertionPointCount: 1 },
+  sidebar: { rowCount: 0, titleOwnerCount: 0, resolvedThreadCount: 0, ambiguousThreadCount: 0 },
+  fork: { annotatedResponseCount: 0, candidateButtonCount: 0, verifiedButtonCount: 0 },
+  production: {
+    bindingPresent: false,
+    adapterState: "absent",
+    adapterReason: "absent",
+    titlePolicyState: "absent",
+    draftPrewarmPolicyState: "absent",
+  },
+};
+
+function reportFor(surfaces) {
+  return {
+    schemaVersion: 1,
+    recordedAt: "2026-08-30T00:00:00.000Z",
+    mode: "read-only",
+    verdict: aggregateVerdict(surfaces),
+    desktop: { version: "26.1", build: "100", asarIntegrity: `sha256:${"a".repeat(64)}` },
+    browser: { browser: "Chrome/151", protocolVersion: "1.3" },
+    checksRun: ["renderer-contracts-read-only"],
+    baseline: { supplied: false, version: null, build: null },
+    surfaces,
+  };
+}
+
+describe("Codex Desktop contract audit report", () => {
+  it("keeps state-conditional surfaces unverified instead of failed", () => {
+    const surfaces = buildSurfaceResults(contracts);
+    expect(surfaces.find(({ id }) => id === "permission")?.verdict).toBe("unverified");
+    expect(surfaces.find(({ id }) => id === "fork")?.verdict).toBe("unverified");
+    expect(surfaces.find(({ id }) => id === "composer")?.verdict).toBe("no-impact");
+  });
+
+  it("reports ambiguous active ownership as confirmed impact", () => {
+    const surfaces = buildSurfaceResults({
+      ...contracts,
+      model: { draftCount: 0, conversationCount: 0, missingCount: 0, ambiguousCount: 1 },
+    });
+    expect(surfaces.find(({ id }) => id === "model")?.verdict).toBe("confirmed-impact");
+    expect(aggregateVerdict(surfaces)).toBe("confirmed-impact");
+  });
+
+  it("separates controlled installation from unexercised behavior", () => {
+    const surfaces = buildSurfaceResults(contracts, null, {
+      adapterState: "ready",
+      titlePolicyState: "ready",
+      draftPrewarmPolicyState: "ready",
+      titleBehavior: "not-run",
+      settingsBehavior: "not-run",
+      forkBehavior: "not-run",
+    });
+    const title = surfaces.find(({ id }) => id === "title");
+    expect(title?.evidence.installation).toBe("pass");
+    expect(title?.evidence.behavior).toBe("not-run");
+  });
+
+  it("treats a changed inactive baseline surface as possible impact", () => {
+    const baselineSurfaces = buildSurfaceResults(contracts);
+    const baseline = validateAuditReport(reportFor(baselineSurfaces));
+    const surfaces = buildSurfaceResults(
+      {
+        ...contracts,
+        fork: { annotatedResponseCount: 0, candidateButtonCount: 1, verifiedButtonCount: 0 },
+      },
+      baseline,
+    );
+    expect(surfaces.find(({ id }) => id === "fork")?.verdict).toBe("possible-impact");
+  });
+
+  it("rejects unknown report fields instead of persisting them", () => {
+    const surfaces = buildSurfaceResults(contracts);
+    expect(() => validateAuditReport({ ...reportFor(surfaces), privatePrompt: "secret" })).toThrow(
+      "unknown or missing fields",
+    );
+  });
+});

--- a/tools/codex-desktop-contract-audit/run.mjs
+++ b/tools/codex-desktop-contract-audit/run.mjs
@@ -1,0 +1,287 @@
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+
+import {
+  aggregateVerdict,
+  auditReportMarkdown,
+  buildSurfaceResults,
+  validateAuditReport,
+} from "./report.mjs";
+
+const repositoryRoot = path.resolve(import.meta.dirname, "../..");
+const defaultOutputRoot = path.join(repositoryRoot, ".codexhost", "update-impact");
+const defaultEndpoint = "http://127.0.0.1:9222";
+const defaultInspectorEndpoint = "http://127.0.0.1:9223";
+const productionRendererAgents = Object.freeze([
+  "codex",
+  "pi",
+  "claude-code",
+  "deepseek-harness",
+  "grok",
+  "omp",
+]);
+
+function usage() {
+  console.error(`usage:
+  npm run audit:codex-desktop -- [--mode read-only|controlled]
+    [--endpoint <loopback-url>] [--inspector-endpoint <loopback-url>]
+    [--baseline <audit-report.json>] [--output <directory>]
+    [--desktop-version <version>] [--desktop-build <build>]
+    [--asar-integrity <sha256:value>] [--launcher <absolute-codexhost-file>]
+
+Read-only mode is the default. Controlled mode installs the existing production Renderer policies
+and binding in the selected Desktop; it still does not submit, create a Thread, open Settings, fork,
+or exercise title creation.`);
+}
+
+function boundedText(value, option, maximum = 128) {
+  if (
+    typeof value !== "string" ||
+    value.length === 0 ||
+    value.length > maximum ||
+    /[\r\n\0]/u.test(value)
+  ) {
+    throw new Error(`${option} must be bounded single-line text`);
+  }
+  return value;
+}
+
+export function parseAuditArguments(arguments_) {
+  const options = {
+    mode: "read-only",
+    endpoint: defaultEndpoint,
+    inspectorEndpoint: defaultInspectorEndpoint,
+    baselinePath: null,
+    outputRoot: defaultOutputRoot,
+    desktopVersion: null,
+    desktopBuild: null,
+    asarIntegrity: null,
+    launcher: null,
+  };
+  for (let index = 0; index < arguments_.length; index += 1) {
+    const argument = arguments_[index];
+    const value = () => {
+      index += 1;
+      if (index >= arguments_.length) throw new Error(`${argument} requires a value`);
+      return arguments_[index];
+    };
+    switch (argument) {
+      case "--mode":
+        options.mode = value();
+        if (!["read-only", "controlled"].includes(options.mode)) {
+          throw new Error("--mode must be read-only or controlled");
+        }
+        break;
+      case "--endpoint":
+        options.endpoint = value();
+        break;
+      case "--inspector-endpoint":
+        options.inspectorEndpoint = value();
+        break;
+      case "--baseline":
+        options.baselinePath = path.resolve(value());
+        break;
+      case "--output":
+        options.outputRoot = path.resolve(value());
+        break;
+      case "--desktop-version":
+        options.desktopVersion = boundedText(value(), argument, 64);
+        break;
+      case "--desktop-build":
+        options.desktopBuild = boundedText(value(), argument, 64);
+        break;
+      case "--asar-integrity":
+        options.asarIntegrity = boundedText(value(), argument, 80);
+        break;
+      case "--launcher":
+        options.launcher = path.resolve(value());
+        break;
+      case "--help":
+      case "-h":
+        usage();
+        process.exit(0);
+        break;
+      default:
+        throw new Error(`unknown option: ${argument}`);
+    }
+  }
+  validateLoopbackEndpoint(options.endpoint, "--endpoint");
+  validateLoopbackEndpoint(options.inspectorEndpoint, "--inspector-endpoint");
+  return options;
+}
+
+export function validateLoopbackEndpoint(value, option) {
+  const url = new URL(value);
+  if (url.protocol !== "http:" || !["127.0.0.1", "localhost", "[::1]"].includes(url.hostname)) {
+    throw new Error(`${option} must be a loopback HTTP URL`);
+  }
+  const port = url.port === "" ? 80 : Number.parseInt(url.port, 10);
+  if (!Number.isInteger(port) || port < 1 || port > 65_535) {
+    throw new Error(`${option} must contain a valid port`);
+  }
+}
+
+function parseInspectOutput(output) {
+  const values = {};
+  for (const line of output.split(/\r?\n/u)) {
+    const separator = line.indexOf("=");
+    if (separator <= 0) continue;
+    values[line.slice(0, separator)] = line.slice(separator + 1);
+  }
+  return {
+    version: values.desktop_version ?? "unknown",
+    build: values.desktop_build ?? values.desktop_version ?? "unknown",
+    asarIntegrity: values.desktop_asar_integrity ?? "unknown",
+  };
+}
+
+function readDesktopIdentity(options) {
+  if (options.desktopVersion && options.desktopBuild && options.asarIntegrity) {
+    return {
+      version: options.desktopVersion,
+      build: options.desktopBuild,
+      asarIntegrity: options.asarIntegrity,
+    };
+  }
+  const launcher = options.launcher ?? path.join(repositoryRoot, "target", "debug", "codexhost");
+  if (!path.isAbsolute(launcher) || !fs.existsSync(launcher)) {
+    throw new Error(
+      "Desktop identity requires --desktop-version, --desktop-build, and --asar-integrity, or a built --launcher",
+    );
+  }
+  const inspected = parseInspectOutput(
+    execFileSync(launcher, ["inspect"], { encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] }),
+  );
+  return {
+    version: options.desktopVersion ?? inspected.version,
+    build: options.desktopBuild ?? inspected.build,
+    asarIntegrity: options.asarIntegrity ?? inspected.asarIntegrity,
+  };
+}
+
+function loadBaseline(pathname) {
+  if (pathname === null) return null;
+  return validateAuditReport(JSON.parse(fs.readFileSync(pathname, "utf8")));
+}
+
+function safeDirectorySegment(value) {
+  return value.replace(/[^a-zA-Z0-9._-]+/gu, "-").slice(0, 96) || "unknown";
+}
+
+function controlledEvidence(snapshot) {
+  return {
+    adapterState: snapshot.binding.adapter.state,
+    titlePolicyState: snapshot.titlePolicyReadiness.state,
+    draftPrewarmPolicyState: snapshot.draftPrewarmPolicy.state,
+    titleBehavior: "not-run",
+    settingsBehavior: "not-run",
+    forkBehavior: "not-run",
+  };
+}
+
+async function runControlled(options, rendererSource, installRendererControlSession) {
+  const session = await installRendererControlSession({
+    inspectorEndpoint: options.inspectorEndpoint,
+    rendererSource,
+    enabledAgents: productionRendererAgents,
+    timeoutMs: 60_000,
+  });
+  try {
+    return controlledEvidence(session.snapshot);
+  } finally {
+    session.close();
+  }
+}
+
+async function main() {
+  const options = parseAuditArguments(process.argv.slice(2));
+  const auditBundlePath = path.join(
+    repositoryRoot,
+    "packages",
+    "renderer-extension",
+    "dist",
+    "contract-audit.js",
+  );
+  const productionBundlePath = path.join(
+    repositoryRoot,
+    "packages",
+    "renderer-extension",
+    "dist",
+    "production.js",
+  );
+  if (!fs.existsSync(auditBundlePath))
+    throw new Error("Renderer audit bundle is missing; run npm run build:renderer");
+  if (options.mode === "controlled" && !fs.existsSync(productionBundlePath)) {
+    throw new Error("Production Renderer bundle is missing; run npm run build:renderer");
+  }
+  const identity = readDesktopIdentity(options);
+  const baseline = loadBaseline(options.baselinePath);
+  const rendererAuditSource = fs.readFileSync(auditBundlePath, "utf8");
+  const { inspectDesktopContracts, installRendererControlSession } =
+    await import("../../packages/desktop-control/dist/index.js");
+  const observation = await inspectDesktopContracts({
+    endpoint: options.endpoint,
+    inspectorEndpoint: options.inspectorEndpoint,
+    rendererAuditSource,
+  });
+  const controlled =
+    options.mode === "controlled"
+      ? await runControlled(
+          options,
+          fs.readFileSync(productionBundlePath, "utf8"),
+          installRendererControlSession,
+        )
+      : null;
+  const finalObservation = controlled
+    ? await inspectDesktopContracts({
+        endpoint: options.endpoint,
+        inspectorEndpoint: options.inspectorEndpoint,
+        rendererAuditSource,
+      })
+    : observation;
+  const surfaces = buildSurfaceResults(finalObservation.contracts, baseline, controlled);
+  const report = validateAuditReport({
+    schemaVersion: 1,
+    recordedAt: new Date().toISOString(),
+    mode: options.mode,
+    verdict: aggregateVerdict(surfaces),
+    desktop: identity,
+    browser: observation.browser,
+    checksRun: [
+      "desktop-identity",
+      "browser-identity",
+      "renderer-contracts-read-only",
+      ...(baseline ? ["reviewed-baseline-comparison"] : []),
+      ...(controlled ? ["controlled-production-installation"] : []),
+    ],
+    baseline: {
+      supplied: baseline !== null,
+      version: baseline?.desktop.version ?? null,
+      build: baseline?.desktop.build ?? null,
+    },
+    surfaces,
+  });
+  const outputDirectory = path.join(options.outputRoot, safeDirectorySegment(identity.version));
+  fs.mkdirSync(outputDirectory, { recursive: true });
+  const jsonPath = path.join(outputDirectory, "audit-report.json");
+  const markdownPath = path.join(outputDirectory, "audit-report.md");
+  fs.writeFileSync(jsonPath, `${JSON.stringify(report, null, 2)}\n`, "utf8");
+  fs.writeFileSync(markdownPath, auditReportMarkdown(report), "utf8");
+  console.log(
+    JSON.stringify({
+      type: "codex-desktop-contract-audit",
+      verdict: report.verdict,
+      jsonPath,
+      markdownPath,
+    }),
+  );
+  if (report.verdict === "confirmed-impact") process.exitCode = 2;
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === path.resolve(import.meta.filename)) {
+  main().catch((error) => {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 1;
+  });
+}

--- a/tools/codex-desktop-contract-audit/run.test.mjs
+++ b/tools/codex-desktop-contract-audit/run.test.mjs
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+
+import { parseAuditArguments, validateLoopbackEndpoint } from "./run.mjs";
+
+describe("Codex Desktop contract audit CLI", () => {
+  it("defaults to read-only loopback inspection", () => {
+    expect(parseAuditArguments([])).toMatchObject({
+      mode: "read-only",
+      endpoint: "http://127.0.0.1:9222",
+      inspectorEndpoint: "http://127.0.0.1:9223",
+      baselinePath: null,
+    });
+  });
+
+  it("requires controlled mode explicitly", () => {
+    expect(parseAuditArguments(["--mode", "controlled"]).mode).toBe("controlled");
+    expect(() => parseAuditArguments(["--mode", "automatic"])).toThrow(
+      "--mode must be read-only or controlled",
+    );
+  });
+
+  it("rejects non-loopback endpoints", () => {
+    expect(() => validateLoopbackEndpoint("http://example.com:9222", "--endpoint")).toThrow(
+      "loopback HTTP URL",
+    );
+    expect(() => parseAuditArguments(["--endpoint", "https://127.0.0.1:9222"])).toThrow(
+      "loopback HTTP URL",
+    );
+  });
+});


### PR DESCRIPTION
## Purpose

Add a local, developer-only audit command for checking whether a Codex Desktop update changed the private GUI and Renderer contracts consumed by codexhost.

## What changed

- add `npm run audit:codex-desktop` with default read-only and explicit controlled modes
- inspect Composer, Model, Permission, Request/Prewarm, Title, Settings, Sidebar, Usage/Credits, and Fork contracts
- reuse production-owned discovery and Renderer Control Session logic instead of duplicating selectors or binding flows
- emit bounded, sanitized JSON and Markdown reports with reviewed-baseline comparison
- keep the audit bundle out of production packaging and runtime startup
- add and archive the OpenSpec change, and sync the affected main specs

## Validation

- `npm run typecheck`
- `npm run lint`
- `npm run format:check`
- `npm run build:renderer`
- focused Vitest: 5 files, 17 tests passed
- `openspec validate --all`: 47 passed, 0 failed
- `git diff --check`
- live read-only audit against Codex Desktop 26.825.41651 / build 7345
- live controlled installation audit; active contracts passed, Usage/Credits and Fork remained unverified because their UI states were not present

## Notes

This is not invoked by Launcher, Controller readiness, Host runtime, Renderer production entry, or Settings updates. It does not restore compatibility dialogs or block normal Desktop startup.
