### PR TITLE
fix: retry DeepSeek Host connection

### DIFF
--- a/packages/adapters/deepseek-harness/src/host-client.ts
+++ b/packages/adapters/deepseek-harness/src/host-client.ts
@@ -347,8 +347,13 @@ export class DeepSeekHostConnection {
   }
 
   connect(): Promise<void> {
-    this.#connectPromise ??= this.#performConnect();
-    return this.#connectPromise;
+    if (this.#connectPromise) return this.#connectPromise;
+    const attempt = this.#performConnect();
+    this.#connectPromise = attempt;
+    void attempt.catch(() => {
+      if (this.#connectPromise === attempt) this.#connectPromise = null;
+    });
+    return attempt;
   }
 
   subscribe(sessionId: string, subscriber: DeepSeekHostSubscriber): () => void {

--- a/packages/adapters/deepseek-harness/test/host-client.test.ts
+++ b/packages/adapters/deepseek-harness/test/host-client.test.ts
@@ -74,6 +74,41 @@ describe("DeepSeek local Host connection", () => {
     expect(spawn).not.toHaveBeenCalled();
   });
 
+  it("retries after a failed connection attempt", async () => {
+    let ready = false;
+    const dependencies: DeepSeekHostConnectionDependencies = {
+      createClient: () =>
+        fakeClient(() =>
+          ready
+            ? Promise.resolve(
+                success({
+                  version: "0.0.1",
+                  cwd: "/workspace",
+                  provider: "deepseek-official",
+                  model: "deepseek-v4-flash",
+                  attachedSessions: 0,
+                  canOpenPath: false,
+                }),
+              )
+            : Promise.reject(new TypeError("fetch failed")),
+        ),
+      spawn: vi.fn(),
+      sleep: () => Promise.resolve(),
+    };
+    const connection = new DeepSeekHostConnection(
+      {
+        command: "/missing/dsh",
+        endpoint: "http://127.0.0.1:43123",
+      },
+      dependencies,
+    );
+
+    await expect(connection.connect()).rejects.toMatchObject({ code: "notInstalled" });
+    ready = true;
+    await expect(connection.connect()).resolves.toBeUndefined();
+    await connection.close();
+  });
+
   it("starts a configured local dsh Web profile and stops only that managed process", async () => {
     const executableDirectory = mkdtempSync(path.join(os.tmpdir(), "codexhost-dsh-command-"));
     const executable = path.join(executableDirectory, "dsh");


### PR DESCRIPTION
## Purpose
Allow DeepSeek Harness connection diagnostics to recover after an initial Host startup failure.

## Changes
- clear the cached connection promise when a connection attempt fails
- add a regression test covering a failed attempt followed by a successful retry

## Validation
- targeted Vitest: 7 passed
- TypeScript build for the DeepSeek Harness adapter
- ESLint on changed files
- Prettier check on changed files
- git diff --check