### PR TITLE
test: 覆盖 OMP 终态错误回归

### DIFF
--- a/packages/adapters/omp/test/omp-rpc-session.test.ts
+++ b/packages/adapters/omp/test/omp-rpc-session.test.ts
@@ -27,7 +27,7 @@ class FakeOmpProcess extends EventEmitter {
   constructor(
     readonly compactMode: "complete" | "stalled" = "complete",
     readonly sessionFile?: string,
-    readonly terminalMessageMode: "none" | "replay" | "fallback" = "none",
+    readonly terminalMessageMode: "none" | "replay" | "fallback" | "failure" = "none",
   ) {
     super();
     this.stdin.on("data", (chunk: Buffer) => {
@@ -179,13 +179,24 @@ class FakeOmpProcess extends EventEmitter {
           ...(this.terminalMessageMode !== "none"
             ? {
                 messages: [
-                  {
-                    role: "assistant",
-                    responseId: "assistant-before-final",
-                    content: [{ type: "text", text: "Earlier tool setup" }],
-                    stopReason: "toolUse",
-                  },
-                  { ...message, stopReason: "stop" },
+                  ...(this.terminalMessageMode === "failure"
+                    ? [
+                        {
+                          role: "assistant",
+                          content: [],
+                          stopReason: "aborted",
+                          errorMessage: "Request was aborted",
+                        },
+                      ]
+                    : [
+                        {
+                          role: "assistant",
+                          responseId: "assistant-before-final",
+                          content: [{ type: "text", text: "Earlier tool setup" }],
+                          stopReason: "toolUse",
+                        },
+                        { ...message, stopReason: "stop" },
+                      ]),
                 ],
               }
             : {}),
@@ -301,6 +312,22 @@ describe("OMP RPC session", () => {
     ]);
     expect(events.filter((event) => event.type === "message.completed")).toEqual([
       { type: "message.completed", messageId: "assistant-1" },
+    ]);
+    await session.close();
+  });
+
+  it("preserves a terminal Assistant failure reported only by agent_end", async () => {
+    const process = new FakeOmpProcess("complete", undefined, "failure");
+    const adapter: OmpRpcProcessAdapter = { spawn: () => process as never };
+    const session = new OmpRpcSession({ cwd: "/synthetic", commandTimeoutMs: 2_000 }, adapter);
+    await session.start();
+    const events: OmpTurnEvent[] = [];
+
+    await expect(session.runTurn("hello", (event) => events.push(event))).rejects.toThrow(
+      "Request was aborted",
+    );
+    expect(events.filter((event) => event.type === "text.delta")).toEqual([
+      { type: "text.delta", messageId: "assistant-1", delta: "PONG" },
     ]);
     await session.close();
   });


### PR DESCRIPTION
## 目的

补充 OMP `agent_end.messages` 修复的终态错误回归覆盖，关联 #63。

上游提交 `c612b58` 已将 `agent_end.messages` 从“重放全部 Assistant 消息”调整为只处理最后一条 Assistant，从而避免工具/思考回合重复输出最终答案。本 PR 锁定一个关键兼容场景：正文已通过 `message_end` 输出，但 aborted/error 终态仅由 `agent_end.messages` 报告。

## 变更

- 扩展 OMP RPC 假进程的终态消息场景。
- 新增回归测试，验证：
  - 已流式输出的正文不会重复；
  - 仅由 `agent_end` 携带的 `Request was aborted` 会使 Turn 正确失败。

## 验证

- `npm exec vitest -- run packages/adapters/omp/test/omp-rpc-session.test.ts --config tests/vitest.config.js`
- `npm exec vitest -- run packages/adapters/omp/test --config tests/vitest.config.js`
- `npm run build --workspace=@codexhost/adapter-omp`
- `npm run typecheck`
- `npm exec eslint -- packages/adapters/omp/test/omp-rpc-session.test.ts`
- `npm exec prettier -- --check packages/adapters/omp/test/omp-rpc-session.test.ts`

以上均通过。

Relates to #63