### PR TITLE
feat(deepseek-harness): 接入原生 dsh.compact Harness 命令

### DIFF
--- a/packages/adapters/deepseek-harness/src/deepseek-harness-adapter.ts
+++ b/packages/adapters/deepseek-harness/src/deepseek-harness-adapter.ts
@@ -29,6 +29,7 @@ import {
   type HostAgentMessageItem,
   type HostApprovalInteraction,
   type HostCommand,
+  type HostContextCompactionItem,
   type HostFileChangeItem,
   type HostItem,
   type HostItemOutcome,
@@ -71,6 +72,7 @@ import {
 import {
   DeepSeekHarnessTransportError,
   DeepSeekHostConnection,
+  type DeepSeekCommandClient,
   type DeepSeekHostClient,
   type DeepSeekHostConnectionOptions,
   type DeepSeekHostSubscriber,
@@ -146,6 +148,13 @@ interface ActiveTurn {
   snapshots: HostItemSnapshot[];
 }
 
+interface ActiveCommand {
+  command: HarnessCommandInvocation;
+  abort: AbortController;
+  cancellationRequested: boolean;
+  item: HostContextCompactionItem;
+}
+
 const deepSeekHarnessId = harnessIdSchema.parse("deepseek-harness");
 const deepSeekCommandCatalog = harnessCommandCatalogSchema.parse({
   commands: [
@@ -159,6 +168,10 @@ const deepSeekCommandCatalog = harnessCommandCatalogSchema.parse({
     },
   ],
 });
+const emptyDeepSeekCommandCatalog = harnessCommandCatalogSchema.parse({ commands: [] });
+const DSH_COMPACT_BUSY =
+  "Compaction is unavailable because this process has an active compaction, or the agent is not idle.";
+const DSH_COMPACT_CANCELLED = "Compaction cancelled.";
 const DEFAULT_TOOL_OUTPUT_LIMIT = 64_000;
 const HISTORY_PAGE_MESSAGES = 100;
 const HISTORY_PAGE_LIMIT = 10_000;
@@ -184,6 +197,15 @@ function invalidState(message: string): HarnessError {
 
 function unsupported(message: string): HarnessError {
   return { code: "unsupported", message, retryable: false };
+}
+
+function commandFailure(operation: string, error: { code: string; message: string }): HarnessError {
+  const code = error.code === "session-not-found" ? "unavailable" : "nativeFailure";
+  return {
+    code,
+    message: `DeepSeek Harness '${operation}' failed: ${error.message}`,
+    retryable: code === "unavailable" || error.code === "internal",
+  };
 }
 
 function unwrapRpc<T>(response: RpcResponse<T>, operation: string): T {
@@ -238,7 +260,7 @@ class DeepSeekHarnessSession implements HarnessSession, DeepSeekHostSubscriber {
     history: { fork: false, forkAcrossCwd: false, rollbackLastTurn: false },
   };
   readonly commands: HarnessCommandCapability = {
-    list: () => Promise.resolve({ ok: true, value: deepSeekCommandCatalog }),
+    list: () => this.#listHarnessCommands(),
     execute: (command) => this.#executeHarnessCommand(command),
   };
   readonly initialState: HarnessSessionState;
@@ -247,11 +269,13 @@ class DeepSeekHarnessSession implements HarnessSession, DeepSeekHostSubscriber {
   readonly outputs: AsyncIterable<HarnessOutput>;
   readonly #channel = new HarnessOutputChannel<HarnessOutput>();
   readonly #client: DeepSeekHostClient;
+  readonly #commandClient: DeepSeekCommandClient;
   readonly #nativeRef: NativeSessionRef;
   readonly #onClosed: () => void;
   readonly #toolOutputLimit: number;
   readonly #unsubscribe: () => void;
   #active: ActiveTurn | null = null;
+  #activeCommand: ActiveCommand | null = null;
   #closePromise: Promise<void> | null = null;
   #closed = false;
   #configuring = false;
@@ -280,6 +304,7 @@ class DeepSeekHarnessSession implements HarnessSession, DeepSeekHostSubscriber {
     unsubscribe(): void;
   }) {
     this.#client = input.client;
+    this.#commandClient = input.client.commands;
     this.#model = input.model;
     this.#onClosed = input.onClosed;
     this.#toolOutputLimit = input.toolOutputLimit;
@@ -303,7 +328,7 @@ class DeepSeekHarnessSession implements HarnessSession, DeepSeekHostSubscriber {
     if (this.#closed) {
       return { ok: false, error: invalidState("DeepSeek Harness Session is closed") };
     }
-    if (this.#active || this.#configuring || this.#reading) {
+    if (this.#active || this.#activeCommand || this.#configuring || this.#reading) {
       return {
         ok: false,
         error: {
@@ -383,7 +408,7 @@ class DeepSeekHarnessSession implements HarnessSession, DeepSeekHostSubscriber {
         error: unsupported(`DeepSeek Harness does not support '${command.type}'`),
       };
     }
-    if (this.#active || this.#configuring || this.#reading) {
+    if (this.#active || this.#activeCommand || this.#configuring || this.#reading) {
       return {
         ok: false,
         error: {
@@ -483,6 +508,15 @@ class DeepSeekHarnessSession implements HarnessSession, DeepSeekHostSubscriber {
 
   async #performClose(): Promise<void> {
     if (this.#closed) return;
+    const activeCommand = this.#activeCommand;
+    if (activeCommand) {
+      activeCommand.cancellationRequested = true;
+      activeCommand.abort.abort(new Error("codexhost Session closed"));
+      this.#finishCommand(activeCommand, {
+        status: "cancelled",
+        reason: "DeepSeek Harness command was cancelled because the Session closed",
+      });
+    }
     const active = this.#active;
     if (active) {
       for (const pending of active.interactions.values()) {
@@ -505,7 +539,7 @@ class DeepSeekHarnessSession implements HarnessSession, DeepSeekHostSubscriber {
   }
 
   async #selectModel(command: ModelSelectCommand): Promise<HarnessResult<ModelSelectCompleted>> {
-    if (this.#active || this.#configuring || this.#reading) {
+    if (this.#active || this.#activeCommand || this.#configuring || this.#reading) {
       return {
         ok: false,
         error: {
@@ -567,9 +601,28 @@ class DeepSeekHarnessSession implements HarnessSession, DeepSeekHostSubscriber {
     }
   }
 
+  async #listHarnessCommands(): Promise<HarnessResult<typeof deepSeekCommandCatalog>> {
+    if (this.#closed) {
+      return { ok: false, error: invalidState("DeepSeek Harness Session is closed") };
+    }
+    try {
+      const result = await this.#commandClient.list(this.#nativeRef.nativeSessionId as SessionId);
+      if (!result.ok) return { ok: false, error: commandFailure("commands/list", result.error) };
+      const available = result.value.some(
+        (descriptor) => descriptor.name === "compact" && descriptor.input === undefined,
+      );
+      return { ok: true, value: available ? deepSeekCommandCatalog : emptyDeepSeekCommandCatalog };
+    } catch (error) {
+      return { ok: false, error: normalizedError(error, "unavailable") };
+    }
+  }
+
   async #executeHarnessCommand(
     command: HarnessCommandInvocation,
   ): Promise<HarnessResult<HarnessCommandAccepted>> {
+    if (this.#closed) {
+      return { ok: false, error: invalidState("DeepSeek Harness Session is closed") };
+    }
     if (command.commandId !== "dsh.compact") {
       return {
         ok: false,
@@ -580,7 +633,7 @@ class DeepSeekHarnessSession implements HarnessSession, DeepSeekHostSubscriber {
         },
       };
     }
-    if (this.#active || this.#configuring || this.#reading) {
+    if (this.#active || this.#activeCommand || this.#configuring || this.#reading) {
       return {
         ok: false,
         error: {
@@ -602,45 +655,106 @@ class DeepSeekHarnessSession implements HarnessSession, DeepSeekHostSubscriber {
       };
     }
 
-    this.#configuring = true;
+    const active: ActiveCommand = {
+      command,
+      abort: new AbortController(),
+      cancellationRequested: false,
+      item: { type: "contextCompaction", itemId: this.#newItemId() },
+    };
+    this.#activeCommand = active;
+    this.#emit({ type: "turn.started", turnId: command.turnId });
+    this.#emit({ type: "item.started", turnId: command.turnId, item: active.item });
+    void this.#runHarnessCommand(active);
+    return { ok: true, value: { turnId: command.turnId } };
+  }
+
+  async #runHarnessCommand(active: ActiveCommand): Promise<void> {
     try {
-      try {
-        const response = unwrapRpc(
-          await this.#client.sessions.prompt({
-            sessionId: this.#nativeRef.nativeSessionId as SessionId,
-            mode: "queue",
-            content: [{ type: "text", text: "/compact" }],
-          }),
-          "session.prompt",
-        );
-        if (!response.command) {
-          return {
-            ok: false,
-            error: {
-              code: "nativeFailure",
-              message: "DeepSeek Harness did not treat the invocation as a command",
-              retryable: false,
-            },
-          };
+      const response = await this.#commandClient.execute(
+        this.#nativeRef.nativeSessionId as SessionId,
+        "/compact",
+        active.abort.signal,
+      );
+      if (this.#activeCommand !== active) return;
+      if (!response.ok) {
+        if (active.cancellationRequested || response.error.code === "cancelled") {
+          this.#finishCommand(active, {
+            status: "cancelled",
+            reason: "DeepSeek Harness context compaction was cancelled",
+          });
+        } else {
+          this.#finishCommand(active, {
+            status: "failed",
+            error: commandFailure("commands/execute", response.error),
+          });
         }
-        // Temporary command projection Turn: lifecycle events only, never persisted
-        // into the ordinary conversation history and carrying no native turn identity.
-        this.#emit({ type: "turn.started", turnId: command.turnId });
-        this.#emit({
-          type: "turn.completed",
-          turnId: command.turnId,
-          outcome: { status: "succeeded" },
-        });
-        return { ok: true, value: { turnId: command.turnId } };
-      } catch (error) {
-        return { ok: false, error: normalizedError(error, "nativeFailure") };
+        return;
       }
-    } finally {
-      this.#configuring = false;
+      const execution = response.value;
+      if (!execution) {
+        this.#finishCommand(active, {
+          status: "failed",
+          error: {
+            code: "nativeFailure",
+            message: "DeepSeek Harness did not resolve the registered /compact command",
+            retryable: false,
+          },
+        });
+        return;
+      }
+      if (execution.result.kind === "success") {
+        this.#finishCommand(active, { status: "succeeded" });
+      } else if (active.cancellationRequested || execution.result.text === DSH_COMPACT_CANCELLED) {
+        this.#finishCommand(active, {
+          status: "cancelled",
+          reason: execution.result.text,
+        });
+      } else {
+        this.#finishCommand(active, {
+          status: "failed",
+          error: {
+            code: execution.result.text === DSH_COMPACT_BUSY ? "sessionBusy" : "nativeFailure",
+            message: execution.result.text,
+            retryable: true,
+          },
+        });
+      }
+    } catch (error) {
+      if (this.#activeCommand !== active) return;
+      if (active.cancellationRequested || active.abort.signal.aborted) {
+        this.#finishCommand(active, {
+          status: "cancelled",
+          reason: "DeepSeek Harness context compaction was cancelled",
+        });
+      } else {
+        this.#finishCommand(active, {
+          status: "failed",
+          error: normalizedError(error, "nativeFailure"),
+        });
+      }
     }
   }
 
+  #finishCommand(active: ActiveCommand, outcome: HostItemOutcome): void {
+    if (this.#activeCommand !== active) return;
+    this.#activeCommand = null;
+    this.#emit({
+      type: "item.completed",
+      turnId: active.command.turnId,
+      snapshot: { item: active.item, outcome },
+    });
+    this.#emit({ type: "turn.completed", turnId: active.command.turnId, outcome });
+  }
+
   async #cancel(command: TurnCancelCommand): Promise<HarnessResult<TurnCancelAccepted>> {
+    const activeCommand = this.#activeCommand;
+    if (activeCommand?.command.turnId === command.turnId) {
+      if (!activeCommand.cancellationRequested) {
+        activeCommand.cancellationRequested = true;
+        activeCommand.abort.abort(new Error("DeepSeek Harness command cancelled by user"));
+      }
+      return { ok: true, value: { cancellationRequested: true } };
+    }
     const active = this.#active;
     if (!active || active.command.turnId !== command.turnId) {
       return { ok: false, error: invalidState("DeepSeek Harness cancel requires the active Turn") };
@@ -1141,6 +1255,11 @@ class DeepSeekHarnessSession implements HarnessSession, DeepSeekHostSubscriber {
 
   #fault(error: HarnessError): void {
     if (this.#closed) return;
+    const activeCommand = this.#activeCommand;
+    if (activeCommand) {
+      activeCommand.abort.abort(new Error(error.message));
+      this.#finishCommand(activeCommand, { status: "failed", error });
+    }
     const active = this.#active;
     if (active) {
       const outcome: HostItemOutcome = { status: "failed", error };

--- a/packages/adapters/deepseek-harness/src/deepseek-harness-adapter.ts
+++ b/packages/adapters/deepseek-harness/src/deepseek-harness-adapter.ts
@@ -15,6 +15,9 @@ import {
   validateHostApprovalResponse,
   validateHostQuestionResponse,
   type HarnessAdapter,
+  type HarnessCommandAccepted,
+  type HarnessCommandCapability,
+  type HarnessCommandInvocation,
   type HarnessError,
   type HarnessInspection,
   type HarnessModelRef,
@@ -51,6 +54,7 @@ import {
   type TurnStartCommand,
 } from "@codexhost/harness-adapter";
 import {
+  harnessCommandCatalogSchema,
   harnessIdSchema,
   hostInteractionIdSchema,
   hostItemIdSchema,
@@ -143,6 +147,18 @@ interface ActiveTurn {
 }
 
 const deepSeekHarnessId = harnessIdSchema.parse("deepseek-harness");
+const deepSeekCommandCatalog = harnessCommandCatalogSchema.parse({
+  commands: [
+    {
+      id: "dsh.compact",
+      invocation: "/compact",
+      label: "Compact context",
+      description:
+        "Compact the current conversation context through the DeepSeek Harness command registry",
+      argumentMode: "none",
+    },
+  ],
+});
 const DEFAULT_TOOL_OUTPUT_LIMIT = 64_000;
 const HISTORY_PAGE_MESSAGES = 100;
 const HISTORY_PAGE_LIMIT = 10_000;
@@ -220,6 +236,10 @@ class DeepSeekHarnessSession implements HarnessSession, DeepSeekHostSubscriber {
       selectPermissionMode: false,
     },
     history: { fork: false, forkAcrossCwd: false, rollbackLastTurn: false },
+  };
+  readonly commands: HarnessCommandCapability = {
+    list: () => Promise.resolve({ ok: true, value: deepSeekCommandCatalog }),
+    execute: (command) => this.#executeHarnessCommand(command),
   };
   readonly initialState: HarnessSessionState;
   readonly initialUsage: HostUsage | null;
@@ -539,6 +559,79 @@ class DeepSeekHarnessSession implements HarnessSession, DeepSeekHostSubscriber {
           state: { nativeRef: this.#nativeRef, effectiveModel: this.#model },
         });
         return { ok: true, value: { completed: true } };
+      } catch (error) {
+        return { ok: false, error: normalizedError(error, "nativeFailure") };
+      }
+    } finally {
+      this.#configuring = false;
+    }
+  }
+
+  async #executeHarnessCommand(
+    command: HarnessCommandInvocation,
+  ): Promise<HarnessResult<HarnessCommandAccepted>> {
+    if (command.commandId !== "dsh.compact") {
+      return {
+        ok: false,
+        error: {
+          code: "unsupported",
+          message: `DeepSeek Harness does not expose command '${command.commandId}'`,
+          retryable: false,
+        },
+      };
+    }
+    if (this.#active || this.#configuring || this.#reading) {
+      return {
+        ok: false,
+        error: {
+          code: "sessionBusy",
+          message:
+            "DeepSeek Harness Session cannot execute a command while another operation is active",
+          retryable: true,
+        },
+      };
+    }
+    if (command.arguments && Object.keys(command.arguments).length > 0) {
+      return {
+        ok: false,
+        error: {
+          code: "invalidRequest",
+          message: "DeepSeek Harness compact command does not accept arguments",
+          retryable: false,
+        },
+      };
+    }
+
+    this.#configuring = true;
+    try {
+      try {
+        const response = unwrapRpc(
+          await this.#client.sessions.prompt({
+            sessionId: this.#nativeRef.nativeSessionId as SessionId,
+            mode: "queue",
+            content: [{ type: "text", text: "/compact" }],
+          }),
+          "session.prompt",
+        );
+        if (!response.command) {
+          return {
+            ok: false,
+            error: {
+              code: "nativeFailure",
+              message: "DeepSeek Harness did not treat the invocation as a command",
+              retryable: false,
+            },
+          };
+        }
+        // Temporary command projection Turn: lifecycle events only, never persisted
+        // into the ordinary conversation history and carrying no native turn identity.
+        this.#emit({ type: "turn.started", turnId: command.turnId });
+        this.#emit({
+          type: "turn.completed",
+          turnId: command.turnId,
+          outcome: { status: "succeeded" },
+        });
+        return { ok: true, value: { turnId: command.turnId } };
       } catch (error) {
         return { ok: false, error: normalizedError(error, "nativeFailure") };
       }

--- a/packages/adapters/deepseek-harness/src/host-client.ts
+++ b/packages/adapters/deepseek-harness/src/host-client.ts
@@ -1,16 +1,49 @@
 import { spawn, type ChildProcess } from "node:child_process";
+import { randomUUID } from "node:crypto";
 import { accessSync, constants, statSync } from "node:fs";
 import path from "node:path";
 
 import { sanitizeDiagnosticTail } from "@codexhost/harness-adapter";
-import type { HostFrame, MuxFrame, RpcRequest } from "@deepseek-ai/dsh-host-apiproxy/api";
+import type { HostFrame, MuxFrame, RpcError, RpcRequest } from "@deepseek-ai/dsh-host-apiproxy/api";
 import { hostFrameSchema, muxFrameSchema } from "@deepseek-ai/dsh-host-apiproxy/api/events.schema";
-import { serverRequestSchema } from "@deepseek-ai/dsh-host-apiproxy/api/rpc.schema";
+import {
+  serverRequestSchema,
+  serverResponseSchema,
+} from "@deepseek-ai/dsh-host-apiproxy/api/rpc.schema";
 import { AbstractApiClient, type IApiClient } from "@deepseek-ai/dsh-host-apiproxy/client";
+import type { SessionId } from "@deepseek-ai/dsh-session/types";
 
-export type DeepSeekHostClient = IApiClient;
+export type DeepSeekHostClient = IApiClient & { readonly commands: DeepSeekCommandClient };
 export type DeepSeekMuxEnvelope = RpcRequest<MuxFrame>;
 export type DeepSeekHostEnvelope = RpcRequest<HostFrame>;
+
+export interface DeepSeekCommandDescriptor {
+  readonly name: string;
+  readonly description: string;
+  readonly input?: { readonly hint: string; readonly images?: boolean };
+}
+
+export interface DeepSeekCommandExecution {
+  readonly commandId: string;
+  readonly result:
+    | { readonly kind: "success"; readonly text?: string; readonly sourceEventSeq?: number }
+    | { readonly kind: "error"; readonly text: string };
+}
+
+export type DeepSeekCommandResult<T> =
+  { readonly ok: true; readonly value: T } | { readonly ok: false; readonly error: RpcError };
+
+export interface DeepSeekCommandClient {
+  list(
+    sessionId: SessionId,
+    signal?: AbortSignal,
+  ): Promise<DeepSeekCommandResult<DeepSeekCommandDescriptor[]>>;
+  execute(
+    sessionId: SessionId,
+    line: string,
+    signal?: AbortSignal,
+  ): Promise<DeepSeekCommandResult<DeepSeekCommandExecution | undefined>>;
+}
 
 export type DeepSeekHarnessTransportErrorCode =
   "notInstalled" | "unavailable" | "protocolError" | "processExited";
@@ -28,13 +61,72 @@ export class DeepSeekHarnessTransportError extends Error {
 type StreamFrame = MuxFrame | HostFrame;
 type StreamItem<F> = { type: "frame"; envelope: RpcRequest<F> } | { type: "end" };
 type FrameSchema<F> = { parse(value: unknown): F };
+const MISSING_COMMAND_IMAGES =
+  'typert gateway: commands/execute: args fields do not match the descriptor: missing "images"';
+
+function commandProtocolError(method: string, detail: string): DeepSeekHarnessTransportError {
+  return new DeepSeekHarnessTransportError(
+    "protocolError",
+    `DeepSeek Harness '${method}' returned ${detail}`,
+  );
+}
+
+function record(value: unknown): Record<string, unknown> | null {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+function parseCommandDescriptors(value: unknown): DeepSeekCommandDescriptor[] {
+  const valid =
+    Array.isArray(value) &&
+    value.every((entry) => {
+      const descriptor = record(entry);
+      if (
+        !descriptor ||
+        typeof descriptor.name !== "string" ||
+        typeof descriptor.description !== "string"
+      ) {
+        return false;
+      }
+      if (descriptor.input === undefined) return true;
+      const input = record(descriptor.input);
+      return (
+        !!input &&
+        typeof input.hint === "string" &&
+        (input.images === undefined || typeof input.images === "boolean")
+      );
+    });
+  if (!valid) throw new TypeError("an invalid command catalog");
+  return value as DeepSeekCommandDescriptor[];
+}
+
+function parseCommandExecution(value: unknown): DeepSeekCommandExecution | undefined {
+  if (value === undefined) return undefined;
+  const execution = record(value);
+  const result = record(execution?.result);
+  const validResult =
+    !!result &&
+    ((result.kind === "error" && typeof result.text === "string") ||
+      (result.kind === "success" &&
+        (result.text === undefined || typeof result.text === "string") &&
+        (result.sourceEventSeq === undefined ||
+          (Number.isSafeInteger(result.sourceEventSeq) &&
+            (result.sourceEventSeq as number) >= 0))));
+  if (!execution || typeof execution.commandId !== "string" || !validResult) {
+    throw new TypeError("an invalid command execution");
+  }
+  return value as DeepSeekCommandExecution;
+}
 
 export class NodeDeepSeekHostClient extends AbstractApiClient {
+  readonly commands: DeepSeekCommandClient;
   readonly #endpoint: URL;
 
   constructor(endpoint: string, timeoutMs?: number) {
     super(timeoutMs);
     this.#endpoint = parseLoopbackEndpoint(endpoint);
+    this.commands = new NodeDeepSeekCommandClient(endpoint, timeoutMs);
   }
 
   protected override resolveBase(): string {
@@ -129,6 +221,98 @@ export class NodeDeepSeekHostClient extends AbstractApiClient {
       socket.removeEventListener("error", handleError);
       socket.removeEventListener("close", handleClose);
       socket.close();
+    }
+  }
+}
+
+export class NodeDeepSeekCommandClient implements DeepSeekCommandClient {
+  readonly #endpoint: URL;
+  readonly #timeoutMs: number;
+
+  constructor(endpoint: string, timeoutMs = 5_000) {
+    this.#endpoint = parseLoopbackEndpoint(endpoint);
+    this.#timeoutMs = timeoutMs;
+  }
+
+  list(
+    sessionId: SessionId,
+    signal?: AbortSignal,
+  ): Promise<DeepSeekCommandResult<DeepSeekCommandDescriptor[]>> {
+    const timeout = AbortSignal.timeout(this.#timeoutMs);
+    return this.#call(
+      "commands/list",
+      { agentId: sessionId },
+      parseCommandDescriptors,
+      signal ? AbortSignal.any([signal, timeout]) : timeout,
+    );
+  }
+
+  async execute(
+    sessionId: SessionId,
+    line: string,
+    signal?: AbortSignal,
+  ): Promise<DeepSeekCommandResult<DeepSeekCommandExecution | undefined>> {
+    const result = await this.#call(
+      "commands/execute",
+      { agentId: sessionId, line },
+      parseCommandExecution,
+      signal,
+    );
+    if (
+      !result.ok &&
+      result.error.code === "internal" &&
+      result.error.message === MISSING_COMMAND_IMAGES
+    ) {
+      // rc.6 has no images parameter; newer DSH requires an explicit empty batch.
+      return this.#call(
+        "commands/execute",
+        { agentId: sessionId, line, images: [] },
+        parseCommandExecution,
+        signal,
+      );
+    }
+    return result;
+  }
+
+  async #call<T>(
+    method: string,
+    args: Record<string, unknown>,
+    parse: (value: unknown) => T,
+    signal?: AbortSignal,
+  ): Promise<DeepSeekCommandResult<T>> {
+    const rpcId = randomUUID();
+    const response = await globalThis.fetch(new URL(`/api/${method}`, this.#endpoint), {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ type: "client-request", rpcId, method, payload: { args } }),
+      ...(signal ? { signal } : {}),
+    });
+    if (!response.ok) {
+      throw new DeepSeekHarnessTransportError(
+        "unavailable",
+        `DeepSeek Harness '${method}' transport failed with HTTP ${response.status}`,
+      );
+    }
+    let envelope: ReturnType<typeof serverResponseSchema.parse>;
+    try {
+      envelope = serverResponseSchema.parse(await response.json());
+    } catch (error) {
+      throw commandProtocolError(
+        method,
+        `an invalid response: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
+    if (envelope.rpcId !== rpcId) {
+      throw new DeepSeekHarnessTransportError(
+        "protocolError",
+        `DeepSeek Harness '${method}' returned an unexpected RPC identity`,
+      );
+    }
+    if (!envelope.result.ok) return envelope.result;
+    try {
+      return { ok: true, value: parse(envelope.result.value) };
+    } catch (error) {
+      throw commandProtocolError(method, error instanceof Error ? error.message : String(error));
     }
   }
 }

--- a/packages/adapters/deepseek-harness/test/deepseek-harness-adapter.test.ts
+++ b/packages/adapters/deepseek-harness/test/deepseek-harness-adapter.test.ts
@@ -20,6 +20,7 @@ import {
   type DeepSeekHostConnectionLike,
 } from "../src/deepseek-harness-adapter.js";
 import type {
+  DeepSeekCommandExecution,
   DeepSeekHostClient,
   DeepSeekHostSubscriber,
   DeepSeekMuxEnvelope,
@@ -47,6 +48,10 @@ function success<T>(value: T) {
   return { rpcId: RpcId("response"), result: { ok: true as const, value } };
 }
 
+function commandSuccess<T>(value: T) {
+  return { ok: true as const, value };
+}
+
 function event(seq: number, type: string, data: Record<string, unknown>): HistoryEntry {
   return {
     event: { type, seq, time: seq, data } as HistoryEntry["event"],
@@ -63,6 +68,8 @@ class FakeConnection implements DeepSeekHostConnectionLike {
     models: vi.fn(),
     selectModel: vi.fn(),
     prompt: vi.fn(),
+    commandList: vi.fn(),
+    commandExecute: vi.fn(),
     cancel: vi.fn(),
     respond: vi.fn(),
   };
@@ -104,10 +111,19 @@ class FakeConnection implements DeepSeekHostConnectionLike {
       },
     );
     this.calls.prompt.mockResolvedValue(success({ accepted: true }));
+    this.calls.commandList.mockResolvedValue(
+      commandSuccess([{ name: "compact", description: "Compact older conversation history" }]),
+    );
+    this.calls.commandExecute.mockResolvedValue(commandSuccess(undefined));
     this.calls.cancel.mockResolvedValue(success({ accepted: true }));
     this.calls.respond.mockResolvedValue({ accepted: true });
+    const commands = {
+      list: this.calls.commandList,
+      execute: this.calls.commandExecute,
+    };
     this.client = {
       sessions,
+      commands,
       host: {
         describe: vi.fn().mockResolvedValue(
           success({
@@ -177,6 +193,12 @@ async function collectUntilTurn(session: Awaited<ReturnType<typeof openCreated>>
     if (output.kind === "event" && output.event.type === "turn.completed") return outputs;
   }
   throw new Error("Output stream ended before Turn completion");
+}
+
+async function nextEvent(iterator: AsyncIterator<HarnessOutput>) {
+  const next = await iterator.next();
+  if (next.done || next.value.kind !== "event") throw new Error("Expected a Harness event");
+  return next.value.event;
 }
 
 async function openCreated(adapter: DeepSeekHarnessAdapter) {
@@ -342,7 +364,7 @@ describe("DeepSeekHarnessAdapter local Host", () => {
     await adapter.close();
   });
 
-  it("exposes the command catalog and executes dsh.compact through the native prompt command seam", async () => {
+  it("discovers and executes dsh.compact through the native Remote command service", async () => {
     const { adapter, connection } = fixture();
     const opened = await adapter.open({
       kind: "resume",
@@ -362,54 +384,90 @@ describe("DeepSeekHarnessAdapter local Host", () => {
       ok: true,
       value: { commands: [{ id: "dsh.compact", invocation: "/compact" }] },
     });
-    connection.calls.prompt.mockResolvedValueOnce(
-      success({ accepted: true, command: { kind: "success", text: "compacted" } }),
+    expect(connection.calls.commandList).toHaveBeenCalledWith(SESSION_ID);
+    let resolveExecution:
+      ((value: { ok: true; value: DeepSeekCommandExecution }) => void) | undefined;
+    connection.calls.commandExecute.mockImplementationOnce(
+      () =>
+        new Promise<{ ok: true; value: DeepSeekCommandExecution }>((resolve) => {
+          resolveExecution = resolve;
+        }),
     );
     const iterator = session.outputs[Symbol.asyncIterator]();
-    const executing = commands.execute({
-      turnId: hostTurnIdSchema.parse("manual-compact"),
-      commandId: "dsh.compact",
+    const turnId = hostTurnIdSchema.parse("manual-compact");
+    await expect(
+      commands.execute({
+        turnId,
+        commandId: "dsh.compact",
+      }),
+    ).resolves.toEqual({ ok: true, value: { turnId } });
+    expect(await nextEvent(iterator)).toEqual({ type: "turn.started", turnId });
+    const started = await nextEvent(iterator);
+    if (started.type !== "item.started") throw new Error("Expected compaction Item start");
+    expect(started).toMatchObject({
+      type: "item.started",
+      turnId,
+      item: { type: "contextCompaction" },
     });
-    await expect(iterator.next()).resolves.toMatchObject({
-      done: false,
-      value: { kind: "event", event: { type: "turn.started", turnId: "manual-compact" } },
+    await expect(session.readSnapshot()).resolves.toMatchObject({
+      ok: false,
+      error: { code: "sessionBusy" },
     });
-    await expect(iterator.next()).resolves.toMatchObject({
-      done: false,
-      value: {
-        kind: "event",
-        event: {
-          type: "turn.completed",
-          turnId: "manual-compact",
-          outcome: { status: "succeeded" },
-        },
-      },
+
+    resolveExecution?.(
+      commandSuccess({
+        commandId: "native-command-1",
+        result: { kind: "success", text: "compacted" },
+      }),
+    );
+    expect(await nextEvent(iterator)).toEqual({
+      type: "item.completed",
+      turnId,
+      snapshot: { item: started.item, outcome: { status: "succeeded" } },
     });
-    await expect(executing).resolves.toEqual({
+    expect(await nextEvent(iterator)).toEqual({
+      type: "turn.completed",
+      turnId,
+      outcome: { status: "succeeded" },
+    });
+    expect(connection.calls.commandExecute).toHaveBeenCalledWith(
+      SESSION_ID,
+      "/compact",
+      expect.any(AbortSignal),
+    );
+    expect(connection.calls.prompt).not.toHaveBeenCalled();
+    await expect(session.readSnapshot()).resolves.toMatchObject({
       ok: true,
-      value: { turnId: "manual-compact" },
+      value: { turns: [] },
     });
-    expect(connection.calls.prompt).toHaveBeenCalledWith({
-      sessionId: SESSION_ID,
-      mode: "queue",
-      content: [{ type: "text", text: "/compact" }],
+    await adapter.close();
+  });
+
+  it("hides dsh.compact when the native deployment does not advertise the argument-free command", async () => {
+    const { adapter, connection } = fixture();
+    connection.calls.commandList.mockResolvedValueOnce(
+      commandSuccess([
+        {
+          name: "compact",
+          description: "Different deployment contract",
+          input: { hint: "<instructions>" },
+        },
+      ]),
+    );
+    const session = await openCreated(adapter);
+    const commands = session.commands;
+    if (!commands) throw new Error("DeepSeek Harness Session did not expose commands");
+
+    await expect(commands.list()).resolves.toEqual({
+      ok: true,
+      value: { commands: [] },
     });
     await adapter.close();
   });
 
   it("rejects unknown Harness commands and command arguments without touching the Host", async () => {
     const { adapter, connection } = fixture();
-    const opened = await adapter.open({
-      kind: "resume",
-      cwd: "/workspace",
-      nativeRef: {
-        harnessId: adapter.harnessId,
-        nativeSessionId: SESSION_ID,
-        formatVersion: 1,
-      },
-    });
-    if (!opened.ok) throw new Error(opened.error.message);
-    const session = opened.value;
+    const session = await openCreated(adapter);
     const commands = session.commands;
     if (!commands) throw new Error("DeepSeek Harness Session did not expose commands");
 
@@ -426,33 +484,105 @@ describe("DeepSeekHarnessAdapter local Host", () => {
         arguments: { text: "keep details" },
       }),
     ).resolves.toMatchObject({ ok: false, error: { code: "invalidRequest" } });
+    expect(connection.calls.commandExecute).not.toHaveBeenCalled();
     expect(connection.calls.prompt).not.toHaveBeenCalled();
     await adapter.close();
   });
 
-  it("fails closed when DeepSeek Harness does not treat the invocation as a command", async () => {
+  it("fails the temporary Turn when the native command does not resolve", async () => {
     const { adapter, connection } = fixture();
-    const opened = await adapter.open({
-      kind: "resume",
-      cwd: "/workspace",
-      nativeRef: {
-        harnessId: adapter.harnessId,
-        nativeSessionId: SESSION_ID,
-        formatVersion: 1,
-      },
-    });
-    if (!opened.ok) throw new Error(opened.error.message);
-    const session = opened.value;
+    const session = await openCreated(adapter);
     const commands = session.commands;
     if (!commands) throw new Error("DeepSeek Harness Session did not expose commands");
+    const iterator = session.outputs[Symbol.asyncIterator]();
+    const turnId = hostTurnIdSchema.parse("missing-compact");
 
-    await expect(
-      commands.execute({
-        turnId: hostTurnIdSchema.parse("manual-compact"),
-        commandId: "dsh.compact",
+    await expect(commands.execute({ turnId, commandId: "dsh.compact" })).resolves.toEqual({
+      ok: true,
+      value: { turnId },
+    });
+    expect((await nextEvent(iterator)).type).toBe("turn.started");
+    const started = await nextEvent(iterator);
+    expect(started.type).toBe("item.started");
+    await expect(nextEvent(iterator)).resolves.toMatchObject({
+      type: "item.completed",
+      snapshot: { outcome: { status: "failed", error: { code: "nativeFailure" } } },
+    });
+    await expect(nextEvent(iterator)).resolves.toMatchObject({
+      type: "turn.completed",
+      outcome: { status: "failed", error: { code: "nativeFailure" } },
+    });
+    expect(connection.calls.prompt).not.toHaveBeenCalled();
+    await adapter.close();
+  });
+
+  it("projects the native compact busy result as a failed temporary Turn", async () => {
+    const { adapter, connection } = fixture();
+    const session = await openCreated(adapter);
+    const commands = session.commands;
+    if (!commands) throw new Error("DeepSeek Harness Session did not expose commands");
+    connection.calls.commandExecute.mockResolvedValueOnce(
+      commandSuccess({
+        commandId: "native-command-1",
+        result: {
+          kind: "error",
+          text: "Compaction is unavailable because this process has an active compaction, or the agent is not idle.",
+        },
       }),
-    ).resolves.toMatchObject({ ok: false, error: { code: "nativeFailure" } });
-    expect(connection.calls.prompt).toHaveBeenCalledTimes(1);
+    );
+    const iterator = session.outputs[Symbol.asyncIterator]();
+    const turnId = hostTurnIdSchema.parse("busy-compact");
+
+    await commands.execute({ turnId, commandId: "dsh.compact" });
+    await nextEvent(iterator);
+    await nextEvent(iterator);
+    await expect(nextEvent(iterator)).resolves.toMatchObject({
+      type: "item.completed",
+      snapshot: { outcome: { status: "failed", error: { code: "sessionBusy" } } },
+    });
+    await expect(nextEvent(iterator)).resolves.toMatchObject({
+      type: "turn.completed",
+      outcome: { status: "failed", error: { code: "sessionBusy" } },
+    });
+    await expect(session.readSnapshot()).resolves.toMatchObject({ ok: true });
+    await adapter.close();
+  });
+
+  it("cancels a running native compact command through its AbortSignal", async () => {
+    const { adapter, connection } = fixture();
+    const session = await openCreated(adapter);
+    const commands = session.commands;
+    if (!commands) throw new Error("DeepSeek Harness Session did not expose commands");
+    let commandSignal: AbortSignal | undefined;
+    connection.calls.commandExecute.mockImplementationOnce(
+      (_sessionId: SessionId, _line: string, signal: AbortSignal) =>
+        new Promise((_resolve, reject) => {
+          commandSignal = signal;
+          signal.addEventListener("abort", () => reject(signal.reason), { once: true });
+        }),
+    );
+    const iterator = session.outputs[Symbol.asyncIterator]();
+    const turnId = hostTurnIdSchema.parse("cancel-compact");
+
+    await commands.execute({
+      turnId,
+      commandId: "dsh.compact",
+    });
+    await nextEvent(iterator);
+    await nextEvent(iterator);
+    await expect(session.execute({ type: "turn.cancel", turnId })).resolves.toEqual({
+      ok: true,
+      value: { cancellationRequested: true },
+    });
+    expect(commandSignal?.aborted).toBe(true);
+    await expect(nextEvent(iterator)).resolves.toMatchObject({
+      type: "item.completed",
+      snapshot: { outcome: { status: "cancelled" } },
+    });
+    await expect(nextEvent(iterator)).resolves.toMatchObject({
+      type: "turn.completed",
+      outcome: { status: "cancelled" },
+    });
     await adapter.close();
   });
 

--- a/packages/adapters/deepseek-harness/test/deepseek-harness-adapter.test.ts
+++ b/packages/adapters/deepseek-harness/test/deepseek-harness-adapter.test.ts
@@ -342,6 +342,120 @@ describe("DeepSeekHarnessAdapter local Host", () => {
     await adapter.close();
   });
 
+  it("exposes the command catalog and executes dsh.compact through the native prompt command seam", async () => {
+    const { adapter, connection } = fixture();
+    const opened = await adapter.open({
+      kind: "resume",
+      cwd: "/workspace",
+      nativeRef: {
+        harnessId: adapter.harnessId,
+        nativeSessionId: SESSION_ID,
+        formatVersion: 1,
+      },
+    });
+    if (!opened.ok) throw new Error(opened.error.message);
+    const session = opened.value;
+    const commands = session.commands;
+    if (!commands) throw new Error("DeepSeek Harness Session did not expose commands");
+
+    await expect(commands.list()).resolves.toMatchObject({
+      ok: true,
+      value: { commands: [{ id: "dsh.compact", invocation: "/compact" }] },
+    });
+    connection.calls.prompt.mockResolvedValueOnce(
+      success({ accepted: true, command: { kind: "success", text: "compacted" } }),
+    );
+    const iterator = session.outputs[Symbol.asyncIterator]();
+    const executing = commands.execute({
+      turnId: hostTurnIdSchema.parse("manual-compact"),
+      commandId: "dsh.compact",
+    });
+    await expect(iterator.next()).resolves.toMatchObject({
+      done: false,
+      value: { kind: "event", event: { type: "turn.started", turnId: "manual-compact" } },
+    });
+    await expect(iterator.next()).resolves.toMatchObject({
+      done: false,
+      value: {
+        kind: "event",
+        event: {
+          type: "turn.completed",
+          turnId: "manual-compact",
+          outcome: { status: "succeeded" },
+        },
+      },
+    });
+    await expect(executing).resolves.toEqual({
+      ok: true,
+      value: { turnId: "manual-compact" },
+    });
+    expect(connection.calls.prompt).toHaveBeenCalledWith({
+      sessionId: SESSION_ID,
+      mode: "queue",
+      content: [{ type: "text", text: "/compact" }],
+    });
+    await adapter.close();
+  });
+
+  it("rejects unknown Harness commands and command arguments without touching the Host", async () => {
+    const { adapter, connection } = fixture();
+    const opened = await adapter.open({
+      kind: "resume",
+      cwd: "/workspace",
+      nativeRef: {
+        harnessId: adapter.harnessId,
+        nativeSessionId: SESSION_ID,
+        formatVersion: 1,
+      },
+    });
+    if (!opened.ok) throw new Error(opened.error.message);
+    const session = opened.value;
+    const commands = session.commands;
+    if (!commands) throw new Error("DeepSeek Harness Session did not expose commands");
+
+    await expect(
+      commands.execute({
+        turnId: hostTurnIdSchema.parse("manual-x"),
+        commandId: "dsh.unknown",
+      }),
+    ).resolves.toMatchObject({ ok: false, error: { code: "unsupported" } });
+    await expect(
+      commands.execute({
+        turnId: hostTurnIdSchema.parse("manual-compact"),
+        commandId: "dsh.compact",
+        arguments: { text: "keep details" },
+      }),
+    ).resolves.toMatchObject({ ok: false, error: { code: "invalidRequest" } });
+    expect(connection.calls.prompt).not.toHaveBeenCalled();
+    await adapter.close();
+  });
+
+  it("fails closed when DeepSeek Harness does not treat the invocation as a command", async () => {
+    const { adapter, connection } = fixture();
+    const opened = await adapter.open({
+      kind: "resume",
+      cwd: "/workspace",
+      nativeRef: {
+        harnessId: adapter.harnessId,
+        nativeSessionId: SESSION_ID,
+        formatVersion: 1,
+      },
+    });
+    if (!opened.ok) throw new Error(opened.error.message);
+    const session = opened.value;
+    const commands = session.commands;
+    if (!commands) throw new Error("DeepSeek Harness Session did not expose commands");
+
+    await expect(
+      commands.execute({
+        turnId: hostTurnIdSchema.parse("manual-compact"),
+        commandId: "dsh.compact",
+      }),
+    ).resolves.toMatchObject({ ok: false, error: { code: "nativeFailure" } });
+    expect(connection.calls.prompt).toHaveBeenCalledTimes(1);
+    await adapter.close();
+  });
+
   it("preserves the confirmed Model when native selection fails", async () => {
     const { adapter, connection } = fixture();
     const session = await openCreated(adapter);

--- a/packages/adapters/deepseek-harness/test/host-client.test.ts
+++ b/packages/adapters/deepseek-harness/test/host-client.test.ts
@@ -9,6 +9,7 @@ import { describe, expect, it, vi } from "vitest";
 import type { DeepSeekHostClient } from "../src/host-client.js";
 import {
   DeepSeekHostConnection,
+  NodeDeepSeekCommandClient,
   NodeDeepSeekHostClient,
   deepSeekProcessInvocation,
   resolveDeepSeekCommand,
@@ -47,6 +48,97 @@ function childProcess(): ChildProcess {
 }
 
 describe("DeepSeek local Host connection", () => {
+  it("calls the Typert Remote command wire and validates its catalog", async () => {
+    const requests: Array<{ url: string; body: Record<string, unknown> }> = [];
+    vi.stubGlobal(
+      "fetch",
+      vi.fn((input: URL, init?: RequestInit) => {
+        const body = JSON.parse(String(init?.body)) as Record<string, unknown>;
+        requests.push({ url: input.href, body });
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({
+              type: "server-response",
+              rpcId: body.rpcId,
+              result: {
+                ok: true,
+                value: [{ name: "compact", description: "Compact older conversation history" }],
+              },
+            }),
+          ),
+        );
+      }),
+    );
+    try {
+      const client = new NodeDeepSeekCommandClient("http://127.0.0.1:43123");
+
+      await expect(client.list("session-1" as never)).resolves.toEqual({
+        ok: true,
+        value: [{ name: "compact", description: "Compact older conversation history" }],
+      });
+      expect(requests).toHaveLength(1);
+      expect(requests[0]?.url).toBe("http://127.0.0.1:43123/api/commands/list");
+      expect(requests[0]?.body).toMatchObject({
+        type: "client-request",
+        method: "commands/list",
+        payload: { args: { agentId: "session-1" } },
+      });
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+
+  it("retries commands/execute with the newer empty images field only when requested", async () => {
+    const payloads: Array<Record<string, unknown>> = [];
+    vi.stubGlobal(
+      "fetch",
+      vi.fn((input: URL, init?: RequestInit) => {
+        const body = JSON.parse(String(init?.body)) as Record<string, unknown>;
+        payloads.push(body.payload as Record<string, unknown>);
+        const first = payloads.length === 1;
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({
+              type: "server-response",
+              rpcId: body.rpcId,
+              result: first
+                ? {
+                    ok: false,
+                    error: {
+                      code: "internal",
+                      message:
+                        'typert gateway: commands/execute: args fields do not match the descriptor: missing "images"',
+                      details: {},
+                    },
+                  }
+                : {
+                    ok: true,
+                    value: {
+                      commandId: "command-1",
+                      result: { kind: "success", text: "compacted" },
+                    },
+                  },
+            }),
+          ),
+        );
+      }),
+    );
+    try {
+      const client = new NodeDeepSeekCommandClient("http://127.0.0.1:43123");
+
+      await expect(client.execute("session-1" as never, "/compact")).resolves.toEqual({
+        ok: true,
+        value: { commandId: "command-1", result: { kind: "success", text: "compacted" } },
+      });
+      expect(payloads).toEqual([
+        { args: { agentId: "session-1", line: "/compact" } },
+        { args: { agentId: "session-1", line: "/compact", images: [] } },
+      ]);
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+
   it("connects to an existing compatible Host without spawning or stopping it", async () => {
     const spawn = vi.fn();
     const dependencies: DeepSeekHostConnectionDependencies = {


### PR DESCRIPTION
## 目的

为 DeepSeek Harness adapter 注册首个 Harness 命令 `dsh.compact`（`/compact`，`argumentMode: "none"`），并通过 DSH 原生命令服务执行，而不是把 `/compact` 作为普通 Prompt 发给模型。

本 PR 与 #53 独立，基于 upstream `main` @ `64ae4c3`，改动仅位于 `packages/adapters/deepseek-harness`。

## 协议核对与修正

- 锁定的 `@deepseek-ai/dsh-host-apiproxy` 为 `0.1.0-rc.6`。
- `sessions.d.ts` 中关于单文本 `/...` 的 Prompt 命令缝说明与 rc.6 实际实现不一致：实际 `sessions.prompt` 会进入普通 followup/steer 流程，不能用于执行 `/compact`。
- DSH 的正式命令入口已经迁移到 Typert Remote：
  - `commands/list`：读取当前 Agent 的原生命令目录；
  - `commands/execute`：执行命令并返回 `CommandExecution | undefined`，同时接受调用方 `AbortSignal`。
- rc.6 的 `commands/execute` 参数为 `agentId + line`；较新的 DSH 增加必填 `images`。adapter 先按锁定协议发送，仅在收到 Typert Gateway 精确的“缺少 images 字段”错误时，以 `images: []` 重试一次。

## 实现

- 仅当原生 `commands/list` 广告无参数的 `compact` 时，目录才发布静态白名单命令 `dsh.compact`。
- `execute` 仍只接受 `dsh.compact`，拒绝未知 ID 和所有参数，不提供任意原生命令透传。
- `/compact` 通过 Connection 的正式 Remote envelope 发送到 `POST /api/commands/execute`，不再调用 `sessions.prompt`。
- 命令可能包含一次 LLM 摘要请求，因此执行没有 5 秒 unary 超时：adapter 立即接受并发布临时 Turn，后台等待原生结果。
- 临时 Turn 发布标准生命周期：
  - `turn.started`
  - `item.started(contextCompaction)`
  - `item.completed`
  - `turn.completed`
- 临时 Turn 不带 `nativeTurnRef`，也不写入 `#turns` / 普通会话历史。
- `turn.cancel` 会中止命令专属 `AbortController`；成功、失败、取消和原生 busy 结果分别投影为对应 Host outcome。
- Remote 响应 envelope、RPC ID、命令目录和 `CommandExecution` 均在信任边界进行运行时校验；未知命令返回 `undefined` 时 fail-closed 为失败 Turn。

DSH 仍会在 mux 中发布 log-only 的 `command/*` 与 `compaction/*` 事件；本实现不把这些维护记录重复投影为普通历史 Turn，标准 `contextCompaction` UI 生命周期由本次原生命令调用的开始与终态驱动。

## 测试

- FakeConnection 不再伪造不存在的 `sessions.prompt.command` 回显。
- 新增/更新覆盖：
  - 原生目录广告及部署差异；
  - Remote wire envelope 与 RPC ID；
  - rc.6 参数和新版 `images: []` 窄兼容；
  - 异步接受、`contextCompaction` 投影和历史不落盘；
  - 未知命令、参数、未解析命令、busy、取消路径；
  - 命令路径绝不调用 `sessions.prompt`。

验证结果：

- `npm run typecheck` ✅
- `npx vitest run --config tests/vitest.config.js packages/adapters/deepseek-harness`：2 files / 30 tests passed ✅
- `npx prettier --check packages/adapters/deepseek-harness` ✅
- `npx eslint packages/adapters/deepseek-harness` ✅
- `node tools/check-boundaries.mjs` ✅
- 本机正在运行的 DSH 实机只读探测：`commands/list` 返回 `compact`；不存在的命令安全返回未解析，且验证了新版 `images: []` 兼容分支 ✅
