### PR TITLE
feat: 适配 DeepSeek Harness goal 与 plan 文本命令

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -11,3 +11,4 @@ playwright-report/
 test-results/
 package-lock.json
 Cargo.lock
+packages/renderer-extension/src/settings/windows-update.preview.html

--- a/docs/harness-command-integration.md
+++ b/docs/harness-command-integration.md
@@ -8,9 +8,9 @@ Choose a stable command ID and descriptor:
 
 ```ts
 {
-  id: "pi.compact",
-  invocation: "/compact",
-  label: "Compact context",
+  id: "dsh.plan",
+  invocation: "/plan",
+  label: "Plan mode",
   argumentMode: "text",
 }
 ```
@@ -41,11 +41,13 @@ For commands with visible progress, decide explicitly whether they need:
 
 ## 4. Reuse Host and Renderer routing
 
-The shared command catalog and Host command RPC should not need command-specific branches. The Renderer should consume the catalog and execute by command ID through the Composer's independent Harness Commands button and popover.
+The shared command catalog and Host command RPC should not need command-specific branches. The Renderer should consume the catalog through the Composer's independent Harness Commands button and popover. Selecting an argument-free command executes it directly; selecting a text command prefixes its invocation in the current editor and leaves the draft and attachments in place for the ordinary submit path.
 
 The command button belongs to the active external Harness controls, near the Composer's left-side actions. It MUST remain outside the Codex React-managed Slash command list; the independent popover owns its own focus, keyboard navigation, positioning, and scrolling.
 
 Only add Renderer-specific code when the command needs a new presentation or interaction.
+
+External Harness text Turns do not accept image input. Host rejects those submissions before Adapter execution instead of silently dropping attachments.
 
 ## 5. Add focused tests
 
@@ -54,6 +56,7 @@ At minimum, cover:
 - command appears in the owning Adapter catalog;
 - unknown command is rejected;
 - invalid arguments are rejected;
+- image-bearing External Harness Turns fail before command execution;
 - busy Session is rejected;
 - native operation is called with the expected payload;
 - success, failure, and cancellation are projected correctly;
@@ -71,13 +74,15 @@ git diff --check
 
 For native RPC changes, also verify the request and event sequence against the real Harness when available.
 
-## Current examples: Pi, Grok, and Claude commands
+## Current examples: Pi, Grok, Claude, and DeepSeek commands
 
 ```text
 Renderer command catalog
   -> Composer Harness Commands button
   -> independent command popover
-  -> Host command/execute
+  -> argumentMode none: fixed Host command/execute
+     argumentMode text: prefix the Composer, then ordinary turn/start
+  -> current Host catalog validation
   -> owning Adapter
        Pi:     native { type: "compact" }
        Grok:   x.ai/compact_conversation { sessionId, userContext? }
@@ -85,6 +90,12 @@ Renderer command catalog
                /compact  context compaction
                /init     generate CLAUDE.md
                /recap    one-line session recap
+       DeepSeek: commands/list for the current Native Session
+                 /compact
+                 /dsh-goal [<objective>|clear|edit <objective>|pause|resume]
+                   -> native /goal
+                 /plan [off|message]
+                 -> commands/execute { agentId, line }
   -> existing Host Item projection
   -> temporary Turn cleanup unless the command requires persistence
 ```
@@ -93,6 +104,10 @@ Grok maps optional trailing text to native `userContext`. Claude `/compact`
 maps it to custom summarization instructions. `/init` and `/recap` take no
 arguments. These commands invoke Harness-native operations and must not be
 submitted as Host text Turns.
+
+DeepSeek is dynamic rather than a fixed catalog. The Adapter preserves the relative order of the current Session's native `commands/list` response and maps only valid `compact`, `goal`, and `plan` descriptors to stable codexhost IDs. Missing or incompatible entries disappear; malformed catalogs fail explicitly. Native `feedback` conflicts with Codex Desktop's built-in command of the same name and is not exposed. Native `permission` and `export`, the Client-side `/model`, and unknown future commands are also not exposed through this surface.
+
+The public `/dsh-goal` invocation avoids Codex Desktop's built-in `/goal` command and maps only inside the Adapter to native DSH `/goal`. `/dsh-goal` and `/plan` accept text arguments only. DSH remains the owner of goal and plan state and any model-visible follow-up.
 
 ## Boundaries
 

--- a/openspec/specs/harness-command-capabilities/spec.md
+++ b/openspec/specs/harness-command-capabilities/spec.md
@@ -28,6 +28,27 @@ A Harness Adapter MUST publish a command catalog containing stable command IDs, 
 - **THEN** the catalog contains the registered `claude.init` and `claude.recap` commands
 - **AND** both commands declare their invocations and argument mode `none`
 
+#### Scenario: DeepSeek exposes only reviewed native commands
+
+- **WHEN** a DeepSeek Session lists Harness commands
+- **THEN** the Adapter reads that Session's current native `commands/list` catalog
+- **AND** it maps valid advertised entries only to `dsh.compact`, `dsh.goal`, and `dsh.plan`, preserving their native relative order
+- **AND** the mapped commands declare `/compact` with argument mode `none`, plus `/dsh-goal` and `/plan` with argument mode `text`
+- **AND** `/dsh-goal` maps to native DSH `/goal` without entering Codex Desktop's built-in `/goal` flow
+- **AND** it does not expose native `/feedback` because Codex Desktop owns a conflicting built-in command
+
+#### Scenario: DeepSeek native catalog is missing or malformed
+
+- **WHEN** a reviewed command is absent, has an incompatible input descriptor, or the native catalog contains invalid fields, duplicate names, or invalid descriptions
+- **THEN** an absent or incompatible command is omitted, while a malformed catalog fails with a protocol error and exposes no partial result
+- **AND** codexhost MUST NOT substitute a fixed catalog
+
+#### Scenario: DeepSeek control and future commands remain excluded
+
+- **WHEN** DSH advertises `permission`, `export`, or an unknown future command, or the Client contributes `/model`
+- **THEN** none is exposed as a normal Harness command
+- **AND** Permission Mode and Model selection remain on their existing first-class controls
+
 ### Requirement: Host validates and routes registered commands
 
 The Host MUST obtain the current Harness command catalog before execution, MUST reject unknown command IDs, and MUST validate arguments at the command boundary. The Host MUST NOT provide an arbitrary native RPC passthrough.
@@ -37,6 +58,18 @@ The Host MUST obtain the current Harness command catalog before execution, MUST 
 - **WHEN** a command execution request references an ID absent from the current catalog
 - **THEN** the Host rejects the request
 - **AND** no native Harness operation is started
+
+#### Scenario: Unmatched slash input fails closed
+
+- **WHEN** an external Thread submits slash-shaped text that matches no command in its current catalog
+- **THEN** Host rejects the submission as an unavailable Harness command
+- **AND** it does not send that text as a normal model Prompt or attempt an arbitrary native command
+
+#### Scenario: External command image input fails closed
+
+- **WHEN** an External Harness command submission carries `image` or `localImage` inputs
+- **THEN** Host rejects the submission before Adapter execution
+- **AND** it does not silently drop the images or submit the remaining text
 
 ### Requirement: Native command semantics remain inside the owning Adapter
 
@@ -60,15 +93,38 @@ The Adapter MUST translate a registered command into the Harness-native operatio
 - **THEN** the Claude Adapter calls the dedicated init or recap transport
 - **AND** it does not submit those invocations as Host text Turns
 
+#### Scenario: DeepSeek commands use the native command Remote
+
+- **WHEN** a reviewed DeepSeek command is executed
+- **THEN** the Adapter rechecks the current Session catalog and calls native `commands/execute` with the exact command line and cancellation signal
+- **AND** codexhost does not reproduce the command's state changes or send it as a normal Prompt
+
 ### Requirement: Command UI and lifecycle follow Host contracts
 
 A command MAY be discovered by the Renderer through the Host command catalog. The Renderer SHALL present discovered commands through an independent Composer Harness Commands control rather than mutating the Codex-native Slash command list. Its popover SHALL own its layout, scrolling, focus, and keyboard navigation. If execution produces visible lifecycle events, those events MUST use existing Host projection contracts. Temporary command projection Turns MUST NOT be persisted as ordinary conversation history unless the command explicitly requires persistence.
 
+#### Scenario: Text command selection claims the Composer
+
+- **WHEN** the user selects a command with argument mode `text` from the Harness Commands popover
+- **THEN** Renderer prefixes its invocation and one space to the current Composer editor while preserving the existing draft and attachments
+- **AND** the command uses the ordinary Composer submission path instead of executing a bare invocation immediately
+
+#### Scenario: Argument-free command selection executes directly
+
+- **WHEN** the user selects a command with argument mode `none`
+- **THEN** Renderer executes that registered command directly through the fixed Host command route
+
 #### Scenario: Manual compaction is projected without a user Turn
 
-- **WHEN** Pi or Claude Code emits native compaction start and end events for their compact command
+- **WHEN** Pi, Grok, Claude Code, or DeepSeek emits native compaction start and end events for its compact command
 - **THEN** codexhost projects the standard context-compaction UI lifecycle
 - **AND** the temporary command Turn is not added to ordinary Thread history
+
+#### Scenario: DeepSeek command result text uses existing projection
+
+- **WHEN** DeepSeek `/goal` or `/plan` returns native success or error text
+- **THEN** codexhost projects the text through the existing Command Execution Item and completes the temporary Turn with the native outcome
+- **AND** native log-only command lifecycle records do not become ordinary conversation Turns
 
 ### Requirement: Commands remain isolated by Harness ownership
 

--- a/packages/adapters/deepseek-harness/src/deepseek-harness-adapter.ts
+++ b/packages/adapters/deepseek-harness/src/deepseek-harness-adapter.ts
@@ -31,6 +31,7 @@ import {
   type HostAgentMessageItem,
   type HostApprovalInteraction,
   type HostCommand,
+  type HostCommandExecutionItem,
   type HostContextCompactionItem,
   type HostFileChangeItem,
   type HostItem,
@@ -57,12 +58,12 @@ import {
   type TurnStartCommand,
 } from "@codexhost/harness-adapter";
 import {
-  harnessCommandCatalogSchema,
   harnessIdSchema,
   harnessPermissionModeIdSchema,
   harnessThinkingOptionIdSchema,
   hostInteractionIdSchema,
   hostItemIdSchema,
+  hostTurnIdSchema,
   nativeCheckpointRefSchema,
   nativeSessionRefSchema,
   nativeTurnRefSchema,
@@ -86,6 +87,7 @@ import {
   type DeepSeekHostSubscriber,
   type DeepSeekMuxEnvelope,
 } from "./host-client.js";
+import { deepSeekHarnessCommandCatalog, parseDeepSeekHarnessCommand } from "./harness-commands.js";
 import {
   deepSeekCheckpointRef,
   matchesDeepSeekForkHistory,
@@ -172,25 +174,33 @@ interface ActiveTurn {
 
 interface ActiveCommand {
   command: HarnessCommandInvocation;
+  line: string;
   abort: AbortController;
   cancellationRequested: boolean;
-  item: HostContextCompactionItem;
+  item: HostContextCompactionItem | HostCommandExecutionItem;
+}
+
+interface CommandAdmission {
+  turnId: HostTurnId;
+  abort: AbortController;
+  cancellationRequested: boolean;
+}
+
+interface BufferedNativeEvent {
+  type: string;
+  data: Record<string, unknown>;
+  seq: number;
+}
+
+interface PendingAutonomousTurn {
+  nativeTurn: number;
+  events: BufferedNativeEvent[];
+  input: TurnStartCommand["input"];
+  ready: boolean;
+  ended: boolean;
 }
 
 const deepSeekHarnessId = harnessIdSchema.parse("deepseek-harness");
-const deepSeekCommandCatalog = harnessCommandCatalogSchema.parse({
-  commands: [
-    {
-      id: "dsh.compact",
-      invocation: "/compact",
-      label: "Compact context",
-      description:
-        "Compact the current conversation context through the DeepSeek Harness command registry",
-      argumentMode: "none",
-    },
-  ],
-});
-const emptyDeepSeekCommandCatalog = harnessCommandCatalogSchema.parse({ commands: [] });
 const DSH_COMPACT_BUSY =
   "Compaction is unavailable because this process has an active compaction, or the agent is not idle.";
 const DSH_COMPACT_CANCELLED = "Compaction cancelled.";
@@ -198,6 +208,15 @@ const DEFAULT_TOOL_OUTPUT_LIMIT = 64_000;
 const HISTORY_PAGE_MESSAGES = 100;
 const HISTORY_PAGE_LIMIT = 10_000;
 const DELEGATION_PERMISSION_PRESET = "danger-full-access";
+const AUTONOMOUS_TURN_READY_EVENTS = new Set([
+  "request/header",
+  "request/context",
+  "assistant/chunk",
+  "assistant/message",
+  "tool/call",
+  "tool/result",
+  "turn/end",
+]);
 
 function normalizedError(error: unknown, fallback: HarnessError["code"]): HarnessError {
   if (error instanceof DeepSeekHarnessTransportError) {
@@ -220,6 +239,60 @@ function invalidState(message: string): HarnessError {
 
 function unsupported(message: string): HarnessError {
   return { code: "unsupported", message, retryable: false };
+}
+
+function createActiveTurn(command: TurnStartCommand): ActiveTurn {
+  return {
+    command,
+    nativeTurn: null,
+    started: false,
+    cancellationRequested: false,
+    agentItem: null,
+    reasoningItem: null,
+    tools: new Map(),
+    interactions: new Map(),
+    snapshots: [],
+  };
+}
+
+function incompleteTurnEvents(entries: HistoryEntry[]): BufferedNativeEvent[] {
+  let pending: { nativeTurn: number; events: BufferedNativeEvent[] } | null = null;
+  for (const { event } of entries) {
+    if (!isRecord(event.data)) {
+      if (pending) {
+        throw new DeepSeekHarnessTransportError(
+          "protocolError",
+          "DeepSeek Harness history contains invalid active Turn event data",
+        );
+      }
+      continue;
+    }
+    if (event.type === "turn/start") {
+      if (!Number.isSafeInteger(event.data.turn) || pending) {
+        throw new DeepSeekHarnessTransportError(
+          "protocolError",
+          "DeepSeek Harness history contains an invalid active Turn boundary",
+        );
+      }
+      pending = {
+        nativeTurn: event.data.turn as number,
+        events: [{ type: event.type, data: event.data, seq: event.seq }],
+      };
+      continue;
+    }
+    if (!pending) continue;
+    pending.events.push({ type: event.type, data: event.data, seq: event.seq });
+    if (event.type === "turn/end") {
+      if (event.data.turn !== pending.nativeTurn) {
+        throw new DeepSeekHarnessTransportError(
+          "protocolError",
+          "DeepSeek Harness history contains a mismatched active Turn boundary",
+        );
+      }
+      pending = null;
+    }
+  }
+  return pending?.events ?? [];
 }
 
 function commandFailure(operation: string, error: { code: string; message: string }): HarnessError {
@@ -436,6 +509,8 @@ class DeepSeekHarnessSession implements HarnessSession, DeepSeekHostSubscriber {
   readonly #unsubscribe: () => void;
   #active: ActiveTurn | null = null;
   #activeCommand: ActiveCommand | null = null;
+  #commandAdmission: CommandAdmission | null = null;
+  #pendingAutonomousTurns: PendingAutonomousTurn[] = [];
   #closePromise: Promise<void> | null = null;
   #closed = false;
   #configuring = false;
@@ -470,6 +545,7 @@ class DeepSeekHarnessSession implements HarnessSession, DeepSeekHostSubscriber {
     thinkingOptionId?: HarnessThinkingOption["id"];
     availableThinkingOptions?: HarnessThinkingOption[];
     initialUsage?: HostUsage | null;
+    pendingAutonomousEvents?: BufferedNativeEvent[];
     onClosed(): void;
     snapshot: HostThreadSnapshot;
     toolOutputLimit: number;
@@ -507,6 +583,10 @@ class DeepSeekHarnessSession implements HarnessSession, DeepSeekHostSubscriber {
     };
     this.initialState = this.#configurationState();
     this.outputs = this.#channel.outputs;
+    for (const event of input.pendingAutonomousEvents ?? []) {
+      if (!this.#active && this.#bufferAutonomousEvent(event.type, event.data, event.seq)) continue;
+      this.#event(event.type, event.data, event.seq);
+    }
   }
 
   #configurationState(): HarnessSessionState {
@@ -567,7 +647,14 @@ class DeepSeekHarnessSession implements HarnessSession, DeepSeekHostSubscriber {
     if (this.#closed) {
       return { ok: false, error: invalidState("DeepSeek Harness Session is closed") };
     }
-    if (this.#active || this.#activeCommand || this.#configuring || this.#reading) {
+    if (
+      this.#active ||
+      this.#activeCommand ||
+      this.#commandAdmission ||
+      this.#pendingAutonomousTurns.length > 0 ||
+      this.#configuring ||
+      this.#reading
+    ) {
       return {
         ok: false,
         error: {
@@ -594,6 +681,12 @@ class DeepSeekHarnessSession implements HarnessSession, DeepSeekHostSubscriber {
         fallbackModel: model,
         toolOutputLimit: this.#toolOutputLimit,
       });
+      const hydratedNativeTurns = new Set(
+        projection.snapshot.turns.map(({ nativeTurnRef }) => nativeTurnRef.nativeTurnKey),
+      );
+      this.#pendingAutonomousTurns = this.#pendingAutonomousTurns.filter(
+        ({ nativeTurn }) => !hydratedNativeTurns.has(`turn:${nativeTurn}`),
+      );
       const observedPermissionState = readDeepSeekPermissionModeState(
         history.projections,
         this.#permissionModes,
@@ -634,6 +727,7 @@ class DeepSeekHarnessSession implements HarnessSession, DeepSeekHostSubscriber {
       return { ok: false, error: normalized };
     } finally {
       this.#reading = false;
+      this.#activatePendingAutonomousTurn();
     }
   }
 
@@ -664,7 +758,14 @@ class DeepSeekHarnessSession implements HarnessSession, DeepSeekHostSubscriber {
     if (command.type === "model.select") return this.#selectModel(command);
     if (command.type === "thinking.select") return this.#selectThinking(command);
     if (command.type === "permissionMode.select") return this.#selectPermissionMode(command);
-    if (this.#active || this.#activeCommand || this.#configuring || this.#reading) {
+    if (
+      this.#active ||
+      this.#activeCommand ||
+      this.#commandAdmission ||
+      this.#pendingAutonomousTurns.length > 0 ||
+      this.#configuring ||
+      this.#reading
+    ) {
       return {
         ok: false,
         error: {
@@ -685,17 +786,7 @@ class DeepSeekHarnessSession implements HarnessSession, DeepSeekHostSubscriber {
         },
       };
     }
-    const active: ActiveTurn = {
-      command,
-      nativeTurn: null,
-      started: false,
-      cancellationRequested: false,
-      agentItem: null,
-      reasoningItem: null,
-      tools: new Map(),
-      interactions: new Map(),
-      snapshots: [],
-    };
+    const active = createActiveTurn(command);
     this.#active = active;
     try {
       unwrapRpc(
@@ -755,6 +846,12 @@ class DeepSeekHarnessSession implements HarnessSession, DeepSeekHostSubscriber {
         return;
       }
       try {
+        if (
+          !this.#active &&
+          this.#bufferAutonomousEvent(frame.event.type, frame.event.data, frame.event.seq)
+        ) {
+          return;
+        }
         this.#event(frame.event.type, frame.event.data, frame.event.seq);
       } catch (error) {
         this.#fault(normalizedError(error, "protocolError"));
@@ -783,6 +880,12 @@ class DeepSeekHarnessSession implements HarnessSession, DeepSeekHostSubscriber {
 
   async #performClose(): Promise<void> {
     if (this.#closed) return;
+    this.#pendingAutonomousTurns = [];
+    const admission = this.#commandAdmission;
+    if (admission) {
+      admission.cancellationRequested = true;
+      admission.abort.abort(new Error("codexhost Session closed"));
+    }
     const activeCommand = this.#activeCommand;
     if (activeCommand) {
       activeCommand.cancellationRequested = true;
@@ -814,7 +917,14 @@ class DeepSeekHarnessSession implements HarnessSession, DeepSeekHostSubscriber {
   }
 
   async #selectModel(command: ModelSelectCommand): Promise<HarnessResult<ModelSelectCompleted>> {
-    if (this.#active || this.#activeCommand || this.#configuring || this.#reading) {
+    if (
+      this.#active ||
+      this.#activeCommand ||
+      this.#commandAdmission ||
+      this.#pendingAutonomousTurns.length > 0 ||
+      this.#configuring ||
+      this.#reading
+    ) {
       return {
         ok: false,
         error: {
@@ -875,13 +985,21 @@ class DeepSeekHarnessSession implements HarnessSession, DeepSeekHostSubscriber {
       }
     } finally {
       this.#configuring = false;
+      this.#activatePendingAutonomousTurn();
     }
   }
 
   async #selectThinking(
     command: ThinkingSelectCommand,
   ): Promise<HarnessResult<ThinkingSelectCompleted>> {
-    if (this.#active || this.#configuring || this.#reading) {
+    if (
+      this.#active ||
+      this.#activeCommand ||
+      this.#commandAdmission ||
+      this.#pendingAutonomousTurns.length > 0 ||
+      this.#configuring ||
+      this.#reading
+    ) {
       return {
         ok: false,
         error: {
@@ -948,6 +1066,7 @@ class DeepSeekHarnessSession implements HarnessSession, DeepSeekHostSubscriber {
       }
     } finally {
       this.#configuring = false;
+      this.#activatePendingAutonomousTurn();
     }
   }
 
@@ -969,7 +1088,14 @@ class DeepSeekHarnessSession implements HarnessSession, DeepSeekHostSubscriber {
         },
       };
     }
-    if (this.#activeCommand || this.#configuring || this.#reading || this.#permissionRefresh) {
+    if (
+      this.#activeCommand ||
+      this.#commandAdmission ||
+      this.#pendingAutonomousTurns.length > 0 ||
+      this.#configuring ||
+      this.#reading ||
+      this.#permissionRefresh
+    ) {
       return {
         ok: false,
         error: {
@@ -1033,20 +1159,23 @@ class DeepSeekHarnessSession implements HarnessSession, DeepSeekHostSubscriber {
     } finally {
       this.#selectingPermission = false;
       this.#configuring = false;
+      this.#activatePendingAutonomousTurn();
     }
   }
 
-  async #listHarnessCommands(): Promise<HarnessResult<typeof deepSeekCommandCatalog>> {
+  async #listHarnessCommands(
+    signal?: AbortSignal,
+  ): Promise<HarnessResult<ReturnType<typeof deepSeekHarnessCommandCatalog>>> {
     if (this.#closed) {
       return { ok: false, error: invalidState("DeepSeek Harness Session is closed") };
     }
     try {
-      const result = await this.#commandClient.list(this.#nativeRef.nativeSessionId as SessionId);
+      const sessionId = this.#nativeRef.nativeSessionId as SessionId;
+      const result = await (signal
+        ? this.#commandClient.list(sessionId, signal)
+        : this.#commandClient.list(sessionId));
       if (!result.ok) return { ok: false, error: commandFailure("commands/list", result.error) };
-      const available = result.value.some(
-        (descriptor) => descriptor.name === "compact" && descriptor.input === undefined,
-      );
-      return { ok: true, value: available ? deepSeekCommandCatalog : emptyDeepSeekCommandCatalog };
+      return { ok: true, value: deepSeekHarnessCommandCatalog(result.value) };
     } catch (error) {
       return { ok: false, error: normalizedError(error, "unavailable") };
     }
@@ -1058,17 +1187,16 @@ class DeepSeekHarnessSession implements HarnessSession, DeepSeekHostSubscriber {
     if (this.#closed) {
       return { ok: false, error: invalidState("DeepSeek Harness Session is closed") };
     }
-    if (command.commandId !== "dsh.compact") {
-      return {
-        ok: false,
-        error: {
-          code: "unsupported",
-          message: `DeepSeek Harness does not expose command '${command.commandId}'`,
-          retryable: false,
-        },
-      };
-    }
-    if (this.#active || this.#activeCommand || this.#configuring || this.#reading) {
+    const parsed = parseDeepSeekHarnessCommand(command);
+    if (!parsed.ok) return parsed;
+    if (
+      this.#active ||
+      this.#activeCommand ||
+      this.#commandAdmission ||
+      this.#pendingAutonomousTurns.length > 0 ||
+      this.#configuring ||
+      this.#reading
+    ) {
       return {
         ok: false,
         error: {
@@ -1079,35 +1207,83 @@ class DeepSeekHarnessSession implements HarnessSession, DeepSeekHostSubscriber {
         },
       };
     }
-    if (command.arguments && Object.keys(command.arguments).length > 0) {
-      return {
-        ok: false,
-        error: {
-          code: "invalidRequest",
-          message: "DeepSeek Harness compact command does not accept arguments",
-          retryable: false,
-        },
-      };
-    }
 
-    const active: ActiveCommand = {
-      command,
+    const admission: CommandAdmission = {
+      turnId: command.turnId,
       abort: new AbortController(),
       cancellationRequested: false,
-      item: { type: "contextCompaction", itemId: this.#newItemId() },
     };
-    this.#activeCommand = active;
-    this.#emit({ type: "turn.started", turnId: command.turnId });
-    this.#emit({ type: "item.started", turnId: command.turnId, item: active.item });
-    void this.#runHarnessCommand(active);
-    return { ok: true, value: { turnId: command.turnId } };
+    this.#commandAdmission = admission;
+    try {
+      const catalog = await this.#listHarnessCommands(admission.abort.signal);
+      if (admission.cancellationRequested) {
+        return {
+          ok: false,
+          error: invalidState("DeepSeek Harness command admission was cancelled"),
+        };
+      }
+      if (this.#closed) {
+        return { ok: false, error: invalidState("DeepSeek Harness Session is closed") };
+      }
+      if (!catalog.ok) return catalog;
+      const descriptor = catalog.value.commands.find(({ id }) => id === parsed.value.commandId);
+      if (!descriptor) {
+        return {
+          ok: false,
+          error: unsupported(
+            `DeepSeek Harness does not currently expose command '${command.commandId}'`,
+          ),
+        };
+      }
+      if (
+        this.#active ||
+        this.#activeCommand ||
+        this.#pendingAutonomousTurns.length > 0 ||
+        this.#configuring ||
+        this.#reading
+      ) {
+        return {
+          ok: false,
+          error: {
+            code: "sessionBusy",
+            message:
+              "DeepSeek Harness Session cannot execute a command while another operation is active",
+            retryable: true,
+          },
+        };
+      }
+
+      const item: ActiveCommand["item"] =
+        parsed.value.commandId === "dsh.compact"
+          ? { type: "contextCompaction", itemId: this.#newItemId() }
+          : {
+              type: "commandExecution",
+              itemId: this.#newItemId(),
+              command: parsed.value.line,
+            };
+      const active: ActiveCommand = {
+        command,
+        line: parsed.value.line,
+        abort: new AbortController(),
+        cancellationRequested: false,
+        item,
+      };
+      this.#activeCommand = active;
+      this.#emit({ type: "turn.started", turnId: command.turnId });
+      this.#emit({ type: "item.started", turnId: command.turnId, item: active.item });
+      void this.#runHarnessCommand(active);
+      return { ok: true, value: { turnId: command.turnId } };
+    } finally {
+      if (this.#commandAdmission === admission) this.#commandAdmission = null;
+      this.#activatePendingAutonomousTurn();
+    }
   }
 
   async #runHarnessCommand(active: ActiveCommand): Promise<void> {
     try {
       const response = await this.#commandClient.execute(
         this.#nativeRef.nativeSessionId as SessionId,
-        "/compact",
+        active.line,
         active.abort.signal,
       );
       if (this.#activeCommand !== active) return;
@@ -1115,7 +1291,10 @@ class DeepSeekHarnessSession implements HarnessSession, DeepSeekHostSubscriber {
         if (active.cancellationRequested || response.error.code === "cancelled") {
           this.#finishCommand(active, {
             status: "cancelled",
-            reason: "DeepSeek Harness context compaction was cancelled",
+            reason:
+              active.command.commandId === "dsh.compact"
+                ? "DeepSeek Harness context compaction was cancelled"
+                : "DeepSeek Harness command was cancelled",
           });
         } else {
           this.#finishCommand(active, {
@@ -1131,35 +1310,54 @@ class DeepSeekHarnessSession implements HarnessSession, DeepSeekHostSubscriber {
           status: "failed",
           error: {
             code: "nativeFailure",
-            message: "DeepSeek Harness did not resolve the registered /compact command",
+            message: `DeepSeek Harness did not resolve registered command '${active.command.commandId}'`,
             retryable: false,
           },
         });
         return;
       }
       if (execution.result.kind === "success") {
-        this.#finishCommand(active, { status: "succeeded" });
-      } else if (active.cancellationRequested || execution.result.text === DSH_COMPACT_CANCELLED) {
-        this.#finishCommand(active, {
-          status: "cancelled",
-          reason: execution.result.text,
-        });
-      } else {
-        this.#finishCommand(active, {
-          status: "failed",
-          error: {
-            code: execution.result.text === DSH_COMPACT_BUSY ? "sessionBusy" : "nativeFailure",
-            message: execution.result.text,
-            retryable: true,
+        this.#finishCommand(active, { status: "succeeded" }, execution.result.text);
+      } else if (
+        active.cancellationRequested ||
+        (active.command.commandId === "dsh.compact" &&
+          execution.result.text === DSH_COMPACT_CANCELLED)
+      ) {
+        this.#finishCommand(
+          active,
+          {
+            status: "cancelled",
+            reason: execution.result.text,
           },
-        });
+          execution.result.text,
+        );
+      } else {
+        this.#finishCommand(
+          active,
+          {
+            status: "failed",
+            error: {
+              code:
+                active.command.commandId === "dsh.compact" &&
+                execution.result.text === DSH_COMPACT_BUSY
+                  ? "sessionBusy"
+                  : "nativeFailure",
+              message: execution.result.text,
+              retryable: true,
+            },
+          },
+          execution.result.text,
+        );
       }
     } catch (error) {
       if (this.#activeCommand !== active) return;
       if (active.cancellationRequested || active.abort.signal.aborted) {
         this.#finishCommand(active, {
           status: "cancelled",
-          reason: "DeepSeek Harness context compaction was cancelled",
+          reason:
+            active.command.commandId === "dsh.compact"
+              ? "DeepSeek Harness context compaction was cancelled"
+              : "DeepSeek Harness command was cancelled",
         });
       } else {
         this.#finishCommand(active, {
@@ -1170,18 +1368,31 @@ class DeepSeekHarnessSession implements HarnessSession, DeepSeekHostSubscriber {
     }
   }
 
-  #finishCommand(active: ActiveCommand, outcome: HostItemOutcome): void {
+  #finishCommand(active: ActiveCommand, outcome: HostItemOutcome, output?: string): void {
     if (this.#activeCommand !== active) return;
     this.#activeCommand = null;
+    const item =
+      active.item.type === "commandExecution" && output !== undefined
+        ? { ...active.item, output }
+        : active.item;
     this.#emit({
       type: "item.completed",
       turnId: active.command.turnId,
-      snapshot: { item: active.item, outcome },
+      snapshot: { item, outcome },
     });
     this.#emit({ type: "turn.completed", turnId: active.command.turnId, outcome });
+    this.#activatePendingAutonomousTurn();
   }
 
   async #cancel(command: TurnCancelCommand): Promise<HarnessResult<TurnCancelAccepted>> {
+    const admission = this.#commandAdmission;
+    if (admission?.turnId === command.turnId) {
+      if (!admission.cancellationRequested) {
+        admission.cancellationRequested = true;
+        admission.abort.abort(new Error("DeepSeek Harness command cancelled by user"));
+      }
+      return { ok: true, value: { cancellationRequested: true } };
+    }
     const activeCommand = this.#activeCommand;
     if (activeCommand?.command.turnId === command.turnId) {
       if (!activeCommand.cancellationRequested) {
@@ -1281,6 +1492,68 @@ class DeepSeekHarnessSession implements HarnessSession, DeepSeekHostSubscriber {
       return { ok: true, value: { accepted: true } };
     } catch (error) {
       return { ok: false, error: normalizedError(error, "nativeFailure") };
+    }
+  }
+
+  #bufferAutonomousEvent(type: string, data: Record<string, unknown>, seq: number): boolean {
+    if (type === "turn/start") {
+      if (!Number.isSafeInteger(data.turn)) {
+        throw new Error("DeepSeek Harness autonomous turn/start is invalid");
+      }
+      const previous = this.#pendingAutonomousTurns.at(-1);
+      if (previous && !previous.ended) {
+        throw new Error("DeepSeek Harness started overlapping autonomous Turns");
+      }
+      this.#pendingAutonomousTurns.push({
+        nativeTurn: data.turn as number,
+        events: [{ type, data, seq }],
+        input: [],
+        ready: false,
+        ended: false,
+      });
+      return true;
+    }
+
+    const pending = this.#pendingAutonomousTurns.at(-1);
+    if (!pending || pending.ended) return false;
+    pending.events.push({ type, data, seq });
+    if (type === "user/message" && isRecord(data.source) && data.source.kind === "user") {
+      const text = contentText(data);
+      if (text) pending.input.push({ type: "text", text });
+    }
+    if (AUTONOMOUS_TURN_READY_EVENTS.has(type)) pending.ready = true;
+    if (type === "turn/end") {
+      if (data.turn !== pending.nativeTurn) {
+        throw new Error("DeepSeek Harness autonomous turn/end does not match turn/start");
+      }
+      pending.ended = true;
+    }
+    this.#activatePendingAutonomousTurn();
+    return true;
+  }
+
+  #activatePendingAutonomousTurn(): void {
+    if (
+      this.#closed ||
+      this.#active ||
+      this.#activeCommand ||
+      this.#commandAdmission ||
+      this.#configuring ||
+      this.#reading
+    ) {
+      return;
+    }
+    const pending = this.#pendingAutonomousTurns[0];
+    if (!pending?.ready) return;
+    this.#pendingAutonomousTurns.shift();
+    const turnId = hostTurnIdSchema.parse(randomUUID());
+    const input = [...pending.input];
+    this.#active = createActiveTurn({ type: "turn.start", turnId, input });
+    this.#emit({ type: "turn.autonomous.started", turnId, input });
+    try {
+      for (const event of pending.events) this.#event(event.type, event.data, event.seq);
+    } catch (error) {
+      this.#fault(normalizedError(error, "protocolError"));
     }
   }
 
@@ -1638,7 +1911,10 @@ class DeepSeekHarnessSession implements HarnessSession, DeepSeekHostSubscriber {
       nativeTurnRef,
       outcome: { ...terminal.outcome, checkpoint },
     });
-    if (this.#active === active) this.#active = null;
+    if (this.#active === active) {
+      this.#active = null;
+      this.#activatePendingAutonomousTurn();
+    }
   }
 
   #completeItem(active: ActiveTurn, item: HostItem, outcome: HostItemOutcome): void {
@@ -1692,6 +1968,12 @@ class DeepSeekHarnessSession implements HarnessSession, DeepSeekHostSubscriber {
 
   #fault(error: HarnessError): void {
     if (this.#closed) return;
+    this.#pendingAutonomousTurns = [];
+    const admission = this.#commandAdmission;
+    if (admission) {
+      admission.cancellationRequested = true;
+      admission.abort.abort(new Error(error.message));
+    }
     const activeCommand = this.#activeCommand;
     if (activeCommand) {
       activeCommand.abort.abort(new Error(error.message));
@@ -2112,6 +2394,7 @@ export class DeepSeekHarnessAdapter implements HarnessAdapter {
             ? { contextWindowTokens: projection.contextWindowTokens }
             : {}),
           initialUsage: projection.usage,
+          pendingAutonomousEvents: incompleteTurnEvents(history.entries),
           snapshot: projection.snapshot,
           toolOutputLimit: this.#toolOutputLimit,
           unsubscribe,

--- a/packages/adapters/deepseek-harness/src/harness-commands.ts
+++ b/packages/adapters/deepseek-harness/src/harness-commands.ts
@@ -1,0 +1,162 @@
+import { type HarnessCommandInvocation, type HarnessResult } from "@codexhost/harness-adapter";
+import {
+  harnessCommandCatalogSchema,
+  harnessCommandDescriptorSchema,
+  type HarnessCommandCatalog,
+} from "@codexhost/shared-contracts";
+
+import type { DeepSeekCommandDescriptor } from "./host-client.js";
+
+const commandDefinitions = [
+  {
+    id: "dsh.compact",
+    nativeName: "compact",
+    invocation: "/compact",
+    label: "Compact context",
+    argumentMode: "none",
+  },
+  {
+    id: "dsh.goal",
+    nativeName: "goal",
+    invocation: "/dsh-goal",
+    label: "Goal",
+    argumentMode: "text",
+  },
+  {
+    id: "dsh.plan",
+    nativeName: "plan",
+    invocation: "/plan",
+    label: "Plan mode",
+    argumentMode: "text",
+  },
+] as const;
+
+interface CommandLineDescriptor {
+  readonly id: string;
+  readonly invocation: string;
+  readonly argumentMode: "none" | "text";
+}
+
+export interface ParsedDeepSeekHarnessCommand {
+  readonly commandId: string;
+  readonly line: string;
+}
+
+function invalidArguments(message: string): HarnessResult<never> {
+  return {
+    ok: false,
+    error: { code: "invalidRequest", message, retryable: false },
+  };
+}
+
+export function buildDeepSeekHarnessCommandLine(
+  command: HarnessCommandInvocation,
+  descriptor: CommandLineDescriptor,
+): HarnessResult<string> {
+  if (command.commandId !== descriptor.id) {
+    return {
+      ok: false,
+      error: {
+        code: "unsupported",
+        message: `DeepSeek Harness does not expose command '${command.commandId}'`,
+        retryable: false,
+      },
+    };
+  }
+
+  const arguments_ = command.arguments;
+  if (descriptor.argumentMode === "none") {
+    return arguments_ && Object.keys(arguments_).length > 0
+      ? invalidArguments(
+          `DeepSeek Harness ${descriptor.invocation} command does not accept arguments`,
+        )
+      : { ok: true, value: descriptor.invocation };
+  }
+
+  const text = arguments_?.text;
+  if (text !== undefined && typeof text !== "string") {
+    return invalidArguments(
+      `DeepSeek Harness ${descriptor.invocation} command argument 'text' must be a string`,
+    );
+  }
+  if (arguments_ && Object.keys(arguments_).some((key) => key !== "text")) {
+    return invalidArguments(
+      `DeepSeek Harness ${descriptor.invocation} command has an unknown argument`,
+    );
+  }
+  return { ok: true, value: text ? `${descriptor.invocation} ${text}` : descriptor.invocation };
+}
+
+export function deepSeekHarnessCommandCatalog(
+  nativeDescriptors: readonly DeepSeekCommandDescriptor[],
+): HarnessCommandCatalog {
+  const commands = nativeDescriptors.flatMap((native) => {
+    const definition = commandDefinitions.find(({ nativeName }) => nativeName === native.name);
+    if (
+      !definition ||
+      (definition.argumentMode === "none"
+        ? native.input !== undefined
+        : native.input === undefined || native.input.hint.trim().length === 0)
+    ) {
+      return [];
+    }
+    const parsed = harnessCommandDescriptorSchema.safeParse({
+      id: definition.id,
+      invocation: definition.invocation,
+      label: definition.label,
+      description: native.description,
+      argumentMode: definition.argumentMode,
+    });
+    return parsed.success ? [parsed.data] : [];
+  });
+  return harnessCommandCatalogSchema.parse({ commands });
+}
+
+export function parseDeepSeekHarnessCommand(
+  command: HarnessCommandInvocation,
+): HarnessResult<ParsedDeepSeekHarnessCommand> {
+  const definition = commandDefinitions.find(({ id }) => id === command.commandId);
+  if (!definition) {
+    return {
+      ok: false,
+      error: {
+        code: "unsupported",
+        message: `DeepSeek Harness does not expose command '${command.commandId}'`,
+        retryable: false,
+      },
+    };
+  }
+  const nativeInvocation = definition.id === "dsh.goal" ? "/goal" : definition.invocation;
+  const line = buildDeepSeekHarnessCommandLine(command, {
+    ...definition,
+    invocation: nativeInvocation,
+  });
+  if (!line.ok) return line;
+  if (definition.id === "dsh.goal") {
+    const text = (command.arguments?.text as string | undefined)?.trim() ?? "";
+    const control = text.toLowerCase();
+    if (control === "edit") {
+      return invalidArguments(
+        "DeepSeek Harness /goal edit command requires a replacement objective",
+      );
+    }
+    return {
+      ok: true,
+      value: {
+        commandId: definition.id,
+        line: text.length > 0 ? `${nativeInvocation} ${text}` : nativeInvocation,
+      },
+    };
+  }
+  if (definition.id === "dsh.plan") {
+    const text = (command.arguments?.text as string | undefined)?.trim() ?? "";
+    return {
+      ok: true,
+      value: {
+        commandId: definition.id,
+        line: text.length > 0 ? `${nativeInvocation} ${text}` : nativeInvocation,
+      },
+    };
+  }
+  return { ok: true, value: { commandId: definition.id, line: line.value } };
+}

--- a/packages/adapters/deepseek-harness/src/host-client.ts
+++ b/packages/adapters/deepseek-harness/src/host-client.ts
@@ -64,6 +64,7 @@ type StreamItem<F> = { type: "frame"; envelope: RpcRequest<F> } | { type: "end" 
 type FrameSchema<F> = { parse(value: unknown): F };
 const MISSING_COMMAND_IMAGES =
   'typert gateway: commands/execute: args fields do not match the descriptor: missing "images"';
+const COMMAND_NAME = /^[a-z][a-z0-9_-]*$/u;
 
 function commandProtocolError(method: string, detail: string): DeepSeekHarnessTransportError {
   return new DeepSeekHarnessTransportError(
@@ -79,25 +80,34 @@ function record(value: unknown): Record<string, unknown> | null {
 }
 
 function parseCommandDescriptors(value: unknown): DeepSeekCommandDescriptor[] {
-  const valid =
-    Array.isArray(value) &&
-    value.every((entry) => {
-      const descriptor = record(entry);
-      if (
-        !descriptor ||
-        typeof descriptor.name !== "string" ||
-        typeof descriptor.description !== "string"
-      ) {
-        return false;
-      }
-      if (descriptor.input === undefined) return true;
-      const input = record(descriptor.input);
-      return (
-        !!input &&
-        typeof input.hint === "string" &&
-        (input.images === undefined || typeof input.images === "boolean")
-      );
-    });
+  if (!Array.isArray(value)) throw new TypeError("an invalid command catalog");
+  const names = new Set<string>();
+  const valid = value.every((entry) => {
+    const descriptor = record(entry);
+    if (
+      !descriptor ||
+      Object.keys(descriptor).some((key) => !["name", "description", "input"].includes(key)) ||
+      typeof descriptor.name !== "string" ||
+      !COMMAND_NAME.test(descriptor.name) ||
+      names.has(descriptor.name) ||
+      typeof descriptor.description !== "string" ||
+      descriptor.description.trim().length === 0 ||
+      descriptor.description.length > 512
+    ) {
+      return false;
+    }
+    names.add(descriptor.name);
+    if (descriptor.input === undefined) return true;
+    const input = record(descriptor.input);
+    return (
+      !!input &&
+      Object.keys(input).every((key) => key === "hint" || key === "images") &&
+      typeof input.hint === "string" &&
+      input.hint.trim().length > 0 &&
+      input.hint.length <= 512 &&
+      (input.images === undefined || typeof input.images === "boolean")
+    );
+  });
   if (!valid) throw new TypeError("an invalid command catalog");
   return value as DeepSeekCommandDescriptor[];
 }
@@ -264,7 +274,7 @@ export class NodeDeepSeekCommandClient implements DeepSeekCommandClient {
       result.error.code === "internal" &&
       result.error.message === MISSING_COMMAND_IMAGES
     ) {
-      // rc.6 has no images parameter; newer DSH requires an explicit empty batch.
+      // Keep the older wire first; newer DSH requires an explicit empty batch.
       return this.#call(
         "commands/execute",
         { agentId: sessionId, line, images: [] },

--- a/packages/adapters/deepseek-harness/test/deepseek-harness-adapter.test.ts
+++ b/packages/adapters/deepseek-harness/test/deepseek-harness-adapter.test.ts
@@ -26,11 +26,12 @@ import {
   type DeepSeekHarnessAdapterDependencies,
   type DeepSeekHostConnectionLike,
 } from "../src/deepseek-harness-adapter.js";
-import type {
-  DeepSeekCommandExecution,
-  DeepSeekHostClient,
-  DeepSeekHostSubscriber,
-  DeepSeekMuxEnvelope,
+import {
+  type DeepSeekCommandDescriptor,
+  type DeepSeekCommandExecution,
+  type DeepSeekHostClient,
+  type DeepSeekHostSubscriber,
+  type DeepSeekMuxEnvelope,
 } from "../src/host-client.js";
 import { encodeDeepSeekHarnessModelRef } from "../src/model-catalog.js";
 import { projectToolResult } from "../src/projection.js";
@@ -1770,12 +1771,12 @@ describe("DeepSeekHarnessAdapter local Host", () => {
     );
     const iterator = session.outputs[Symbol.asyncIterator]();
     const turnId = hostTurnIdSchema.parse("manual-compact");
-    await expect(
-      commands.execute({
-        turnId,
-        commandId: "dsh.compact",
-      }),
-    ).resolves.toEqual({ ok: true, value: { turnId } });
+    const accepted = await commands.execute({
+      turnId,
+      commandId: "dsh.compact",
+    });
+    expect(accepted).toMatchObject({ ok: true, value: { turnId } });
+    if (!accepted.ok) throw new Error(accepted.error.message);
     expect(await nextEvent(iterator)).toEqual({ type: "turn.started", turnId });
     const started = await nextEvent(iterator);
     if (started.type !== "item.started") throw new Error("Expected compaction Item start");
@@ -1788,6 +1789,12 @@ describe("DeepSeekHarnessAdapter local Host", () => {
       ok: false,
       error: { code: "sessionBusy" },
     });
+    await expect(
+      session.execute({
+        type: "thinking.select",
+        thinkingOptionId: harnessThinkingOptionIdSchema.parse("high"),
+      }),
+    ).resolves.toMatchObject({ ok: false, error: { code: "sessionBusy" } });
 
     resolveExecution?.(
       commandSuccess({
@@ -1818,6 +1825,77 @@ describe("DeepSeekHarnessAdapter local Host", () => {
     await adapter.close();
   });
 
+  it.each([
+    {
+      commandId: "dsh.goal",
+      invocation: "/dsh-goal",
+      nativeDescriptor: {
+        name: "goal",
+        description: "set or view the goal for a long-running task",
+        input: { hint: "[<objective>|clear|edit <objective>|pause|resume]", images: true },
+      },
+      arguments: { text: "  ship the release  " },
+      nativeLine: "/goal ship the release",
+    },
+    {
+      commandId: "dsh.plan",
+      invocation: "/plan",
+      nativeDescriptor: {
+        name: "plan",
+        description: "Enter or leave plan mode",
+        input: { hint: "[off|message]", images: true },
+      },
+      arguments: { text: "  inspect the change  " },
+      nativeLine: "/plan inspect the change",
+    },
+  ])("executes $commandId as a text-only native command", async (scenario) => {
+    const { adapter, connection } = fixture();
+    connection.calls.commandList.mockResolvedValue(commandSuccess([scenario.nativeDescriptor]));
+    connection.calls.commandExecute.mockResolvedValueOnce(
+      commandSuccess({
+        commandId: `native-${scenario.commandId}`,
+        result: { kind: "success", text: "accepted" },
+      }),
+    );
+    const session = await openCreated(adapter);
+    const commands = session.commands;
+    if (!commands) throw new Error("DeepSeek Harness Session did not expose commands");
+    await expect(commands.list()).resolves.toMatchObject({
+      ok: true,
+      value: { commands: [{ id: scenario.commandId, invocation: scenario.invocation }] },
+    });
+    const iterator = session.outputs[Symbol.asyncIterator]();
+    const turnId = hostTurnIdSchema.parse(`${scenario.commandId}-text`);
+
+    await expect(
+      commands.execute({
+        turnId,
+        commandId: scenario.commandId,
+        arguments: scenario.arguments,
+      }),
+    ).resolves.toEqual({ ok: true, value: { turnId } });
+    await expect(nextEvent(iterator)).resolves.toEqual({ type: "turn.started", turnId });
+    await expect(nextEvent(iterator)).resolves.toMatchObject({
+      type: "item.started",
+      item: { type: "commandExecution", command: scenario.nativeLine },
+    });
+    await expect(nextEvent(iterator)).resolves.toMatchObject({
+      type: "item.completed",
+      snapshot: { outcome: { status: "succeeded" } },
+    });
+    await expect(nextEvent(iterator)).resolves.toMatchObject({
+      type: "turn.completed",
+      outcome: { status: "succeeded" },
+    });
+    expect(connection.calls.commandExecute).toHaveBeenCalledWith(
+      SESSION_ID,
+      scenario.nativeLine,
+      expect.any(AbortSignal),
+    );
+    expect(connection.calls.prompt).not.toHaveBeenCalled();
+    await adapter.close();
+  });
+
   it("hides dsh.compact when the native deployment does not advertise the argument-free command", async () => {
     const { adapter, connection } = fixture();
     connection.calls.commandList.mockResolvedValueOnce(
@@ -1837,6 +1915,90 @@ describe("DeepSeekHarnessAdapter local Host", () => {
       ok: true,
       value: { commands: [] },
     });
+    await adapter.close();
+  });
+
+  it("rechecks the current native catalog before command execution", async () => {
+    const { adapter, connection } = fixture();
+    const session = await openCreated(adapter);
+    const commands = session.commands;
+    if (!commands) throw new Error("DeepSeek Harness Session did not expose commands");
+    connection.calls.commandList.mockResolvedValueOnce(commandSuccess([]));
+
+    await expect(
+      commands.execute({
+        turnId: hostTurnIdSchema.parse("missing-native-compact"),
+        commandId: "dsh.compact",
+      }),
+    ).resolves.toMatchObject({ ok: false, error: { code: "unsupported" } });
+    expect(connection.calls.commandExecute).not.toHaveBeenCalled();
+    await adapter.close();
+  });
+
+  it("serializes command admission while the native catalog is pending", async () => {
+    const { adapter, connection } = fixture();
+    const session = await openCreated(adapter);
+    const commands = session.commands;
+    if (!commands) throw new Error("DeepSeek Harness Session did not expose commands");
+    let resolveCatalog:
+      ((value: ReturnType<typeof commandSuccess<DeepSeekCommandDescriptor[]>>) => void) | undefined;
+    connection.calls.commandList.mockImplementationOnce(
+      () =>
+        new Promise<ReturnType<typeof commandSuccess<DeepSeekCommandDescriptor[]>>>((resolve) => {
+          resolveCatalog = resolve;
+        }),
+    );
+    connection.calls.commandExecute.mockResolvedValueOnce(
+      commandSuccess({
+        commandId: "native-command-1",
+        result: { kind: "success", text: "compacted" },
+      }),
+    );
+    const firstTurnId = hostTurnIdSchema.parse("admitting-command");
+    const first = commands.execute({ turnId: firstTurnId, commandId: "dsh.compact" });
+    await vi.waitFor(() => expect(connection.calls.commandList).toHaveBeenCalledOnce());
+
+    await expect(
+      commands.execute({
+        turnId: hostTurnIdSchema.parse("concurrent-command"),
+        commandId: "dsh.compact",
+      }),
+    ).resolves.toMatchObject({ ok: false, error: { code: "sessionBusy" } });
+    resolveCatalog?.(
+      commandSuccess([{ name: "compact", description: "Compact older conversation history" }]),
+    );
+    await expect(first).resolves.toMatchObject({ ok: true, value: { turnId: firstTurnId } });
+    await vi.waitFor(() => expect(connection.calls.commandExecute).toHaveBeenCalledOnce());
+    await adapter.close();
+  });
+
+  it("cancels command admission before native execution starts", async () => {
+    const { adapter, connection } = fixture();
+    const session = await openCreated(adapter);
+    const commands = session.commands;
+    if (!commands) throw new Error("DeepSeek Harness Session did not expose commands");
+    let admissionSignal: AbortSignal | undefined;
+    connection.calls.commandList.mockImplementationOnce(
+      (_sessionId: SessionId, signal: AbortSignal) =>
+        new Promise((_resolve, reject) => {
+          admissionSignal = signal;
+          signal.addEventListener("abort", () => reject(signal.reason), { once: true });
+        }),
+    );
+    const turnId = hostTurnIdSchema.parse("cancel-command-admission");
+    const execution = commands.execute({ turnId, commandId: "dsh.compact" });
+    await vi.waitFor(() => expect(admissionSignal).toBeDefined());
+
+    await expect(session.execute({ type: "turn.cancel", turnId })).resolves.toEqual({
+      ok: true,
+      value: { cancellationRequested: true },
+    });
+    expect(admissionSignal?.aborted).toBe(true);
+    await expect(execution).resolves.toMatchObject({
+      ok: false,
+      error: { code: "invalidState", message: expect.stringContaining("cancelled") },
+    });
+    expect(connection.calls.commandExecute).not.toHaveBeenCalled();
     await adapter.close();
   });
 
@@ -1872,10 +2034,9 @@ describe("DeepSeekHarnessAdapter local Host", () => {
     const iterator = session.outputs[Symbol.asyncIterator]();
     const turnId = hostTurnIdSchema.parse("missing-compact");
 
-    await expect(commands.execute({ turnId, commandId: "dsh.compact" })).resolves.toEqual({
-      ok: true,
-      value: { turnId },
-    });
+    const accepted = await commands.execute({ turnId, commandId: "dsh.compact" });
+    expect(accepted).toMatchObject({ ok: true, value: { turnId } });
+    if (!accepted.ok) throw new Error(accepted.error.message);
     expect((await nextEvent(iterator)).type).toBe("turn.started");
     const started = await nextEvent(iterator);
     expect(started.type).toBe("item.started");
@@ -1958,6 +2119,381 @@ describe("DeepSeekHarnessAdapter local Host", () => {
       type: "turn.completed",
       outcome: { status: "cancelled" },
     });
+    await adapter.close();
+  });
+
+  it("buffers native Turns until the command response and projects later autonomous Turns", async () => {
+    const { adapter, connection } = fixture();
+    const session = await openCreated(adapter);
+    const commands = session.commands;
+    if (!commands) throw new Error("DeepSeek Harness Session did not expose commands");
+    let resolveExecution:
+      ((value: { ok: true; value: DeepSeekCommandExecution }) => void) | undefined;
+    connection.calls.commandExecute.mockImplementationOnce(
+      () =>
+        new Promise<{ ok: true; value: DeepSeekCommandExecution }>((resolve) => {
+          resolveExecution = resolve;
+        }),
+    );
+    const iterator = session.outputs[Symbol.asyncIterator]();
+    const commandTurnId = hostTurnIdSchema.parse("command-before-autonomous");
+
+    await commands.execute({ turnId: commandTurnId, commandId: "dsh.compact" });
+    await nextEvent(iterator);
+    await nextEvent(iterator);
+    await expect(
+      session.execute({
+        type: "thinking.select",
+        thinkingOptionId: harnessThinkingOptionIdSchema.parse("high"),
+      }),
+    ).resolves.toMatchObject({ ok: false, error: { code: "sessionBusy" } });
+    connection.sessionEvent(SESSION_ID, 1, "turn/start", { turn: 1 });
+    connection.sessionEvent(SESSION_ID, 2, "step/start", { turn: 1, step: 1 });
+    connection.sessionEvent(SESSION_ID, 3, "user/message", {
+      source: { kind: "user" },
+      content: [{ type: "text", text: "first autonomous input" }],
+    });
+    connection.sessionEvent(SESSION_ID, 4, "user/message", {
+      source: { kind: "plugin", plugin: "goal" },
+      content: [{ type: "text", text: "injected context" }],
+    });
+    connection.sessionEvent(SESSION_ID, 5, "user/message", {
+      source: { kind: "user" },
+      content: [{ type: "text", text: "second autonomous input" }],
+    });
+    connection.sessionEvent(SESSION_ID, 6, "request/header", {
+      header: { config: CURRENT_MODEL },
+    });
+    connection.sessionEvent(SESSION_ID, 7, "assistant/message", {
+      turn: 1,
+      step: 1,
+      message: { content: [{ type: "text", text: "autonomous answer" }] },
+    });
+    connection.sessionEvent(SESSION_ID, 8, "turn/end", {
+      turn: 1,
+      reason: { kind: "completed" },
+    });
+    resolveExecution?.(
+      commandSuccess({
+        commandId: "native-command-1",
+        result: { kind: "success", text: "compacted" },
+      }),
+    );
+    await expect(nextEvent(iterator)).resolves.toMatchObject({
+      type: "item.completed",
+      turnId: commandTurnId,
+    });
+    await expect(nextEvent(iterator)).resolves.toEqual({
+      type: "turn.completed",
+      turnId: commandTurnId,
+      outcome: { status: "succeeded" },
+    });
+    const autonomous = await nextEvent(iterator);
+    expect(autonomous).toMatchObject({
+      type: "turn.autonomous.started",
+      input: [
+        { type: "text", text: "first autonomous input" },
+        { type: "text", text: "second autonomous input" },
+      ],
+    });
+    if (autonomous.type !== "turn.autonomous.started") {
+      throw new Error("Expected autonomous Turn start");
+    }
+    expect(autonomous.turnId).not.toBe(commandTurnId);
+    await expect(nextEvent(iterator)).resolves.toEqual({
+      type: "turn.started",
+      turnId: autonomous.turnId,
+    });
+    await expect(nextEvent(iterator)).resolves.toMatchObject({
+      type: "item.started",
+      turnId: autonomous.turnId,
+      item: { type: "agentMessage", text: "" },
+    });
+    await expect(nextEvent(iterator)).resolves.toMatchObject({
+      type: "item.updated",
+      turnId: autonomous.turnId,
+      update: { type: "text.append", text: "autonomous answer" },
+    });
+    await expect(nextEvent(iterator)).resolves.toMatchObject({
+      type: "item.completed",
+      turnId: autonomous.turnId,
+      snapshot: { outcome: { status: "succeeded" } },
+    });
+    await expect(nextEvent(iterator)).resolves.toMatchObject({
+      type: "turn.completed",
+      turnId: autonomous.turnId,
+      nativeTurnRef: { nativeTurnKey: "turn:1" },
+      outcome: { status: "succeeded" },
+    });
+
+    connection.sessionEvent(SESSION_ID, 9, "turn/start", { turn: 2 });
+    connection.sessionEvent(SESSION_ID, 10, "user/message", {
+      source: { kind: "user" },
+      content: [{ type: "text", text: "follow-up autonomous input" }],
+    });
+    connection.sessionEvent(SESSION_ID, 11, "request/context", { contextWindow: 128_000 });
+    connection.sessionEvent(SESSION_ID, 12, "assistant/message", {
+      turn: 2,
+      step: 1,
+      message: { content: [{ type: "text", text: "follow-up answer" }] },
+    });
+    connection.sessionEvent(SESSION_ID, 13, "turn/end", {
+      turn: 2,
+      reason: { kind: "completed" },
+    });
+    const followUp = await nextEvent(iterator);
+    expect(followUp).toMatchObject({
+      type: "turn.autonomous.started",
+      input: [{ type: "text", text: "follow-up autonomous input" }],
+    });
+    if (followUp.type !== "turn.autonomous.started") {
+      throw new Error("Expected follow-up autonomous Turn start");
+    }
+    expect(followUp.turnId).not.toBe(autonomous.turnId);
+    const followUpOutputs = await collectUntilTurnFrom(iterator);
+    expect(followUpOutputs).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          kind: "event",
+          event: expect.objectContaining({
+            type: "turn.completed",
+            turnId: followUp.turnId,
+            nativeTurnRef: expect.objectContaining({ nativeTurnKey: "turn:2" }),
+          }),
+        }),
+      ]),
+    );
+    await adapter.close();
+  });
+
+  it("keeps an unmaterialized autonomous Turn busy and drops it on close", async () => {
+    const { adapter, connection } = fixture();
+    const session = await openCreated(adapter);
+    const commands = session.commands;
+    if (!commands) throw new Error("DeepSeek Harness Session did not expose commands");
+    const iterator = session.outputs[Symbol.asyncIterator]();
+    connection.sessionEvent(SESSION_ID, 0, "turn/start", { turn: 1 });
+    connection.sessionEvent(SESSION_ID, 1, "user/message", {
+      source: { kind: "user" },
+      content: [{ type: "text", text: "pending input" }],
+    });
+
+    await expect(session.readSnapshot()).resolves.toMatchObject({
+      ok: false,
+      error: { code: "sessionBusy" },
+    });
+    await expect(
+      session.execute({
+        type: "turn.start",
+        turnId: hostTurnIdSchema.parse("blocked-turn"),
+        input: [{ type: "text", text: "blocked" }],
+      }),
+    ).resolves.toMatchObject({ ok: false, error: { code: "sessionBusy" } });
+    await expect(
+      session.execute({
+        type: "model.select",
+        model: encodeDeepSeekHarnessModelRef({
+          provider: "deepseek-official",
+          model: "deepseek-v4-pro",
+        }),
+      }),
+    ).resolves.toMatchObject({ ok: false, error: { code: "sessionBusy" } });
+    await expect(
+      session.execute({
+        type: "thinking.select",
+        thinkingOptionId: harnessThinkingOptionIdSchema.parse("high"),
+      }),
+    ).resolves.toMatchObject({ ok: false, error: { code: "sessionBusy" } });
+    await expect(
+      commands.execute({
+        turnId: hostTurnIdSchema.parse("blocked-command"),
+        commandId: "dsh.compact",
+      }),
+    ).resolves.toMatchObject({ ok: false, error: { code: "sessionBusy" } });
+
+    await session.close();
+    await expect(iterator.next()).resolves.toEqual({ done: true, value: undefined });
+    await adapter.close();
+  });
+
+  it("cancels an autonomous Turn through the existing native cancellation path", async () => {
+    const { adapter, connection } = fixture();
+    const session = await openCreated(adapter);
+    const iterator = session.outputs[Symbol.asyncIterator]();
+    connection.sessionEvent(SESSION_ID, 1, "turn/start", { turn: 1 });
+    connection.sessionEvent(SESSION_ID, 2, "user/message", {
+      source: { kind: "user" },
+      content: [{ type: "text", text: "cancel this" }],
+    });
+    connection.sessionEvent(SESSION_ID, 3, "request/header", {
+      header: { config: CURRENT_MODEL },
+    });
+    const autonomous = await nextEvent(iterator);
+    if (autonomous.type !== "turn.autonomous.started") {
+      throw new Error("Expected autonomous Turn start");
+    }
+    await nextEvent(iterator);
+
+    await expect(
+      session.execute({ type: "turn.cancel", turnId: autonomous.turnId }),
+    ).resolves.toEqual({ ok: true, value: { cancellationRequested: true } });
+    expect(connection.calls.cancel).toHaveBeenCalledWith({ sessionId: SESSION_ID });
+    connection.sessionEvent(SESSION_ID, 4, "turn/end", {
+      turn: 1,
+      reason: { kind: "aborted", reason: { kind: "user" } },
+    });
+    await expect(nextEvent(iterator)).resolves.toMatchObject({
+      type: "turn.completed",
+      turnId: autonomous.turnId,
+      outcome: { status: "cancelled" },
+    });
+    await adapter.close();
+  });
+
+  it("reconciles a buffered Turn already hydrated by a concurrent snapshot read", async () => {
+    const { adapter, connection } = fixture();
+    const session = await openCreated(adapter);
+    const historyGate = Promise.withResolvers<undefined>();
+    connection.calls.history.mockImplementationOnce(
+      async ({ sessionId }: { sessionId: SessionId }) => {
+        await historyGate.promise;
+        return success({ events: connection.history.get(sessionId) ?? [], hasMore: false });
+      },
+    );
+    const reading = session.readSnapshot();
+    connection.sessionEvent(SESSION_ID, 0, "turn/start", { turn: 1 });
+    connection.sessionEvent(SESSION_ID, 1, "user/message", {
+      source: { kind: "user" },
+      content: [{ type: "text", text: "hydrated input" }],
+    });
+    connection.history.set(SESSION_ID, [
+      event(0, "turn/start", { turn: 1 }),
+      event(1, "user/message", {
+        source: { kind: "user" },
+        content: [{ type: "text", text: "hydrated input" }],
+      }),
+      event(2, "request/header", { header: { config: CURRENT_MODEL } }),
+      event(3, "turn/end", { turn: 1, reason: { kind: "completed" } }),
+    ]);
+    historyGate.resolve(undefined);
+
+    await expect(reading).resolves.toMatchObject({
+      ok: true,
+      value: {
+        turns: [
+          {
+            nativeTurnRef: { nativeTurnKey: "turn:1" },
+            input: [{ type: "text", text: "hydrated input" }],
+          },
+        ],
+      },
+    });
+    connection.sessionEvent(SESSION_ID, 2, "request/header", {
+      header: { config: CURRENT_MODEL },
+    });
+    connection.sessionEvent(SESSION_ID, 3, "turn/end", {
+      turn: 1,
+      reason: { kind: "completed" },
+    });
+    const iterator = session.outputs[Symbol.asyncIterator]();
+    const turnId = hostTurnIdSchema.parse("turn-after-snapshot");
+    await expect(
+      session.execute({
+        type: "turn.start",
+        turnId,
+        input: [{ type: "text", text: "next" }],
+      }),
+    ).resolves.toEqual({ ok: true, value: { turnId } });
+    connection.sessionEvent(SESSION_ID, 4, "turn/start", { turn: 2 });
+    connection.sessionEvent(SESSION_ID, 5, "turn/end", {
+      turn: 2,
+      reason: { kind: "completed" },
+    });
+    await expect(nextEvent(iterator)).resolves.toEqual({ type: "turn.started", turnId });
+    await expect(nextEvent(iterator)).resolves.toMatchObject({
+      type: "turn.completed",
+      turnId,
+      nativeTurnRef: { nativeTurnKey: "turn:2" },
+    });
+    await adapter.close();
+  });
+
+  it("resumes an unfinished native Turn as an autonomous Host Turn", async () => {
+    const { adapter, connection } = fixture();
+    connection.history.set(SESSION_ID, [
+      event(0, "turn/start", { turn: 1 }),
+      event(1, "user/message", {
+        source: { kind: "user" },
+        content: [{ type: "text", text: "resumed autonomous input" }],
+      }),
+      event(2, "user/message", {
+        source: { kind: "plugin", plugin: "goal" },
+        content: [{ type: "text", text: "injected resume context" }],
+      }),
+    ]);
+    const opened = await adapter.open({
+      kind: "resume",
+      cwd: "/workspace",
+      nativeRef: {
+        harnessId: adapter.harnessId,
+        nativeSessionId: SESSION_ID,
+        formatVersion: 1,
+      },
+    });
+    if (!opened.ok) throw new Error(opened.error.message);
+    const session = opened.value;
+    const iterator = session.outputs[Symbol.asyncIterator]();
+
+    connection.sessionEvent(SESSION_ID, 3, "assistant/message", {
+      turn: 1,
+      step: 1,
+      message: { content: [{ type: "text", text: "resumed answer" }] },
+    });
+    connection.sessionEvent(SESSION_ID, 4, "turn/end", {
+      turn: 1,
+      reason: { kind: "completed" },
+    });
+    const autonomous = await nextEvent(iterator);
+    expect(autonomous).toMatchObject({
+      type: "turn.autonomous.started",
+      input: [{ type: "text", text: "resumed autonomous input" }],
+    });
+    if (autonomous.type !== "turn.autonomous.started") {
+      throw new Error("Expected resumed autonomous Turn start");
+    }
+    await expect(nextEvent(iterator)).resolves.toEqual({
+      type: "turn.started",
+      turnId: autonomous.turnId,
+    });
+    const outputs = await collectUntilTurnFrom(iterator);
+    expect(outputs).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          kind: "event",
+          event: expect.objectContaining({
+            type: "turn.completed",
+            turnId: autonomous.turnId,
+            nativeTurnRef: expect.objectContaining({ nativeTurnKey: "turn:1" }),
+          }),
+        }),
+      ]),
+    );
+    expect(connection.calls.prompt).not.toHaveBeenCalled();
+    await adapter.close();
+  });
+
+  it("faults closed on overlapping autonomous native Turns", async () => {
+    const { adapter, connection } = fixture();
+    const session = await openCreated(adapter);
+    const iterator = session.outputs[Symbol.asyncIterator]();
+    connection.sessionEvent(SESSION_ID, 1, "turn/start", { turn: 1 });
+    connection.sessionEvent(SESSION_ID, 2, "turn/start", { turn: 2 });
+
+    await expect(nextEvent(iterator)).resolves.toMatchObject({
+      type: "session.faulted",
+      error: { code: "protocolError" },
+    });
+    await expect(iterator.next()).resolves.toEqual({ done: true, value: undefined });
     await adapter.close();
   });
 

--- a/packages/adapters/deepseek-harness/test/harness-commands.test.ts
+++ b/packages/adapters/deepseek-harness/test/harness-commands.test.ts
@@ -1,0 +1,245 @@
+import { describe, expect, it } from "vitest";
+
+import type { HarnessCommandInvocation } from "@codexhost/harness-adapter";
+import { hostTurnIdSchema } from "@codexhost/shared-contracts";
+
+import {
+  buildDeepSeekHarnessCommandLine,
+  deepSeekHarnessCommandCatalog,
+  parseDeepSeekHarnessCommand,
+} from "../src/harness-commands.js";
+
+const turnId = hostTurnIdSchema.parse("command-turn");
+
+describe("DeepSeek Harness command registry", () => {
+  it("exposes compact only when the current native catalog advertises its exact shape", () => {
+    expect(
+      deepSeekHarnessCommandCatalog([
+        { name: "future", description: "A future command" },
+        { name: "compact", description: "  Compact older conversation history  " },
+      ]),
+    ).toEqual({
+      commands: [
+        {
+          id: "dsh.compact",
+          invocation: "/compact",
+          label: "Compact context",
+          description: "Compact older conversation history",
+          argumentMode: "none",
+        },
+      ],
+    });
+
+    expect(
+      deepSeekHarnessCommandCatalog([
+        {
+          name: "compact",
+          description: "Compact with instructions",
+          input: { hint: "<instructions>" },
+        },
+      ]),
+    ).toEqual({ commands: [] });
+    expect(deepSeekHarnessCommandCatalog([])).toEqual({ commands: [] });
+  });
+
+  it("omits compact when its native description cannot enter the Host catalog", () => {
+    expect(deepSeekHarnessCommandCatalog([{ name: "compact", description: "   " }])).toEqual({
+      commands: [],
+    });
+    expect(
+      deepSeekHarnessCommandCatalog([{ name: "compact", description: "x".repeat(513) }]),
+    ).toEqual({ commands: [] });
+  });
+
+  it("exposes goal only when the current native catalog advertises text input", () => {
+    expect(
+      deepSeekHarnessCommandCatalog([
+        {
+          name: "goal",
+          description: "set or view the goal for a long-running task",
+          input: {
+            hint: "[<objective>|clear|edit <objective>|pause|resume]",
+            images: true,
+          },
+        },
+      ]),
+    ).toEqual({
+      commands: [
+        {
+          id: "dsh.goal",
+          invocation: "/dsh-goal",
+          label: "Goal",
+          description: "set or view the goal for a long-running task",
+          argumentMode: "text",
+        },
+      ],
+    });
+    expect(deepSeekHarnessCommandCatalog([{ name: "goal", description: "Missing input" }])).toEqual(
+      { commands: [] },
+    );
+  });
+
+  it("parses compact without arguments and rejects unknown IDs or arguments", () => {
+    expect(parseDeepSeekHarnessCommand({ turnId, commandId: "dsh.compact" })).toEqual({
+      ok: true,
+      value: { commandId: "dsh.compact", line: "/compact" },
+    });
+    expect(
+      parseDeepSeekHarnessCommand({ turnId, commandId: "dsh.compact", arguments: {} }),
+    ).toEqual({
+      ok: true,
+      value: { commandId: "dsh.compact", line: "/compact" },
+    });
+    expect(
+      parseDeepSeekHarnessCommand({
+        turnId,
+        commandId: "dsh.compact",
+        arguments: { text: "keep details" },
+      }),
+    ).toMatchObject({ ok: false, error: { code: "invalidRequest" } });
+    expect(parseDeepSeekHarnessCommand({ turnId, commandId: "dsh.future" })).toMatchObject({
+      ok: false,
+      error: { code: "unsupported" },
+    });
+  });
+
+  it("builds an exact text command line without registering that command", () => {
+    const descriptor = {
+      id: "dsh.synthetic",
+      invocation: "/synthetic",
+      argumentMode: "text" as const,
+    };
+    const command = (
+      arguments_?: HarnessCommandInvocation["arguments"],
+    ): HarnessCommandInvocation => ({
+      turnId,
+      commandId: "dsh.synthetic",
+      ...(arguments_ ? { arguments: arguments_ } : {}),
+    });
+
+    expect(buildDeepSeekHarnessCommandLine(command(), descriptor)).toEqual({
+      ok: true,
+      value: "/synthetic",
+    });
+    expect(buildDeepSeekHarnessCommandLine(command({ text: "" }), descriptor)).toEqual({
+      ok: true,
+      value: "/synthetic",
+    });
+    expect(
+      buildDeepSeekHarnessCommandLine(command({ text: "edit objective" }), descriptor),
+    ).toEqual({ ok: true, value: "/synthetic edit objective" });
+    expect(buildDeepSeekHarnessCommandLine(command({ text: 1 }), descriptor)).toMatchObject({
+      ok: false,
+      error: { code: "invalidRequest" },
+    });
+    expect(buildDeepSeekHarnessCommandLine(command({ extra: true }), descriptor)).toMatchObject({
+      ok: false,
+      error: { code: "invalidRequest" },
+    });
+  });
+
+  it("maps goal grammar to exact command lines", () => {
+    for (const [text, expected] of [
+      [undefined, "/goal"],
+      ["   ", "/goal"],
+      ["  ship the release  ", "/goal ship the release"],
+      ["edit replace the objective", "/goal edit replace the objective"],
+      ["clear", "/goal clear"],
+      ["pause", "/goal pause"],
+      ["resume", "/goal resume"],
+    ] as const) {
+      expect(
+        parseDeepSeekHarnessCommand({
+          turnId,
+          commandId: "dsh.goal",
+          ...(text === undefined ? {} : { arguments: { text } }),
+        }),
+      ).toEqual({ ok: true, value: { commandId: "dsh.goal", line: expected } });
+    }
+  });
+
+  it("rejects bare goal edits", () => {
+    for (const text of ["edit", " EDIT ", "edit   "]) {
+      expect(
+        parseDeepSeekHarnessCommand({
+          turnId,
+          commandId: "dsh.goal",
+          arguments: { text },
+        }),
+      ).toMatchObject({ ok: false, error: { code: "invalidRequest" } });
+    }
+  });
+
+  it("exposes plan only when the current native catalog advertises text input", () => {
+    expect(
+      deepSeekHarnessCommandCatalog([
+        {
+          name: "plan",
+          description: "Enter or leave plan mode",
+          input: { hint: "[off|message]", images: true },
+        },
+      ]),
+    ).toEqual({
+      commands: [
+        {
+          id: "dsh.plan",
+          invocation: "/plan",
+          label: "Plan mode",
+          description: "Enter or leave plan mode",
+          argumentMode: "text",
+        },
+      ],
+    });
+    expect(deepSeekHarnessCommandCatalog([{ name: "plan", description: "Missing input" }])).toEqual(
+      { commands: [] },
+    );
+  });
+
+  it("maps plan messages to exact command lines", () => {
+    for (const [text, expected] of [
+      [undefined, "/plan"],
+      ["   ", "/plan"],
+      ["  sketch the layout  ", "/plan sketch the layout"],
+      ["off", "/plan off"],
+    ] as const) {
+      expect(
+        parseDeepSeekHarnessCommand({
+          turnId,
+          commandId: "dsh.plan",
+          ...(text === undefined ? {} : { arguments: { text } }),
+        }),
+      ).toEqual({ ok: true, value: { commandId: "dsh.plan", line: expected } });
+    }
+  });
+
+  it("filters client-only, first-class, export, and unknown native commands", () => {
+    expect(
+      deepSeekHarnessCommandCatalog([
+        { name: "model", description: "Client model command", input: { hint: "<model>" } },
+        {
+          name: "goal",
+          description: "Goal",
+          input: { hint: "[objective]", images: true },
+        },
+        {
+          name: "permission",
+          description: "Permission Mode",
+          input: { hint: "<preset>" },
+        },
+        { name: "compact", description: "Compact" },
+        { name: "export", description: "Export" },
+        {
+          name: "feedback",
+          description: "Feedback",
+          input: { hint: "<text>" },
+        },
+        { name: "future", description: "Future command", input: { hint: "[args]" } },
+        {
+          name: "plan",
+          description: "Plan",
+          input: { hint: "[off|message]", images: true },
+        },
+      ]).commands.map(({ id }) => id),
+    ).toEqual(["dsh.goal", "dsh.compact", "dsh.plan"]);
+  });
+});

--- a/packages/adapters/deepseek-harness/test/host-client.test.ts
+++ b/packages/adapters/deepseek-harness/test/host-client.test.ts
@@ -89,6 +89,96 @@ describe("DeepSeek local Host connection", () => {
     }
   });
 
+  it("preserves validated command input metadata and native order", async () => {
+    const catalog = [
+      {
+        name: "goal",
+        description: "set or view the goal for a long-running task",
+        input: {
+          hint: "[<objective>|clear|edit <objective>|pause|resume]",
+          images: true,
+        },
+      },
+      {
+        name: "feedback",
+        description: "record feedback about this session",
+        input: { hint: "<text>", images: false },
+      },
+    ];
+    vi.stubGlobal(
+      "fetch",
+      vi.fn((_input: URL, init?: RequestInit) => {
+        const body = JSON.parse(String(init?.body)) as Record<string, unknown>;
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({
+              type: "server-response",
+              rpcId: body.rpcId,
+              result: { ok: true, value: catalog },
+            }),
+          ),
+        );
+      }),
+    );
+    try {
+      const client = new NodeDeepSeekCommandClient("http://127.0.0.1:43123");
+      await expect(client.list("session-1" as never)).resolves.toEqual({
+        ok: true,
+        value: catalog,
+      });
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+
+  it.each([
+    ["non-array catalog", {}],
+    ["invalid name", [{ name: "Goal", description: "goal" }]],
+    ["blank description", [{ name: "goal", description: " " }]],
+    ["unknown descriptor field", [{ name: "goal", description: "goal", future: true }]],
+    ["blank input hint", [{ name: "goal", description: "goal", input: { hint: " " } }]],
+    [
+      "unknown input field",
+      [{ name: "goal", description: "goal", input: { hint: "objective", future: true } }],
+    ],
+    [
+      "invalid images flag",
+      [{ name: "goal", description: "goal", input: { hint: "objective", images: "yes" } }],
+    ],
+    [
+      "duplicate name",
+      [
+        { name: "goal", description: "first" },
+        { name: "goal", description: "second" },
+      ],
+    ],
+  ])("rejects a %s", async (_label, catalog) => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn((_input: URL, init?: RequestInit) => {
+        const body = JSON.parse(String(init?.body)) as Record<string, unknown>;
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({
+              type: "server-response",
+              rpcId: body.rpcId,
+              result: { ok: true, value: catalog },
+            }),
+          ),
+        );
+      }),
+    );
+    try {
+      const client = new NodeDeepSeekCommandClient("http://127.0.0.1:43123");
+      await expect(client.list("session-1" as never)).rejects.toMatchObject({
+        code: "protocolError",
+        message: expect.stringContaining("invalid command catalog"),
+      });
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+
   it("retries commands/execute with the newer empty images field only when requested", async () => {
     const payloads: Array<Record<string, unknown>> = [];
     vi.stubGlobal(
@@ -135,6 +225,39 @@ describe("DeepSeek local Host connection", () => {
         { args: { agentId: "session-1", line: "/compact" } },
         { args: { agentId: "session-1", line: "/compact", images: [] } },
       ]);
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+
+  it("does not retry near-miss native errors", async () => {
+    const fetch = vi.fn((_input: URL, init?: RequestInit) => {
+      const body = JSON.parse(String(init?.body)) as Record<string, unknown>;
+      return Promise.resolve(
+        new Response(
+          JSON.stringify({
+            type: "server-response",
+            rpcId: body.rpcId,
+            result: {
+              ok: false,
+              error: {
+                code: "internal",
+                message:
+                  'typert gateway: commands/execute: args fields do not match the descriptor: missing "images".',
+                details: {},
+              },
+            },
+          }),
+        ),
+      );
+    });
+    vi.stubGlobal("fetch", fetch);
+    try {
+      const client = new NodeDeepSeekCommandClient("http://127.0.0.1:43123");
+      await expect(client.execute("session-1" as never, "/compact")).resolves.toMatchObject({
+        ok: false,
+      });
+      expect(fetch).toHaveBeenCalledOnce();
     } finally {
       vi.unstubAllGlobals();
     }

--- a/packages/harness-adapter/src/testing.ts
+++ b/packages/harness-adapter/src/testing.ts
@@ -262,6 +262,21 @@ export class FakeHarnessSession implements HarnessSession {
     this.#event({ type: "turn.completed", turnId, outcome: { status: "succeeded" } });
   }
 
+  publishAutonomousTurn(turnId: HostTurnId, input: TurnStartCommand["input"]): void {
+    if (this.#closed) throw new Error("Fake Harness Session is closed");
+    if (this.#active) throw new Error("Fake Harness Session already has an active Turn");
+    this.#active = {
+      command: { type: "turn.start", turnId, input },
+      items: new Map(),
+      completedItems: [],
+      interactions: new Map(),
+      cancellationRequested: false,
+    };
+    this.#event({ type: "turn.autonomous.started", turnId, input });
+    this.#event({ type: "turn.started", turnId });
+    this.succeedTurn();
+  }
+
   publishUsage(usage: HostUsage | null, observedForTurnId?: HostTurnId): void {
     if (this.#closed) throw new Error("Fake Harness Session is closed");
     this.#event({

--- a/packages/host-runtime/src/app-server-host.ts
+++ b/packages/host-runtime/src/app-server-host.ts
@@ -366,7 +366,10 @@ function requestObject(request: JsonRpcRequest): JsonObject {
   return request.params as JsonObject;
 }
 
-function requestText(params: JsonObject): string {
+function requestExternalInput(params: JsonObject): {
+  text: string;
+  hasImages: boolean;
+} {
   if (!Array.isArray(params.input)) throw new Error("turn/start input must be an array");
   const text = params.input
     .filter((item): item is JsonObject => isRecord(item) && item.type === "text")
@@ -374,7 +377,10 @@ function requestText(params: JsonObject): string {
     .filter((value): value is string => typeof value === "string")
     .join("\n");
   if (!text) throw new Error("turn/start must contain text input");
-  return text;
+  const hasImages = params.input.some(
+    (item) => isRecord(item) && (item.type === "image" || item.type === "localImage"),
+  );
+  return { text, hasImages };
 }
 
 function sandboxResult(params: JsonObject): JsonObject {
@@ -446,6 +452,7 @@ export class AppServerHost {
   #writer: OrderedWriter;
   #subagentThreadStatuses = new Map<string, "active" | "idle">();
   #runningSubagentsByParent = new Map<string, Set<string>>();
+  #pendingExternalCommandRequests = new Set<string>();
   #closeRequested = false;
 
   constructor(options: AppServerHostOptions) {
@@ -656,7 +663,7 @@ export class AppServerHost {
         continue;
       }
       if (request.method === "codexhost/thread/command/execute") {
-        await this.#executeThreadCommand(request);
+        this.#dispatchDesktopRequest(() => this.#executeThreadCommand(request));
         continue;
       }
       if (request.method === "thread/list") {
@@ -855,7 +862,7 @@ export class AppServerHost {
         }
         if (await this.#writeResolutionError(request, resolution)) continue;
         if (resolution.kind === "external") {
-          await this.#startExternalTurn(request, resolution.thread);
+          this.#dispatchDesktopRequest(() => this.#startExternalTurn(request, resolution.thread));
           continue;
         }
       }
@@ -1892,49 +1899,54 @@ export class AppServerHost {
       return;
     }
     const thread = resolution.thread;
-    if (thread.running) {
+    if (thread.running || this.#pendingExternalCommandRequests.has(thread.id)) {
       await this.#writer.json(
         rpcError(request, -32072, "External Thread already has an active operation"),
       );
       return;
     }
-    const commands = thread.session.commands;
-    if (!commands) {
-      await this.#writer.json(
-        rpcError(request, -32078, "External Harness does not expose commands"),
-      );
-      return;
-    }
-    const catalog = await commands.list();
-    if (!catalog.ok) {
-      await this.#writer.json(rpcError(request, -32078, catalog.error.message));
-      return;
-    }
-    if (!catalog.value.commands.some(({ id }) => id === params.data.commandId)) {
-      await this.#writer.json(
-        rpcError(
-          request,
-          -32078,
-          `External Harness does not expose command '${params.data.commandId}'`,
-        ),
-      );
-      return;
-    }
-
+    this.#pendingExternalCommandRequests.add(thread.id);
     try {
-      await this.#startExternalCommand(
-        request,
-        thread,
-        params.data.commandId,
-        params.data.arguments,
-        params.data.turnId,
-        "command",
-      );
-    } catch (error) {
-      this.#diagnose(error);
-      await this.#writer.json(
-        rpcError(request, -32073, `External Harness command failed: ${errorMessage(error)}`),
-      );
+      const commands = thread.session.commands;
+      if (!commands) {
+        await this.#writer.json(
+          rpcError(request, -32078, "External Harness does not expose commands"),
+        );
+        return;
+      }
+      const catalog = await commands.list();
+      if (!catalog.ok) {
+        await this.#writer.json(rpcError(request, -32078, catalog.error.message));
+        return;
+      }
+      const descriptor = catalog.value.commands.find(({ id }) => id === params.data.commandId);
+      if (!descriptor) {
+        await this.#writer.json(
+          rpcError(
+            request,
+            -32078,
+            `External Harness does not expose command '${params.data.commandId}'`,
+          ),
+        );
+        return;
+      }
+      try {
+        await this.#startExternalCommand(
+          request,
+          thread,
+          params.data.commandId,
+          params.data.arguments,
+          params.data.turnId,
+          "command",
+        );
+      } catch (error) {
+        this.#diagnose(error);
+        await this.#writer.json(
+          rpcError(request, -32073, `External Harness command failed: ${errorMessage(error)}`),
+        );
+      }
+    } finally {
+      this.#pendingExternalCommandRequests.delete(thread.id);
     }
   }
 
@@ -2809,7 +2821,10 @@ export class AppServerHost {
     thread.running = true;
     thread.activeTurnId = turnId;
     thread.projectedTurns.set(turnId, projection);
-    thread.responseGates.set(turnId, { promise: Promise.resolve(), resolve: () => undefined });
+    thread.responseGates.set(turnId, {
+      promise: Promise.resolve(),
+      resolve: () => undefined,
+    });
     const result = await thread.session.execute({
       type: "turn.start",
       turnId,
@@ -2825,7 +2840,7 @@ export class AppServerHost {
   }
 
   async #startExternalTurn(request: JsonRpcRequest, thread: ExternalThread): Promise<void> {
-    if (thread.running) {
+    if (thread.running || this.#pendingExternalCommandRequests.has(thread.id)) {
       await this.#writer.json(
         rpcError(request, -32072, "External Thread already has an active Turn"),
       );
@@ -2847,43 +2862,64 @@ export class AppServerHost {
         return;
       }
     }
-    let text: string;
+    let input: ReturnType<typeof requestExternalInput>;
     try {
-      text = requestText(params);
+      input = requestExternalInput(params);
     } catch (error) {
       await this.#writer.json(rpcError(request, -32602, errorMessage(error)));
       return;
     }
+    const { text, hasImages } = input;
+    const commandText = text.trimStart();
+    if (hasImages) {
+      await this.#writer.json(
+        rpcError(request, -32078, "External Harness text Turns do not accept image input"),
+      );
+      return;
+    }
     if (thread.session.commands) {
-      const catalog = await thread.session.commands.list();
-      if (!catalog.ok) {
-        await this.#writer.json(rpcError(request, -32073, catalog.error.message));
-        return;
-      }
-      const matched = catalog.value.commands
-        .toSorted((left, right) => right.invocation.length - left.invocation.length)
-        .find((command) => {
-          if (text === command.invocation) return true;
-          return command.argumentMode === "text" && text.startsWith(`${command.invocation} `);
-        });
-      if (matched) {
-        const argumentText = text.slice(matched.invocation.length).trimStart();
-        try {
-          await this.#startExternalCommand(
-            request,
-            thread,
-            matched.id,
-            argumentText.length > 0 ? { text: argumentText } : undefined,
-            undefined,
-            "turn",
-          );
-        } catch (error) {
-          this.#diagnose(error);
-          await this.#writer.json(
-            rpcError(request, -32073, `External Harness command failed: ${errorMessage(error)}`),
-          );
+      this.#pendingExternalCommandRequests.add(thread.id);
+      try {
+        const catalog = await thread.session.commands.list();
+        if (!catalog.ok) {
+          await this.#writer.json(rpcError(request, -32073, catalog.error.message));
+          return;
         }
-        return;
+        const matched = catalog.value.commands
+          .toSorted((left, right) => right.invocation.length - left.invocation.length)
+          .find((command) => {
+            if (commandText === command.invocation) return true;
+            return (
+              command.argumentMode === "text" && commandText.startsWith(`${command.invocation} `)
+            );
+          });
+        if (matched) {
+          const argumentText = commandText.slice(matched.invocation.length).trimStart();
+          try {
+            await this.#startExternalCommand(
+              request,
+              thread,
+              matched.id,
+              argumentText.length > 0 ? { text: argumentText } : undefined,
+              undefined,
+              "turn",
+            );
+          } catch (error) {
+            this.#diagnose(error);
+            await this.#writer.json(
+              rpcError(request, -32073, `External Harness command failed: ${errorMessage(error)}`),
+            );
+          }
+          return;
+        }
+        if (/^\/[^\s/]+(?:\s|$)/u.test(commandText)) {
+          await this.#writer.json(
+            rpcError(request, -32078, "External Harness does not expose the requested command"),
+          );
+          return;
+        }
+      } finally {
+        this.#pendingExternalCommandRequests.delete(thread.id);
       }
     }
     const turnId = hostTurnIdSchema.parse(randomUUID());
@@ -2941,12 +2977,22 @@ export class AppServerHost {
       return;
     }
     const turnId = thread.activeTurnId;
-    const gate = turnProjectionGate();
+    const cancellationGate = turnProjectionGate();
+    const gate: TurnProjectionGate = {
+      promise: Promise.all([
+        thread.responseGates.get(turnId)?.promise ?? Promise.resolve(),
+        cancellationGate.promise,
+      ]).then(() => undefined),
+      resolve: cancellationGate.resolve,
+    };
     thread.responseGates.set(turnId, gate);
     const result = await thread.session.execute({ type: "turn.cancel", turnId });
     if (!result.ok) {
-      gate.resolve();
-      await this.#writer.json(rpcError(request, -32074, result.error.message));
+      try {
+        await this.#writer.json(rpcError(request, -32074, result.error.message));
+      } finally {
+        gate.resolve();
+      }
       return;
     }
     try {
@@ -3107,6 +3153,7 @@ export class AppServerHost {
           turnId: event.turnId,
           cwd: thread.cwd,
           startedAtMs: Date.now(),
+          initialInput: event.input,
         }),
       };
       thread.running = true;

--- a/packages/host-runtime/src/app-server-host.ts
+++ b/packages/host-runtime/src/app-server-host.ts
@@ -2922,6 +2922,12 @@ export class AppServerHost {
         this.#pendingExternalCommandRequests.delete(thread.id);
       }
     }
+    if (thread.running || thread.activeTurnId) {
+      await this.#writer.json(
+        rpcError(request, -32072, "External Thread already has an active Turn"),
+      );
+      return;
+    }
     const turnId = hostTurnIdSchema.parse(randomUUID());
     const startedAtMs = Date.now();
     const projection: ProjectedTurn = {

--- a/packages/host-runtime/test/app-server-host.test.ts
+++ b/packages/host-runtime/test/app-server-host.test.ts
@@ -2734,6 +2734,40 @@ describe("AppServerHost HarnessAdapter projection", () => {
     await stopFixture(fixture);
   });
 
+  it("projects autonomous Harness Turn input in the live turn/started payload", async () => {
+    const fixture = createFixture();
+    await startPiThread(fixture);
+    const session = fixture.adapter.sessions[0];
+    if (!session) throw new Error("Fake Pi Session was not opened");
+    const turnId = hostTurnIdSchema.parse("autonomous-turn");
+
+    session.publishAutonomousTurn(turnId, [
+      { type: "text", text: "native follow-up" },
+      { type: "text", text: "second line" },
+    ]);
+
+    await expect(
+      fixture.collector.waitFor((message) => turnEvent(message, "turn/started", turnId)),
+    ).resolves.toMatchObject({
+      params: {
+        turn: {
+          id: turnId,
+          items: [
+            {
+              type: "userMessage",
+              content: [
+                { type: "text", text: "native follow-up" },
+                { type: "text", text: "second line" },
+              ],
+            },
+          ],
+        },
+      },
+    });
+    await fixture.collector.waitFor((message) => turnEvent(message, "turn/completed", turnId));
+    await stopFixture(fixture);
+  });
+
   it("acknowledges an accepted Harness command through the public command contract", async () => {
     const fixture = createFixture();
     const threadId = await startPiThread(fixture);
@@ -2758,7 +2792,10 @@ describe("AppServerHost HarnessAdapter projection", () => {
           type: "contextCompaction",
           itemId: hostItemIdSchema.parse("fake-command-compaction-item"),
         });
-        return { ok: true, value: { turnId } };
+        return {
+          ok: true,
+          value: { turnId },
+        };
       },
     };
     const turnId = hostTurnIdSchema.parse("manual-compact");
@@ -2778,6 +2815,172 @@ describe("AppServerHost HarnessAdapter projection", () => {
     await fixture.collector.waitFor((message) => turnEvent(message, "turn/started", nextTurnId));
     session.succeedTurn();
     await fixture.collector.waitFor((message) => turnEvent(message, "turn/completed", nextTurnId));
+    await stopFixture(fixture);
+  });
+
+  it("rejects images for registered commands and ordinary external text Turns", async () => {
+    const fixture = createFixture();
+    const threadId = await startPiThread(fixture);
+    const session = fixture.adapter.sessions[0];
+    if (!session) throw new Error("Fake Pi Session was not opened");
+    const executeCommand = vi.fn();
+    session.commands = {
+      list: async () => ({
+        ok: true,
+        value: {
+          commands: [
+            harnessCommandDescriptorSchema.parse({
+              id: "fake.plan",
+              invocation: "/plan",
+              label: "Plan",
+              argumentMode: "text",
+            }),
+          ],
+        },
+      }),
+      execute: executeCommand,
+    };
+    const execute = vi.spyOn(session, "execute");
+
+    writeRequest(fixture.desktopInput, {
+      id: 2,
+      method: "turn/start",
+      params: {
+        threadId,
+        input: [
+          { type: "text", text: "/plan inspect" },
+          { type: "image", url: "data:image/png;base64,AA==" },
+        ],
+      },
+    });
+    await expect(
+      fixture.collector.waitFor((message) => requestId(message, 2)),
+    ).resolves.toMatchObject({
+      error: { code: -32078, message: expect.stringContaining("text Turns") },
+    });
+
+    writeRequest(fixture.desktopInput, {
+      id: 3,
+      method: "turn/start",
+      params: {
+        threadId,
+        input: [
+          { type: "text", text: "ordinary message" },
+          { type: "localImage", path: "C:\\images\\ordinary.png" },
+        ],
+      },
+    });
+    await expect(
+      fixture.collector.waitFor((message) => requestId(message, 3)),
+    ).resolves.toMatchObject({
+      error: { code: -32078, message: expect.stringContaining("text Turns") },
+    });
+    expect(executeCommand).not.toHaveBeenCalled();
+    expect(execute).not.toHaveBeenCalled();
+    await stopFixture(fixture);
+  });
+
+  it("forwards Codex-owned image input without applying Harness command routing", async () => {
+    const fixture = createFixture();
+    const forwarded: JsonObject[] = [];
+    fixture.official.stdin.on("data", (chunk: Buffer) => {
+      for (const line of chunk.toString("utf8").split("\n")) {
+        if (line) forwarded.push(JSON.parse(line) as JsonObject);
+      }
+    });
+    const input = [
+      { type: "text", text: "/plan keep this native" },
+      { type: "image", url: "data:image/png;base64,AA==" },
+      { type: "localImage", path: "C:\\images\\native.webp" },
+    ];
+
+    writeRequest(fixture.desktopInput, {
+      id: 99,
+      method: "turn/start",
+      params: { threadId: "official-thread", input },
+    });
+    await vi.waitFor(() => {
+      expect(forwarded.some((message) => message.id === 99)).toBe(true);
+    });
+    expect(forwarded.find((message) => message.id === 99)).toEqual({
+      id: 99,
+      method: "turn/start",
+      params: { threadId: "official-thread", input },
+    });
+    await stopFixture(fixture);
+  });
+
+  it("serializes command catalog admission and releases it after discovery failure", async () => {
+    const fixture = createFixture();
+    const threadId = await startPiThread(fixture);
+    const session = fixture.adapter.sessions[0];
+    if (!session) throw new Error("Fake Pi Session was not opened");
+    let resolveCatalog:
+      | ((value: {
+          ok: false;
+          error: {
+            code: "unavailable";
+            message: string;
+            retryable: true;
+          };
+        }) => void)
+      | undefined;
+    const descriptor = harnessCommandDescriptorSchema.parse({
+      id: "fake.compact",
+      invocation: "/compact",
+      label: "Compact",
+      argumentMode: "none",
+    });
+    const list = vi
+      .fn()
+      .mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            resolveCatalog = resolve;
+          }),
+      )
+      .mockResolvedValue({ ok: true, value: { commands: [descriptor] } });
+    const execute = vi.fn(async ({ turnId }) => {
+      session.publishEphemeralCommand(turnId, {
+        type: "contextCompaction",
+        itemId: hostItemIdSchema.parse(`retried-command-${turnId}`),
+      });
+      return { ok: true as const, value: { turnId } };
+    });
+    session.commands = { list, execute };
+
+    writeRequest(fixture.desktopInput, {
+      id: 2,
+      method: "codexhost/thread/command/execute",
+      params: { threadId, commandId: "fake.compact" },
+    });
+    await vi.waitFor(() => expect(list).toHaveBeenCalledOnce());
+    writeRequest(fixture.desktopInput, {
+      id: 3,
+      method: "codexhost/thread/command/execute",
+      params: { threadId, commandId: "fake.compact" },
+    });
+    await expect(
+      fixture.collector.waitFor((message) => requestId(message, 3)),
+    ).resolves.toMatchObject({ error: { code: -32072 } });
+
+    resolveCatalog?.({
+      ok: false,
+      error: { code: "unavailable", message: "catalog offline", retryable: true },
+    });
+    await expect(
+      fixture.collector.waitFor((message) => requestId(message, 2)),
+    ).resolves.toMatchObject({ error: { code: -32078, message: "catalog offline" } });
+
+    writeRequest(fixture.desktopInput, {
+      id: 4,
+      method: "codexhost/thread/command/execute",
+      params: { threadId, commandId: "fake.compact" },
+    });
+    await expect(
+      fixture.collector.waitFor((message) => requestId(message, 4)),
+    ).resolves.toMatchObject({ result: { accepted: true } });
+    expect(execute).toHaveBeenCalledOnce();
     await stopFixture(fixture);
   });
 

--- a/packages/host-runtime/test/app-server-host.test.ts
+++ b/packages/host-runtime/test/app-server-host.test.ts
@@ -2984,6 +2984,51 @@ describe("AppServerHost HarnessAdapter projection", () => {
     await stopFixture(fixture);
   });
 
+  it("rejects an ordinary Turn when an autonomous Turn starts during command discovery", async () => {
+    const fixture = createFixture();
+    const threadId = await startPiThread(fixture);
+    const session = fixture.adapter.sessions[0];
+    if (!session) throw new Error("Fake Pi Session was not opened");
+    const catalog = { ok: true as const, value: { commands: [] } };
+    let releaseCatalog = (): void => undefined;
+    const list = vi.fn(
+      () =>
+        new Promise<typeof catalog>((resolve) => {
+          releaseCatalog = () => resolve(catalog);
+        }),
+    );
+    session.commands = { list, execute: vi.fn() };
+    const execute = vi.spyOn(session, "execute");
+    const autonomousTurnId = hostTurnIdSchema.parse("catalog-race-autonomous-turn");
+    const completeAutonomousTurn = vi
+      .spyOn(session, "succeedTurn")
+      .mockImplementationOnce(() => undefined);
+
+    writeRequest(fixture.desktopInput, {
+      id: 2,
+      method: "turn/start",
+      params: { threadId, input: [{ type: "text", text: "ordinary message" }] },
+    });
+    await vi.waitFor(() => expect(list).toHaveBeenCalledOnce());
+    session.publishAutonomousTurn(autonomousTurnId, [{ type: "text", text: "native follow-up" }]);
+    await fixture.collector.waitFor((message) =>
+      turnEvent(message, "turn/started", autonomousTurnId),
+    );
+
+    releaseCatalog();
+    await expect(
+      fixture.collector.waitFor((message) => requestId(message, 2)),
+    ).resolves.toMatchObject({ error: { code: -32072 } });
+    expect(execute).not.toHaveBeenCalled();
+
+    completeAutonomousTurn.mockRestore();
+    session.succeedTurn();
+    await fixture.collector.waitFor((message) =>
+      turnEvent(message, "turn/completed", autonomousTurnId),
+    );
+    await stopFixture(fixture);
+  });
+
   it("projects a Harness command's native compaction Item through the existing UI lane", async () => {
     const fixture = createFixture();
     const threadId = await startPiThread(fixture);

--- a/packages/host-runtime/test/remote-host-lifecycle.test.ts
+++ b/packages/host-runtime/test/remote-host-lifecycle.test.ts
@@ -150,12 +150,9 @@ describe("remote Host lifecycle", () => {
       startRemoteHost({ platform: "linux", environment: { HOME: home } }),
     ).rejects.toThrow("socket owner does not match");
     expect(launch).not.toHaveBeenCalled();
-    expect(terminate).toHaveBeenCalledWith(
-      expect.objectContaining(manifest),
-      socketPath,
-      "stock",
-      { HOME: home },
-    );
+    expect(terminate).toHaveBeenCalledWith(expect.objectContaining(manifest), socketPath, "stock", {
+      HOME: home,
+    });
   });
 
   it("stops only a protocol-verified managed Host", async () => {

--- a/packages/renderer-extension/src/renderer-binding-probe.ts
+++ b/packages/renderer-extension/src/renderer-binding-probe.ts
@@ -67,6 +67,7 @@ import {
   writeNewThreadExternalConfigurationPreference,
 } from "./renderer-new-thread-preference.js";
 import { installRendererSidebarAgentIcons } from "./renderer-sidebar-agent-icons.js";
+import { routeRendererHarnessCommandSelection } from "./renderer-harness-command-claim.js";
 import { installRendererSettingsLifecycle } from "./renderer-settings-lifecycle.js";
 import type {
   RendererConnectionDiagnostics,
@@ -693,6 +694,20 @@ export function installRendererBindingProbe(
     } finally {
       mounted.control.harnessCommands.setExecuting(null);
     }
+  };
+
+  const selectCommand = (mounted: MountedComposer, command: HarnessCommandDescriptor): void => {
+    const threadId = threadIdFromComposerModelTarget(mounted.modelTarget);
+    if (!threadId || !modelControl || controller.get(mounted.composer).agent === "codex") return;
+    const editor = mounted.composer.querySelector<HTMLElement>(EDITOR_SELECTOR);
+    if (
+      routeRendererHarnessCommandSelection(editor, command, () => {
+        void executeCommand(mounted, command);
+      })
+    ) {
+      return;
+    }
+    console.error("codexhost Harness command could not claim the current Composer editor");
   };
 
   const applyThreadUsageUpdate = (update: ThreadUsageInspection): void => {
@@ -1909,7 +1924,7 @@ export function installRendererBindingProbe(
       },
       (command) => {
         const mounted = mountedByComposer.get(composer);
-        if (mounted) void executeCommand(mounted, command);
+        if (mounted) selectCommand(mounted, command);
       },
     );
     const mounted: MountedComposer = {

--- a/packages/renderer-extension/src/renderer-harness-command-claim.ts
+++ b/packages/renderer-extension/src/renderer-harness-command-claim.ts
@@ -1,0 +1,59 @@
+import type { HarnessCommandDescriptor } from "@codexhost/shared-contracts";
+
+function inputEvent(editor: HTMLElement, text: string): Event {
+  const view = editor.ownerDocument.defaultView;
+  return view?.InputEvent
+    ? new view.InputEvent("input", {
+        bubbles: true,
+        composed: true,
+        data: text,
+        inputType: "insertText",
+      })
+    : new (view?.Event ?? Event)("input", { bubbles: true, composed: true });
+}
+
+function prependTextarea(editor: HTMLElement, prefix: string): boolean {
+  const view = editor.ownerDocument.defaultView;
+  if (!view || !(editor instanceof view.HTMLTextAreaElement)) return false;
+  const setter = Object.getOwnPropertyDescriptor(view.HTMLTextAreaElement.prototype, "value")?.set;
+  if (!setter) return false;
+  const start = editor.selectionStart;
+  const end = editor.selectionEnd;
+  setter.call(editor, prefix + editor.value);
+  editor.dispatchEvent(inputEvent(editor, prefix));
+  editor.focus({ preventScroll: true });
+  if (start !== null && end !== null) {
+    editor.setSelectionRange(start + prefix.length, end + prefix.length);
+  }
+  return true;
+}
+
+function prependContentEditable(editor: HTMLElement, prefix: string): boolean {
+  if (editor.getAttribute("contenteditable") !== "true") return false;
+  const document = editor.ownerDocument;
+  const selection = document.getSelection();
+  if (!selection || typeof document.execCommand !== "function") return false;
+  const range = document.createRange();
+  range.selectNodeContents(editor);
+  range.collapse(true);
+  editor.focus({ preventScroll: true });
+  selection.removeAllRanges();
+  selection.addRange(range);
+  return document.execCommand("insertText", false, prefix);
+}
+
+function prependEditor(editor: HTMLElement, prefix: string): boolean {
+  return prependTextarea(editor, prefix) || prependContentEditable(editor, prefix);
+}
+
+export function routeRendererHarnessCommandSelection(
+  editor: HTMLElement | null,
+  command: HarnessCommandDescriptor,
+  execute: () => void,
+): boolean {
+  if (command.argumentMode === "none") {
+    execute();
+    return true;
+  }
+  return editor !== null && prependEditor(editor, `${command.invocation} `);
+}

--- a/packages/renderer-extension/test/renderer-harness-command-claim.test.ts
+++ b/packages/renderer-extension/test/renderer-harness-command-claim.test.ts
@@ -1,0 +1,139 @@
+import type { HarnessCommandDescriptor } from "@codexhost/shared-contracts";
+import { describe, expect, it, vi } from "vitest";
+
+import { routeRendererHarnessCommandSelection } from "../src/renderer-harness-command-claim.js";
+
+const textCommand = {
+  id: "dsh.goal",
+  invocation: "/dsh-goal",
+  label: "Goal",
+  argumentMode: "text",
+} as HarnessCommandDescriptor;
+
+const noneCommand = {
+  id: "dsh.compact",
+  invocation: "/compact",
+  label: "Compact",
+  argumentMode: "none",
+} as HarnessCommandDescriptor;
+
+class FakeInputEvent {
+  constructor(
+    readonly type: string,
+    readonly init: Record<string, unknown>,
+  ) {}
+}
+
+class FakeTextarea {
+  #value = "keep this draft";
+  selectionStart: number | null = 5;
+  selectionEnd: number | null = 9;
+  readonly events: FakeInputEvent[] = [];
+  readonly focus = vi.fn();
+  readonly setSelectionRange = vi.fn();
+  readonly ownerDocument = {
+    defaultView: {
+      HTMLTextAreaElement: FakeTextarea,
+      InputEvent: FakeInputEvent,
+    },
+  };
+
+  get value(): string {
+    return this.#value;
+  }
+
+  set value(value: string) {
+    this.#value = value;
+  }
+
+  dispatchEvent(event: FakeInputEvent): boolean {
+    this.events.push(event);
+    return true;
+  }
+}
+
+describe("Renderer Harness command Composer claims", () => {
+  it("prefixes a textarea draft and leaves execution to the normal submit path", () => {
+    const editor = new FakeTextarea();
+    const execute = vi.fn();
+
+    expect(
+      routeRendererHarnessCommandSelection(editor as unknown as HTMLElement, textCommand, execute),
+    ).toBe(true);
+    expect(editor.value).toBe("/dsh-goal keep this draft");
+    expect(editor.events).toHaveLength(1);
+    expect(editor.events[0]).toMatchObject({
+      type: "input",
+      init: { bubbles: true, data: "/dsh-goal ", inputType: "insertText" },
+    });
+    expect(editor.setSelectionRange).toHaveBeenCalledWith(15, 19);
+    expect(editor.focus).toHaveBeenCalledWith({ preventScroll: true });
+    expect(execute).not.toHaveBeenCalled();
+  });
+
+  it("uses Chromium insertText for a Lexical contenteditable without replacing its draft", () => {
+    const range = {
+      selectNodeContents: vi.fn(),
+      collapse: vi.fn(),
+    };
+    const selection = {
+      removeAllRanges: vi.fn(),
+      addRange: vi.fn(),
+    };
+    const editor = {
+      textContent: "existing rich draft",
+      getAttribute: (name: string) => (name === "contenteditable" ? "true" : null),
+      focus: vi.fn(),
+    };
+    const execCommand = vi.fn((_command: string, _showUi: boolean, prefix: string) => {
+      editor.textContent = prefix + editor.textContent;
+      return true;
+    });
+    Object.assign(editor, {
+      ownerDocument: {
+        defaultView: { HTMLTextAreaElement: FakeTextarea },
+        createRange: () => range,
+        execCommand,
+        getSelection: () => selection,
+      },
+    });
+    const execute = vi.fn();
+
+    expect(
+      routeRendererHarnessCommandSelection(editor as unknown as HTMLElement, textCommand, execute),
+    ).toBe(true);
+    expect(range.selectNodeContents).toHaveBeenCalledWith(editor);
+    expect(range.collapse).toHaveBeenCalledWith(true);
+    expect(execCommand).toHaveBeenCalledWith("insertText", false, "/dsh-goal ");
+    expect(editor.textContent).toBe("/dsh-goal existing rich draft");
+    expect(execute).not.toHaveBeenCalled();
+  });
+
+  it("fails closed when contenteditable insertion is unavailable", () => {
+    const editor = {
+      textContent: "keep this draft",
+      getAttribute: () => "true",
+      focus: vi.fn(),
+      ownerDocument: {
+        defaultView: { HTMLTextAreaElement: FakeTextarea },
+        createRange: () => ({ selectNodeContents: vi.fn(), collapse: vi.fn() }),
+        execCommand: vi.fn(() => false),
+        getSelection: () => ({ removeAllRanges: vi.fn(), addRange: vi.fn() }),
+      },
+    };
+    const execute = vi.fn();
+
+    expect(
+      routeRendererHarnessCommandSelection(editor as unknown as HTMLElement, textCommand, execute),
+    ).toBe(false);
+    expect(editor.textContent).toBe("keep this draft");
+    expect(execute).not.toHaveBeenCalled();
+  });
+
+  it("keeps argument-free commands on detached execution", () => {
+    const execute = vi.fn();
+
+    expect(routeRendererHarnessCommandSelection(null, noneCommand, execute)).toBe(true);
+    expect(execute).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/shared-contracts/test/browser-bundle.test.ts
+++ b/packages/shared-contracts/test/browser-bundle.test.ts
@@ -15,8 +15,8 @@ describe("shared-contracts browser bundle", () => {
       write: false,
       stdin: {
         contents: [
-          'import { codexhostErrorSchema, harnessInspectionSchema, harnessThinkingOptionSchema, hostThreadIdSchema, jsonRpcEnvelopeSchema, nativeSessionRefSchema, threadModelSelectParamsSchema, threadThinkingSelectParamsSchema } from "@codexhost/shared-contracts";',
-          "export const schemas = { codexhostErrorSchema, harnessInspectionSchema, harnessThinkingOptionSchema, hostThreadIdSchema, jsonRpcEnvelopeSchema, nativeSessionRefSchema, threadModelSelectParamsSchema, threadThinkingSelectParamsSchema };",
+          'import { codexhostErrorSchema, harnessCommandDescriptorSchema, harnessInspectionSchema, harnessThinkingOptionSchema, hostThreadIdSchema, jsonRpcEnvelopeSchema, nativeSessionRefSchema, threadModelSelectParamsSchema, threadThinkingSelectParamsSchema } from "@codexhost/shared-contracts";',
+          "export const schemas = { codexhostErrorSchema, harnessCommandDescriptorSchema, harnessInspectionSchema, harnessThinkingOptionSchema, hostThreadIdSchema, jsonRpcEnvelopeSchema, nativeSessionRefSchema, threadModelSelectParamsSchema, threadThinkingSelectParamsSchema };",
         ].join("\n"),
         loader: "ts",
         resolveDir: resolve(import.meta.dirname, "../../.."),

--- a/packages/shared-contracts/test/harness-commands.test.ts
+++ b/packages/shared-contracts/test/harness-commands.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  harnessCommandDescriptorSchema,
+  threadCommandExecuteParamsSchema,
+  threadCommandExecuteResultSchema,
+} from "@codexhost/shared-contracts";
+
+describe("Harness Command runtime contracts", () => {
+  it("round-trips strict text command input", () => {
+    const params = {
+      threadId: "thread-1",
+      commandId: "dsh.goal",
+      arguments: { text: "ship it" },
+    };
+
+    expect(threadCommandExecuteParamsSchema.parse(params)).toEqual(params);
+    expect(JSON.parse(JSON.stringify(threadCommandExecuteParamsSchema.parse(params)))).toEqual(
+      params,
+    );
+    expect(
+      harnessCommandDescriptorSchema.parse({
+        id: "dsh.goal",
+        invocation: "/dsh-goal",
+        label: "Goal",
+        argumentMode: "text",
+      }),
+    ).toEqual({
+      id: "dsh.goal",
+      invocation: "/dsh-goal",
+      label: "Goal",
+      argumentMode: "text",
+    });
+  });
+
+  it("rejects command image fields and capability declarations", () => {
+    expect(
+      threadCommandExecuteParamsSchema.safeParse({
+        threadId: "thread-1",
+        commandId: "dsh.goal",
+        images: [{ type: "image", url: "data:image/png;base64,AA==" }],
+      }).success,
+    ).toBe(false);
+    expect(
+      harnessCommandDescriptorSchema.safeParse({
+        id: "dsh.goal",
+        invocation: "/dsh-goal",
+        label: "Goal",
+        argumentMode: "text",
+        acceptsImages: true,
+      }).success,
+    ).toBe(false);
+  });
+
+  it("keeps completion promises out of the RPC result", () => {
+    expect(
+      threadCommandExecuteResultSchema.safeParse({
+        accepted: true,
+        turnId: "turn-1",
+        completion: Promise.resolve({ status: "succeeded" }),
+      }).success,
+    ).toBe(false);
+  });
+});


### PR DESCRIPTION
## 目标

为 DeepSeek Harness 接入 codexhost 现有 Harness Command 流程，支持通过 Composer 的 Harness 命令入口调用 DSH 原生 `/goal` 与 `/plan`，同时保留动态发现的 `/compact`。codexhost 只负责能力发现、路由和结果投影，DSH 继续拥有 goal、plan 与会话状态。

## 实现

- 按当前 Native Session 的 `commands/list` 动态生成命令目录，并在执行前重新确认能力。
- 仅映射经过审查的 `compact`、`goal`、`plan`；目录缺失、不兼容或畸形时失败关闭。
- 公开 `/dsh-goal [<objective>|clear|edit <objective>|pause|resume]`，并在 DeepSeek Adapter 内映射为 DSH 原生 `/goal`。
- 公开 `/plan [off|message]`，直接映射为 DSH 原生 `/plan`。
- Renderer 使用独立的 Harness Commands Popover；选择文本命令后写入 Composer，并通过现有提交事务路由。
- Host 重新校验当前目录、参数和 Session 状态；Adapter 使用原生 `commands/execute`，并复用现有 Command Execution Item、Turn 生命周期、取消和错误投影。
- 命令目录异步发现结束后重新检查 Thread 状态，避免期间启动的 autonomous Turn 被普通消息覆盖。
- DSH 特有 descriptor、wire 与结果解析仅存在于 DeepSeek Adapter；Shared、Host 与 Renderer 保持 Harness 中立。

## 为什么使用 `/dsh-goal` 而不是 `/goal`

Codex Desktop 已内置 `/goal`，该名称属于 Codex 自身的目标流程。若再把 DSH 命令公开为 `/goal`，同一输入会产生所有权歧义，并可能在进入 Harness 路由前被 Codex Desktop 原生逻辑消费。

因此 codexhost 对用户公开带命名空间的 `/dsh-goal`，只在 DeepSeek Adapter 的协议边界内将其翻译为 DSH 原生 `/goal`。这样既不劫持或修改 Codex 原生 Slash 命令，也能确保目标状态仍由 DSH 管理。`/plan` 当前没有 Codex 内置同名冲突，因此保持 DSH 原生命令名。

## 边界

- `/dsh-goal` 与 `/plan` 仅支持文本输入。External Harness 文本 Turn 携带 `image` 或 `localImage` 时，Host 会在 Adapter 执行前明确拒绝，不会静默丢图。
- 不公开 DSH 原生 `/feedback`，因为它与 Codex Desktop 内置 `/feedback` 冲突。
- 不公开 `/permission`、`/model`、`/export` 或未知命令；权限与模型继续使用 codexhost 现有一级控件。
- 不复制或重建 DSH 的 goal、plan 状态。
- 本 PR 不修改 README，也不建立新的通用命令抽象。

## 提交

1. `d7a3dc7 feat: 扩展 DeepSeek Harness 文本命令适配`
2. `6900461 feat: 路由 Harness 文本命令提交`
3. `4f7062b feat: 添加 Harness 文本命令编辑器入口`
4. `9f79f7d docs: 更新 DeepSeek Harness 命令规范`
5. `05e6e9f chore: 修复上游格式检查`
6. `f460864 fix: 避免目录发现期间覆盖自主回合`

`05e6e9f` 仅格式化上游带入的 `remote-host-lifecycle.test.ts`，并将生成型 `windows-update.preview.html` 加入 `.prettierignore`，没有修改相关运行逻辑。

## 验证

- [x] `npm ci`
- [x] 聚焦 `app-server-host.test.ts`：117 项通过
- [x] `npm run check`：Prettier、ESLint、boundary、TypeScript typecheck、TypeScript tests、Clippy 与全部 Rust tests 本地通过
- [x] TypeScript：1529 项通过，15 项跳过
- [x] `npx openspec validate --all --strict --no-interactive`：53/53 通过
- [x] `git diff --check`
- [x] [GitHub CI Run 33397992661](https://github.com/BytePioneer-AI/codex-host/actions/runs/33397992661)：Linux ARM64、macOS、Ubuntu、Windows 全部通过
- [x] [Codex Review](https://github.com/BytePioneer-AI/codex-host/pull/71#issuecomment-5479231558)：审查最新提交 `f460864`，未发现重大问题
- [x] 最终版本的真实 DSH 文本命令流程已完成人工复测

自动化检查、Codex Review 与真实 DSH 文本命令人工复测均已完成，现请求 Owner 审阅合并。