### PR TITLE
fix(renderer): 修正窗口缩放时 Agent 与权限菜单偏移

### DIFF
--- a/packages/renderer-extension/src/renderer-agent-picker.ts
+++ b/packages/renderer-extension/src/renderer-agent-picker.ts
@@ -46,6 +46,24 @@ export interface RendererAgentPickerView {
   downloadVisible: Partial<Record<ExternalRendererAgent, boolean>>;
 }
 
+export function rendererAgentMenuPlacement(
+  triggerRect: Pick<DOMRectReadOnly, "right" | "top">,
+  viewport: { width: number; height: number },
+  windowZoom: number,
+): { left: number; bottom: number } {
+  const zoom = Number.isFinite(windowZoom) && windowZoom > 0 ? windowZoom : 1;
+  const viewportWidth = viewport.width / zoom;
+  const viewportHeight = viewport.height / zoom;
+  const left = Math.max(
+    8,
+    Math.min(triggerRect.right / zoom - AGENT_MENU_WIDTH, viewportWidth - AGENT_MENU_WIDTH - 8),
+  );
+  return {
+    left,
+    bottom: Math.max(8, viewportHeight - triggerRect.top / zoom + 6),
+  };
+}
+
 export function rendererAgentPickerView(
   state: { agent: RendererAgent; phase: ComposerAgentPhase },
   adapterState: RendererAdapterStatus["state"],
@@ -77,10 +95,16 @@ export function rendererAgentPickerView(
 
 function setMenuPosition(control: RendererAgentPickerControl): void {
   const rect = control.trigger.getBoundingClientRect();
-  const width = AGENT_MENU_WIDTH;
-  const left = Math.max(8, Math.min(rect.right - width, window.innerWidth - width - 8));
-  control.menu.style.left = `${left}px`;
-  control.menu.style.bottom = `${Math.max(8, window.innerHeight - rect.top + 6)}px`;
+  const rawWindowZoom = getComputedStyle(document.documentElement)
+    .getPropertyValue("--codex-window-zoom")
+    .trim();
+  const placement = rendererAgentMenuPlacement(
+    rect,
+    { width: window.innerWidth, height: window.innerHeight },
+    Number.parseFloat(rawWindowZoom),
+  );
+  control.menu.style.left = `${placement.left}px`;
+  control.menu.style.bottom = `${placement.bottom}px`;
 }
 
 function popoverOpen(menu: HTMLElement): boolean {

--- a/packages/renderer-extension/src/renderer-permission-mode-picker.ts
+++ b/packages/renderer-extension/src/renderer-permission-mode-picker.ts
@@ -90,13 +90,35 @@ export function rendererPermissionModeLabel(
   return messages.permissions;
 }
 
+export function rendererPermissionModeMenuPlacement(
+  triggerRect: Pick<DOMRectReadOnly, "left" | "top">,
+  viewport: { width: number; height: number },
+  windowZoom: number,
+): { width: number; left: number; bottom: number } {
+  const zoom = Number.isFinite(windowZoom) && windowZoom > 0 ? windowZoom : 1;
+  const viewportWidth = viewport.width / zoom;
+  const viewportHeight = viewport.height / zoom;
+  const width = Math.min(320, viewportWidth - 16);
+  return {
+    width,
+    left: Math.max(8, Math.min(triggerRect.left / zoom, viewportWidth - width - 8)),
+    bottom: Math.max(8, viewportHeight - triggerRect.top / zoom + 6),
+  };
+}
+
 function positionMenu(control: RendererPermissionModePickerControl): void {
   const rect = control.trigger.getBoundingClientRect();
-  const width = Math.min(320, window.innerWidth - 16);
-  const left = Math.max(8, Math.min(rect.left, window.innerWidth - width - 8));
-  control.menu.style.width = `${width}px`;
-  control.menu.style.left = `${left}px`;
-  control.menu.style.bottom = `${Math.max(8, window.innerHeight - rect.top + 6)}px`;
+  const rawWindowZoom = getComputedStyle(document.documentElement)
+    .getPropertyValue("--codex-window-zoom")
+    .trim();
+  const placement = rendererPermissionModeMenuPlacement(
+    rect,
+    { width: window.innerWidth, height: window.innerHeight },
+    Number.parseFloat(rawWindowZoom),
+  );
+  control.menu.style.width = `${placement.width}px`;
+  control.menu.style.left = `${placement.left}px`;
+  control.menu.style.bottom = `${placement.bottom}px`;
 }
 
 export function syncRendererPermissionModeTriggerClass(
@@ -158,6 +180,7 @@ export function mountRendererPermissionModePicker(
   menu.className = MENU_CLASSES;
   menu.style.inset = "auto";
   menu.style.margin = "0";
+  menu.style.boxSizing = "border-box";
   menu.style.padding = "4px";
   menu.style.maxHeight = "min(420px, 70vh)";
   menu.style.overflowY = "auto";

--- a/packages/renderer-extension/test/renderer-agent-picker.test.ts
+++ b/packages/renderer-extension/test/renderer-agent-picker.test.ts
@@ -1,9 +1,32 @@
 import { describe, expect, it } from "vitest";
 
 import { isNativeModelControlCandidate } from "../src/renderer-composer-dom.js";
-import { rendererAgentPickerView } from "../src/renderer-agent-picker.js";
+import {
+  rendererAgentMenuPlacement,
+  rendererAgentPickerView,
+} from "../src/renderer-agent-picker.js";
 
 describe("Renderer Agent picker presentation", () => {
+  it("normalizes viewport coordinates against the Codex window zoom", () => {
+    expect(
+      rendererAgentMenuPlacement(
+        { right: 1_440, top: 1_312 },
+        { width: 1_920, height: 1_440 },
+        1.6,
+      ),
+    ).toEqual({ left: 700, bottom: 86 });
+  });
+
+  it("falls back to unscaled positioning when the Codex window zoom is unavailable", () => {
+    expect(
+      rendererAgentMenuPlacement(
+        { right: 900, top: 820 },
+        { width: 1_200, height: 900 },
+        Number.NaN,
+      ),
+    ).toEqual({ left: 700, bottom: 86 });
+  });
+
   it("keeps a Codex draft switchable while disabling unavailable external Agents", () => {
     expect(
       rendererAgentPickerView({ agent: "codex", phase: "draft" }, "unsupported", false, [

--- a/packages/renderer-extension/test/renderer-permission-mode-picker.test.ts
+++ b/packages/renderer-extension/test/renderer-permission-mode-picker.test.ts
@@ -8,6 +8,7 @@ import { rendererPermissionModePresentation } from "../src/renderer-harness-loca
 import {
   isPermissionModeControlReady,
   rendererPermissionModeLabel,
+  rendererPermissionModeMenuPlacement,
 } from "../src/renderer-permission-mode-picker.js";
 
 const catalog = harnessPermissionModeCatalogSchema.parse({
@@ -24,6 +25,26 @@ const catalog = harnessPermissionModeCatalogSchema.parse({
 });
 
 describe("Renderer Permission Mode picker presentation", () => {
+  it("normalizes menu geometry against the Codex window zoom", () => {
+    expect(
+      rendererPermissionModeMenuPlacement(
+        { left: 800, top: 1_312 },
+        { width: 1_920, height: 1_440 },
+        1.6,
+      ),
+    ).toEqual({ width: 320, left: 500, bottom: 86 });
+  });
+
+  it("falls back to unscaled menu geometry when the Codex window zoom is unavailable", () => {
+    expect(
+      rendererPermissionModeMenuPlacement(
+        { left: 500, top: 820 },
+        { width: 1_200, height: 900 },
+        Number.NaN,
+      ),
+    ).toEqual({ width: 320, left: 500, bottom: 86 });
+  });
+
   it("is ready only for an Adapter-confirmed catalog entry", () => {
     const selected = harnessPermissionModeIdSchema.parse("default");
     expect(isPermissionModeControlReady({ status: "ready", catalog, selected })).toBe(true);

--- a/tests/e2e/renderer-agent-picker.spec.ts
+++ b/tests/e2e/renderer-agent-picker.spec.ts
@@ -1,0 +1,87 @@
+import { expect, test } from "@playwright/test";
+import { build } from "esbuild";
+import path from "node:path";
+
+const repositoryRoot = path.resolve(import.meta.dirname, "../..");
+const browserExecutable = process.env.CODEXHOST_PLAYWRIGHT_EXECUTABLE_PATH;
+if (browserExecutable) test.use({ launchOptions: { executablePath: browserExecutable } });
+
+const { outputFiles } = await build({
+  stdin: {
+    contents: `
+      import {
+        mountRendererAgentPicker,
+        renderRendererAgentPicker,
+      } from "./packages/renderer-extension/src/renderer-agent-picker.ts";
+
+      globalThis.setupRendererAgentPicker = () => {
+        document.documentElement.style.setProperty("--codex-window-zoom", "1.6");
+
+        const shell = document.createElement("div");
+        shell.style.position = "fixed";
+        shell.style.inset = "0";
+        shell.style.display = "flex";
+        shell.style.alignItems = "flex-end";
+        shell.style.justifyContent = "center";
+        shell.style.boxSizing = "border-box";
+        shell.style.paddingBottom = "60px";
+        shell.style.width = "calc(100vw / var(--codex-window-zoom))";
+        shell.style.height = "calc(100vh / var(--codex-window-zoom))";
+        shell.style.zoom = "var(--codex-window-zoom)";
+
+        const control = mountRendererAgentPicker(
+          "test-composer",
+          ["codex", "pi"],
+          () => {},
+          () => {},
+        );
+        shell.append(control.root);
+        document.body.append(shell);
+        renderRendererAgentPicker(
+          control,
+          { agent: "codex", phase: "draft" },
+          "ready",
+          false,
+          { pi: "ready" },
+        );
+      };
+    `,
+    resolveDir: repositoryRoot,
+    sourcefile: "renderer-agent-picker-e2e-entry.ts",
+    loader: "ts",
+  },
+  bundle: true,
+  format: "iife",
+  loader: { ".png": "dataurl", ".svg": "dataurl" },
+  platform: "browser",
+  target: "es2024",
+  write: false,
+});
+
+const browserBundle = outputFiles[0]?.text;
+if (!browserBundle) throw new Error("Renderer Agent picker E2E bundle was not generated");
+
+test("keeps the Agent menu anchored inside the Codex window zoom", async ({ page }) => {
+  await page.setViewportSize({ width: 1_920, height: 1_440 });
+  await page.setContent('<!doctype html><body style="margin:0"></body>');
+  await page.addScriptTag({ content: browserBundle });
+  await page.evaluate(() => {
+    const setup = Reflect.get(globalThis, "setupRendererAgentPicker");
+    if (typeof setup !== "function") throw new Error("Agent picker setup is unavailable");
+    setup();
+  });
+
+  const trigger = page.locator(
+    '[data-codexhost-agent-control="test-composer"] > button[aria-haspopup="menu"]',
+  );
+  const menu = page.locator("#test-composer-agent-menu");
+  await trigger.click();
+  await expect(menu).toBeVisible();
+
+  const [triggerBox, menuBox] = await Promise.all([trigger.boundingBox(), menu.boundingBox()]);
+  if (!triggerBox || !menuBox) throw new Error("Agent picker geometry is unavailable");
+
+  expect(menuBox.x + menuBox.width).toBeCloseTo(triggerBox.x + triggerBox.width, 0);
+  expect(menuBox.width).toBeCloseTo(200 * 1.6, 0);
+  expect(triggerBox.y - (menuBox.y + menuBox.height)).toBeCloseTo(6 * 1.6, 0);
+});

--- a/tests/e2e/renderer-harness-controls-localization.spec.ts
+++ b/tests/e2e/renderer-harness-controls-localization.spec.ts
@@ -54,6 +54,38 @@ const { outputFiles } = await build({
           selected: catalog.defaultModeId,
         }, true, "zh-CN");
       };
+
+      globalThis.setupPermissionModePickerZoomed = () => {
+        document.documentElement.style.setProperty("--codex-window-zoom", "1.6");
+
+        const shell = document.createElement("div");
+        shell.style.position = "fixed";
+        shell.style.inset = "0";
+        shell.style.display = "flex";
+        shell.style.alignItems = "flex-end";
+        shell.style.justifyContent = "center";
+        shell.style.boxSizing = "border-box";
+        shell.style.paddingBottom = "60px";
+        shell.style.width = "calc(100vw / var(--codex-window-zoom))";
+        shell.style.height = "calc(100vh / var(--codex-window-zoom))";
+        shell.style.zoom = "var(--codex-window-zoom)";
+
+        const permissions = mountRendererPermissionModePicker("zoomed-permissions", () => {});
+        const catalog = harnessPermissionModeCatalogSchema.parse({
+          modes: [
+            { id: "default", label: "Default" },
+            { id: "full-access", label: "Full access", dangerous: true },
+          ],
+          defaultModeId: "default",
+        });
+        renderRendererPermissionModePicker(permissions, {
+          status: "ready",
+          catalog,
+          selected: catalog.defaultModeId,
+        }, true);
+        shell.append(permissions.root);
+        document.body.append(shell);
+      };
     `,
     resolveDir: repositoryRoot,
     sourcefile: "renderer-harness-controls-localization-entry.ts",
@@ -101,4 +133,29 @@ test("localizes shared Harness command and Permission Mode controls in Chinese",
   await expect(permissionMenu).toContainText("写入");
   await expect(permissionMenu).toContainText("完全访问");
   await expect(permissionMenu).toContainText("无需批准提示即可运行所有工具操作。");
+});
+
+test("keeps the Permission Mode menu anchored inside the Codex window zoom", async ({ page }) => {
+  await page.setViewportSize({ width: 1_920, height: 1_440 });
+  await page.setContent('<!doctype html><body style="margin:0"></body>');
+  await page.addScriptTag({ content: browserBundle });
+  await page.evaluate(() => {
+    const setup = Reflect.get(globalThis, "setupPermissionModePickerZoomed");
+    if (typeof setup !== "function") throw new Error("Permission Mode picker setup is unavailable");
+    setup();
+  });
+
+  const trigger = page.locator(
+    '[data-codexhost-permission-mode-control="zoomed-permissions"] > button',
+  );
+  const menu = page.locator("#zoomed-permissions-permission-mode-menu");
+  await trigger.click();
+  await expect(menu).toBeVisible();
+
+  const [triggerBox, menuBox] = await Promise.all([trigger.boundingBox(), menu.boundingBox()]);
+  if (!triggerBox || !menuBox) throw new Error("Permission Mode picker geometry is unavailable");
+
+  expect(menuBox.x).toBeCloseTo(triggerBox.x, 0);
+  expect(menuBox.width).toBeCloseTo(320 * 1.6, 0);
+  expect(triggerBox.y - (menuBox.y + menuBox.height)).toBeCloseTo(6 * 1.6, 0);
 });


### PR DESCRIPTION
## 问题

Codex Desktop 使用 `--codex-window-zoom` 对应用根节点进行缩放时，Agent 选择菜单和非 Codex Agent 的权限模式菜单仍直接使用 `getBoundingClientRect()` 返回的物理坐标计算位置。菜单位于同一个缩放上下文中，这些坐标会再次被缩放，导致菜单相对触发按钮产生明显偏移。

## 修复

- 读取并校验 `--codex-window-zoom`
- 将视口尺寸、触发按钮坐标以及权限菜单宽度换算为缩放前的逻辑坐标后再计算位置
- Agent 菜单与权限模式菜单均保留 8px 视口边距和 6px 触发器间距
- 无效或缺失的缩放值继续回退到 `1`
- 权限菜单显式使用 `border-box`，避免依赖宿主页面的全局样式重置
- 增加 Agent 与权限菜单的缩放坐标单元测试
- 增加使用真实 Picker、CSS zoom `1.6` 的 Playwright 回归测试

## 验证

- `npm run build`
- `npm run typecheck`
- `npm run lint`
- Agent 与权限模式 Picker 单元测试（13 tests passed）
- Agent Picker 缩放 E2E 测试
- 权限模式 Picker 缩放及本地化 E2E 测试（2 tests passed）
- `npm run test:rust`（107 tests passed）

修复后，Agent 菜单与权限模式菜单在 Codex Desktop 非 100% 缩放下仍与各自触发按钮正确对齐，菜单宽度和垂直间距也按窗口缩放比例显示。

Closes #69
