### PR TITLE
feat(deepseek-harness): 通过 reasoningEffort 支持 Thinking 档位选择

### DIFF
--- a/packages/adapters/deepseek-harness/src/deepseek-harness-adapter.ts
+++ b/packages/adapters/deepseek-harness/src/deepseek-harness-adapter.ts
@@ -52,11 +52,13 @@ import {
 } from "@codexhost/harness-adapter";
 import {
   harnessIdSchema,
+  harnessThinkingOptionIdSchema,
   hostInteractionIdSchema,
   hostItemIdSchema,
   nativeSessionRefSchema,
   nativeTurnRefSchema,
   type HarnessId,
+  type HarnessThinkingOption,
   type HostInteractionId,
   type HostItemId,
   type HostTurnId,
@@ -77,6 +79,8 @@ import {
   decodeDeepSeekHarnessModelRef,
   encodeDeepSeekHarnessModelRef,
   normalizeDeepSeekModelCatalog,
+  normalizeDeepSeekThinkingOptions,
+  parseDeepSeekThinkingOptionId,
 } from "./model-catalog.js";
 import {
   contentText,
@@ -216,7 +220,7 @@ class DeepSeekHarnessSession implements HarnessSession, DeepSeekHostSubscriber {
   readonly capabilities: HarnessSessionCapabilities = {
     configuration: {
       selectModel: true,
-      selectThinkingOption: false,
+      selectThinkingOption: true,
       selectPermissionMode: false,
     },
     history: { fork: false, forkAcrossCwd: false, rollbackLastTurn: false },
@@ -238,6 +242,8 @@ class DeepSeekHarnessSession implements HarnessSession, DeepSeekHostSubscriber {
   #lastSeq: number;
   #reading = false;
   #model: HarnessModelRef;
+  #thinkingOptionId: HarnessThinkingOption["id"] | undefined;
+  #availableThinkingOptions: HarnessThinkingOption[];
   #contextWindowTokens: number | undefined;
   #turns: HostTurnSnapshot[];
   #usageBaseline: HostUsage | null;
@@ -253,6 +259,8 @@ class DeepSeekHarnessSession implements HarnessSession, DeepSeekHostSubscriber {
     nativeSessionId: string;
     lastSeq: number;
     contextWindowTokens?: number;
+    thinkingOptionId?: HarnessThinkingOption["id"];
+    availableThinkingOptions?: HarnessThinkingOption[];
     initialUsage?: HostUsage | null;
     onClosed(): void;
     snapshot: HostThreadSnapshot;
@@ -261,6 +269,8 @@ class DeepSeekHarnessSession implements HarnessSession, DeepSeekHostSubscriber {
   }) {
     this.#client = input.client;
     this.#model = input.model;
+    this.#thinkingOptionId = input.thinkingOptionId;
+    this.#availableThinkingOptions = input.availableThinkingOptions ?? [];
     this.#onClosed = input.onClosed;
     this.#toolOutputLimit = input.toolOutputLimit;
     this.#unsubscribe = input.unsubscribe;
@@ -275,7 +285,14 @@ class DeepSeekHarnessSession implements HarnessSession, DeepSeekHostSubscriber {
       nativeSessionId: input.nativeSessionId,
       formatVersion: 1,
     });
-    this.initialState = { nativeRef: this.#nativeRef, effectiveModel: input.model };
+    this.initialState = {
+      nativeRef: this.#nativeRef,
+      effectiveModel: input.model,
+      ...(input.thinkingOptionId ? { effectiveThinkingOptionId: input.thinkingOptionId } : {}),
+      ...(input.availableThinkingOptions && input.availableThinkingOptions.length > 0
+        ? { availableThinkingOptions: input.availableThinkingOptions }
+        : {}),
+    };
     this.outputs = this.#channel.outputs;
   }
 
@@ -322,7 +339,16 @@ class DeepSeekHarnessSession implements HarnessSession, DeepSeekHostSubscriber {
         ok: true,
         value: {
           ...projection.snapshot,
-          state: { nativeRef: this.#nativeRef, effectiveModel: this.#model },
+          state: {
+            nativeRef: this.#nativeRef,
+            effectiveModel: this.#model,
+            ...(this.#thinkingOptionId
+              ? { effectiveThinkingOptionId: this.#thinkingOptionId }
+              : {}),
+            ...(this.#availableThinkingOptions.length > 0
+              ? { availableThinkingOptions: this.#availableThinkingOptions }
+              : {}),
+          },
         },
       };
     } catch (error) {
@@ -357,6 +383,7 @@ class DeepSeekHarnessSession implements HarnessSession, DeepSeekHostSubscriber {
     if (command.type === "turn.cancel") return this.#cancel(command);
     if (command.type === "interaction.respond") return this.#respond(command);
     if (command.type === "model.select") return this.#selectModel(command);
+    if (command.type === "thinking.select") return this.#selectThinking(command);
     if (command.type !== "turn.start") {
       return {
         ok: false,
@@ -534,9 +561,100 @@ class DeepSeekHarnessSession implements HarnessSession, DeepSeekHostSubscriber {
           };
         }
         this.#model = encodeDeepSeekHarnessModelRef(models.current);
+        this.#thinkingOptionId = parseDeepSeekThinkingOptionId(models.current.reasoningEffort);
+        this.#availableThinkingOptions = normalizeDeepSeekThinkingOptions(models);
         this.#emit({
           type: "session.state.changed",
-          state: { nativeRef: this.#nativeRef, effectiveModel: this.#model },
+          state: {
+            nativeRef: this.#nativeRef,
+            effectiveModel: this.#model,
+            ...(this.#thinkingOptionId
+              ? { effectiveThinkingOptionId: this.#thinkingOptionId }
+              : {}),
+            ...(this.#availableThinkingOptions.length > 0
+              ? { availableThinkingOptions: this.#availableThinkingOptions }
+              : {}),
+          },
+        });
+        return { ok: true, value: { completed: true } };
+      } catch (error) {
+        return { ok: false, error: normalizedError(error, "nativeFailure") };
+      }
+    } finally {
+      this.#configuring = false;
+    }
+  }
+
+  async #selectThinking(
+    command: ThinkingSelectCommand,
+  ): Promise<HarnessResult<ThinkingSelectCompleted>> {
+    if (this.#active || this.#configuring || this.#reading) {
+      return {
+        ok: false,
+        error: {
+          code: "sessionBusy",
+          message:
+            "DeepSeek Harness Session cannot select Thinking while another operation is active",
+          retryable: true,
+        },
+      };
+    }
+    const requested = harnessThinkingOptionIdSchema.safeParse(command.thinkingOptionId);
+    if (!requested.success) {
+      return {
+        ok: false,
+        error: {
+          code: "invalidRequest",
+          message: "DeepSeek Harness Thinking option is invalid",
+          retryable: false,
+        },
+      };
+    }
+    const current = decodeDeepSeekHarnessModelRef(this.#model);
+    this.#configuring = true;
+    try {
+      try {
+        unwrapRpc(
+          await this.#client.sessions.selectModel({
+            sessionId: this.#nativeRef.nativeSessionId as SessionId,
+            provider: current.provider,
+            model: current.model,
+            reasoningEffort: requested.data,
+          }),
+          "session.selectModel",
+        );
+        const models = unwrapRpc(
+          await this.#client.sessions.models({
+            sessionId: this.#nativeRef.nativeSessionId as SessionId,
+          }),
+          "session.models",
+        );
+        if (
+          models.current.provider !== current.provider ||
+          models.current.model !== current.model ||
+          models.current.reasoningEffort !== requested.data
+        ) {
+          return {
+            ok: false,
+            error: {
+              code: "nativeFailure",
+              message: "DeepSeek Harness did not activate the requested Thinking option",
+              retryable: false,
+            },
+          };
+        }
+        this.#thinkingOptionId = requested.data;
+        this.#availableThinkingOptions = normalizeDeepSeekThinkingOptions(models);
+        this.#emit({
+          type: "session.state.changed",
+          state: {
+            nativeRef: this.#nativeRef,
+            effectiveModel: this.#model,
+            effectiveThinkingOptionId: this.#thinkingOptionId,
+            ...(this.#availableThinkingOptions.length > 0
+              ? { availableThinkingOptions: this.#availableThinkingOptions }
+              : {}),
+          },
         });
         return { ok: true, value: { completed: true } };
       } catch (error) {
@@ -1130,7 +1248,7 @@ export class DeepSeekHarnessAdapter implements HarnessAdapter {
         capabilities: {
           configuration: {
             selectModel: true,
-            selectThinkingOption: false,
+            selectThinkingOption: true,
             selectPermissionMode: false,
           },
           history: { fork: false, forkAcrossCwd: false, rollbackLastTurn: false },
@@ -1169,10 +1287,10 @@ export class DeepSeekHarnessAdapter implements HarnessAdapter {
     if (input.kind !== "create" && input.kind !== "resume") {
       return { ok: false, error: unsupported(`DeepSeek Harness does not support '${input.kind}'`) };
     }
-    if (input.kind === "create" && (input.thinkingOptionId || input.permissionModeId)) {
+    if (input.kind === "create" && input.permissionModeId) {
       return {
         ok: false,
-        error: unsupported("DeepSeek Harness does not select Thinking or Permission Mode"),
+        error: unsupported("DeepSeek Harness does not select Permission Mode"),
       };
     }
     try {
@@ -1217,13 +1335,26 @@ export class DeepSeekHarnessAdapter implements HarnessAdapter {
               "DeepSeek Harness created an unexpected Session identity",
             );
           }
-          if (input.model) {
-            const requested = decodeDeepSeekHarnessModelRef(input.model);
+          if (input.model || input.thinkingOptionId) {
+            let target = input.model ? decodeDeepSeekHarnessModelRef(input.model) : null;
+            if (!target) {
+              const currentModels = unwrapRpc(
+                await this.#connection.client.sessions.models({
+                  sessionId: sessionId as SessionId,
+                }),
+                "session.models",
+              );
+              target = {
+                provider: currentModels.current.provider,
+                model: currentModels.current.model,
+              };
+            }
             unwrapRpc(
               await this.#connection.client.sessions.selectModel({
                 sessionId: sessionId as SessionId,
-                provider: requested.provider,
-                model: requested.model,
+                provider: target.provider,
+                model: target.model,
+                ...(input.thinkingOptionId ? { reasoningEffort: input.thinkingOptionId } : {}),
               }),
               "session.selectModel",
             );
@@ -1242,11 +1373,14 @@ export class DeepSeekHarnessAdapter implements HarnessAdapter {
           fallbackModel: model,
           toolOutputLimit: this.#toolOutputLimit,
         });
+        const thinkingOptionId = parseDeepSeekThinkingOptionId(models.current.reasoningEffort);
         session = new DeepSeekHarnessSession({
           client: this.#connection.client,
           model: projection.effectiveModel ?? model,
           nativeSessionId: sessionId,
           lastSeq: projection.lastSeq,
+          ...(thinkingOptionId ? { thinkingOptionId } : {}),
+          availableThinkingOptions: normalizeDeepSeekThinkingOptions(models),
           ...(projection.contextWindowTokens !== undefined
             ? { contextWindowTokens: projection.contextWindowTokens }
             : {}),

--- a/packages/adapters/deepseek-harness/src/deepseek-harness-adapter.ts
+++ b/packages/adapters/deepseek-harness/src/deepseek-harness-adapter.ts
@@ -312,15 +312,19 @@ class DeepSeekHarnessSession implements HarnessSession, DeepSeekHostSubscriber {
     }
     this.#reading = true;
     try {
-      const entries = await readAllDeepSeekHistory(
-        this.#client,
-        this.#nativeRef.nativeSessionId as SessionId,
-      );
+      const [entries, modelState] = await Promise.all([
+        readAllDeepSeekHistory(this.#client, this.#nativeRef.nativeSessionId as SessionId),
+        this.#client.sessions.models({
+          sessionId: this.#nativeRef.nativeSessionId as SessionId,
+        }),
+      ]);
+      const models = unwrapRpc(modelState, "session.models");
+      const model = encodeDeepSeekHarnessModelRef(models.current);
       const projection = projectDeepSeekHistory({
         harnessId: this.harnessId,
         sessionId: this.#nativeRef.nativeSessionId,
         entries,
-        fallbackModel: this.#model,
+        fallbackModel: model,
         toolOutputLimit: this.#toolOutputLimit,
       });
       this.#lastSeq = Math.max(this.#lastSeq, projection.lastSeq);
@@ -329,7 +333,9 @@ class DeepSeekHarnessSession implements HarnessSession, DeepSeekHostSubscriber {
       this.#usageBaseline = projection.usage;
       this.#usageByStep.clear();
       this.#latestUsageKey = undefined;
-      if (projection.effectiveModel) this.#model = projection.effectiveModel;
+      this.#model = model;
+      this.#thinkingOptionId = parseDeepSeekThinkingOptionId(models.current.reasoningEffort);
+      this.#availableThinkingOptions = normalizeDeepSeekThinkingOptions(models);
       const usage = this.#withOutputSpeed(projection.usage);
       if (JSON.stringify(usage) !== JSON.stringify(this.#usage)) {
         this.#usage = usage;
@@ -1376,7 +1382,7 @@ export class DeepSeekHarnessAdapter implements HarnessAdapter {
         const thinkingOptionId = parseDeepSeekThinkingOptionId(models.current.reasoningEffort);
         session = new DeepSeekHarnessSession({
           client: this.#connection.client,
-          model: projection.effectiveModel ?? model,
+          model,
           nativeSessionId: sessionId,
           lastSeq: projection.lastSeq,
           ...(thinkingOptionId ? { thinkingOptionId } : {}),

--- a/packages/adapters/deepseek-harness/src/model-catalog.ts
+++ b/packages/adapters/deepseek-harness/src/model-catalog.ts
@@ -1,13 +1,19 @@
 import { Buffer } from "node:buffer";
 
-import type { ModelProviderGroup, ModelSelection } from "@deepseek-ai/dsh-host-apiproxy/api";
+import type {
+  ModelProviderGroup,
+  ModelSelection,
+  SessionModels,
+} from "@deepseek-ai/dsh-host-apiproxy/api";
 
 import {
   HARNESS_MODEL_REF_MAX_LENGTH,
   harnessModelCatalogSchema,
   harnessModelRefSchema,
+  harnessThinkingOptionIdSchema,
   type HarnessModelCatalog,
   type HarnessModelRef,
+  type HarnessThinkingOption,
 } from "@codexhost/shared-contracts";
 
 const MODEL_REF_PREFIX = "deepseek-harness-model-v2.";
@@ -63,20 +69,63 @@ export function decodeDeepSeekHarnessModelRef(ref: HarnessModelRef): DeepSeekNat
   return native;
 }
 
+/** Adapter-owned reasoning effort identifier when the Host reports one. */
+export function parseDeepSeekThinkingOptionId(
+  value: string | undefined,
+): HarnessThinkingOption["id"] | undefined {
+  if (value === undefined) return undefined;
+  const parsed = harnessThinkingOptionIdSchema.safeParse(value);
+  return parsed.success ? parsed.data : undefined;
+}
+
+/** Thinking options advertised by the exact Model route the Session currently serves. */
+export function normalizeDeepSeekThinkingOptions(models: SessionModels): HarnessThinkingOption[] {
+  const group = models.groups.find((candidate) => candidate.id === models.current.provider);
+  const model = group?.models.find((candidate) => candidate.id === models.current.model);
+  return (model?.reasoning?.efforts ?? []).flatMap((effort) => {
+    const parsedId = harnessThinkingOptionIdSchema.safeParse(effort.id);
+    return parsedId.success ? [{ id: parsedId.data, label: effort.name }] : [];
+  });
+}
+
 export function normalizeDeepSeekModelCatalog(
   groups: readonly ModelProviderGroup[],
   selection: ModelSelection,
 ): HarnessModelCatalog {
+  const thinkingOptions: HarnessThinkingOption[] = [];
+  const knownEffortIds = new Set<string>();
+  for (const group of groups) {
+    for (const model of group.models) {
+      for (const effort of model.reasoning?.efforts ?? []) {
+        if (knownEffortIds.has(effort.id)) continue;
+        const parsedId = harnessThinkingOptionIdSchema.safeParse(effort.id);
+        if (!parsedId.success) continue;
+        knownEffortIds.add(effort.id);
+        thinkingOptions.push({ id: parsedId.data, label: effort.name });
+      }
+    }
+  }
   const models = groups.flatMap((group) =>
     group.models.map((model) => ({
       ref: encodeDeepSeekHarnessModelRef({ provider: group.id, model: model.id }),
       label: `${group.name} / ${model.name}`,
       ...(model.description ? { description: model.description } : {}),
+      ...(model.reasoning && model.reasoning.efforts.length > 0
+        ? { supportedThinkingOptionIds: model.reasoning.efforts.map((effort) => effort.id) }
+        : {}),
     })),
   );
   const defaultModel = encodeDeepSeekHarnessModelRef(selection);
   if (!models.some((model) => model.ref.id === defaultModel.id)) {
     models.unshift({ ref: defaultModel, label: `${selection.provider} / ${selection.model}` });
   }
-  return harnessModelCatalogSchema.parse({ models, defaultModel, thinkingOptions: [] });
+  const defaultThinkingOptionId = parseDeepSeekThinkingOptionId(selection.reasoningEffort);
+  return harnessModelCatalogSchema.parse({
+    models,
+    defaultModel,
+    thinkingOptions,
+    ...(defaultThinkingOptionId && knownEffortIds.has(defaultThinkingOptionId)
+      ? { defaultThinkingOptionId }
+      : {}),
+  });
 }

--- a/packages/adapters/deepseek-harness/src/model-catalog.ts
+++ b/packages/adapters/deepseek-harness/src/model-catalog.ts
@@ -119,12 +119,18 @@ export function normalizeDeepSeekModelCatalog(
   if (!models.some((model) => model.ref.id === defaultModel.id)) {
     models.unshift({ ref: defaultModel, label: `${selection.provider} / ${selection.model}` });
   }
-  const defaultThinkingOptionId = parseDeepSeekThinkingOptionId(selection.reasoningEffort);
+  const defaultReasoning = groups
+    .find((group) => group.id === selection.provider)
+    ?.models.find((model) => model.id === selection.model)?.reasoning;
+  const defaultThinkingOptionId = parseDeepSeekThinkingOptionId(
+    selection.reasoningEffort ?? defaultReasoning?.defaultEffort,
+  );
   return harnessModelCatalogSchema.parse({
     models,
     defaultModel,
     thinkingOptions,
-    ...(defaultThinkingOptionId && knownEffortIds.has(defaultThinkingOptionId)
+    ...(defaultThinkingOptionId &&
+    defaultReasoning?.efforts.some((effort) => effort.id === defaultThinkingOptionId)
       ? { defaultThinkingOptionId }
       : {}),
   });

--- a/packages/adapters/deepseek-harness/test/deepseek-harness-adapter.test.ts
+++ b/packages/adapters/deepseek-harness/test/deepseek-harness-adapter.test.ts
@@ -12,7 +12,7 @@ import { RpcId } from "@deepseek-ai/dsh-host-apiproxy/api";
 import type { SessionId } from "@deepseek-ai/dsh-session/types";
 
 import type { HarnessOutput } from "@codexhost/harness-adapter";
-import { hostTurnIdSchema } from "@codexhost/shared-contracts";
+import { harnessThinkingOptionIdSchema, hostTurnIdSchema } from "@codexhost/shared-contracts";
 
 import {
   DeepSeekHarnessAdapter,
@@ -37,8 +37,30 @@ const MODEL_GROUPS = [
     id: "deepseek-official",
     name: "DeepSeek",
     models: [
-      { id: "deepseek-v4-flash", name: "DeepSeek V4 Flash" },
-      { id: "deepseek-v4-pro", name: "DeepSeek V4 Pro" },
+      {
+        id: "deepseek-v4-flash",
+        name: "DeepSeek V4 Flash",
+        reasoning: {
+          efforts: [
+            { id: "off", name: "Off" },
+            { id: "low", name: "Low" },
+            { id: "high", name: "High" },
+          ],
+        },
+      },
+      {
+        id: "deepseek-v4-pro",
+        name: "DeepSeek V4 Pro",
+        reasoning: {
+          efforts: [
+            { id: "off", name: "Off" },
+            { id: "low", name: "Low" },
+            { id: "high", name: "High" },
+            { id: "max", name: "Max" },
+          ],
+          defaultEffort: "high",
+        },
+      },
     ],
   },
 ];
@@ -98,8 +120,16 @@ class FakeConnection implements DeepSeekHostConnectionLike {
       ),
     );
     this.calls.selectModel.mockImplementation(
-      ({ provider, model }: { provider: string; model: string }) => {
-        this.currentModel = { provider, model };
+      ({
+        provider,
+        model,
+        reasoningEffort,
+      }: {
+        provider: string;
+        model: string;
+        reasoningEffort?: string;
+      }) => {
+        this.currentModel = { provider, model, ...(reasoningEffort ? { reasoningEffort } : {}) };
         return Promise.resolve(success({ selected: this.currentModel }));
       },
     );
@@ -339,6 +369,108 @@ describe("DeepSeekHarnessAdapter local Host", () => {
       model: "deepseek-v4-pro",
     });
     expect(connection.calls.models).toHaveBeenCalledTimes(2);
+    await adapter.close();
+  });
+
+  it("advertises Thinking options from the Host model catalog", async () => {
+    const { adapter } = fixture();
+
+    await expect(adapter.inspect()).resolves.toMatchObject({
+      status: "ready",
+      capabilities: { configuration: { selectThinkingOption: true } },
+      catalog: {
+        thinkingOptions: [
+          { id: "off", label: "Off" },
+          { id: "low", label: "Low" },
+          { id: "high", label: "High" },
+          { id: "max", label: "Max" },
+        ],
+        models: [
+          { supportedThinkingOptionIds: ["off", "low", "high"] },
+          { supportedThinkingOptionIds: ["off", "low", "high", "max"] },
+        ],
+      },
+    });
+    await adapter.close();
+  });
+
+  it("creates a Session with the requested Thinking option", async () => {
+    const { adapter, connection } = fixture();
+    const opened = await adapter.open({
+      kind: "create",
+      cwd: "/workspace",
+      thinkingOptionId: harnessThinkingOptionIdSchema.parse("high"),
+    });
+    if (!opened.ok) throw new Error(opened.error.message);
+    const session = opened.value;
+    expect(session.capabilities.configuration.selectThinkingOption).toBe(true);
+    expect(connection.calls.selectModel).toHaveBeenCalledWith({
+      sessionId: "session-native-1",
+      provider: "deepseek-official",
+      model: "deepseek-v4-flash",
+      reasoningEffort: "high",
+    });
+    await expect(session.readSnapshot()).resolves.toMatchObject({
+      ok: true,
+      value: {
+        state: {
+          effectiveThinkingOptionId: "high",
+          availableThinkingOptions: expect.arrayContaining([
+            { id: "off", label: "Off" },
+            { id: "high", label: "High" },
+          ]),
+        },
+      },
+    });
+    await session.close();
+    await adapter.close();
+  });
+
+  it("selects Thinking for a resumed Session and publishes confirmed state", async () => {
+    const { adapter, connection } = fixture();
+    const opened = await adapter.open({
+      kind: "resume",
+      cwd: "/workspace",
+      nativeRef: {
+        harnessId: adapter.harnessId,
+        nativeSessionId: SESSION_ID,
+        formatVersion: 1,
+      },
+    });
+    if (!opened.ok) throw new Error(opened.error.message);
+    const session = opened.value;
+    const iterator = session.outputs[Symbol.asyncIterator]();
+
+    const selecting = session.execute({
+      type: "thinking.select",
+      thinkingOptionId: harnessThinkingOptionIdSchema.parse("high"),
+    });
+    await expect(iterator.next()).resolves.toMatchObject({
+      done: false,
+      value: {
+        kind: "event",
+        event: {
+          type: "session.state.changed",
+          state: {
+            nativeRef: { nativeSessionId: SESSION_ID },
+            effectiveModel: expect.anything(),
+            effectiveThinkingOptionId: "high",
+            availableThinkingOptions: expect.arrayContaining([
+              { id: "off", label: "Off" },
+              { id: "low", label: "Low" },
+              { id: "high", label: "High" },
+            ]),
+          },
+        },
+      },
+    });
+    await expect(selecting).resolves.toEqual({ ok: true, value: { completed: true } });
+    expect(connection.calls.selectModel).toHaveBeenLastCalledWith({
+      sessionId: SESSION_ID,
+      provider: "deepseek-official",
+      model: "deepseek-v4-flash",
+      reasoningEffort: "high",
+    });
     await adapter.close();
   });
 

--- a/packages/adapters/deepseek-harness/test/deepseek-harness-adapter.test.ts
+++ b/packages/adapters/deepseek-harness/test/deepseek-harness-adapter.test.ts
@@ -46,6 +46,7 @@ const MODEL_GROUPS = [
             { id: "low", name: "Low" },
             { id: "high", name: "High" },
           ],
+          defaultEffort: "high",
         },
       },
       {
@@ -129,7 +130,15 @@ class FakeConnection implements DeepSeekHostConnectionLike {
         model: string;
         reasoningEffort?: string;
       }) => {
-        this.currentModel = { provider, model, ...(reasoningEffort ? { reasoningEffort } : {}) };
+        const defaultEffort = MODEL_GROUPS.find((group) => group.id === provider)?.models.find(
+          (candidate) => candidate.id === model,
+        )?.reasoning.defaultEffort;
+        const effectiveEffort = reasoningEffort ?? defaultEffort;
+        this.currentModel = {
+          provider,
+          model,
+          ...(effectiveEffort ? { reasoningEffort: effectiveEffort } : {}),
+        };
         return Promise.resolve(success({ selected: this.currentModel }));
       },
     );
@@ -253,6 +262,14 @@ describe("DeepSeekHarnessAdapter local Host", () => {
       provider: "deepseek-official",
       model: "deepseek-v4-pro",
     });
+    expect(session.initialState).toMatchObject({
+      effectiveModel: model,
+      effectiveThinkingOptionId: "high",
+      availableThinkingOptions: expect.arrayContaining([
+        { id: "high", label: "High" },
+        { id: "max", label: "Max" },
+      ]),
+    });
 
     const turnId = hostTurnIdSchema.parse("host-turn-1");
     await expect(
@@ -358,6 +375,11 @@ describe("DeepSeekHarnessAdapter local Host", () => {
           state: {
             nativeRef: { nativeSessionId: SESSION_ID },
             effectiveModel: model,
+            effectiveThinkingOptionId: "high",
+            availableThinkingOptions: expect.arrayContaining([
+              { id: "high", label: "High" },
+              { id: "max", label: "Max" },
+            ]),
           },
         },
       },
@@ -379,6 +401,7 @@ describe("DeepSeekHarnessAdapter local Host", () => {
       status: "ready",
       capabilities: { configuration: { selectThinkingOption: true } },
       catalog: {
+        defaultThinkingOptionId: "high",
         thinkingOptions: [
           { id: "off", label: "Off" },
           { id: "low", label: "Low" },
@@ -389,6 +412,52 @@ describe("DeepSeekHarnessAdapter local Host", () => {
           { supportedThinkingOptionIds: ["off", "low", "high"] },
           { supportedThinkingOptionIds: ["off", "low", "high", "max"] },
         ],
+      },
+    });
+    await adapter.close();
+  });
+
+  it("keeps current Model and Thinking state ahead of the last historical request", async () => {
+    const { adapter, connection } = fixture();
+    const current: ModelSelection = {
+      provider: "deepseek-official",
+      model: "deepseek-v4-pro",
+      reasoningEffort: "high",
+    };
+    const model = encodeDeepSeekHarnessModelRef(current);
+    connection.currentModel = current;
+    connection.history.set(SESSION_ID, [
+      event(0, "turn/start", { turn: 1 }),
+      event(1, "request/header", { header: { config: CURRENT_MODEL } }),
+      event(2, "turn/end", { turn: 1, reason: { kind: "completed" } }),
+    ]);
+
+    const opened = await adapter.open({
+      kind: "resume",
+      cwd: "/workspace",
+      nativeRef: {
+        harnessId: adapter.harnessId,
+        nativeSessionId: SESSION_ID,
+        formatVersion: 1,
+      },
+    });
+    if (!opened.ok) throw new Error(opened.error.message);
+    const session = opened.value;
+    const expectedState = {
+      effectiveModel: model,
+      effectiveThinkingOptionId: "high",
+      availableThinkingOptions: expect.arrayContaining([
+        { id: "high", label: "High" },
+        { id: "max", label: "Max" },
+      ]),
+    };
+
+    expect(session.initialState).toMatchObject(expectedState);
+    await expect(session.readSnapshot()).resolves.toMatchObject({
+      ok: true,
+      value: {
+        state: expectedState,
+        turns: [{ model: encodeDeepSeekHarnessModelRef(CURRENT_MODEL) }],
       },
     });
     await adapter.close();
@@ -423,6 +492,47 @@ describe("DeepSeekHarnessAdapter local Host", () => {
       },
     });
     await session.close();
+    await adapter.close();
+  });
+
+  it("rejects Thinking selection when native readback differs without publishing state", async () => {
+    const { adapter, connection } = fixture();
+    const opened = await adapter.open({
+      kind: "resume",
+      cwd: "/workspace",
+      nativeRef: {
+        harnessId: adapter.harnessId,
+        nativeSessionId: SESSION_ID,
+        formatVersion: 1,
+      },
+    });
+    if (!opened.ok) throw new Error(opened.error.message);
+    const session = opened.value;
+    const output = session.outputs[Symbol.asyncIterator]().next();
+    connection.calls.models.mockResolvedValueOnce(
+      success<SessionModels>({
+        current: { ...CURRENT_MODEL, reasoningEffort: "low" },
+        routable: true,
+        groups: MODEL_GROUPS,
+        failures: [],
+      }),
+    );
+
+    await expect(
+      session.execute({
+        type: "thinking.select",
+        thinkingOptionId: harnessThinkingOptionIdSchema.parse("high"),
+      }),
+    ).resolves.toEqual({
+      ok: false,
+      error: {
+        code: "nativeFailure",
+        message: "DeepSeek Harness did not activate the requested Thinking option",
+        retryable: false,
+      },
+    });
+    await session.close();
+    await expect(output).resolves.toEqual({ done: true, value: undefined });
     await adapter.close();
   });
 
@@ -493,11 +603,12 @@ describe("DeepSeekHarnessAdapter local Host", () => {
       ok: false,
       error: { message: expect.stringContaining("Model is unavailable") },
     });
+    expect(connection.calls.models).toHaveBeenCalledTimes(1);
     await expect(session.readSnapshot()).resolves.toMatchObject({
       ok: true,
       value: { state: { effectiveModel: encodeDeepSeekHarnessModelRef(CURRENT_MODEL) } },
     });
-    expect(connection.calls.models).toHaveBeenCalledTimes(1);
+    expect(connection.calls.models).toHaveBeenCalledTimes(2);
     await adapter.close();
   });
 
@@ -535,7 +646,7 @@ describe("DeepSeekHarnessAdapter local Host", () => {
       ({ provider, model: modelId }: { provider: string; model: string }) =>
         new Promise((resolve) => {
           releaseSelection = () => {
-            connection.currentModel = { provider, model: modelId };
+            connection.currentModel = { provider, model: modelId, reasoningEffort: "high" };
             resolve(success({ selected: connection.currentModel }));
           };
         }),
@@ -567,12 +678,13 @@ describe("DeepSeekHarnessAdapter local Host", () => {
       provider: "deepseek-official",
       model: "deepseek-v4-pro",
     });
-    connection.calls.models.mockResolvedValueOnce(
-      success<SessionModels>({
-        current: CURRENT_MODEL,
-        routable: true,
-        groups: MODEL_GROUPS,
-        failures: [],
+    connection.calls.selectModel.mockResolvedValueOnce(
+      success({
+        selected: {
+          provider: "deepseek-official",
+          model: "deepseek-v4-pro",
+          reasoningEffort: "high",
+        },
       }),
     );
 


### PR DESCRIPTION
## 背景

README 能力矩阵把 DeepSeek Harness 的 **模型 / Thinking 档位选择** 标为 🚧。模型切换原本已可用，但 Thinking 档位仍被硬编码禁用：adapter 报告 `selectThinkingOption: false`、目录固定为 `thinkingOptions: []`，且 `open()` 会拒绝 `thinkingOptionId`。

DeepSeek Harness Host 协议早已提供所需能力；本 PR 仅将既有协议字段接入 adapter，沿用 Pi 与 Claude Code 已采用的模式。

## 版本 / 对接点（已核验）

| 项目 | 版本 / 证据 |
| --- | --- |
| 基线 | `main` @ `64ae4c3`（v0.3.5 之后） |
| 锁定的协议依赖 | `@deepseek-ai/dsh-host-apiproxy` **0.1.0-rc.6**（见 `package-lock.json`；adapter 也声明完全相同的版本） |
| 选择 RPC | `sessions.selectModel({ sessionId, provider, model, reasoningEffort? })` —— 自 rc.6 起可用 |
| 目录元数据 | `ModelCatalogModel.reasoning?: ModelReasoning { efforts: { id, name, description? }[], defaultEffort? }` —— 自 rc.6 起可用 |
| 回读状态 | `sessions.models` → `ModelSelection.reasoningEffort?: string` |
| 交叉验证 | `@deepseek-ai/dsh` **0.1.1-rc.2**（字段完全一致，向后兼容 rc.6） |
| 档位语义 | `dsh-llm-deepseek` 按顺序公开 `off / low / high / max`；`off` 映射为 `thinking: disabled`；省略档位时保留部署默认值（`high`）；锁定 Thinking 的部署仅公开 `off` |

## 改动

- **`model-catalog.ts`** —— 将每个模型的 `reasoning.efforts` 投影为目录的 `thinkingOptions`（并集，保留 adapter 顺序）和每个模型的 `supportedThinkingOptionIds`；从当前选择或默认模型的 `reasoning.defaultEffort` 推导 `defaultThinkingOptionId`，避免未显式指定档位时错误落到第一个公开的 `off` 选项。新增 `normalizeDeepSeekThinkingOptions()` / `parseDeepSeekThinkingOptionId()` 均采用 fail-closed 策略：无法识别的 effort id 会被丢弃，不进行猜测。
- **`deepseek-harness-adapter.ts`**
  - 公开 `selectThinkingOption: true`（inspect 与 session capabilities）
  - 处理 `thinking.select`：使用当前 provider/model 加 `reasoningEffort` 调用 `sessions.selectModel`，再通过 `sessions.models` 回读并要求精确匹配后才发布状态（fail-closed，与 `#selectModel` 保持一致）
  - `model.select` 有意省略 `reasoningEffort`，使模型切换回退到目标模型自己的默认档位；随后从回读值刷新 `effectiveThinkingOptionId`
  - `open({ kind: "create", thinkingOptionId })` 不再拒绝该参数；未显式给出 `model` 时，会先读取 Host 默认选择，再带档位执行选择
  - `initialState`、`readSnapshot()` 与选择事件均携带 `effectiveThinkingOptionId` + `availableThinkingOptions`
  - 顶层当前模型和 Thinking 状态统一来自同一份 `sessions.models.current` 快照；历史请求头仍只归属于各自的历史 Turn
- **测试** —— fixture 中的 `selectModel` 现在会像 DSH 一样物化每个模型的默认档位；新增 5 个聚焦用例，覆盖目录公开/默认值、创建时指定档位、恢复会话后的选择与发布、当前配置与历史配置的区分，以及 Thinking 回读不匹配时不发布状态。

## 验证

- `npm run typecheck` ✅
- `npx vitest run --config tests/vitest.config.js packages/adapters/deepseek-harness` → **27 passed**（22 个既有 + 5 个新增）✅
- `npx prettier --check packages/adapters/deepseek-harness` ✅
- `npx eslint packages/adapters/deepseek-harness` ✅
- `node tools/check-boundaries.mjs` ✅

合入后，README 能力矩阵中 DeepSeek Harness 的 **模型 / Thinking 档位选择** 可由 🚧 更新为 ✅。