### PR TITLE
feat(renderer): add opt-in external reasoning summaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,8 @@ xattr -dr com.apple.quarantine /Applications/codexhost.app
 | 斜杠命令 | 原生 | ✅ | ✅ | ✅ | ✅ | — |
 | 修订上一条消息 | 原生 | ✅ | ✅ | ✅ | ✅ | — |
 
+外部 Harness 明确输出的推理摘要可在 **codexhost 设置 → 模型池 → 显示推理摘要** 中开启。该功能默认关闭，只展示经过验证的可见摘要；隐藏、加密或原始思维链不会被读取或保存。
+
 <details>
 <summary><h3 id="远程连接-harness">远程连接 Harness</h3></summary>
 

--- a/docs/README.en.md
+++ b/docs/README.en.md
@@ -133,6 +133,8 @@ Fully quit Codex Desktop, open a new terminal, and start codexhost.
 | Slash commands | Native | ✅ | ✅ | ✅ | ✅ | — |
 | Edit previous message | Native | ✅ | ✅ | ✅ | ✅ | — |
 
+To display reasoning summaries explicitly emitted by an external Harness, enable **codexhost Settings → Model Pool → Show reasoning summaries**. The option is off by default and never reads or stores hidden, encrypted, or raw chain-of-thought content.
+
 <details>
 <summary><h3>Remote Harness</h3></summary>
 

--- a/docs/README.ko.md
+++ b/docs/README.ko.md
@@ -132,6 +132,8 @@ xattr -dr com.apple.quarantine /Applications/codexhost.app
 | 슬래시 명령 | 기본 제공 | ✅ | ✅ | ✅ | ✅ | — |
 | 이전 메시지 수정 | 기본 제공 | ✅ | ✅ | ✅ | ✅ | — |
 
+외부 Harness가 명시적으로 내보낸 추론 요약을 표시하려면 **codexhost 설정 → 모델 풀 → 추론 요약 표시**를 활성화하세요. 기본값은 꺼짐이며 숨김, 암호화 또는 원시 사고 과정은 읽거나 저장하지 않습니다.
+
 <details>
 <summary><h3>원격 Harness</h3></summary>
 

--- a/openspec/changes/add-optional-reasoning-display/.openspec.yaml
+++ b/openspec/changes/add-optional-reasoning-display/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-30

--- a/openspec/changes/add-optional-reasoning-display/design.md
+++ b/openspec/changes/add-optional-reasoning-display/design.md
@@ -1,0 +1,80 @@
+## Context
+
+Protocol Core already projects a minimal Host Reasoning Item into Codex app-server notifications:
+
+- `item/started` for a `reasoning` Item;
+- `item/reasoning/summaryTextDelta` for explicit visible text;
+- `item/completed` with the accumulated `summary` array.
+
+Claude Code's `thinking_delta` is already normalized into this lifecycle. The missing boundary is presentation: current Desktop builds may accept the Item notifications without retaining a visible text lane. Injecting final-answer text would corrupt the transcript, while reading complete native thinking blocks would cross the privacy boundary.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Provide an explicit default-off preference.
+- Show exact validated summary text for the active external Thread.
+- Expand during streaming, auto-scroll, and collapse after completion.
+- Remain event-driven and browser-safe.
+- Fail closed on unknown ownership, malformed notifications, unsupported DOM, or unavailable request bridges.
+
+**Non-Goals:**
+
+- Display hidden, redacted, encrypted, signed, or inferred chain-of-thought.
+- Reconstruct historical reasoning from Mapping Store or a second transcript.
+- Alter Claude Code, Grok, Codex, provider, login, or permission configuration.
+- Replace a verified native Desktop reasoning surface or render a second panel for native Codex Threads.
+- Add polling, background refresh loops, or periodic model/Harness discovery.
+
+## Decisions
+
+### 1. Consume only the native summary lane
+
+The Renderer validates three notification forms and ignores every other payload. Delta notifications must identify a Thread, Turn, Item, summary index, and string delta. Start/completion notifications must carry a `reasoning` Item whose `summary` is an array of strings. Only `summary` is joined for display; `content` and unknown fields are ignored even when present on the same object.
+
+This keeps the Renderer downstream of the existing UI-independent Host Item contract and prevents Harness-native payloads from leaking into browser code.
+
+### 2. Gate every Thread through fixed ownership inspection
+
+The request manager receives notifications for native and external Threads. On the first reasoning event for a Thread, the display performs one fixed `codexhost/thread/inspect` request and queues that Thread's events until ownership is known. External ownership releases the queue in order; Codex ownership or inspection failure discards it and is cached as non-displayable for the current in-memory generation.
+
+This avoids duplicate native Codex presentation and avoids a request per delta.
+
+### 3. Store only current in-memory presentation state
+
+The display keeps the latest reasoning Item snapshot per Thread in a Map. A start replaces an older Item, deltas append exactly once, and completion replaces the text with the authoritative summary when present. Disabling the preference or disposing the extension removes panels, subscriptions, ownership results, queued events, and text.
+
+No reasoning text enters localStorage. Only the boolean opt-in is persisted.
+
+### 4. Mount beside the verified Composer contract
+
+The panel uses the existing `data-codex-composer-root` and direct `data-above-composer-portal` identity contract. It is inserted immediately before the matching Composer, not inside React-owned transcript nodes. Unsupported or ambiguous Composer identities render nothing.
+
+The panel uses a native `<details>` element. It is open for live output, scrolls the plain-text body to the newest content, and closes on completion while remaining manually expandable.
+
+### 5. Observe DOM only while opted in
+
+When disabled, the feature has no app-server reasoning subscription and no MutationObserver. Enabling attaches one notification subscription and one event-driven DOM observer; disabling tears both down. DOM writes are equality-guarded so the observer cannot self-trigger a Renderer refresh loop.
+
+### 6. Scope state to one live Host route and bound ownership checks
+
+The reasoning notification relay carries a monotonically increasing connection token. Replacing or losing the active Host route invalidates the old callback before source-side teardown, clears ownership decisions and visible state, and rejects late ownership results from the previous route. A Thread ID alone is never treated as identity across Hosts.
+
+Each new desktop-control policy exposes the exact request target that was already validated when the policy was installed. A replacement-policy event therefore reconnects the relay directly to that target without repeating Composer DOM/Fiber discovery. A policy that claims this contract but returns a malformed target or a target for another Host fails closed. Policies from older desktop-control versions may still use Fiber discovery and a temporary DOM observer as a best-effort compatibility path; that observer is disconnected as soon as the route is restored, another policy event arrives, or the adapter is disposed.
+
+The fixed ownership inspection fails closed after five seconds. While it is pending, deltas for the current Item are coalesced into a per-Thread buffer capped at 256 KiB. Timeout, cancellation, inspection failure, or buffer overflow discards the whole pending summary for that route rather than rendering an incomplete or unproven result.
+
+## Risks / Trade-offs
+
+- **Desktop DOM contract changes:** the panel fails closed and the Composer remains usable; no broad selector fallback is used.
+- **Ownership inspection races:** events are coalesced per Thread behind one five-second request, capped at 256 KiB, and discarded on route change or failure rather than shown under the wrong owner.
+- **Long summaries:** the body has a bounded height and scrolls while live; completion collapses it.
+- **Historical visibility:** reopening a Thread may not reconstruct an old summary panel. Native Session history remains authoritative, and this change intentionally avoids a second transcript.
+- **Native surface becomes available later:** ownership gating prevents native Codex duplication; a future Desktop contract gate can disable the fallback for external Threads when a faithful native external lane is proven.
+
+## Migration Plan
+
+1. Ship the preference disabled by default.
+2. Validate notification decoding and in-memory state with unit tests.
+3. Validate the real DOM lifecycle in Chromium, including live expansion, completion collapse, privacy-field omission, opt-out teardown, and Codex ownership exclusion.
+4. Keep the existing Protocol Core projection unchanged so disabling or removing the Renderer surface is a reversible presentation-only rollback.

--- a/openspec/changes/add-optional-reasoning-display/proposal.md
+++ b/openspec/changes/add-optional-reasoning-display/proposal.md
@@ -1,0 +1,31 @@
+## Why
+
+External Harnesses such as Claude Code already publish explicit user-visible reasoning text through the Host `reasoning` Item lifecycle, but current Codex Desktop builds do not provide a reliable inspectable text surface for that projection. For complex tasks this leaves users unable to see the progress summaries that the Harness deliberately exposed.
+
+The feature must remain opt-in. Reasoning may be noisy, and codexhost must not treat hidden, redacted, encrypted, or provider-private chain-of-thought as display content.
+
+## What Changes
+
+- Add a **Show reasoning summaries** switch under codexhost Settings → Model Pool. It is disabled by default and stored as a browser-local boolean preference.
+- Subscribe to the existing app-server reasoning Item notifications only while the preference is enabled.
+- Render explicit summary text for the active external Harness Thread in a compact panel above the Composer.
+- Keep the panel expanded while summary deltas are streaming and collapse it when the reasoning Item completes.
+- Confirm Thread ownership before rendering so native Codex Threads retain their stock presentation and do not receive a duplicate panel.
+- Never render `content`, encrypted/redacted fields, signatures, inferred text, or arbitrary Assistant messages.
+- Keep all display state in memory; do not add a second transcript or persist reasoning text.
+
+## Capabilities
+
+### New Capabilities
+
+- `renderer-reasoning-summary-surface`: opt-in, browser-safe presentation of explicit external Harness reasoning summaries.
+
+### Modified Capabilities
+
+- `harness-reasoning-projection`: allows a bounded opt-in Renderer summary surface when a controlled Desktop has no faithful native reasoning text lane, while retaining the existing native Item projection and privacy boundary.
+
+## Impact
+
+- `packages/renderer-extension`: notification validation/subscription, external ownership gating, in-memory state, Composer-adjacent panel, settings toggle, localization, and tests.
+- No Harness Adapter, Mapping Store, Native Session, account configuration, or provider traffic changes.
+- No raw reasoning payloads or reasoning text are added to diagnostics, persistence, logs, or shared contracts.

--- a/openspec/changes/add-optional-reasoning-display/specs/harness-reasoning-projection/spec.md
+++ b/openspec/changes/add-optional-reasoning-display/specs/harness-reasoning-projection/spec.md
@@ -1,0 +1,25 @@
+## MODIFIED Requirements
+
+### Requirement: Protocol Core projects Reasoning through a proven Codex native carrier
+
+Protocol Core SHALL convert Host Reasoning lifecycle events and historical snapshots into the current Codex app-server `reasoning` Item and one Desktop-verified native Reasoning text lane when available. It SHALL keep Codex wire fields out of HarnessAdapter and SHALL NOT fall back to Agent Message text. When the controlled Desktop has no faithful native text lane, Renderer MAY provide the bounded opt-in summary surface defined by `renderer-reasoning-summary-surface`; that surface SHALL consume only the already-projected explicit summary lane and SHALL NOT replace or mutate Transcript Items.
+
+#### Scenario: Live Reasoning is projected
+
+- **WHEN** an external Turn emits a Reasoning start, one or more text appends, and completion
+- **THEN** the originating Codex Thread SHALL receive one Reasoning Item lifecycle with each character represented exactly once
+- **AND** Reasoning that natively precedes the first Agent Message text SHALL remain ordered before that text in the protocol lifecycle
+
+#### Scenario: Historical Reasoning is projected
+
+- **WHEN** `readSnapshot()` returns completed Reasoning Items for an external Thread
+- **THEN** historical Codex Turn projection SHALL include those Items in deterministic native order
+- **AND** reopening the Thread SHALL not require replaying live delta notifications
+- **AND** the opt-in Renderer summary surface SHALL NOT create or persist a second historical Transcript
+
+#### Scenario: Current Desktop has no faithful Reasoning carrier
+
+- **WHEN** the controlled Desktop Gate cannot prove a native Reasoning lane with correct text, ordering, and completion behavior
+- **THEN** Protocol Core SHALL preserve the native Reasoning Item projection without merging it into final Agent Message text
+- **AND** Renderer MAY show explicit summary notifications only after the user opts in
+- **AND** disabling that preference SHALL leave no custom reasoning panel or retained display text

--- a/openspec/changes/add-optional-reasoning-display/specs/renderer-reasoning-summary-surface/spec.md
+++ b/openspec/changes/add-optional-reasoning-display/specs/renderer-reasoning-summary-surface/spec.md
@@ -1,0 +1,47 @@
+## ADDED Requirements
+
+### Requirement: Renderer provides an optional external Reasoning summary surface
+
+Renderer SHALL offer a persisted boolean preference for showing explicit external Harness Reasoning summaries. The preference SHALL default to disabled. While enabled, Renderer SHALL validate the native summary notification lane, confirm that the Thread owner is external, and display the current Thread's exact summary text in a collapsible plain-text panel. It SHALL NOT display native Codex reasoning, arbitrary Item content, encrypted or redacted fields, signatures, inferred text, or unknown payload fields.
+
+#### Scenario: User enables reasoning summaries for an external Thread
+
+- **WHEN** the preference is enabled and an externally owned Thread emits validated summary deltas
+- **THEN** Renderer SHALL show those deltas exactly once in arrival order
+- **AND** the panel SHALL remain expanded and scrollable while the Reasoning Item is live
+
+#### Scenario: External Reasoning completes
+
+- **WHEN** the live Reasoning Item emits a validated completion summary
+- **THEN** Renderer SHALL use that explicit summary as the completed plain-text content
+- **AND** the panel SHALL collapse by default while remaining manually expandable
+
+#### Scenario: Reasoning display is disabled
+
+- **WHEN** the preference is absent, false, or changed from true to false
+- **THEN** Renderer SHALL attach no ongoing Reasoning notification subscription or DOM observer
+- **AND** it SHALL remove any panel, queued event, ownership result, and in-memory Reasoning text
+
+#### Scenario: Reasoning payload contains private or unrelated fields
+
+- **WHEN** a notification includes `content`, encrypted/redacted data, signatures, a non-reasoning Item, or an unrecognized method
+- **THEN** Renderer SHALL ignore those fields or the entire notification as applicable
+- **AND** none of that content SHALL appear in DOM, persistence, diagnostics, or logs
+
+#### Scenario: Thread ownership is native Codex or unavailable
+
+- **WHEN** fixed Thread inspection reports Codex ownership or cannot prove external ownership
+- **THEN** Renderer SHALL render no custom Reasoning panel for that Thread
+- **AND** the native Codex presentation SHALL remain unchanged
+
+#### Scenario: Active Host route changes during ownership inspection
+
+- **WHEN** the request manager or active Host policy changes before a queued ownership inspection completes
+- **THEN** Renderer SHALL invalidate the old notification source, ownership result, queued summary, and visible panel
+- **AND** a late callback or inspection result from the old route SHALL NOT affect the replacement route
+
+#### Scenario: Ownership inspection hangs or pending output exceeds its limit
+
+- **WHEN** fixed ownership inspection does not complete within the bounded timeout or its coalesced pending summary exceeds the bounded text limit
+- **THEN** Renderer SHALL fail closed and discard that Thread's pending summary for the current route
+- **AND** it SHALL NOT retain an unbounded event queue or render partial unverified text

--- a/openspec/changes/add-optional-reasoning-display/tasks.md
+++ b/openspec/changes/add-optional-reasoning-display/tasks.md
@@ -1,0 +1,28 @@
+## 1. Preference and settings
+
+- [x] 1.1 Add a browser-local boolean preference with a fail-closed default
+- [x] 1.2 Add an accessible Settings → Model Pool switch with English and Chinese copy
+- [x] 1.3 Notify the live Renderer when the preference changes without persisting reasoning text
+
+## 2. Notification boundary
+
+- [x] 2.1 Validate only reasoning start, summary delta, and reasoning completion notifications
+- [x] 2.2 Ignore content, encrypted/redacted fields, non-reasoning Items, malformed IDs, and unknown methods
+- [x] 2.3 Add a request-manager relay that reconnects once when the active Host route changes
+
+## 3. Presentation
+
+- [x] 3.1 Gate notifications through one fixed external Thread ownership inspection
+- [x] 3.2 Keep per-Thread reasoning summary state in memory only
+- [x] 3.3 Mount a plain-text collapsible panel beside the verified Composer contract
+- [x] 3.4 Expand and auto-scroll live output, then collapse completed output
+- [x] 3.5 Subscribe and observe only while opted in, and prevent observer self-refresh loops
+
+## 4. Validation
+
+- [x] 4.1 Cover default-off persistence and settings interaction
+- [x] 4.2 Cover notification validation, exact delta accumulation, Thread isolation, and completion state
+- [x] 4.3 Cover request-manager subscription and route replacement
+- [x] 4.4 Add Chromium coverage for live expansion, completion collapse, private-field omission, opt-out teardown, and native Codex exclusion
+- [x] 4.5 Cover stale-route callbacks, route-scoped ownership, ownership timeout, and bounded pending output
+- [x] 4.6 Run repository format, lint, typecheck, TypeScript, Rust, and packaging gates

--- a/packages/desktop-control/src/renderer-draft-prewarm-runtime.ts
+++ b/packages/desktop-control/src/renderer-draft-prewarm-runtime.ts
@@ -592,6 +592,9 @@ export function installDraftPrewarmPolicyBridge(
         candidatePrewarmedThreadManager === prewarmedThreadManager
       );
     },
+    requestTarget(): RendererHostRequestManager {
+      return manager;
+    },
     select(model: string | null): boolean {
       if (model !== null && (typeof model !== "string" || !model.startsWith("codexhost/"))) {
         throw new Error("Draft route Model must be a codexhost transport carrier");

--- a/packages/desktop-control/test/renderer-draft-prewarm-policy.test.ts
+++ b/packages/desktop-control/test/renderer-draft-prewarm-policy.test.ts
@@ -392,6 +392,30 @@ describe("Renderer draft prewarm policy", () => {
     expect(sendRequest).not.toHaveBeenCalled();
   });
 
+  it("publishes the exact owned request target before announcing the policy", () => {
+    const manager = requestManagerFixture();
+    const bridge = requestBridgeFixture();
+    let announcedPolicy: unknown;
+    const target: DraftPrewarmPolicyTarget = {
+      dispatchEvent: vi.fn(() => {
+        announcedPolicy = target.__codexhostDraftPrewarmPolicyV1;
+        return true;
+      }),
+    };
+
+    installDraftPrewarmPolicyBridge(manager, bridge, "remote-ssh-discovered:mac", target, {
+      discardAllPrewarmedThreads: vi.fn(),
+    });
+
+    const policy = target.__codexhostDraftPrewarmPolicyV1 as {
+      requestTarget(): RendererHostRequestManager;
+    };
+    expect(announcedPolicy).toBe(policy);
+    expect(Object.isFrozen(policy)).toBe(true);
+    expect(policy.requestTarget()).toBe(manager);
+    expect(target.dispatchEvent).toHaveBeenCalledOnce();
+  });
+
   it("keeps the selected route when the same Host bridge is reconciled", () => {
     const sendRequest = vi.fn();
     const prewarmThreadStart = vi.fn();

--- a/packages/renderer-extension/src/index.ts
+++ b/packages/renderer-extension/src/index.ts
@@ -41,8 +41,36 @@ export {
   UPDATE_START_METHOD,
   UPDATE_STATUS_METHOD,
   createRendererModelClient,
+  createThreadReasoningSubscriptionRelay,
 } from "./renderer-model-client.js";
 export type { RendererModelClient } from "./renderer-model-client.js";
+export {
+  RENDERER_REASONING_NOTIFICATION_METHODS,
+  RendererReasoningPendingBuffer,
+  RendererReasoningStore,
+  decodeRendererReasoningNotification,
+  rendererReasoningPanelView,
+} from "./renderer-reasoning-events.js";
+export type {
+  RendererReasoningEvent,
+  RendererReasoningPanelView,
+  RendererReasoningPhase,
+  RendererReasoningSnapshot,
+} from "./renderer-reasoning-events.js";
+export {
+  RENDERER_REASONING_DISPLAY_PREFERENCE_EVENT,
+  RENDERER_REASONING_DISPLAY_PREFERENCE_KEY,
+  readRendererReasoningDisplayPreference,
+  setRendererReasoningDisplayPreference,
+  writeRendererReasoningDisplayPreference,
+} from "./renderer-reasoning-preference.js";
+export type { RendererReasoningPreferenceStorage } from "./renderer-reasoning-preference.js";
+export { installRendererReasoningDisplay } from "./renderer-reasoning-display.js";
+export type {
+  RendererReasoningDisplayClient,
+  RendererReasoningDisplayControl,
+  RendererReasoningDisplayOptions,
+} from "./renderer-reasoning-display.js";
 export {
   inspectRendererComposerContract,
   isNativeContextUsageControlCandidate,
@@ -184,6 +212,7 @@ export type {
   RendererConnectionDiagnostics,
   RendererConnectionHostSnapshot,
   RendererConnectionSnapshot,
+  RendererReasoningDisplayPreference,
   RendererUpdateClient,
 } from "./settings/pages.js";
 export {

--- a/packages/renderer-extension/src/renderer-model-client.ts
+++ b/packages/renderer-extension/src/renderer-model-client.ts
@@ -47,6 +47,12 @@ import {
   type UpdateStatusResult,
 } from "@codexhost/shared-contracts";
 
+import {
+  RENDERER_REASONING_NOTIFICATION_METHODS,
+  decodeRendererReasoningNotification,
+  type RendererReasoningEvent,
+} from "./renderer-reasoning-events.js";
+
 export const HARNESS_INSPECT_METHOD = "codexhost/harness/inspect";
 export const THREAD_FORK_METHOD = "codexhost/thread/fork";
 export const THREAD_INSPECT_METHOD = "codexhost/thread/inspect";
@@ -90,7 +96,7 @@ interface RequestManagerCandidate {
   requestClient?: RequestManagerCandidate;
 }
 
-function usageNotificationTarget(manager: RequestManagerCandidate): RequestManagerCandidate | null {
+function notificationTarget(manager: RequestManagerCandidate): RequestManagerCandidate | null {
   if (typeof manager.addNotificationCallback === "function") return manager;
   const nested = manager.requestClient;
   return nested && typeof nested.addNotificationCallback === "function" ? nested : null;
@@ -107,6 +113,7 @@ export interface RendererModelClient {
   listThreadOwnership(input: ThreadOwnershipListParams): Promise<ThreadOwnershipListResult>;
   inspectThreadUsage(input: ThreadUsageInspectionParams): Promise<ThreadUsageInspection>;
   subscribeThreadUsage?(listener: (update: ThreadUsageInspection) => void): () => void;
+  subscribeThreadReasoning?(listener: (event: RendererReasoningEvent) => void): () => void;
   selectThreadModel(input: ThreadModelSelectParams): Promise<HarnessModelSelectionState>;
   selectThreadThinking(input: ThreadThinkingSelectParams): Promise<HarnessModelSelectionState>;
   selectThreadPermissionMode(
@@ -115,6 +122,70 @@ export interface RendererModelClient {
   checkUpdate(): Promise<UpdateCheckResult>;
   startUpdate(): Promise<UpdateStartResult>;
   readUpdateStatus(): Promise<UpdateStatusResult>;
+}
+
+export function createThreadReasoningSubscriptionRelay(): {
+  connect(client: Pick<RendererModelClient, "subscribeThreadReasoning">): void;
+  disconnect(): void;
+  subscribe(listener: (event: RendererReasoningEvent) => void): () => void;
+  dispose(): void;
+} {
+  const listeners = new Set<(event: RendererReasoningEvent) => void>();
+  let connectedClient: Pick<RendererModelClient, "subscribeThreadReasoning"> | null = null;
+  let removeNotificationCallback: (() => void) | null = null;
+  let connectionToken = 0;
+
+  const disconnect = (): void => {
+    connectionToken += 1;
+    const remove = removeNotificationCallback;
+    removeNotificationCallback = null;
+    connectedClient = null;
+    try {
+      remove?.();
+    } catch {
+      // The source is already detached from the relay. A broken source-side
+      // remover must not preserve stale routing or prevent a replacement.
+    }
+  };
+
+  return {
+    connect(client) {
+      if (connectedClient === client || listeners.size === 0) return;
+      disconnect();
+      connectedClient = client;
+      const token = connectionToken;
+      try {
+        const remove = client.subscribeThreadReasoning?.((event) => {
+          if (connectionToken !== token || connectedClient !== client) return;
+          for (const listener of listeners) listener(event);
+        });
+        if (connectionToken === token && connectedClient === client && remove) {
+          removeNotificationCallback = remove;
+        } else {
+          if (connectionToken === token && connectedClient === client) disconnect();
+          try {
+            remove?.();
+          } catch {
+            // A newer connection remains authoritative even if stale cleanup fails.
+          }
+        }
+      } catch {
+        disconnect();
+      }
+    },
+    disconnect,
+    subscribe(listener) {
+      listeners.add(listener);
+      return () => {
+        listeners.delete(listener);
+        if (listeners.size === 0) disconnect();
+      };
+    },
+    dispose() {
+      disconnect();
+      listeners.clear();
+    },
+  };
 }
 
 export function createThreadUsageSubscriptionRelay(): {
@@ -243,8 +314,21 @@ export function createRendererModelClient(
       return result;
     },
     inspectThreadUsage,
+    subscribeThreadReasoning(listener: (event: RendererReasoningEvent) => void): () => void {
+      const notifications = notificationTarget(manager);
+      if (!notifications?.addNotificationCallback) {
+        throw new Error("Renderer Reasoning notification callback is unavailable");
+      }
+      return notifications.addNotificationCallback(
+        RENDERER_REASONING_NOTIFICATION_METHODS,
+        (notification) => {
+          const event = decodeRendererReasoningNotification(notification);
+          if (event) listener(event);
+        },
+      );
+    },
     subscribeThreadUsage(listener: (update: ThreadUsageInspection) => void): () => void {
-      const notifications = usageNotificationTarget(manager);
+      const notifications = notificationTarget(manager);
       if (!notifications?.addNotificationCallback) {
         throw new Error("Renderer Usage notification callback is unavailable");
       }

--- a/packages/renderer-extension/src/renderer-reasoning-display.ts
+++ b/packages/renderer-extension/src/renderer-reasoning-display.ts
@@ -1,0 +1,445 @@
+import {
+  hostThreadIdSchema,
+  type HostThreadId,
+  type HostTurnId,
+  type ThreadInspection,
+  type ThreadInspectionParams,
+} from "@codexhost/shared-contracts";
+
+import { CODEX_COMPOSER_SELECTOR } from "./renderer-composer-dom.js";
+import {
+  RendererReasoningPendingBuffer,
+  RendererReasoningStore,
+  rendererReasoningPanelView,
+  type RendererReasoningEvent,
+} from "./renderer-reasoning-events.js";
+import {
+  RENDERER_REASONING_DISPLAY_PREFERENCE_EVENT,
+  RENDERER_REASONING_DISPLAY_PREFERENCE_KEY,
+  readRendererReasoningDisplayPreference,
+} from "./renderer-reasoning-preference.js";
+import {
+  rendererSettingsMessages,
+  resolveRendererSettingsLocale,
+} from "./settings/localization.js";
+
+const REASONING_DISPLAY_ATTRIBUTE = "data-codexhost-reasoning-display";
+const ABOVE_COMPOSER_PORTAL_ATTRIBUTE = "data-above-composer-portal";
+const ABOVE_COMPOSER_THREAD_ATTRIBUTE = "data-above-composer-conversation-id";
+const DEFAULT_OWNERSHIP_INSPECTION_TIMEOUT_MS = 5_000;
+const DEFAULT_MAX_PENDING_REASONING_TEXT_LENGTH = 256 * 1024;
+
+export interface RendererReasoningDisplayClient {
+  inspectThread?(input: ThreadInspectionParams): Promise<ThreadInspection>;
+  subscribeThreadReasoning?(listener: (event: RendererReasoningEvent) => void): () => void;
+}
+
+export interface RendererReasoningDisplayControl {
+  refresh(): void;
+  reset(): void;
+  dispose(): void;
+}
+
+export interface RendererReasoningDisplayOptions {
+  readonly ownershipInspectionTimeoutMs?: number;
+  readonly maxPendingTextLength?: number;
+}
+
+interface PendingOwnershipInspection {
+  cancel(): void;
+  promise: Promise<void>;
+}
+
+interface MountedReasoningPanel {
+  readonly root: HTMLElement;
+  readonly details: HTMLDetailsElement;
+  readonly label: HTMLElement;
+  readonly status: HTMLElement;
+  readonly body: HTMLElement;
+  threadId: HostThreadId | null;
+  turnId: HostTurnId | null;
+  itemId: string | null;
+  phase: "live" | "completed" | null;
+  text: string;
+}
+
+function positiveIntegerOr(value: number | undefined, fallback: number): number {
+  return Number.isSafeInteger(value) && Number(value) > 0 ? Number(value) : fallback;
+}
+
+function inspectWithTimeout(
+  ownerWindow: Window,
+  timeoutMs: number,
+  inspect: () => Promise<ThreadInspection>,
+): { readonly promise: Promise<ThreadInspection>; cancel(): void } {
+  let timeout: number | null = null;
+  let rejectBoundary: ((reason: Error) => void) | null = null;
+  let settled = false;
+  const boundary = new Promise<never>((_resolve, reject) => {
+    rejectBoundary = reject;
+    timeout = ownerWindow.setTimeout(() => {
+      if (settled) return;
+      settled = true;
+      reject(new Error("Renderer Reasoning ownership inspection timed out"));
+    }, timeoutMs);
+  });
+  const promise = Promise.race([Promise.resolve().then(inspect), boundary]).finally(() => {
+    settled = true;
+    if (timeout !== null) ownerWindow.clearTimeout(timeout);
+    timeout = null;
+    rejectBoundary = null;
+  });
+  return {
+    promise,
+    cancel() {
+      if (settled) return;
+      settled = true;
+      if (timeout !== null) ownerWindow.clearTimeout(timeout);
+      timeout = null;
+      const reject = rejectBoundary;
+      rejectBoundary = null;
+      reject?.(new Error("Renderer Reasoning ownership inspection was cancelled"));
+    },
+  };
+}
+
+function preferenceStorage(ownerWindow: Window): Storage | null {
+  try {
+    return ownerWindow.localStorage;
+  } catch {
+    return null;
+  }
+}
+
+function composerThreadId(composer: Element): HostThreadId | null {
+  const portals = [...composer.children].filter((child) =>
+    child.hasAttribute(ABOVE_COMPOSER_PORTAL_ATTRIBUTE),
+  );
+  if (portals.length !== 1) return null;
+  const parsed = hostThreadIdSchema.safeParse(
+    portals[0]?.getAttribute(ABOVE_COMPOSER_THREAD_ATTRIBUTE),
+  );
+  return parsed.success ? parsed.data : null;
+}
+
+function eligibleComposers(ownerDocument: Document): readonly HTMLElement[] {
+  return [...ownerDocument.querySelectorAll<HTMLElement>(CODEX_COMPOSER_SELECTOR)].filter(
+    (composer) =>
+      composer.isConnected &&
+      !composer.hidden &&
+      composer.getAttribute("aria-hidden") !== "true" &&
+      composerThreadId(composer) !== null,
+  );
+}
+
+function createPanel(ownerDocument: Document, liveLabel: string): MountedReasoningPanel {
+  const root = ownerDocument.createElement("section");
+  root.setAttribute(REASONING_DISPLAY_ATTRIBUTE, "v1");
+  root.style.width = "100%";
+  root.style.maxWidth = "48rem";
+  root.style.margin = "0 auto 10px";
+  root.style.padding = "0 12px";
+  root.style.boxSizing = "border-box";
+  root.style.color = "inherit";
+
+  const details = ownerDocument.createElement("details");
+  details.style.overflow = "hidden";
+  details.style.border = "1px solid rgba(127, 127, 127, 0.22)";
+  details.style.borderRadius = "12px";
+  details.style.background = "rgba(127, 127, 127, 0.07)";
+
+  const summary = ownerDocument.createElement("summary");
+  summary.style.display = "flex";
+  summary.style.alignItems = "center";
+  summary.style.justifyContent = "space-between";
+  summary.style.gap = "12px";
+  summary.style.padding = "10px 12px";
+  summary.style.cursor = "pointer";
+  summary.style.userSelect = "none";
+
+  const label = ownerDocument.createElement("strong");
+  label.textContent = liveLabel;
+  label.style.font = "600 13px/18px system-ui, sans-serif";
+  const status = ownerDocument.createElement("span");
+  status.style.color = "rgba(127, 127, 127, 0.9)";
+  status.style.font = "400 11px/16px system-ui, sans-serif";
+  summary.append(label, status);
+
+  const body = ownerDocument.createElement("div");
+  body.style.maxHeight = "min(30vh, 260px)";
+  body.style.padding = "0 12px 12px";
+  body.style.overflowY = "auto";
+  body.style.whiteSpace = "pre-wrap";
+  body.style.overflowWrap = "anywhere";
+  body.style.color = "rgba(127, 127, 127, 0.98)";
+  body.style.font = "400 13px/20px system-ui, sans-serif";
+  details.append(summary, body);
+  root.append(details);
+  return {
+    root,
+    details,
+    label,
+    status,
+    body,
+    threadId: null,
+    turnId: null,
+    itemId: null,
+    phase: null,
+    text: "",
+  };
+}
+
+export function installRendererReasoningDisplay(
+  client: RendererReasoningDisplayClient,
+  ownerWindow: Window = window,
+  options: RendererReasoningDisplayOptions = {},
+): RendererReasoningDisplayControl {
+  const { document: ownerDocument } = ownerWindow;
+  const messages = rendererSettingsMessages(
+    resolveRendererSettingsLocale(ownerWindow.navigator.languages),
+  );
+  const store = new RendererReasoningStore();
+  const externalOwnership = new Map<HostThreadId, boolean>();
+  const pendingEvents = new Map<HostThreadId, RendererReasoningPendingBuffer>();
+  const ownershipRequests = new Map<HostThreadId, PendingOwnershipInspection>();
+  const panels = new Map<HTMLElement, MountedReasoningPanel>();
+  const ownershipInspectionTimeoutMs = positiveIntegerOr(
+    options.ownershipInspectionTimeoutMs,
+    DEFAULT_OWNERSHIP_INSPECTION_TIMEOUT_MS,
+  );
+  const maxPendingTextLength = positiveIntegerOr(
+    options.maxPendingTextLength,
+    DEFAULT_MAX_PENDING_REASONING_TEXT_LENGTH,
+  );
+  let enabled = readRendererReasoningDisplayPreference(preferenceStorage(ownerWindow));
+  let removeReasoningSubscription: (() => void) | null = null;
+  let ownershipGeneration = 0;
+  let observing = false;
+  let disposed = false;
+
+  const removePanel = (composer: HTMLElement): void => {
+    panels.get(composer)?.root.remove();
+    panels.delete(composer);
+  };
+
+  const resetRouteState = (): void => {
+    ownershipGeneration += 1;
+    const requests = [...ownershipRequests.values()];
+    ownershipRequests.clear();
+    externalOwnership.clear();
+    pendingEvents.clear();
+    store.clear();
+    for (const request of requests) request.cancel();
+    for (const composer of panels.keys()) removePanel(composer);
+  };
+
+  const detachReasoningSubscription = (): void => {
+    const remove = removeReasoningSubscription;
+    removeReasoningSubscription = null;
+    try {
+      remove?.();
+    } catch {
+      // The local state is already detached; teardown remains best effort.
+    }
+  };
+
+  const render = (): void => {
+    if (disposed) return;
+    const composers = new Set(eligibleComposers(ownerDocument));
+    for (const composer of panels.keys()) {
+      if (!composers.has(composer) || !enabled) removePanel(composer);
+    }
+    if (!enabled) return;
+
+    for (const composer of composers) {
+      const threadId = composerThreadId(composer);
+      if (!threadId) continue;
+      const snapshot = store.snapshot(threadId);
+      const view = rendererReasoningPanelView(snapshot);
+      if (!view.visible) {
+        removePanel(composer);
+        continue;
+      }
+      const parent = composer.parentElement;
+      if (!parent) continue;
+      let panel = panels.get(composer);
+      if (!panel) {
+        panel = createPanel(ownerDocument, messages.reasoningDisplayLive);
+        panels.set(composer, panel);
+      }
+      if (panel.root.parentElement !== parent || panel.root.nextElementSibling !== composer) {
+        parent.insertBefore(panel.root, composer);
+      }
+      if (panel.root.dataset.threadId !== threadId) panel.root.dataset.threadId = threadId;
+      const textChanged = panel.body.textContent !== view.text;
+      if (textChanged) panel.body.textContent = view.text;
+      const itemChanged =
+        panel.threadId !== snapshot?.threadId ||
+        panel.turnId !== snapshot?.turnId ||
+        panel.itemId !== snapshot?.itemId;
+      const completedTransition = panel.phase === "live" && view.phase === "completed";
+      if (itemChanged) {
+        panel.details.open = view.expanded;
+      } else if (completedTransition) {
+        panel.details.open = false;
+      } else if (view.phase === "live" && panel.text !== view.text) {
+        panel.details.open = true;
+      }
+      panel.threadId = snapshot?.threadId ?? null;
+      panel.turnId = snapshot?.turnId ?? null;
+      panel.itemId = snapshot?.itemId ?? null;
+      panel.phase = view.phase;
+      panel.text = view.text;
+      const label =
+        view.phase === "live" ? messages.reasoningDisplayLive : messages.reasoningDisplayCompleted;
+      if (panel.label.textContent !== label) panel.label.textContent = label;
+      const status = view.phase === "live" ? "●" : "";
+      if (panel.status.textContent !== status) panel.status.textContent = status;
+      if (view.phase === "live" && textChanged) {
+        ownerWindow.requestAnimationFrame(() => {
+          panel?.body.scrollTo({ top: panel.body.scrollHeight });
+        });
+      }
+    }
+  };
+
+  const syncSubscription = (): void => {
+    if (enabled && !removeReasoningSubscription) {
+      try {
+        removeReasoningSubscription =
+          client.subscribeThreadReasoning?.((event) => {
+            const knownExternal = externalOwnership.get(event.threadId);
+            if (knownExternal === true) {
+              store.apply(event);
+              render();
+              return;
+            }
+            if (knownExternal === false) return;
+            let pending = pendingEvents.get(event.threadId);
+            if (!pending) {
+              pending = new RendererReasoningPendingBuffer(maxPendingTextLength);
+              pendingEvents.set(event.threadId, pending);
+            }
+            if (!pending.append(event)) {
+              externalOwnership.set(event.threadId, false);
+              pendingEvents.delete(event.threadId);
+              const request = ownershipRequests.get(event.threadId);
+              ownershipRequests.delete(event.threadId);
+              request?.cancel();
+              return;
+            }
+            if (ownershipRequests.has(event.threadId)) return;
+            if (!client.inspectThread) {
+              externalOwnership.set(event.threadId, false);
+              pendingEvents.delete(event.threadId);
+              return;
+            }
+            const generation = ownershipGeneration;
+            const bounded = inspectWithTimeout(ownerWindow, ownershipInspectionTimeoutMs, () => {
+              if (disposed || generation !== ownershipGeneration) {
+                return Promise.reject(
+                  new Error("Renderer Reasoning ownership generation is no longer active"),
+                );
+              }
+              return (
+                client.inspectThread?.({ threadId: event.threadId }) ??
+                Promise.reject(new Error("Renderer Reasoning ownership inspection is unavailable"))
+              );
+            });
+            const request: PendingOwnershipInspection = {
+              cancel: bounded.cancel,
+              promise: Promise.resolve(),
+            };
+            request.promise = bounded.promise
+              .then((inspection) => {
+                if (disposed || generation !== ownershipGeneration) return;
+                const isExternal = inspection.owner === "external";
+                externalOwnership.set(event.threadId, isExternal);
+                const queued = pendingEvents.get(event.threadId)?.drain() ?? [];
+                pendingEvents.delete(event.threadId);
+                if (!isExternal) return;
+                for (const queuedEvent of queued) store.apply(queuedEvent);
+                render();
+              })
+              .catch(() => {
+                if (generation === ownershipGeneration) {
+                  externalOwnership.set(event.threadId, false);
+                  pendingEvents.delete(event.threadId);
+                }
+              })
+              .finally(() => {
+                if (ownershipRequests.get(event.threadId) === request) {
+                  ownershipRequests.delete(event.threadId);
+                }
+              });
+            ownershipRequests.set(event.threadId, request);
+          }) ?? null;
+      } catch {
+        removeReasoningSubscription = null;
+      }
+    } else if (!enabled) {
+      detachReasoningSubscription();
+      resetRouteState();
+    }
+    if (enabled && !observing) {
+      observer.observe(ownerDocument.documentElement, {
+        attributes: true,
+        attributeFilter: [
+          "aria-hidden",
+          "hidden",
+          "data-codex-composer-root",
+          ABOVE_COMPOSER_THREAD_ATTRIBUTE,
+        ],
+        childList: true,
+        subtree: true,
+      });
+      observing = true;
+    } else if (!enabled && observing) {
+      observer.disconnect();
+      observing = false;
+    }
+    render();
+  };
+
+  const onPreferenceChanged = (event: Event): void => {
+    const detail = (event as CustomEvent<{ enabled?: unknown }>).detail;
+    enabled =
+      typeof detail?.enabled === "boolean"
+        ? detail.enabled
+        : readRendererReasoningDisplayPreference(preferenceStorage(ownerWindow));
+    syncSubscription();
+  };
+  const onStorage = (event: StorageEvent): void => {
+    if (event.key !== null && event.key !== RENDERER_REASONING_DISPLAY_PREFERENCE_KEY) return;
+    enabled = readRendererReasoningDisplayPreference(preferenceStorage(ownerWindow));
+    syncSubscription();
+  };
+  const MutationObserverForWindow = (
+    ownerWindow as Window & { MutationObserver: typeof MutationObserver }
+  ).MutationObserver;
+  const observer = new MutationObserverForWindow(render);
+  ownerWindow.addEventListener(RENDERER_REASONING_DISPLAY_PREFERENCE_EVENT, onPreferenceChanged);
+  ownerWindow.addEventListener("storage", onStorage);
+  syncSubscription();
+
+  return {
+    refresh: render,
+    reset() {
+      if (disposed) return;
+      resetRouteState();
+    },
+    dispose() {
+      if (disposed) return;
+      disposed = true;
+      observer.disconnect();
+      observing = false;
+      ownerWindow.removeEventListener(
+        RENDERER_REASONING_DISPLAY_PREFERENCE_EVENT,
+        onPreferenceChanged,
+      );
+      ownerWindow.removeEventListener("storage", onStorage);
+      detachReasoningSubscription();
+      resetRouteState();
+    },
+  };
+}

--- a/packages/renderer-extension/src/renderer-reasoning-events.ts
+++ b/packages/renderer-extension/src/renderer-reasoning-events.ts
@@ -1,0 +1,180 @@
+import {
+  hostThreadIdSchema,
+  hostTurnIdSchema,
+  type HostThreadId,
+  type HostTurnId,
+} from "@codexhost/shared-contracts";
+
+export const RENDERER_REASONING_NOTIFICATION_METHODS = [
+  "item/started",
+  "item/reasoning/summaryTextDelta",
+  "item/completed",
+] as const;
+
+export type RendererReasoningPhase = "live" | "completed";
+
+export interface RendererReasoningEvent {
+  readonly kind: "started" | "delta" | "completed";
+  readonly threadId: HostThreadId;
+  readonly turnId: HostTurnId;
+  readonly itemId: string;
+  readonly text: string;
+}
+
+export interface RendererReasoningSnapshot {
+  readonly threadId: HostThreadId;
+  readonly turnId: HostTurnId;
+  readonly itemId: string;
+  readonly phase: RendererReasoningPhase;
+  readonly text: string;
+}
+
+export interface RendererReasoningPanelView {
+  readonly visible: boolean;
+  readonly expanded: boolean;
+  readonly phase: RendererReasoningPhase;
+  readonly text: string;
+}
+
+const DEFAULT_PENDING_REASONING_TEXT_LIMIT = 256 * 1024;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function nonEmptyString(value: unknown): string | null {
+  return typeof value === "string" && value.length > 0 ? value : null;
+}
+
+function notificationIdentity(params: Record<string, unknown>): {
+  threadId: HostThreadId;
+  turnId: HostTurnId;
+} | null {
+  const threadId = hostThreadIdSchema.safeParse(params.threadId);
+  const turnId = hostTurnIdSchema.safeParse(params.turnId);
+  return threadId.success && turnId.success
+    ? { threadId: threadId.data, turnId: turnId.data }
+    : null;
+}
+
+export function decodeRendererReasoningNotification(
+  notification: unknown,
+): RendererReasoningEvent | null {
+  if (!isRecord(notification) || !isRecord(notification.params)) return null;
+  const params = notification.params;
+  const identity = notificationIdentity(params);
+  if (!identity) return null;
+
+  if (notification.method === "item/reasoning/summaryTextDelta") {
+    const itemId = nonEmptyString(params.itemId);
+    if (
+      !itemId ||
+      typeof params.delta !== "string" ||
+      !Number.isInteger(params.summaryIndex) ||
+      Number(params.summaryIndex) < 0
+    ) {
+      return null;
+    }
+    return { kind: "delta", ...identity, itemId, text: params.delta };
+  }
+
+  if (notification.method !== "item/started" && notification.method !== "item/completed") {
+    return null;
+  }
+  const item = params.item;
+  if (!isRecord(item) || item.type !== "reasoning") return null;
+  const itemId = nonEmptyString(item.id);
+  if (!itemId) return null;
+  const summary = item.summary;
+  if (!Array.isArray(summary) || !summary.every((part) => typeof part === "string")) return null;
+  return {
+    kind: notification.method === "item/started" ? "started" : "completed",
+    ...identity,
+    itemId,
+    text: summary.join("\n\n"),
+  };
+}
+
+export class RendererReasoningStore {
+  readonly #byThread = new Map<HostThreadId, RendererReasoningSnapshot>();
+
+  apply(event: RendererReasoningEvent): RendererReasoningSnapshot {
+    const current = this.#byThread.get(event.threadId);
+    const sameItem = current?.itemId === event.itemId && current.turnId === event.turnId;
+    const text =
+      event.kind === "delta" ? `${sameItem ? current.text : ""}${event.text}` : event.text;
+    const snapshot: RendererReasoningSnapshot = Object.freeze({
+      threadId: event.threadId,
+      turnId: event.turnId,
+      itemId: event.itemId,
+      phase: event.kind === "completed" ? "completed" : "live",
+      text,
+    });
+    this.#byThread.set(event.threadId, snapshot);
+    return snapshot;
+  }
+
+  snapshot(threadId: HostThreadId): RendererReasoningSnapshot | null {
+    return this.#byThread.get(threadId) ?? null;
+  }
+
+  clear(): void {
+    this.#byThread.clear();
+  }
+}
+
+export class RendererReasoningPendingBuffer {
+  readonly #maxTextLength: number;
+  readonly #events: RendererReasoningEvent[] = [];
+  #textLength = 0;
+
+  constructor(maxTextLength = DEFAULT_PENDING_REASONING_TEXT_LIMIT) {
+    this.#maxTextLength = maxTextLength;
+  }
+
+  append(event: RendererReasoningEvent): boolean {
+    const last = this.#events.at(-1);
+    const sameItem =
+      last?.threadId === event.threadId &&
+      last.turnId === event.turnId &&
+      last.itemId === event.itemId;
+    const replacesPending =
+      !sameItem ||
+      event.kind === "started" ||
+      event.kind === "completed" ||
+      last?.kind === "completed";
+    const retainedTextLength = replacesPending ? 0 : this.#textLength;
+    if (retainedTextLength + event.text.length > this.#maxTextLength) return false;
+    if (replacesPending) {
+      this.#events.splice(0, this.#events.length);
+      this.#textLength = 0;
+    }
+    if (event.kind === "delta" && last?.kind === "delta" && sameItem && !replacesPending) {
+      this.#events[this.#events.length - 1] = Object.freeze({
+        ...last,
+        text: `${last.text}${event.text}`,
+      });
+    } else {
+      this.#events.push(event);
+    }
+    this.#textLength += event.text.length;
+    return true;
+  }
+
+  drain(): readonly RendererReasoningEvent[] {
+    const events = this.#events.splice(0, this.#events.length);
+    this.#textLength = 0;
+    return events;
+  }
+}
+
+export function rendererReasoningPanelView(
+  snapshot: RendererReasoningSnapshot | null,
+): RendererReasoningPanelView {
+  return {
+    visible: Boolean(snapshot?.text.trim()),
+    expanded: snapshot?.phase !== "completed",
+    phase: snapshot?.phase ?? "live",
+    text: snapshot?.text ?? "",
+  };
+}

--- a/packages/renderer-extension/src/renderer-reasoning-preference.ts
+++ b/packages/renderer-extension/src/renderer-reasoning-preference.ts
@@ -1,0 +1,59 @@
+export const RENDERER_REASONING_DISPLAY_PREFERENCE_KEY = "codexhost.renderer.reasoning-display.v1";
+export const RENDERER_REASONING_DISPLAY_PREFERENCE_EVENT = "codexhost:reasoning-display-preference";
+
+export interface RendererReasoningPreferenceStorage {
+  getItem(key: string): string | null;
+  setItem(key: string, value: string): void;
+}
+
+function rendererStorage(): RendererReasoningPreferenceStorage | null {
+  try {
+    return typeof window === "undefined" ? null : window.localStorage;
+  } catch {
+    return null;
+  }
+}
+
+function storageForWindow(ownerWindow: Window | null): RendererReasoningPreferenceStorage | null {
+  if (!ownerWindow) return null;
+  try {
+    return ownerWindow.localStorage;
+  } catch {
+    return null;
+  }
+}
+
+export function readRendererReasoningDisplayPreference(
+  storage: RendererReasoningPreferenceStorage | null = rendererStorage(),
+): boolean {
+  if (!storage) return false;
+  try {
+    return storage.getItem(RENDERER_REASONING_DISPLAY_PREFERENCE_KEY) === "true";
+  } catch {
+    return false;
+  }
+}
+
+export function writeRendererReasoningDisplayPreference(
+  enabled: boolean,
+  storage: RendererReasoningPreferenceStorage | null = rendererStorage(),
+): void {
+  if (!storage) return;
+  try {
+    storage.setItem(RENDERER_REASONING_DISPLAY_PREFERENCE_KEY, String(enabled));
+  } catch {
+    // An unavailable preference store must not affect Harness routing or turns.
+  }
+}
+
+export function setRendererReasoningDisplayPreference(
+  enabled: boolean,
+  ownerWindow: Window | null = typeof window === "undefined" ? null : window,
+): void {
+  writeRendererReasoningDisplayPreference(enabled, storageForWindow(ownerWindow));
+  ownerWindow?.dispatchEvent(
+    new CustomEvent(RENDERER_REASONING_DISPLAY_PREFERENCE_EVENT, {
+      detail: { enabled },
+    }),
+  );
+}

--- a/packages/renderer-extension/src/settings/localization.ts
+++ b/packages/renderer-extension/src/settings/localization.ts
@@ -55,6 +55,13 @@ export interface RendererSettingsMessages {
   readonly connectionStatusError: string;
   readonly connectionStatusInstalling: string;
   readonly connectionStatusUnsupported: string;
+  readonly modelPoolDescription: string;
+  readonly reasoningDisplayTitle: string;
+  readonly reasoningDisplayDescription: string;
+  readonly reasoningDisplayLive: string;
+  readonly reasoningDisplayCompleted: string;
+  readonly enabled: string;
+  readonly disabled: string;
   readonly openSettings: string;
   readonly settingsButtonTitle: string;
   readonly settingsUnavailableTitle: string;
@@ -123,6 +130,14 @@ const ENGLISH_MESSAGES: RendererSettingsMessages = Object.freeze({
   connectionStatusError: "Error",
   connectionStatusInstalling: "Installing",
   connectionStatusUnsupported: "Unsupported",
+  modelPoolDescription: "Configure how external Harness capabilities appear in Codex.",
+  reasoningDisplayTitle: "Show reasoning summaries",
+  reasoningDisplayDescription:
+    "Display explicit reasoning summaries emitted by external Harnesses. Hidden and encrypted reasoning is never shown. Off by default.",
+  reasoningDisplayLive: "Reasoning",
+  reasoningDisplayCompleted: "Reasoning complete",
+  enabled: "Enabled",
+  disabled: "Disabled",
   openSettings: "Open codexhost settings",
   settingsButtonTitle: "codexhost settings",
   settingsUnavailableTitle: "codexhost settings unavailable",
@@ -197,6 +212,14 @@ const CHINESE_MESSAGES: RendererSettingsMessages = Object.freeze({
   connectionStatusError: "错误",
   connectionStatusInstalling: "安装中",
   connectionStatusUnsupported: "不支持",
+  modelPoolDescription: "配置外部 Harness 能力在 Codex 中的显示方式。",
+  reasoningDisplayTitle: "显示推理摘要",
+  reasoningDisplayDescription:
+    "显示外部 Harness 明确输出的推理摘要；隐藏或加密的推理内容永远不会展示。默认关闭。",
+  reasoningDisplayLive: "推理中",
+  reasoningDisplayCompleted: "推理完成",
+  enabled: "已开启",
+  disabled: "已关闭",
   openSettings: "打开 codexhost 设置",
   settingsButtonTitle: "codexhost 设置",
   settingsUnavailableTitle: "codexhost 设置不可用",

--- a/packages/renderer-extension/src/settings/pages.ts
+++ b/packages/renderer-extension/src/settings/pages.ts
@@ -1,5 +1,9 @@
 import type { ExternalRendererAgent, RendererAgentAvailability } from "../agent-selection-state.js";
 import { RENDERER_AGENT_LABELS } from "../renderer-agent-icon.js";
+import {
+  readRendererReasoningDisplayPreference,
+  setRendererReasoningDisplayPreference,
+} from "../renderer-reasoning-preference.js";
 import type { CodexhostError } from "@codexhost/shared-contracts";
 import type { RendererAdapterStatus } from "../versioned-renderer-adapter.js";
 import type {
@@ -40,7 +44,20 @@ export const DEFAULT_RENDERER_SETTINGS_PAGE_IDS = [
 ] as const;
 
 export type DefaultRendererSettingsPageId = (typeof DEFAULT_RENDERER_SETTINGS_PAGE_IDS)[number];
-type UnavailableRendererSettingsPageId = Exclude<DefaultRendererSettingsPageId, "updates">;
+type UnavailableRendererSettingsPageId = Exclude<
+  DefaultRendererSettingsPageId,
+  "connections" | "model-pool" | "updates"
+>;
+
+export interface RendererReasoningDisplayPreference {
+  isEnabled(): boolean;
+  setEnabled(enabled: boolean): void;
+}
+
+const DEFAULT_REASONING_DISPLAY_PREFERENCE: RendererReasoningDisplayPreference = Object.freeze({
+  isEnabled: () => readRendererReasoningDisplayPreference(),
+  setEnabled: (enabled: boolean) => setRendererReasoningDisplayPreference(enabled),
+});
 
 export interface RendererUpdateClient {
   checkUpdate(): Promise<UpdateCheckResult>;
@@ -480,6 +497,61 @@ function connectionsPage(
   });
 }
 
+function modelPoolPage(
+  messages: RendererSettingsMessages,
+  preference: RendererReasoningDisplayPreference,
+): RendererSettingsPageDefinition {
+  return Object.freeze({
+    id: "model-pool",
+    label: messages.pageLabels["model-pool"],
+    icon: "model-pool",
+    mount(context: RendererSettingsPageMountContext) {
+      const document = context.content.ownerDocument;
+      const heading = document.createElement("div");
+      heading.className = "settings-section-label";
+      heading.textContent = messages.pageLabels["model-pool"];
+      const description = document.createElement("p");
+      description.className = "settings-page-description";
+      description.textContent = messages.modelPoolDescription;
+
+      const row = document.createElement("div");
+      row.className = "settings-preference-row";
+      const copy = document.createElement("div");
+      copy.className = "settings-preference-row__copy";
+      const title = document.createElement("strong");
+      title.textContent = messages.reasoningDisplayTitle;
+      const detail = document.createElement("span");
+      detail.textContent = messages.reasoningDisplayDescription;
+      copy.append(title, detail);
+
+      const toggle = document.createElement("button");
+      toggle.type = "button";
+      toggle.className = "settings-preference-switch";
+      toggle.setAttribute("role", "switch");
+      const thumb = document.createElement("span");
+      thumb.className = "settings-preference-switch__thumb";
+      toggle.append(thumb);
+      const render = (enabled: boolean): void => {
+        toggle.setAttribute("aria-checked", String(enabled));
+        toggle.setAttribute(
+          "aria-label",
+          `${messages.reasoningDisplayTitle}: ${enabled ? messages.enabled : messages.disabled}`,
+        );
+        toggle.title = enabled ? messages.enabled : messages.disabled;
+      };
+      render(preference.isEnabled());
+      toggle.addEventListener("click", () => {
+        const enabled = toggle.getAttribute("aria-checked") !== "true";
+        preference.setEnabled(enabled);
+        render(enabled);
+      });
+      row.append(copy, toggle);
+      context.content.append(heading, description, row);
+      return undefined;
+    },
+  });
+}
+
 function versionRow(
   context: RendererSettingsPageMountContext,
   label: string,
@@ -807,12 +879,15 @@ export function createDefaultRendererSettingsPages(
   messages: RendererSettingsMessages = DEFAULT_RENDERER_SETTINGS_MESSAGES,
   getUpdateClient: () => RendererUpdateClient | null = () => null,
   getDiagnostics: () => RendererConnectionDiagnostics | null = () => null,
+  reasoningDisplayPreference: RendererReasoningDisplayPreference = DEFAULT_REASONING_DISPLAY_PREFERENCE,
 ): readonly RendererSettingsPageDefinition[] {
   const unavailableIds = DEFAULT_RENDERER_SETTINGS_PAGE_IDS.filter(
-    (id): id is UnavailableRendererSettingsPageId => id !== "updates" && id !== "connections",
+    (id): id is UnavailableRendererSettingsPageId =>
+      id !== "updates" && id !== "connections" && id !== "model-pool",
   );
   return Object.freeze([
     connectionsPage(messages, getDiagnostics),
+    modelPoolPage(messages, reasoningDisplayPreference),
     ...unavailableIds.map((id) => unavailablePage(id, messages)),
     updatesPage(messages, getUpdateClient),
   ]);
@@ -822,8 +897,14 @@ export function createDefaultRendererSettingsRegistry(
   messages: RendererSettingsMessages = DEFAULT_RENDERER_SETTINGS_MESSAGES,
   getUpdateClient: () => RendererUpdateClient | null = () => null,
   getDiagnostics: () => RendererConnectionDiagnostics | null = () => null,
+  reasoningDisplayPreference: RendererReasoningDisplayPreference = DEFAULT_REASONING_DISPLAY_PREFERENCE,
 ): RendererSettingsPageRegistry {
   return createRendererSettingsPageRegistry(
-    createDefaultRendererSettingsPages(messages, getUpdateClient, getDiagnostics),
+    createDefaultRendererSettingsPages(
+      messages,
+      getUpdateClient,
+      getDiagnostics,
+      reasoningDisplayPreference,
+    ),
   );
 }

--- a/packages/renderer-extension/src/settings/shell.css
+++ b/packages/renderer-extension/src/settings/shell.css
@@ -369,6 +369,71 @@ button {
   line-height: 20px;
 }
 
+.settings-preference-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 32px;
+  min-height: 88px;
+  padding: 18px 0;
+  border-top: 1px solid var(--settings-divider);
+  border-bottom: 1px solid var(--settings-divider);
+}
+
+.settings-preference-row__copy {
+  display: flex;
+  flex: 1 1 auto;
+  flex-direction: column;
+  min-width: 0;
+  gap: 5px;
+}
+
+.settings-preference-row__copy strong {
+  color: var(--settings-text);
+  font-size: 15px;
+  font-weight: 600;
+  line-height: 22px;
+}
+
+.settings-preference-row__copy span {
+  max-width: 680px;
+  color: var(--settings-muted);
+  font-size: 13px;
+  line-height: 20px;
+}
+
+.settings-preference-switch {
+  display: inline-flex;
+  align-items: center;
+  width: 42px;
+  height: 24px;
+  flex: none;
+  padding: 2px;
+  border: 0;
+  border-radius: 999px;
+  background: rgb(255 255 255 / 16%);
+  cursor: pointer;
+  transition: background 120ms ease;
+}
+
+.settings-preference-switch[aria-checked="true"] {
+  justify-content: flex-end;
+  background: var(--settings-focus);
+}
+
+.settings-preference-switch:focus-visible {
+  outline: 2px solid var(--settings-focus);
+  outline-offset: 2px;
+}
+
+.settings-preference-switch__thumb {
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  background: white;
+  box-shadow: 0 1px 3px rgb(0 0 0 / 35%);
+}
+
 .settings-connection-actions {
   display: flex;
   justify-content: flex-end;

--- a/packages/renderer-extension/src/versioned-renderer-adapter.ts
+++ b/packages/renderer-extension/src/versioned-renderer-adapter.ts
@@ -24,9 +24,15 @@ import type { RendererAgent } from "./agent-selection-state.js";
 import { installRendererForkControl } from "./renderer-fork-control.js";
 import {
   createRendererModelClient,
+  createThreadReasoningSubscriptionRelay,
   createThreadUsageSubscriptionRelay,
   type RendererModelClient,
 } from "./renderer-model-client.js";
+import {
+  installRendererReasoningDisplay,
+  type RendererReasoningDisplayControl,
+} from "./renderer-reasoning-display.js";
+import type { RendererReasoningEvent } from "./renderer-reasoning-events.js";
 
 export const PI_TRANSPORT_MODEL_ID = "codexhost/pi-native";
 export const PI_TRANSPORT_MODEL_PREFIX = `${PI_TRANSPORT_MODEL_ID}@`;
@@ -107,6 +113,7 @@ export interface ModelPowerSelection {
 export interface RendererDraftPrewarmPolicy {
   state: "ready";
   hostId: string;
+  readonly requestTarget?: () => unknown;
   select(model: string | null): boolean;
   clear(): Promise<void>;
 }
@@ -619,6 +626,30 @@ function prewarmTargetHostId(target: PrewarmTarget): string | null {
   return typeof hostId === "string" && hostId.length > 0 ? hostId : null;
 }
 
+function isRendererRequestTarget(value: unknown): value is PrewarmTarget {
+  if (!isRecord(value) || typeof value.sendRequest !== "function") return false;
+  return isCurrentRequestBridge(value.requestClient ?? value);
+}
+
+function hasPolicyRequestTarget(policy: RendererDraftPrewarmPolicy): boolean {
+  return "requestTarget" in policy;
+}
+
+function exactRendererRequestTarget(
+  policy: RendererDraftPrewarmPolicy,
+): readonly PrewarmTarget[] | null {
+  if (typeof policy.requestTarget !== "function") return null;
+  try {
+    const target = policy.requestTarget();
+    if (!isRendererRequestTarget(target) || prewarmTargetHostId(target) !== policy.hostId) {
+      return null;
+    }
+    return [target];
+  } catch {
+    return null;
+  }
+}
+
 export function rendererRequestTargetsForHost(
   targets: readonly PrewarmTarget[],
   hostId: string,
@@ -632,6 +663,7 @@ function activeRendererDraftPrewarmTargets(
   targets: readonly PrewarmTarget[],
 ): readonly PrewarmTarget[] | null {
   if (!isDraftPrewarmPolicyReady(policy)) return null;
+  if (hasPolicyRequestTarget(policy)) return exactRendererRequestTarget(policy);
   return rendererRequestTargetsForHost(targets, policy.hostId);
 }
 
@@ -649,6 +681,8 @@ export function resolveRendererRequestRoute(
   if (isDraftPrewarmPolicyReady(policy) && activeTargets) {
     return { policy, targets: activeTargets };
   }
+
+  if (isDraftPrewarmPolicyReady(policy) && hasPolicyRequestTarget(policy)) return null;
 
   // Composer replacement and settings overlays can briefly remove the only
   // Fiber path that exposes the request manager. Retain the confirmed route
@@ -674,7 +708,12 @@ export function createRendererRequestRouteResolver(
     resolve() {
       // Persist null invalidations too, otherwise a later empty discovery gap
       // could revive a request manager that belonged to the previous Host.
-      route = resolveRendererRequestRoute(readPolicy(), discoverTargets(), route);
+      const policy = readPolicy();
+      const discoveredTargets =
+        isDraftPrewarmPolicyReady(policy) && hasPolicyRequestTarget(policy)
+          ? []
+          : discoverTargets();
+      route = resolveRendererRequestRoute(policy, discoveredTargets, route);
       return route;
     },
     clear() {
@@ -759,11 +798,16 @@ export function installCurrentRendererAdapter(): {
     dispose() {},
   });
   const usageSubscription = createThreadUsageSubscriptionRelay();
+  const reasoningSubscription = createThreadReasoningSubscriptionRelay();
+  let reasoningDisplay: RendererReasoningDisplayControl = {
+    refresh() {},
+    reset() {},
+    dispose() {},
+  };
   const requestRouteResolver = createRendererRequestRouteResolver(
     () => window.__codexhostDraftPrewarmPolicyV1,
     () => findActivePrewarmTargets(document),
   );
-  const currentRequestRoute = () => requestRouteResolver.resolve();
   const clientsByTarget = new WeakMap<PrewarmTarget, RendererModelClient>();
   const modelClientForTargets = (targets: readonly PrewarmTarget[]): RendererModelClient | null => {
     const target = targets[0];
@@ -774,8 +818,26 @@ export function installCurrentRendererAdapter(): {
     if (client) clientsByTarget.set(target, client);
     return client;
   };
+  let reasoningRoutePolicy: RendererDraftPrewarmPolicy | null = null;
+  let reasoningRouteClient: RendererModelClient | null = null;
+  const syncReasoningRoute = (route: RendererRequestRoute | null): RendererModelClient | null => {
+    const policy = route?.policy ?? null;
+    const client = route ? modelClientForTargets(route.targets) : null;
+    if (reasoningRoutePolicy === policy && reasoningRouteClient === client) return client;
+    reasoningSubscription.disconnect();
+    reasoningRoutePolicy = policy;
+    reasoningRouteClient = client;
+    reasoningDisplay.reset();
+    if (client) reasoningSubscription.connect(client);
+    return client;
+  };
+  const currentRequestRoute = (): RendererRequestRoute | null => {
+    const route = requestRouteResolver.resolve();
+    syncReasoningRoute(route);
+    return route;
+  };
   const currentModelClient = (): RendererModelClient => {
-    const client = modelClientForTargets(currentRequestRoute()?.targets ?? []);
+    const client = currentRequestRoute() ? reasoningRouteClient : null;
     if (!client) throw new Error("Renderer Model request manager is unavailable");
     usageSubscription.connect(client);
     return client;
@@ -783,6 +845,10 @@ export function installCurrentRendererAdapter(): {
   const modelControl: RendererModelClient = Object.freeze({
     currentHostId: () => currentRequestRoute()?.policy.hostId ?? null,
     clientForHost(hostId: string): RendererModelClient | null {
+      const route = currentRequestRoute();
+      if (route?.policy.hostId === hostId) return modelClientForTargets(route.targets);
+      const policy = window.__codexhostDraftPrewarmPolicyV1;
+      if (isDraftPrewarmPolicyReady(policy) && hasPolicyRequestTarget(policy)) return null;
       const targets = rendererRequestTargetsForHost(findActivePrewarmTargets(document), hostId);
       return modelClientForTargets(targets ?? []);
     },
@@ -797,6 +863,15 @@ export function installCurrentRendererAdapter(): {
       currentModelClient().inspectThreadUsage(input),
     subscribeThreadUsage: (listener: (update: ThreadUsageInspection) => void) =>
       usageSubscription.subscribe(listener),
+    subscribeThreadReasoning: (listener: (event: RendererReasoningEvent) => void) => {
+      const unsubscribe = reasoningSubscription.subscribe(listener);
+      try {
+        reasoningSubscription.connect(currentModelClient());
+      } catch {
+        // A pending route will connect the relay once the request manager appears.
+      }
+      return unsubscribe;
+    },
     listThreadOwnership: (input: ThreadOwnershipListParams) =>
       currentModelClient().listThreadOwnership(input),
     selectThreadModel: (input: ThreadModelSelectParams) =>
@@ -813,6 +888,14 @@ export function installCurrentRendererAdapter(): {
     updateStatus("unsupported", "title-policy-unavailable", null);
     return unsupportedResult();
   }
+  try {
+    reasoningDisplay = installRendererReasoningDisplay(modelControl, window);
+  } catch (error) {
+    console.error(
+      "codexhost optional Reasoning display installation failed",
+      error instanceof Error ? error.name : "UnknownError",
+    );
+  }
   const forkControl = installRendererForkControl({
     getClient: () => modelControl,
     reportError: (error) => {
@@ -825,25 +908,76 @@ export function installCurrentRendererAdapter(): {
 
   let routingPolicy: RendererDraftPrewarmPolicy | null = null;
   let policyTimer: number | null = null;
+  let policyRecaptureObserver: MutationObserver | null = null;
+  let hasCapturedRoutingPolicy = false;
+  let selectedRoutingPolicy: RendererDraftPrewarmPolicy | null = null;
+  let selectedCarrier: string | null = null;
   let desiredCarrier: string | null = null;
+  const stopPolicyCapture = (): void => {
+    if (policyTimer === null) return;
+    window.clearInterval(policyTimer);
+    policyTimer = null;
+  };
+  const stopPolicyRecapture = (): void => {
+    policyRecaptureObserver?.disconnect();
+    policyRecaptureObserver = null;
+  };
   const captureRoutingPolicy = (): boolean => {
     const route = currentRequestRoute();
     if (!route) return false;
     routingPolicy = route.policy;
-    routingPolicy.select(desiredCarrier);
-    if (policyTimer !== null) {
-      window.clearInterval(policyTimer);
-      policyTimer = null;
+    stopPolicyRecapture();
+    if (selectedRoutingPolicy !== routingPolicy || selectedCarrier !== desiredCarrier) {
+      try {
+        routingPolicy.select(desiredCarrier);
+      } catch {
+        updateStatus("installing", "draft-routing-policy-unavailable", null);
+        return false;
+      }
+      selectedRoutingPolicy = routingPolicy;
+      selectedCarrier = desiredCarrier;
     }
+    hasCapturedRoutingPolicy = true;
+    stopPolicyCapture();
     updateStatus("ready", "ready", "request-bridge");
     return true;
   };
+  const startPolicyCapture = (): void => {
+    stopPolicyCapture();
+    policyTimer = window.setInterval(captureRoutingPolicy, DRAFT_PREWARM_POLICY_POLL_INTERVAL_MS);
+  };
+  const startPolicyRecapture = (): void => {
+    stopPolicyRecapture();
+    policyRecaptureObserver = new MutationObserver(() => {
+      captureRoutingPolicy();
+    });
+    policyRecaptureObserver.observe(document.documentElement, {
+      attributes: true,
+      attributeFilter: ["hidden", "aria-hidden", "data-codex-composer-root"],
+      characterData: true,
+      childList: true,
+      subtree: true,
+    });
+  };
   if (!captureRoutingPolicy()) {
     updateStatus("installing", "draft-routing-policy-unavailable", null);
-    policyTimer = window.setInterval(captureRoutingPolicy, DRAFT_PREWARM_POLICY_POLL_INTERVAL_MS);
+    const policy = window.__codexhostDraftPrewarmPolicyV1;
+    if (!isDraftPrewarmPolicyReady(policy) || !hasPolicyRequestTarget(policy)) {
+      startPolicyCapture();
+    }
   }
   const handleRoutingPolicyChange = (): void => {
-    captureRoutingPolicy();
+    stopPolicyRecapture();
+    if (captureRoutingPolicy()) return;
+    const policy = window.__codexhostDraftPrewarmPolicyV1;
+    if (isDraftPrewarmPolicyReady(policy) && hasPolicyRequestTarget(policy)) {
+      stopPolicyCapture();
+    }
+    if (!hasCapturedRoutingPolicy) return;
+    updateStatus("installing", "draft-routing-policy-unavailable", null);
+    if (isDraftPrewarmPolicyReady(policy) && !hasPolicyRequestTarget(policy)) {
+      startPolicyRecapture();
+    }
   };
   window.addEventListener("codexhost:draft-prewarm-policy-changed", handleRoutingPolicyChange);
 
@@ -868,9 +1002,16 @@ export function installCurrentRendererAdapter(): {
     const route = currentRequestRoute();
     if (!route) return false;
     routingPolicy = route.policy;
-    if (route.policy.select(desiredCarrier)) {
-      modelUpdates += 1;
-      liveStatus.modelUpdates = modelUpdates;
+    try {
+      if (route.policy.select(desiredCarrier)) {
+        modelUpdates += 1;
+        liveStatus.modelUpdates = modelUpdates;
+      }
+      selectedRoutingPolicy = route.policy;
+      selectedCarrier = desiredCarrier;
+    } catch {
+      updateStatus("installing", "draft-routing-policy-unavailable", null);
+      return false;
     }
     return true;
   };
@@ -881,16 +1022,30 @@ export function installCurrentRendererAdapter(): {
     dispose() {
       if (disposed) return;
       disposed = true;
-      if (policyTimer !== null) window.clearInterval(policyTimer);
+      stopPolicyCapture();
+      stopPolicyRecapture();
       window.removeEventListener(
         "codexhost:draft-prewarm-policy-changed",
         handleRoutingPolicyChange,
       );
-      routingPolicy?.select(null);
+      const activeRoutingPolicy = routingPolicy;
       routingPolicy = null;
       requestRouteResolver.clear();
-      forkControl.dispose();
-      usageSubscription.dispose();
+      const cleanups = [
+        () => activeRoutingPolicy?.select(null),
+        () => syncReasoningRoute(null),
+        () => reasoningDisplay.dispose(),
+        () => forkControl.dispose(),
+        () => reasoningSubscription.dispose(),
+        () => usageSubscription.dispose(),
+      ];
+      for (const cleanup of cleanups) {
+        try {
+          cleanup();
+        } catch {
+          // Every owned resource must still be released if an external cleanup fails.
+        }
+      }
     },
   };
 }

--- a/packages/renderer-extension/test/renderer-model-client.test.ts
+++ b/packages/renderer-extension/test/renderer-model-client.test.ts
@@ -24,7 +24,9 @@ import {
   UPDATE_START_METHOD,
   UPDATE_STATUS_METHOD,
   createRendererModelClient,
+  createThreadReasoningSubscriptionRelay,
   createThreadUsageSubscriptionRelay,
+  type RendererModelClient,
 } from "../src/renderer-model-client.js";
 
 const piHarnessId = harnessIdSchema.parse("pi");
@@ -148,6 +150,7 @@ describe("Renderer fixed Model request client", () => {
       "selectThreadPermissionMode",
       "selectThreadThinking",
       "startUpdate",
+      "subscribeThreadReasoning",
       "subscribeThreadUsage",
     ]);
 
@@ -268,6 +271,155 @@ describe("Renderer fixed Model request client", () => {
     expect(sendRequest).toHaveBeenNthCalledWith(10, UPDATE_CHECK_METHOD, {});
     expect(sendRequest).toHaveBeenNthCalledWith(11, UPDATE_START_METHOD, {});
     expect(sendRequest).toHaveBeenNthCalledWith(12, UPDATE_STATUS_METHOD, {});
+  });
+
+  it("subscribes to validated native reasoning summary notifications", () => {
+    let reasoningNotification: ((notification: unknown) => void) | undefined;
+    const removeReasoningNotification = vi.fn();
+    const addNotificationCallback = vi.fn(
+      (_method: string | readonly string[], callback: (notification: unknown) => void) => {
+        reasoningNotification = callback;
+        return removeReasoningNotification;
+      },
+    );
+    const client = createRendererModelClient([{ addNotificationCallback, sendRequest: vi.fn() }]);
+    if (!client) throw new Error("Synthetic Model client was not created");
+    const listener = vi.fn();
+
+    const unsubscribe = client.subscribeThreadReasoning?.(listener);
+    reasoningNotification?.({
+      method: "item/reasoning/summaryTextDelta",
+      params: {
+        threadId: "thread-1",
+        turnId: "turn-1",
+        itemId: "reasoning-1",
+        summaryIndex: 0,
+        delta: "Visible summary",
+      },
+    });
+    reasoningNotification?.({
+      method: "item/reasoning/contentTextDelta",
+      params: { threadId: "thread-1", itemId: "reasoning-1", delta: "private" },
+    });
+
+    expect(listener).toHaveBeenCalledOnce();
+    expect(listener).toHaveBeenCalledWith({
+      kind: "delta",
+      threadId: "thread-1",
+      turnId: "turn-1",
+      itemId: "reasoning-1",
+      text: "Visible summary",
+    });
+    unsubscribe?.();
+    expect(removeReasoningNotification).toHaveBeenCalledOnce();
+  });
+
+  it("moves reasoning listeners to a replacement manager and ignores its stale callback", () => {
+    const relay = createThreadReasoningSubscriptionRelay();
+    const listener = vi.fn();
+    const firstRemove = vi.fn();
+    const secondRemove = vi.fn();
+    let firstNotify:
+      Parameters<NonNullable<RendererModelClient["subscribeThreadReasoning"]>>[0] | undefined;
+    let secondNotify:
+      Parameters<NonNullable<RendererModelClient["subscribeThreadReasoning"]>>[0] | undefined;
+    const first = {
+      subscribeThreadReasoning: vi.fn((notify: typeof firstNotify) => {
+        firstNotify = notify;
+        return firstRemove;
+      }),
+    };
+    const second = {
+      subscribeThreadReasoning: vi.fn((notify: typeof secondNotify) => {
+        secondNotify = notify;
+        return secondRemove;
+      }),
+    };
+    const staleEvent = {
+      kind: "delta" as const,
+      threadId: hostThreadIdSchema.parse("thread-1"),
+      turnId: hostTurnIdSchema.parse("turn-1"),
+      itemId: "reasoning-1",
+      text: "stale",
+    };
+    const currentEvent = { ...staleEvent, text: "current" };
+
+    const unsubscribe = relay.subscribe(listener);
+    relay.connect(first);
+    relay.connect(second);
+    if (!firstNotify || !secondNotify) throw new Error("Reasoning callbacks were not registered");
+    firstNotify(staleEvent);
+    secondNotify(currentEvent);
+
+    expect(firstRemove).toHaveBeenCalledOnce();
+    expect(second.subscribeThreadReasoning).toHaveBeenCalledOnce();
+    expect(listener).toHaveBeenCalledOnce();
+    expect(listener).toHaveBeenCalledWith(currentEvent);
+    unsubscribe();
+    expect(secondRemove).toHaveBeenCalledOnce();
+    relay.dispose();
+  });
+
+  it("explicitly disconnects reasoning notifications and rejects late callbacks", () => {
+    const relay = createThreadReasoningSubscriptionRelay();
+    const listener = vi.fn();
+    const remove = vi.fn();
+    let notify:
+      Parameters<NonNullable<RendererModelClient["subscribeThreadReasoning"]>>[0] | undefined;
+    relay.subscribe(listener);
+    relay.connect({
+      subscribeThreadReasoning(callback) {
+        notify = callback;
+        return remove;
+      },
+    });
+
+    relay.disconnect();
+    if (!notify) throw new Error("Reasoning callback was not registered");
+    notify({
+      kind: "delta",
+      threadId: hostThreadIdSchema.parse("thread-1"),
+      turnId: hostTurnIdSchema.parse("turn-1"),
+      itemId: "reasoning-1",
+      text: "late",
+    });
+
+    expect(remove).toHaveBeenCalledOnce();
+    expect(listener).not.toHaveBeenCalled();
+  });
+
+  it("remains disconnected and can reconnect when a reasoning remover throws", () => {
+    const relay = createThreadReasoningSubscriptionRelay();
+    const listener = vi.fn();
+    const throwingRemove = vi.fn(() => {
+      throw new Error("source teardown failed");
+    });
+    const replacementRemove = vi.fn();
+    const replacementSubscribe = vi.fn(() => replacementRemove);
+    relay.subscribe(listener);
+    relay.connect({ subscribeThreadReasoning: vi.fn(() => throwingRemove) });
+
+    expect(() => relay.disconnect()).not.toThrow();
+    expect(throwingRemove).toHaveBeenCalledOnce();
+    relay.connect({ subscribeThreadReasoning: replacementSubscribe });
+
+    expect(replacementSubscribe).toHaveBeenCalledOnce();
+    expect(() => relay.dispose()).not.toThrow();
+    expect(replacementRemove).toHaveBeenCalledOnce();
+  });
+
+  it("can reconnect when a request manager exposes no reasoning subscription", () => {
+    const relay = createThreadReasoningSubscriptionRelay();
+    const replacementRemove = vi.fn();
+    const replacementSubscribe = vi.fn(() => replacementRemove);
+    relay.subscribe(vi.fn());
+
+    relay.connect({});
+    relay.connect({ subscribeThreadReasoning: replacementSubscribe });
+
+    expect(replacementSubscribe).toHaveBeenCalledOnce();
+    relay.dispose();
+    expect(replacementRemove).toHaveBeenCalledOnce();
   });
 
   it("defers Usage notification registration until a request manager is available", () => {

--- a/packages/renderer-extension/test/renderer-reasoning-events.test.ts
+++ b/packages/renderer-extension/test/renderer-reasoning-events.test.ts
@@ -1,0 +1,244 @@
+import {
+  hostThreadIdSchema,
+  hostTurnIdSchema,
+  type HostThreadId,
+  type HostTurnId,
+} from "@codexhost/shared-contracts";
+import { describe, expect, expectTypeOf, it } from "vitest";
+
+import {
+  RendererReasoningPendingBuffer,
+  RendererReasoningStore,
+  decodeRendererReasoningNotification,
+  rendererReasoningPanelView,
+} from "../src/renderer-reasoning-events.js";
+
+const thread1 = hostThreadIdSchema.parse("thread-1");
+const thread2 = hostThreadIdSchema.parse("thread-2");
+const turn1 = hostTurnIdSchema.parse("turn-1");
+const turn2 = hostTurnIdSchema.parse("turn-2");
+
+describe("Renderer reasoning notification projection", () => {
+  it("accepts only explicit reasoning summary notifications", () => {
+    const delta = decodeRendererReasoningNotification({
+      method: "item/reasoning/summaryTextDelta",
+      params: {
+        threadId: "thread-1",
+        turnId: "turn-1",
+        itemId: "reasoning-1",
+        summaryIndex: 0,
+        delta: "Inspecting the request",
+      },
+    });
+    expect(delta).toEqual({
+      kind: "delta",
+      threadId: "thread-1",
+      turnId: "turn-1",
+      itemId: "reasoning-1",
+      text: "Inspecting the request",
+    });
+    if (!delta) throw new Error("Expected a valid reasoning delta");
+    expectTypeOf(delta.threadId).toEqualTypeOf<HostThreadId>();
+    expectTypeOf(delta.turnId).toEqualTypeOf<HostTurnId>();
+
+    expect(
+      decodeRendererReasoningNotification({
+        method: "item/completed",
+        params: {
+          threadId: "thread-1",
+          turnId: "turn-1",
+          item: {
+            id: "reasoning-1",
+            type: "reasoning",
+            summary: ["Inspecting the request", "Checking the result"],
+            content: ["private raw chain"],
+            encrypted_content: "secret",
+          },
+        },
+      }),
+    ).toEqual({
+      kind: "completed",
+      threadId: "thread-1",
+      turnId: "turn-1",
+      itemId: "reasoning-1",
+      text: "Inspecting the request\n\nChecking the result",
+    });
+
+    expect(
+      decodeRendererReasoningNotification({
+        method: "item/completed",
+        params: {
+          threadId: "thread-1",
+          turnId: "turn-1",
+          item: { id: "message-1", type: "agent_message", text: "answer" },
+        },
+      }),
+    ).toBeNull();
+    expect(
+      decodeRendererReasoningNotification({
+        method: "item/reasoning/contentTextDelta",
+        params: { threadId: "thread-1", itemId: "reasoning-1", delta: "private" },
+      }),
+    ).toBeNull();
+  });
+
+  it("keeps thread state isolated, expands live output, and collapses completed output", () => {
+    const store = new RendererReasoningStore();
+
+    store.apply({
+      kind: "started",
+      threadId: thread1,
+      turnId: turn1,
+      itemId: "reasoning-1",
+      text: "",
+    });
+    store.apply({
+      kind: "delta",
+      threadId: thread1,
+      turnId: turn1,
+      itemId: "reasoning-1",
+      text: "First step",
+    });
+    store.apply({
+      kind: "delta",
+      threadId: thread2,
+      turnId: turn2,
+      itemId: "reasoning-2",
+      text: "Other thread",
+    });
+
+    expect(rendererReasoningPanelView(store.snapshot(thread1))).toEqual({
+      visible: true,
+      expanded: true,
+      phase: "live",
+      text: "First step",
+    });
+    expect(store.snapshot(thread2)?.text).toBe("Other thread");
+
+    store.apply({
+      kind: "completed",
+      threadId: thread1,
+      turnId: turn1,
+      itemId: "reasoning-1",
+      text: "First step\n\nFinal check",
+    });
+    expect(rendererReasoningPanelView(store.snapshot(thread1))).toEqual({
+      visible: true,
+      expanded: false,
+      phase: "completed",
+      text: "First step\n\nFinal check",
+    });
+  });
+
+  it("treats an explicit empty completed summary as authoritative", () => {
+    const store = new RendererReasoningStore();
+    const delta = decodeRendererReasoningNotification({
+      method: "item/reasoning/summaryTextDelta",
+      params: {
+        threadId: "thread-1",
+        turnId: "turn-1",
+        itemId: "reasoning-1",
+        summaryIndex: 0,
+        delta: "Streaming summary",
+      },
+    });
+    const completed = decodeRendererReasoningNotification({
+      method: "item/completed",
+      params: {
+        threadId: "thread-1",
+        turnId: "turn-1",
+        item: { id: "reasoning-1", type: "reasoning", summary: [] },
+      },
+    });
+
+    if (!delta || !completed) throw new Error("Expected valid reasoning notifications");
+    store.apply(delta);
+    expect(store.apply(completed)).toMatchObject({
+      phase: "completed",
+      text: "",
+    });
+  });
+
+  it("does not render an empty reasoning item", () => {
+    const store = new RendererReasoningStore();
+    store.apply({
+      kind: "started",
+      threadId: thread1,
+      turnId: turn1,
+      itemId: "reasoning-1",
+      text: "",
+    });
+
+    expect(rendererReasoningPanelView(store.snapshot(thread1))).toEqual({
+      visible: false,
+      expanded: true,
+      phase: "live",
+      text: "",
+    });
+  });
+
+  it("coalesces ownership-pending deltas without growing an event list", () => {
+    const pending = new RendererReasoningPendingBuffer(32);
+
+    expect(
+      pending.append({
+        kind: "started",
+        threadId: thread1,
+        turnId: turn1,
+        itemId: "reasoning-1",
+        text: "",
+      }),
+    ).toBe(true);
+    expect(
+      pending.append({
+        kind: "delta",
+        threadId: thread1,
+        turnId: turn1,
+        itemId: "reasoning-1",
+        text: "First ",
+      }),
+    ).toBe(true);
+    expect(
+      pending.append({
+        kind: "delta",
+        threadId: thread1,
+        turnId: turn1,
+        itemId: "reasoning-1",
+        text: "step",
+      }),
+    ).toBe(true);
+
+    expect(pending.drain()).toEqual([
+      {
+        kind: "started",
+        threadId: thread1,
+        turnId: turn1,
+        itemId: "reasoning-1",
+        text: "",
+      },
+      {
+        kind: "delta",
+        threadId: thread1,
+        turnId: turn1,
+        itemId: "reasoning-1",
+        text: "First step",
+      },
+    ]);
+  });
+
+  it("fails a pending queue closed before it can retain an oversized summary", () => {
+    const pending = new RendererReasoningPendingBuffer(8);
+    const event = {
+      kind: "delta" as const,
+      threadId: thread1,
+      turnId: turn1,
+      itemId: "reasoning-1",
+      text: "12345678",
+    };
+
+    expect(pending.append(event)).toBe(true);
+    expect(pending.append({ ...event, text: "9" })).toBe(false);
+    expect(pending.drain()).toEqual([event]);
+    expect(pending.drain()).toEqual([]);
+  });
+});

--- a/packages/renderer-extension/test/renderer-reasoning-preference.test.ts
+++ b/packages/renderer-extension/test/renderer-reasoning-preference.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  RENDERER_REASONING_DISPLAY_PREFERENCE_KEY,
+  readRendererReasoningDisplayPreference,
+  writeRendererReasoningDisplayPreference,
+  type RendererReasoningPreferenceStorage,
+} from "../src/renderer-reasoning-preference.js";
+
+function memoryStorage(): RendererReasoningPreferenceStorage & { values: Map<string, string> } {
+  const values = new Map<string, string>();
+  return {
+    values,
+    getItem: (key) => values.get(key) ?? null,
+    setItem: (key, value) => values.set(key, value),
+  };
+}
+
+describe("Renderer reasoning display preference", () => {
+  it("is disabled by default and fails closed for unknown persisted values", () => {
+    const storage = memoryStorage();
+
+    expect(readRendererReasoningDisplayPreference(storage)).toBe(false);
+    storage.values.set(RENDERER_REASONING_DISPLAY_PREFERENCE_KEY, "enabled-ish");
+    expect(readRendererReasoningDisplayPreference(storage)).toBe(false);
+  });
+
+  it("round-trips an explicit opt-in and opt-out", () => {
+    const storage = memoryStorage();
+
+    writeRendererReasoningDisplayPreference(true, storage);
+    expect(readRendererReasoningDisplayPreference(storage)).toBe(true);
+    expect(storage.values.get(RENDERER_REASONING_DISPLAY_PREFERENCE_KEY)).toBe("true");
+
+    writeRendererReasoningDisplayPreference(false, storage);
+    expect(readRendererReasoningDisplayPreference(storage)).toBe(false);
+    expect(storage.values.get(RENDERER_REASONING_DISPLAY_PREFERENCE_KEY)).toBe("false");
+  });
+});

--- a/packages/renderer-extension/test/settings/pages.test.ts
+++ b/packages/renderer-extension/test/settings/pages.test.ts
@@ -28,6 +28,7 @@ class FakeElement {
   rel = "";
   target = "";
   textContent = "";
+  title = "";
   type = "";
 
   constructor(
@@ -53,6 +54,10 @@ class FakeElement {
 
   setAttribute(name: string, value: string): void {
     this.attributes.set(name, value);
+  }
+
+  getAttribute(name: string): string | null {
+    return this.attributes.get(name) ?? null;
   }
 }
 
@@ -244,6 +249,42 @@ describe("Renderer Connections page", () => {
     expect(visibleText(content)).not.toContain("pi exited with code 1");
 
     cleanup?.();
+  });
+});
+
+describe("Renderer Model Pool page", () => {
+  it("renders the opt-in reasoning display switch and persists changes", () => {
+    let enabled = false;
+    const setEnabled = vi.fn((next: boolean) => {
+      enabled = next;
+    });
+    const page = createDefaultRendererSettingsPages(
+      rendererSettingsMessages("en"),
+      () => null,
+      () => null,
+      { isEnabled: () => enabled, setEnabled },
+    ).find(({ id }) => id === "model-pool");
+    if (!page) throw new Error("Model Pool page is not registered");
+
+    const document = new FakeDocument();
+    const content = document.createElement("main");
+    const scope = new RendererSettingsPageScope();
+    page.mount({
+      content: content as unknown as HTMLElement,
+      signal: scope.signal,
+      runLatest: (operation, handlers) => scope.runLatest(operation, handlers),
+    });
+
+    const toggle = elementWithClass(content, "settings-preference-switch");
+    expect(toggle.attributes.get("role")).toBe("switch");
+    expect(toggle.attributes.get("aria-checked")).toBe("false");
+    expect(visibleText(content)).toContain("Show reasoning summaries");
+
+    toggle.dispatch("click");
+    expect(setEnabled).toHaveBeenCalledWith(true);
+    expect(toggle.attributes.get("aria-checked")).toBe("true");
+
+    scope.dispose();
   });
 });
 

--- a/packages/renderer-extension/test/versioned-renderer-adapter.test.ts
+++ b/packages/renderer-extension/test/versioned-renderer-adapter.test.ts
@@ -163,6 +163,88 @@ describe("current Codex Renderer Agent adapter", () => {
     expect(resolveRendererRequestRoute(replacementPolicy, [], discovered)).toBeNull();
   });
 
+  it("prefers a policy-owned exact request target without Composer discovery", () => {
+    const manager = {
+      hostId: "remote-ssh-discovered:mac",
+      sendRequest: vi.fn(),
+      prewarmThreadStart: vi.fn(),
+      enqueueRequest: vi.fn(),
+    };
+    const policy = {
+      state: "ready" as const,
+      hostId: manager.hostId,
+      requestTarget: vi.fn(() => manager),
+      select: vi.fn(() => true),
+      clear: vi.fn(async () => undefined),
+    };
+
+    const route = resolveRendererRequestRoute(policy, [], null);
+
+    expect(route).toEqual({ policy, targets: [manager] });
+    expect(policy.requestTarget).toHaveBeenCalledOnce();
+
+    const discoverTargets = vi.fn(() => [manager]);
+    const resolver = createRendererRequestRouteResolver(() => policy, discoverTargets);
+    expect(resolver.resolve()?.targets).toEqual([manager]);
+    expect(discoverTargets).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ["non-callable", {}],
+    ["malformed", () => ({})],
+    [
+      "host-mismatched",
+      () => ({
+        hostId: "remote-ssh-discovered:other",
+        sendRequest: vi.fn(),
+        prewarmThreadStart: vi.fn(),
+        enqueueRequest: vi.fn(),
+      }),
+    ],
+    [
+      "throwing",
+      () => {
+        throw new Error("synthetic target failure");
+      },
+    ],
+  ])("fails closed for a %s policy-owned request target", (_name, requestTarget) => {
+    const matchingDiscoveredManager = {
+      hostId: "remote-ssh-discovered:mac",
+      sendRequest: vi.fn(),
+      prewarmThreadStart: vi.fn(),
+      enqueueRequest: vi.fn(),
+    };
+    const policy = {
+      state: "ready" as const,
+      hostId: matchingDiscoveredManager.hostId,
+      requestTarget,
+      select: vi.fn(() => true),
+      clear: vi.fn(async () => undefined),
+    };
+
+    expect(resolveRendererRequestRoute(policy, [matchingDiscoveredManager], null)).toBeNull();
+  });
+
+  it("keeps Fiber discovery as the fallback for a legacy policy without requestTarget", () => {
+    const manager = {
+      hostId: "remote-ssh-discovered:mac",
+      sendRequest: vi.fn(),
+      prewarmThreadStart: vi.fn(),
+      enqueueRequest: vi.fn(),
+    };
+    const policy = {
+      state: "ready" as const,
+      hostId: manager.hostId,
+      select: vi.fn(() => true),
+      clear: vi.fn(async () => undefined),
+    };
+
+    expect(resolveRendererRequestRoute(policy, [manager], null)).toEqual({
+      policy,
+      targets: [manager],
+    });
+  });
+
   it("does not revive an invalidated request manager after a later discovery gap", () => {
     const policy = {
       state: "ready" as const,

--- a/tests/e2e/renderer-adapter-lifecycle.spec.ts
+++ b/tests/e2e/renderer-adapter-lifecycle.spec.ts
@@ -1,0 +1,632 @@
+import { expect, test, type Page } from "@playwright/test";
+import { build } from "esbuild";
+import path from "node:path";
+
+const repositoryRoot = path.resolve(import.meta.dirname, "../..");
+const browserExecutable = process.env.CODEXHOST_PLAYWRIGHT_EXECUTABLE_PATH;
+if (browserExecutable) test.use({ launchOptions: { executablePath: browserExecutable } });
+
+const { outputFiles } = await build({
+  stdin: {
+    contents: `
+      import { installCurrentRendererAdapter } from "./packages/renderer-extension/src/versioned-renderer-adapter.ts";
+      import { RENDERER_REASONING_DISPLAY_PREFERENCE_KEY } from "./packages/renderer-extension/src/renderer-reasoning-preference.ts";
+
+      const counters = new Map();
+      const managers = new Map();
+      let managerSequence = 0;
+      let policySequence = 0;
+      let throwOnSelect = false;
+      let throwOnNonNullSelect = false;
+
+      const createManager = (hostId) => {
+        const id = \`manager-\${++managerSequence}\`;
+        const counter = {
+          notificationAdds: 0,
+          notificationRemoves: 0,
+          ownershipInspects: 0,
+          ownershipInspectThreads: [],
+        };
+        const notificationCallbacks = new Set();
+        const removedNotificationCallbacks = new Set();
+        const ownershipRequests = [];
+        counters.set(id, counter);
+        const manager = {
+          id,
+          hostId,
+          sendRequest: async (method, params) => {
+            if (method !== "codexhost/thread/inspect") throw new Error("unused request");
+            counter.ownershipInspects += 1;
+            counter.ownershipInspectThreads.push(params.threadId);
+            return new Promise((resolve) => {
+              ownershipRequests.push({ threadId: params.threadId, resolve });
+            });
+          },
+          prewarmThreadStart: () => undefined,
+          enqueueRequest: () => undefined,
+          addNotificationCallback: (_methods, callback) => {
+            counter.notificationAdds += 1;
+            notificationCallbacks.add(callback);
+            let removed = false;
+            return () => {
+              if (removed) return;
+              removed = true;
+              notificationCallbacks.delete(callback);
+              removedNotificationCallbacks.add(callback);
+              counter.notificationRemoves += 1;
+            };
+          },
+          emit(notification) {
+            for (const callback of notificationCallbacks) callback(notification);
+          },
+          emitRemoved(notification) {
+            for (const callback of removedNotificationCallbacks) callback(notification);
+          },
+          resolveOwnership(threadId, owner = "external") {
+            const index = ownershipRequests.findIndex((request) => request.threadId === threadId);
+            if (index < 0) throw new Error(\`No pending ownership request for \${threadId}\`);
+            const [request] = ownershipRequests.splice(index, 1);
+            request.resolve(
+              owner === "external"
+                ? {
+                    owner: "external",
+                    harnessId: "claude-code",
+                    transportModelId: "codexhost/claude-code-native",
+                    history: { fork: true, forkAcrossCwd: true, rollbackLastTurn: false },
+                    locked: true,
+                  }
+                : { owner: "codex", locked: true },
+            );
+          },
+        };
+        managers.set(id, manager);
+        return manager;
+      };
+
+      const createPolicy = (hostId, requestTarget) => {
+        const id = \`policy-\${++policySequence}\`;
+        const counter = { selections: 0, requestTargetReads: 0 };
+        counters.set(id, counter);
+        const policy = {
+          id,
+          state: "ready",
+          hostId,
+          select: (selection) => {
+            counter.selections += 1;
+            if (throwOnSelect || (throwOnNonNullSelect && selection !== null)) {
+              throw new Error("synthetic policy selection failure");
+            }
+            return true;
+          },
+          clear: async () => undefined,
+        };
+        if (requestTarget !== undefined) {
+          policy.requestTarget = () => {
+            counter.requestTargetReads += 1;
+            return requestTarget;
+          };
+        }
+        return policy;
+      };
+
+      globalThis.setupAdapterLifecycle = (reasoningEnabled = false) => {
+        document.body.replaceChildren();
+        if (reasoningEnabled) {
+          localStorage.setItem(RENDERER_REASONING_DISPLAY_PREFERENCE_KEY, "true");
+        } else {
+          localStorage.removeItem(RENDERER_REASONING_DISPLAY_PREFERENCE_KEY);
+        }
+        const editor = document.createElement("div");
+        editor.setAttribute("data-codex-composer", "true");
+        editor.setAttribute("data-codex-composer-root", "true");
+        editor.setAttribute("contenteditable", "true");
+        editor.setAttribute("role", "textbox");
+        const portal = document.createElement("div");
+        portal.setAttribute("data-above-composer-portal", "true");
+        portal.setAttribute("data-above-composer-conversation-id", "thread-displayed-old");
+        editor.append(portal);
+        const initialManager = createManager("remote-ssh-discovered:initial");
+        const managerHook = { memoizedState: initialManager, next: null };
+        Object.defineProperty(editor, "__reactFiber$lifecycle", {
+          configurable: true,
+          value: { memoizedState: managerHook, return: null },
+        });
+        document.body.append(editor);
+
+        const initialPolicy = createPolicy(initialManager.hostId);
+        window.__codexhostMainProcessTitlePolicyV1 = { state: "ready" };
+        window.__codexhostDraftPrewarmPolicyV1 = initialPolicy;
+        const adapter = installCurrentRendererAdapter();
+        const unsubscribeReasoning = adapter.modelControl?.subscribeThreadReasoning?.(() => {});
+
+        const state = {
+          adapter,
+          initialManager,
+          initialPolicy,
+          portal,
+          managerHook,
+          unsubscribeReasoning,
+          replacementManager: null,
+          replacementPolicy: null,
+        };
+        globalThis.__adapterLifecycleState = state;
+        return {
+          initialManagerId: initialManager.id,
+          initialPolicyId: initialPolicy.id,
+        };
+      };
+
+      globalThis.replaceAdapterRoute = (withManager) => {
+        const state = globalThis.__adapterLifecycleState;
+        const replacementManager = createManager("remote-ssh-discovered:replacement");
+        const replacementPolicy = createPolicy(replacementManager.hostId);
+        state.replacementManager = replacementManager;
+        state.replacementPolicy = replacementPolicy;
+        state.managerHook.memoizedState = withManager ? replacementManager : {};
+        window.__codexhostDraftPrewarmPolicyV1 = replacementPolicy;
+        return {
+          replacementManagerId: replacementManager.id,
+          replacementPolicyId: replacementPolicy.id,
+        };
+      };
+
+      globalThis.replaceAdapterRouteWithExactTarget = (mode) => {
+        const state = globalThis.__adapterLifecycleState;
+        const replacementManager = createManager("remote-ssh-discovered:replacement");
+        const exactTarget =
+          mode === "valid"
+            ? replacementManager
+            : mode === "host-mismatch"
+              ? createManager("remote-ssh-discovered:other")
+              : {};
+        const replacementPolicy = createPolicy(replacementManager.hostId, exactTarget);
+        state.replacementManager = replacementManager;
+        state.replacementPolicy = replacementPolicy;
+        state.managerHook.memoizedState = mode === "valid" ? {} : replacementManager;
+        window.__codexhostDraftPrewarmPolicyV1 = replacementPolicy;
+        return {
+          replacementManagerId: replacementManager.id,
+          replacementPolicyId: replacementPolicy.id,
+        };
+      };
+
+      globalThis.revealReplacementManager = () => {
+        const state = globalThis.__adapterLifecycleState;
+        state.managerHook.memoizedState = state.replacementManager;
+      };
+      globalThis.publishRendererMutation = () => {
+        const marker = document.createElement("div");
+        marker.textContent = "route discovery changed";
+        document.body.append(marker);
+      };
+
+      globalThis.readCurrentHostId = () =>
+        globalThis.__adapterLifecycleState.adapter.modelControl?.currentHostId?.() ?? null;
+      globalThis.setLifecycleComposerThread = (threadId) =>
+        globalThis.__adapterLifecycleState.portal.setAttribute(
+          "data-above-composer-conversation-id",
+          threadId,
+        );
+      globalThis.emitLifecycleReasoning = (managerId, notification, removed = false) => {
+        const manager = managers.get(managerId);
+        if (!manager) throw new Error(\`Unknown lifecycle manager \${managerId}\`);
+        if (removed) manager.emitRemoved(notification);
+        else manager.emit(notification);
+      };
+      globalThis.resolveLifecycleOwnership = (managerId, threadId, owner = "external") => {
+        const manager = managers.get(managerId);
+        if (!manager) throw new Error(\`Unknown lifecycle manager \${managerId}\`);
+        manager.resolveOwnership(threadId, owner);
+      };
+      globalThis.publishRouteChange = () =>
+        window.dispatchEvent(new CustomEvent("codexhost:draft-prewarm-policy-changed"));
+      globalThis.enablePolicyCleanupFailure = () => { throwOnSelect = true; };
+      globalThis.enablePolicySelectionFailure = () => { throwOnNonNullSelect = true; };
+      globalThis.disposeAdapter = () => {
+        try {
+          globalThis.__adapterLifecycleState.adapter.dispose();
+          return null;
+        } catch (error) {
+          return error instanceof Error ? error.message : String(error);
+        }
+      };
+      globalThis.readLifecycleCounter = (id) => counters.get(id);
+    `,
+    resolveDir: repositoryRoot,
+    sourcefile: "renderer-adapter-lifecycle-e2e-entry.ts",
+    loader: "ts",
+  },
+  bundle: true,
+  format: "iife",
+  platform: "browser",
+  target: "es2024",
+  loader: { ".css": "text", ".png": "dataurl", ".svg": "dataurl" },
+  write: false,
+});
+
+const browserBundle = outputFiles[0]?.text;
+if (!browserBundle) throw new Error("Renderer adapter lifecycle E2E bundle was not generated");
+const browserBundleText: string = browserBundle;
+
+async function setup(
+  page: Page,
+  reasoningEnabled = false,
+): Promise<{
+  initialManagerId: string;
+  initialPolicyId: string;
+}> {
+  await page.route("https://codexhost.test/**", async (route) => {
+    await route.fulfill({ contentType: "text/html", body: "<!doctype html><body></body>" });
+  });
+  await page.goto("https://codexhost.test/");
+  await page.addScriptTag({ content: browserBundleText });
+  return page.evaluate((enableReasoning) => {
+    const setupAdapterLifecycle = Reflect.get(globalThis, "setupAdapterLifecycle");
+    if (typeof setupAdapterLifecycle !== "function") {
+      throw new Error("Adapter lifecycle setup is unavailable");
+    }
+    return setupAdapterLifecycle(enableReasoning);
+  }, reasoningEnabled);
+}
+
+async function replaceRoute(
+  page: Page,
+  withManager: boolean,
+): Promise<{ replacementManagerId: string; replacementPolicyId: string }> {
+  return page.evaluate((managerReady) => {
+    const replaceAdapterRoute = Reflect.get(globalThis, "replaceAdapterRoute");
+    if (typeof replaceAdapterRoute !== "function") {
+      throw new Error("Adapter route replacement is unavailable");
+    }
+    return replaceAdapterRoute(managerReady);
+  }, withManager);
+}
+
+async function counter(
+  page: Page,
+  id: string,
+): Promise<{
+  notificationAdds?: number;
+  notificationRemoves?: number;
+  ownershipInspects?: number;
+  ownershipInspectThreads?: string[];
+  selections?: number;
+  requestTargetReads?: number;
+}> {
+  return page.evaluate((counterId) => {
+    const readLifecycleCounter = Reflect.get(globalThis, "readLifecycleCounter");
+    if (typeof readLifecycleCounter !== "function") {
+      throw new Error("Adapter lifecycle counter is unavailable");
+    }
+    return readLifecycleCounter(counterId);
+  }, id);
+}
+
+function reasoningDelta(threadId: string, turnId: string, itemId: string, delta: string): unknown {
+  return {
+    method: "item/reasoning/summaryTextDelta",
+    params: { threadId, turnId, itemId, summaryIndex: 0, delta },
+  };
+}
+
+async function emitReasoning(
+  page: Page,
+  managerId: string,
+  notification: unknown,
+  removed = false,
+): Promise<void> {
+  await page.evaluate(
+    ({ id, payload, useRemoved }) => {
+      const emit = Reflect.get(globalThis, "emitLifecycleReasoning");
+      if (typeof emit !== "function") throw new Error("Lifecycle Reasoning emitter is unavailable");
+      emit(id, payload, useRemoved);
+    },
+    { id: managerId, payload: notification, useRemoved: removed },
+  );
+}
+
+async function resolveOwnership(page: Page, managerId: string, threadId: string): Promise<void> {
+  await page.evaluate(
+    ({ id, thread }) => {
+      const resolve = Reflect.get(globalThis, "resolveLifecycleOwnership");
+      if (typeof resolve !== "function") {
+        throw new Error("Lifecycle ownership resolver is unavailable");
+      }
+      resolve(id, thread, "external");
+    },
+    { id: managerId, thread: threadId },
+  );
+}
+
+async function replaceRouteWithExactTarget(
+  page: Page,
+  mode: "valid" | "malformed" | "host-mismatch",
+): Promise<{ replacementManagerId: string; replacementPolicyId: string }> {
+  return page.evaluate((targetMode) => {
+    const replace = Reflect.get(globalThis, "replaceAdapterRouteWithExactTarget");
+    if (typeof replace !== "function") {
+      throw new Error("Adapter exact route replacement is unavailable");
+    }
+    return replace(targetMode);
+  }, mode);
+}
+
+async function publishRouteChange(page: Page): Promise<void> {
+  await page.evaluate(() => {
+    const publish = Reflect.get(globalThis, "publishRouteChange");
+    if (typeof publish !== "function") {
+      throw new Error("Adapter route-change publisher is unavailable");
+    }
+    publish();
+  });
+}
+
+test("an active-route read moves the reasoning relay to the resolved request manager", async ({
+  page,
+}) => {
+  const initial = await setup(page);
+  const replacement = await replaceRoute(page, true);
+
+  await expect
+    .poll(() =>
+      page.evaluate(() => {
+        const readCurrentHostId = Reflect.get(globalThis, "readCurrentHostId");
+        if (typeof readCurrentHostId !== "function") return null;
+        return readCurrentHostId();
+      }),
+    )
+    .toBe("remote-ssh-discovered:replacement");
+  await expect
+    .poll(async () => counter(page, initial.initialManagerId))
+    .toMatchObject({
+      notificationRemoves: 1,
+    });
+  await expect
+    .poll(async () => counter(page, replacement.replacementManagerId))
+    .toMatchObject({
+      notificationAdds: 1,
+    });
+});
+
+test("one policy event reconnects an exact request target without Fiber discovery or DOM mutation", async ({
+  page,
+}) => {
+  const initial = await setup(page);
+  const replacement = await replaceRouteWithExactTarget(page, "valid");
+
+  await publishRouteChange(page);
+  await publishRouteChange(page);
+
+  await expect
+    .poll(async () => counter(page, initial.initialManagerId))
+    .toMatchObject({
+      notificationRemoves: 1,
+    });
+  await expect
+    .poll(async () => counter(page, replacement.replacementManagerId))
+    .toMatchObject({
+      notificationAdds: 1,
+    });
+  expect(await counter(page, replacement.replacementPolicyId)).toMatchObject({
+    selections: 1,
+  });
+});
+
+test("an exact Host replacement clears stale Reasoning ownership and safely reuses the Thread ID", async ({
+  page,
+}) => {
+  const displayedThreadId = "thread-displayed-old";
+  const reusedThreadId = "thread-reused-across-hosts";
+  const initial = await setup(page, true);
+  const panel = page.locator("[data-codexhost-reasoning-display]");
+
+  await emitReasoning(
+    page,
+    initial.initialManagerId,
+    reasoningDelta(displayedThreadId, "turn-displayed-old", "reasoning-displayed-old", "old panel"),
+  );
+  await expect
+    .poll(async () => counter(page, initial.initialManagerId))
+    .toMatchObject({
+      ownershipInspects: 1,
+      ownershipInspectThreads: [displayedThreadId],
+    });
+  await resolveOwnership(page, initial.initialManagerId, displayedThreadId);
+  await expect(panel).toContainText("old panel");
+
+  await emitReasoning(
+    page,
+    initial.initialManagerId,
+    reasoningDelta(reusedThreadId, "turn-pending-old", "reasoning-pending-old", "pending old"),
+  );
+  await expect
+    .poll(async () => counter(page, initial.initialManagerId))
+    .toMatchObject({
+      ownershipInspects: 2,
+      ownershipInspectThreads: [displayedThreadId, reusedThreadId],
+    });
+
+  const replacement = await replaceRouteWithExactTarget(page, "valid");
+  await publishRouteChange(page);
+
+  await expect(panel).toHaveCount(0);
+  await expect
+    .poll(async () => counter(page, initial.initialManagerId))
+    .toMatchObject({
+      notificationRemoves: 1,
+    });
+  await expect
+    .poll(async () => counter(page, replacement.replacementManagerId))
+    .toMatchObject({
+      notificationAdds: 1,
+    });
+
+  await emitReasoning(
+    page,
+    initial.initialManagerId,
+    reasoningDelta(reusedThreadId, "turn-stale-old", "reasoning-stale-old", "released stale old"),
+    true,
+  );
+  await resolveOwnership(page, initial.initialManagerId, reusedThreadId);
+  await page.evaluate((threadId) => {
+    const setThread = Reflect.get(globalThis, "setLifecycleComposerThread");
+    if (typeof setThread !== "function") {
+      throw new Error("Lifecycle Composer Thread control is unavailable");
+    }
+    setThread(threadId);
+  }, reusedThreadId);
+
+  await emitReasoning(
+    page,
+    replacement.replacementManagerId,
+    reasoningDelta(reusedThreadId, "turn-current-new", "reasoning-current-new", "current new"),
+  );
+  await expect
+    .poll(async () => counter(page, replacement.replacementManagerId))
+    .toMatchObject({
+      ownershipInspects: 1,
+      ownershipInspectThreads: [reusedThreadId],
+    });
+  await resolveOwnership(page, replacement.replacementManagerId, reusedThreadId);
+
+  await expect(panel).toContainText("current new");
+  await expect(panel).not.toContainText("old panel");
+  await expect(panel).not.toContainText("pending old");
+  await expect(panel).not.toContainText("released stale old");
+  expect(await counter(page, initial.initialManagerId)).toMatchObject({ ownershipInspects: 2 });
+});
+
+for (const mode of ["malformed", "host-mismatch"] as const) {
+  test(`a ${mode} exact request target fails closed without falling back to Fiber discovery`, async ({
+    page,
+  }) => {
+    const initial = await setup(page);
+    const replacement = await replaceRouteWithExactTarget(page, mode);
+
+    await publishRouteChange(page);
+    await page.evaluate(() => {
+      const publishRendererMutation = Reflect.get(globalThis, "publishRendererMutation");
+      if (typeof publishRendererMutation !== "function") {
+        throw new Error("Renderer mutation publisher is unavailable");
+      }
+      publishRendererMutation();
+    });
+    await page.waitForTimeout(100);
+
+    expect(await counter(page, replacement.replacementPolicyId)).toMatchObject({ selections: 0 });
+    expect(await counter(page, replacement.replacementManagerId)).toMatchObject({
+      notificationAdds: 0,
+    });
+    expect(await counter(page, initial.initialManagerId)).toMatchObject({
+      notificationRemoves: 1,
+    });
+  });
+}
+
+test("a renderer mutation recaptures a request manager after a transient discovery gap", async ({
+  page,
+}) => {
+  await setup(page);
+  const replacement = await replaceRoute(page, false);
+  await page.evaluate(() => {
+    const publishRouteChange = Reflect.get(globalThis, "publishRouteChange");
+    if (typeof publishRouteChange !== "function") {
+      throw new Error("Adapter route-change publisher is unavailable");
+    }
+    publishRouteChange();
+  });
+  await page.waitForTimeout(100);
+  await page.evaluate(() => {
+    const revealReplacementManager = Reflect.get(globalThis, "revealReplacementManager");
+    if (typeof revealReplacementManager !== "function") {
+      throw new Error("Adapter replacement manager is unavailable");
+    }
+    revealReplacementManager();
+  });
+  await page.waitForTimeout(150);
+  expect(await counter(page, replacement.replacementPolicyId)).toMatchObject({ selections: 0 });
+  expect(await counter(page, replacement.replacementManagerId)).toMatchObject({
+    notificationAdds: 0,
+  });
+  await page.evaluate(() => {
+    const publishRendererMutation = Reflect.get(globalThis, "publishRendererMutation");
+    if (typeof publishRendererMutation !== "function") {
+      throw new Error("Renderer mutation publisher is unavailable");
+    }
+    publishRendererMutation();
+  });
+  await expect
+    .poll(async () => counter(page, replacement.replacementPolicyId))
+    .toMatchObject({
+      selections: 1,
+    });
+  await expect
+    .poll(async () => counter(page, replacement.replacementManagerId))
+    .toMatchObject({
+      notificationAdds: 1,
+    });
+});
+
+test("a failed replacement selection disconnects the temporary mutation observer", async ({
+  page,
+}) => {
+  await setup(page);
+  const replacement = await replaceRoute(page, false);
+  await page.evaluate(() => {
+    const publishRouteChange = Reflect.get(globalThis, "publishRouteChange");
+    const revealReplacementManager = Reflect.get(globalThis, "revealReplacementManager");
+    const enablePolicySelectionFailure = Reflect.get(globalThis, "enablePolicySelectionFailure");
+    if (
+      typeof publishRouteChange !== "function" ||
+      typeof revealReplacementManager !== "function" ||
+      typeof enablePolicySelectionFailure !== "function"
+    ) {
+      throw new Error("Adapter selection-failure controls are unavailable");
+    }
+    publishRouteChange();
+    revealReplacementManager();
+    enablePolicySelectionFailure();
+  });
+  await page.evaluate(() => {
+    const publishRendererMutation = Reflect.get(globalThis, "publishRendererMutation");
+    if (typeof publishRendererMutation !== "function") {
+      throw new Error("Renderer mutation publisher is unavailable");
+    }
+    publishRendererMutation();
+  });
+  await expect
+    .poll(async () => counter(page, replacement.replacementPolicyId))
+    .toMatchObject({
+      selections: 1,
+    });
+
+  await page.evaluate(() => {
+    const publishRendererMutation = Reflect.get(globalThis, "publishRendererMutation");
+    if (typeof publishRendererMutation !== "function") {
+      throw new Error("Renderer mutation publisher is unavailable");
+    }
+    publishRendererMutation();
+  });
+  await page.waitForTimeout(150);
+  expect(await counter(page, replacement.replacementPolicyId)).toMatchObject({ selections: 1 });
+});
+
+test("adapter disposal continues after the routing policy rejects cleanup", async ({ page }) => {
+  const initial = await setup(page);
+  const cleanupError = await page.evaluate(() => {
+    const enablePolicyCleanupFailure = Reflect.get(globalThis, "enablePolicyCleanupFailure");
+    const disposeAdapter = Reflect.get(globalThis, "disposeAdapter");
+    if (typeof enablePolicyCleanupFailure !== "function" || typeof disposeAdapter !== "function") {
+      throw new Error("Adapter cleanup controls are unavailable");
+    }
+    enablePolicyCleanupFailure();
+    return disposeAdapter();
+  });
+
+  expect(cleanupError).toBeNull();
+  await expect
+    .poll(async () => counter(page, initial.initialManagerId))
+    .toMatchObject({
+      notificationRemoves: 1,
+    });
+});

--- a/tests/e2e/renderer-reasoning-display.spec.ts
+++ b/tests/e2e/renderer-reasoning-display.spec.ts
@@ -1,0 +1,356 @@
+import { expect, test, type Page } from "@playwright/test";
+import { build } from "esbuild";
+import path from "node:path";
+
+const repositoryRoot = path.resolve(import.meta.dirname, "../..");
+const browserExecutable = process.env.CODEXHOST_PLAYWRIGHT_EXECUTABLE_PATH;
+if (browserExecutable) test.use({ launchOptions: { executablePath: browserExecutable } });
+
+const { outputFiles } = await build({
+  stdin: {
+    contents: `
+      import { installRendererReasoningDisplay } from "./packages/renderer-extension/src/renderer-reasoning-display.ts";
+      import { decodeRendererReasoningNotification } from "./packages/renderer-extension/src/renderer-reasoning-events.ts";
+      import {
+        RENDERER_REASONING_DISPLAY_PREFERENCE_KEY,
+        setRendererReasoningDisplayPreference,
+      } from "./packages/renderer-extension/src/renderer-reasoning-preference.ts";
+
+      globalThis.setupReasoningDisplay = (
+        owner = "external",
+        initiallyEnabled = true,
+        ownershipInspectionTimeoutMs = 5000,
+        maxPendingTextLength = 262144,
+      ) => {
+        if (initiallyEnabled) {
+          localStorage.setItem(RENDERER_REASONING_DISPLAY_PREFERENCE_KEY, "true");
+        } else {
+          localStorage.removeItem(RENDERER_REASONING_DISPLAY_PREFERENCE_KEY);
+        }
+        const wrapper = document.createElement("main");
+        const composer = document.createElement("div");
+        composer.setAttribute("data-codex-composer-root", "true");
+        const portal = document.createElement("div");
+        portal.setAttribute("data-above-composer-portal", "true");
+        portal.setAttribute("data-above-composer-conversation-id", "thread-reasoning-1");
+        composer.append(portal);
+        wrapper.append(composer);
+        document.body.append(wrapper);
+
+        let listener = null;
+        let subscriptionCount = 0;
+        let currentOwner = owner;
+        let holdOwnershipInspection = false;
+        const ownershipResolvers = [];
+        const control = installRendererReasoningDisplay({
+          inspectThread: async () => {
+            const inspectedOwner = currentOwner;
+            if (holdOwnershipInspection) {
+              await new Promise((resolve) => ownershipResolvers.push(resolve));
+            }
+            return inspectedOwner === "external"
+              ? {
+                  owner: "external",
+                  harnessId: "claude-code",
+                  transportModelId: "codexhost/claude-code-native",
+                  history: { fork: true, forkAcrossCwd: true, rollbackLastTurn: false },
+                  locked: true,
+                }
+              : { owner: "codex", locked: false };
+          },
+          subscribeThreadReasoning: (next) => {
+            subscriptionCount += 1;
+            listener = next;
+            return () => { listener = null; };
+          },
+        }, window, { ownershipInspectionTimeoutMs, maxPendingTextLength });
+        globalThis.pushReasoningNotification = (notification) => {
+          const event = decodeRendererReasoningNotification(notification);
+          if (!event || !listener) throw new Error("Reasoning notification was rejected");
+          listener(event);
+        };
+        globalThis.disableReasoningDisplay = () => setRendererReasoningDisplayPreference(false);
+        globalThis.enableReasoningDisplay = () => setRendererReasoningDisplayPreference(true);
+        globalThis.reasoningSubscriptionCount = () => subscriptionCount;
+        globalThis.resetReasoningDisplay = () => control.reset();
+        globalThis.setReasoningOwner = (nextOwner) => { currentOwner = nextOwner; };
+        globalThis.holdReasoningOwnership = (hold) => { holdOwnershipInspection = hold; };
+        globalThis.resolveReasoningOwnership = () => ownershipResolvers.shift()?.();
+        globalThis.disposeReasoningDisplay = () => control.dispose();
+      };
+    `,
+    resolveDir: repositoryRoot,
+    sourcefile: "renderer-reasoning-display-e2e-entry.ts",
+    loader: "ts",
+  },
+  bundle: true,
+  format: "iife",
+  platform: "browser",
+  target: "es2024",
+  loader: { ".css": "text", ".png": "dataurl", ".svg": "dataurl" },
+  write: false,
+});
+
+const browserBundle = outputFiles[0]?.text;
+if (!browserBundle) throw new Error("Renderer reasoning display bundle was not generated");
+const browserBundleText: string = browserBundle;
+
+async function setup(
+  page: Page,
+  owner: "external" | "codex" = "external",
+  initiallyEnabled = true,
+  ownershipInspectionTimeoutMs = 5_000,
+  maxPendingTextLength = 256 * 1024,
+): Promise<void> {
+  await page.route("https://codexhost.test/**", async (route) => {
+    await route.fulfill({ contentType: "text/html", body: "<!doctype html><body></body>" });
+  });
+  await page.goto("https://codexhost.test/");
+  await page.addScriptTag({ content: browserBundleText });
+  await page.evaluate(
+    ({ threadOwner, enabled, timeoutMs, pendingTextLimit }) => {
+      const setupReasoningDisplay = Reflect.get(globalThis, "setupReasoningDisplay");
+      if (typeof setupReasoningDisplay !== "function") {
+        throw new Error("Reasoning display setup is unavailable");
+      }
+      setupReasoningDisplay(threadOwner, enabled, timeoutMs, pendingTextLimit);
+    },
+    {
+      threadOwner: owner,
+      enabled: initiallyEnabled,
+      timeoutMs: ownershipInspectionTimeoutMs,
+      pendingTextLimit: maxPendingTextLength,
+    },
+  );
+}
+
+async function push(page: Page, notification: unknown): Promise<void> {
+  await page.evaluate((payload) => {
+    const pushReasoningNotification = Reflect.get(globalThis, "pushReasoningNotification");
+    if (typeof pushReasoningNotification !== "function") {
+      throw new Error("Reasoning notification bridge is unavailable");
+    }
+    pushReasoningNotification(payload);
+  }, notification);
+}
+
+test("streams explicit external reasoning summaries and collapses on completion", async ({
+  page,
+}) => {
+  await setup(page);
+  const panel = page.locator("[data-codexhost-reasoning-display]");
+  await expect(panel).toHaveCount(0);
+
+  await push(page, {
+    method: "item/started",
+    params: {
+      threadId: "thread-reasoning-1",
+      turnId: "turn-reasoning-1",
+      item: { id: "reasoning-1", type: "reasoning", summary: [], content: [] },
+    },
+  });
+  await push(page, {
+    method: "item/reasoning/summaryTextDelta",
+    params: {
+      threadId: "thread-reasoning-1",
+      turnId: "turn-reasoning-1",
+      itemId: "reasoning-1",
+      summaryIndex: 0,
+      delta: "Inspecting the request",
+    },
+  });
+
+  await expect(panel).toBeVisible();
+  await expect(panel.locator("details")).toHaveAttribute("open", "");
+  await expect(panel).toContainText("Inspecting the request");
+
+  await push(page, {
+    method: "item/completed",
+    params: {
+      threadId: "thread-reasoning-1",
+      turnId: "turn-reasoning-1",
+      item: {
+        id: "reasoning-1",
+        type: "reasoning",
+        summary: ["Inspecting the request", "Checking the result"],
+        content: ["private raw chain"],
+        encrypted_content: "secret",
+      },
+    },
+  });
+
+  await expect(panel.locator("details")).not.toHaveAttribute("open", "");
+  await expect(panel).toContainText("Reasoning complete");
+  await panel.locator("summary").click();
+  await expect(panel.locator("details")).toHaveAttribute("open", "");
+  await expect(panel).toContainText("Checking the result");
+  await expect(panel).not.toContainText("private raw chain");
+  await expect(panel).not.toContainText("secret");
+
+  await page.evaluate(() => {
+    const unrelated = document.createElement("div");
+    unrelated.textContent = "unrelated DOM mutation";
+    document.body.append(unrelated);
+  });
+  await expect(panel.locator("details")).toHaveAttribute("open", "");
+
+  await page.evaluate(() => {
+    const disable = Reflect.get(globalThis, "disableReasoningDisplay");
+    if (typeof disable !== "function") throw new Error("Reasoning disable action is unavailable");
+    disable();
+  });
+  await expect(panel).toHaveCount(0);
+});
+
+test("fails closed for an official Codex-owned thread", async ({ page }) => {
+  await setup(page, "codex");
+  await push(page, {
+    method: "item/reasoning/summaryTextDelta",
+    params: {
+      threadId: "thread-reasoning-1",
+      turnId: "turn-reasoning-1",
+      itemId: "reasoning-1",
+      summaryIndex: 0,
+      delta: "Native Codex reasoning",
+    },
+  });
+
+  await expect(page.locator("[data-codexhost-reasoning-display]")).toHaveCount(0);
+});
+
+test("does not subscribe or observe until the user opts in", async ({ page }) => {
+  await setup(page, "external", false);
+  await expect
+    .poll(() =>
+      page.evaluate(() => {
+        const count = Reflect.get(globalThis, "reasoningSubscriptionCount");
+        return typeof count === "function" ? count() : -1;
+      }),
+    )
+    .toBe(0);
+
+  await page.evaluate(() => {
+    const enable = Reflect.get(globalThis, "enableReasoningDisplay");
+    if (typeof enable !== "function") throw new Error("Reasoning enable action is unavailable");
+    enable();
+  });
+  await expect
+    .poll(() =>
+      page.evaluate(() => {
+        const count = Reflect.get(globalThis, "reasoningSubscriptionCount");
+        return typeof count === "function" ? count() : -1;
+      }),
+    )
+    .toBe(1);
+});
+
+test("drops ownership results and summaries from an invalidated Host route", async ({ page }) => {
+  await setup(page);
+  await page.evaluate(() => {
+    const hold = Reflect.get(globalThis, "holdReasoningOwnership");
+    if (typeof hold !== "function") throw new Error("Reasoning ownership hold is unavailable");
+    hold(true);
+  });
+  await push(page, {
+    method: "item/reasoning/summaryTextDelta",
+    params: {
+      threadId: "thread-reasoning-1",
+      turnId: "turn-old",
+      itemId: "reasoning-old",
+      summaryIndex: 0,
+      delta: "stale summary",
+    },
+  });
+
+  await page.evaluate(() => {
+    const reset = Reflect.get(globalThis, "resetReasoningDisplay");
+    const setOwner = Reflect.get(globalThis, "setReasoningOwner");
+    const hold = Reflect.get(globalThis, "holdReasoningOwnership");
+    if (
+      typeof reset !== "function" ||
+      typeof setOwner !== "function" ||
+      typeof hold !== "function"
+    ) {
+      throw new Error("Reasoning route controls are unavailable");
+    }
+    reset();
+    setOwner("codex");
+    hold(false);
+  });
+  await push(page, {
+    method: "item/reasoning/summaryTextDelta",
+    params: {
+      threadId: "thread-reasoning-1",
+      turnId: "turn-current",
+      itemId: "reasoning-current",
+      summaryIndex: 0,
+      delta: "native summary",
+    },
+  });
+  await page.evaluate(() => {
+    const resolve = Reflect.get(globalThis, "resolveReasoningOwnership");
+    if (typeof resolve !== "function")
+      throw new Error("Reasoning ownership resolver is unavailable");
+    resolve();
+  });
+
+  await expect(page.locator("[data-codexhost-reasoning-display]")).toHaveCount(0);
+  await expect(page.locator("body")).not.toContainText("stale summary");
+});
+
+test("fails closed when ownership inspection times out", async ({ page }) => {
+  await setup(page, "external", true, 25);
+  await page.evaluate(() => {
+    const hold = Reflect.get(globalThis, "holdReasoningOwnership");
+    if (typeof hold !== "function") throw new Error("Reasoning ownership hold is unavailable");
+    hold(true);
+  });
+  await push(page, {
+    method: "item/reasoning/summaryTextDelta",
+    params: {
+      threadId: "thread-reasoning-1",
+      turnId: "turn-reasoning-1",
+      itemId: "reasoning-1",
+      summaryIndex: 0,
+      delta: "timed out summary",
+    },
+  });
+
+  await page.waitForTimeout(50);
+  await page.evaluate(() => {
+    const resolve = Reflect.get(globalThis, "resolveReasoningOwnership");
+    if (typeof resolve !== "function")
+      throw new Error("Reasoning ownership resolver is unavailable");
+    resolve();
+  });
+  await expect(page.locator("[data-codexhost-reasoning-display]")).toHaveCount(0);
+});
+
+test("fails closed when pending reasoning exceeds its bounded buffer", async ({ page }) => {
+  await setup(page, "external", true, 5_000, 8);
+  await page.evaluate(() => {
+    const hold = Reflect.get(globalThis, "holdReasoningOwnership");
+    if (typeof hold !== "function") throw new Error("Reasoning ownership hold is unavailable");
+    hold(true);
+  });
+  for (const delta of ["12345678", "9"]) {
+    await push(page, {
+      method: "item/reasoning/summaryTextDelta",
+      params: {
+        threadId: "thread-reasoning-1",
+        turnId: "turn-reasoning-1",
+        itemId: "reasoning-1",
+        summaryIndex: 0,
+        delta,
+      },
+    });
+  }
+  await page.evaluate(() => {
+    const resolve = Reflect.get(globalThis, "resolveReasoningOwnership");
+    if (typeof resolve !== "function")
+      throw new Error("Reasoning ownership resolver is unavailable");
+    resolve();
+  });
+
+  await expect(page.locator("[data-codexhost-reasoning-display]")).toHaveCount(0);
+});


### PR DESCRIPTION
## Summary

- add a default-off **Show reasoning summaries** preference under **codexhost Settings → Model Pool**
- render only explicit app-server reasoning summary notifications for externally owned Harness threads in a plain-text collapsible panel above the verified Composer
- keep live summaries expanded and auto-scrolled, collapse once on completion, and preserve later manual expansion
- reconnect the reasoning relay through the desktop-control policy's exact validated request target when the active Host changes, with a bounded legacy-policy compatibility path

## Safety and privacy

- never reads or renders arbitrary Item `content`, encrypted/redacted fields, signatures, inferred text, or provider-private/raw chain-of-thought
- performs fixed `codexhost/thread/inspect` ownership gating and never adds the custom surface to native Codex threads
- keeps summary text in memory only; local storage contains only the boolean preference
- invalidates stale callbacks, ownership results, queued summaries, and panels when the Host route changes
- fails closed after a 5-second ownership timeout or a 256 KiB pending-summary limit
- malformed or Host-mismatched exact request targets fail closed instead of falling back to an unrelated DOM/Fiber route

## Validation

- `npm run check` — pass (`166` TypeScript test files passed, `1` skipped; `1371` tests passed, `15` skipped; Rust fmt, Clippy, workspace tests, and boundary checks passed)
- `npm run build` — pass
- system-Chrome Playwright coverage for the reasoning display and adapter lifecycle — `14 passed`
- `npx --yes @fission-ai/openspec@1.10.0 validate add-optional-reasoning-display --strict` — pass
- Windows x64 release npm package build plus isolated tarball install / `codexhost --version` smoke — pass (`0.3.5-issue52.1`)
- macOS arm64 isolated npm package build/install smoke at this PR head — pass (`@codexhost/cli-darwin-arm64`, `0.3.5-issue52.1`)

`openspec validate --all --strict` also validates this change successfully, but the repository currently has two unrelated existing change-validation failures in `optimize-claude-usage-refresh` and `project-claude-code-session-usage`.

Closes #52
