### PR TITLE
fix: reconcile stale OMP thinking on external thread restore

### DIFF
--- a/packages/adapters/omp/src/omp-adapter.ts
+++ b/packages/adapters/omp/src/omp-adapter.ts
@@ -272,6 +272,34 @@ function harnessStateFromOmp(
   };
 }
 
+/**
+ * OMP can retain the previous model's Thinking level when it silently falls
+ * back to another model. Normalize that stale value before publishing the
+ * Session state so a recoverable Native Session is not rejected by the
+ * Host-side state invariant.
+ */
+async function reconcileThinkingLevel(
+  transport: OmpTurnTransport,
+  state: OmpSessionState,
+  thinkingLevels: HarnessThinkingOptionId[] | null,
+): Promise<{ state: OmpSessionState; thinkingLevels: HarnessThinkingOptionId[] | null }> {
+  if (
+    thinkingLevels === null ||
+    (state.thinkingLevel !== null && thinkingLevels.includes(state.thinkingLevel))
+  ) {
+    return { state, thinkingLevels };
+  }
+
+  const fallback = thinkingLevels.find((level) => level === "high") ?? thinkingLevels.at(-1);
+  if (!fallback) return { state, thinkingLevels };
+
+  const selectedState = await transport.selectThinkingOption(fallback);
+  return {
+    state: selectedState,
+    thinkingLevels: await transport.getAvailableThinkingLevels(),
+  };
+}
+
 function nativeModelForHistory(state: OmpSessionState): OmpNativeModelRef | null {
   return nativeModelFromState(state);
 }
@@ -877,6 +905,9 @@ class OmpHarnessSession implements HarnessSession {
       try {
         state = await transport.selectModel(requested);
         thinkingLevels = await transport.getAvailableThinkingLevels();
+        const reconciled = await reconcileThinkingLevel(transport, state, thinkingLevels);
+        state = reconciled.state;
+        thinkingLevels = reconciled.thinkingLevels;
         this.#publishTransportState(state, thinkingLevels);
       } catch (error) {
         if (error instanceof OmpRpcFaultError) this.#fault(error);
@@ -1251,6 +1282,10 @@ class OmpHarnessSession implements HarnessSession {
           }
           state = await transport.selectThinkingOption(this.#requestedThinkingOptionId);
           thinkingLevels = await transport.getAvailableThinkingLevels();
+        } else {
+          const reconciled = await reconcileThinkingLevel(transport, state, thinkingLevels);
+          state = reconciled.state;
+          thinkingLevels = reconciled.thinkingLevels;
         }
         this.#transport = transport;
         this.#publishTransportState(state, thinkingLevels);
@@ -2036,7 +2071,13 @@ export class OmpAdapter implements HarnessAdapter {
         }
       }
 
-      const startedThinkingLevels = await transport.getAvailableThinkingLevels();
+      let startedThinkingLevels = await transport.getAvailableThinkingLevels();
+      const reconciled = await reconcileThinkingLevel(
+        transport,
+        transport.state,
+        startedThinkingLevels,
+      );
+      startedThinkingLevels = reconciled.thinkingLevels;
       this.#thinkingSelectionSupported = startedThinkingLevels !== null;
       const initialUsage = await transport.getSessionUsage().catch(() => null);
       session = this.#trackSession(input.cwd, {

--- a/packages/adapters/omp/test/omp-adapter.test.ts
+++ b/packages/adapters/omp/test/omp-adapter.test.ts
@@ -102,7 +102,8 @@ class FakeOmpTransport implements OmpTurnTransport {
     return this.state;
   }
 
-  async selectThinkingOption(): Promise<OmpSessionState> {
+  async selectThinkingOption(thinkingLevel: HarnessThinkingOptionId): Promise<OmpSessionState> {
+    void thinkingLevel;
     return this.state;
   }
 
@@ -183,6 +184,53 @@ class RestartableOmpTransport extends FakeOmpTransport {
     this.closed = true;
   }
 }
+
+describe("OMP Adapter startup", () => {
+  it("repairs an unavailable persisted Thinking level after model fallback", async () => {
+    const transport = new FakeOmpTransport();
+    const availableThinkingLevels = ["minimal", "low", "medium", "high"].map((level) =>
+      harnessThinkingOptionIdSchema.parse(level),
+    );
+    transport.state = {
+      ...transport.state,
+      thinkingLevel: harnessThinkingOptionIdSchema.parse("xhigh"),
+      availableThinkingLevels,
+    };
+    vi.spyOn(transport, "getAvailableThinkingLevels").mockImplementation(async () => [
+      ...availableThinkingLevels,
+    ]);
+    const selectThinkingOption = vi
+      .spyOn(transport, "selectThinkingOption")
+      .mockImplementation(async (thinkingLevel) => {
+        transport.state = { ...transport.state, thinkingLevel };
+        return transport.state;
+      });
+    const adapter = new OmpAdapter({}, { createTransport: () => transport });
+    const nativeRef = nativeSessionRefSchema.parse({
+      harnessId: "omp",
+      nativeSessionId: "omp-parent",
+      locator: { sessionFile: "/synthetic/omp-parent.jsonl" },
+      formatVersion: 1,
+    });
+
+    const opened = await adapter.open({ kind: "resume", cwd: "/synthetic", nativeRef });
+
+    expect(opened.ok).toBe(true);
+    if (!opened.ok) return;
+    expect(selectThinkingOption).toHaveBeenCalledWith("high");
+    expect(opened.value.initialState).toMatchObject({
+      effectiveThinkingOptionId: "high",
+      availableThinkingOptions: [
+        { id: "minimal" },
+        { id: "low" },
+        { id: "medium" },
+        { id: "high" },
+      ],
+    });
+    await opened.value.close();
+    await adapter.close();
+  });
+});
 
 function historyTurn(input: {
   assistantId: string;

--- a/packages/host-runtime/src/external-thread-runtime.ts
+++ b/packages/host-runtime/src/external-thread-runtime.ts
@@ -232,6 +232,7 @@ export class ExternalThreadRuntime {
     requestedModel?: HarnessModelRef;
     requestedThinkingOptionId?: HarnessThinkingOptionId;
     requestedPermissionModeId?: HarnessPermissionModeId;
+    transportModelId?: string;
     restoredState?: HarnessSessionState;
   }): ExternalThread {
     const harnessId = input.record.harnessId as ExternalHarnessId;
@@ -267,7 +268,7 @@ export class ExternalThreadRuntime {
       sessionId: input.sessionId,
       stateObserver: new SessionStateObserver(observerState),
       thread: input.thread,
-      transportModelId: input.record.transportModelId,
+      transportModelId: input.transportModelId ?? input.record.transportModelId,
       turns: input.turns,
       historyHydrated: true,
       running: false,
@@ -499,27 +500,26 @@ export class ExternalThreadRuntime {
       }
       let aligned = await this.#repository.alignSnapshot(record, snapshot.value);
       const restoredState = snapshot.value.state;
-      const effectiveModel = restoredState?.effectiveModel ?? restoredSelection?.model;
-      const effectiveThinkingOptionId =
-        restoredState?.effectiveThinkingOptionId ?? restoredSelection?.thinkingOptionId;
-      const effectivePermissionModeId =
-        restoredState?.effectivePermissionModeId ?? restoredSelection?.permissionModeId;
+      const effectiveModel = restoredState
+        ? restoredState.effectiveModel
+        : restoredSelection?.model;
+      const effectiveThinkingOptionId = restoredState
+        ? restoredState.effectiveThinkingOptionId
+        : restoredSelection?.thinkingOptionId;
+      const effectivePermissionModeId = restoredState
+        ? restoredState.effectivePermissionModeId
+        : restoredSelection?.permissionModeId;
+      let transportModelId = aligned.record.transportModelId;
       // OMP can silently replace an unavailable Model during resume; persist the live selection
       // so the next restore does not reapply the obsolete transport token.
       if (harnessId === "omp" && restoredState?.effectiveModel) {
         const liveSelection: ExternalConfigurationSelection = {
-          ...(restoredSelection ?? {}),
           model: restoredState.effectiveModel,
+          ...(restoredState.effectiveThinkingOptionId
+            ? { thinkingOptionId: restoredState.effectiveThinkingOptionId }
+            : {}),
         };
-        if (restoredState.effectiveThinkingOptionId) {
-          liveSelection.thinkingOptionId = restoredState.effectiveThinkingOptionId;
-        } else {
-          delete liveSelection.thinkingOptionId;
-        }
-        if (restoredState.effectivePermissionModeId) {
-          liveSelection.permissionModeId = restoredState.effectivePermissionModeId;
-        }
-        const transportModelId = encodeExternalTransportSelection(harnessId, liveSelection);
+        transportModelId = encodeExternalTransportSelection(harnessId, liveSelection);
         if (transportModelId !== aligned.record.transportModelId) {
           try {
             aligned = {
@@ -553,6 +553,7 @@ export class ExternalThreadRuntime {
           ? { requestedPermissionModeId: effectivePermissionModeId }
           : {}),
         ...(restoredState ? { restoredState } : {}),
+        transportModelId,
       });
     } catch (error) {
       await session.close().catch(() => undefined);

--- a/packages/host-runtime/src/external-thread-runtime.ts
+++ b/packages/host-runtime/src/external-thread-runtime.ts
@@ -11,8 +11,10 @@ import type {
 import type { StoredThreadRecordV1 } from "@codexhost/mapping-store";
 import {
   decodeExternalTransportSelection,
+  encodeExternalTransportSelection,
   mapExternalThreadHarnessError,
   type CodexTurnProjector,
+  type ExternalConfigurationSelection,
   type ExternalHarnessId,
   type ExternalThreadRpcError,
   type JsonObject,
@@ -495,7 +497,43 @@ export class ExternalThreadRuntime {
       if (!snapshot.ok) {
         throw new ExternalThreadOpenError(mapExternalThreadHarnessError(snapshot.error, "read"));
       }
-      const aligned = await this.#repository.alignSnapshot(record, snapshot.value);
+      let aligned = await this.#repository.alignSnapshot(record, snapshot.value);
+      const restoredState = snapshot.value.state;
+      const effectiveModel = restoredState?.effectiveModel ?? restoredSelection?.model;
+      const effectiveThinkingOptionId =
+        restoredState?.effectiveThinkingOptionId ?? restoredSelection?.thinkingOptionId;
+      const effectivePermissionModeId =
+        restoredState?.effectivePermissionModeId ?? restoredSelection?.permissionModeId;
+      // OMP can silently replace an unavailable Model during resume; persist the live selection
+      // so the next restore does not reapply the obsolete transport token.
+      if (harnessId === "omp" && restoredState?.effectiveModel) {
+        const liveSelection: ExternalConfigurationSelection = {
+          ...(restoredSelection ?? {}),
+          model: restoredState.effectiveModel,
+        };
+        if (restoredState.effectiveThinkingOptionId) {
+          liveSelection.thinkingOptionId = restoredState.effectiveThinkingOptionId;
+        } else {
+          delete liveSelection.thinkingOptionId;
+        }
+        if (restoredState.effectivePermissionModeId) {
+          liveSelection.permissionModeId = restoredState.effectivePermissionModeId;
+        }
+        const transportModelId = encodeExternalTransportSelection(harnessId, liveSelection);
+        if (transportModelId !== aligned.record.transportModelId) {
+          try {
+            aligned = {
+              ...aligned,
+              record: await this.#repository.setTransportModelId(
+                aligned.record.hostThreadId,
+                transportModelId,
+              ),
+            };
+          } catch (error) {
+            this.#diagnose(error);
+          }
+        }
+      }
       const sessionId = await this.#repository.sessionTreeId(aligned.record);
       return this.register({
         record: aligned.record,
@@ -507,14 +545,14 @@ export class ExternalThreadRuntime {
           sessionId,
         }),
         turns: aligned.turns,
-        ...(restoredSelection?.model ? { requestedModel: restoredSelection.model } : {}),
-        ...(restoredSelection?.thinkingOptionId
-          ? { requestedThinkingOptionId: restoredSelection.thinkingOptionId }
+        ...(effectiveModel ? { requestedModel: effectiveModel } : {}),
+        ...(effectiveThinkingOptionId
+          ? { requestedThinkingOptionId: effectiveThinkingOptionId }
           : {}),
-        ...(restoredSelection?.permissionModeId
-          ? { requestedPermissionModeId: restoredSelection.permissionModeId }
+        ...(effectivePermissionModeId
+          ? { requestedPermissionModeId: effectivePermissionModeId }
           : {}),
-        ...(snapshot.value.state ? { restoredState: snapshot.value.state } : {}),
+        ...(restoredState ? { restoredState } : {}),
       });
     } catch (error) {
       await session.close().catch(() => undefined);

--- a/packages/host-runtime/test/external-thread-runtime.test.ts
+++ b/packages/host-runtime/test/external-thread-runtime.test.ts
@@ -1,4 +1,4 @@
-import { FakeHarnessAdapter } from "@codexhost/harness-adapter/testing";
+import { FakeHarnessAdapter, FakeHarnessSession } from "@codexhost/harness-adapter/testing";
 import type { StoredThreadRecordV1 } from "@codexhost/mapping-store";
 import {
   harnessIdSchema,
@@ -145,6 +145,59 @@ describe("ExternalThreadRuntime register", () => {
     await adapter.close();
   });
 
+  it("does not restore persisted Thinking when live OMP state omits it", async () => {
+    const ompHarnessId = harnessIdSchema.parse("omp");
+    const adapter = new FakeHarnessAdapter(ompHarnessId);
+    const created = await adapter.open({ kind: "create", cwd: "/synthetic" });
+    if (!created.ok) throw new Error(created.error.message);
+
+    const session = created.value;
+    const nativeRef = session.initialState.nativeRef;
+    const actualModel = session.initialState.effectiveModel;
+    const staleThinking = harnessThinkingOptionIdSchema.parse("low");
+    if (!nativeRef || !actualModel || !(session instanceof FakeHarnessSession)) {
+      throw new Error("Fake OMP Session did not expose the expected configuration state");
+    }
+    session.setStateForSnapshot({ nativeRef, effectiveModel: actualModel });
+
+    const staleTransportModelId = encodeOmpTransportModel(actualModel, staleThinking);
+    const stored: StoredThreadRecordV1 = {
+      ...record(),
+      harnessId: ompHarnessId,
+      nativeSessionRef: nativeRef,
+      transportModelId: staleTransportModelId,
+      historyMode: "legacy",
+    } as StoredThreadRecordV1;
+    const repository = {
+      find: async () => stored,
+      alignSnapshot: async (current: StoredThreadRecordV1) => ({ record: current, turns: [] }),
+      sessionTreeId: async () => hostThreadId,
+      setTransportModelId: async (_threadId: string, transportModelId: string) => ({
+        ...stored,
+        transportModelId,
+      }),
+    } as unknown as ExternalThreadRepository;
+    const runtime = new ExternalThreadRuntime({
+      adapters: new Map<ExternalHarnessId, FakeHarnessAdapter>([["omp", adapter]]),
+      repository,
+      consumeOutputs: async () => undefined,
+      diagnose: () => undefined,
+    });
+
+    const resolved = await runtime.resolve(hostThreadId);
+
+    expect(resolved.kind).toBe("external");
+    if (resolved.kind !== "external") return;
+    expect(resolved.thread.stateObserver.state).toMatchObject({
+      effectiveModel: actualModel,
+    });
+    expect(resolved.thread.stateObserver.state.effectiveThinkingOptionId).toBeUndefined();
+    expect(resolved.thread.requestedThinkingOptionId).toBeUndefined();
+    expect(resolved.thread.transportModelId).toBe(encodeOmpTransportModel(actualModel));
+
+    await adapter.close();
+  });
+
   it("keeps OMP restore successful when live selection persistence fails", async () => {
     const ompHarnessId = harnessIdSchema.parse("omp");
     const adapter = new FakeHarnessAdapter(ompHarnessId);
@@ -196,6 +249,9 @@ describe("ExternalThreadRuntime register", () => {
       effectiveThinkingOptionId: actualThinking,
     });
     expect(resolved.thread.record.transportModelId).toBe(staleTransportModelId);
+    expect(resolved.thread.transportModelId).toBe(
+      encodeOmpTransportModel(actualModel, actualThinking),
+    );
     expect(setTransportModelId).toHaveBeenCalledOnce();
     expect(diagnose).toHaveBeenCalledWith(expect.any(Error));
 

--- a/packages/host-runtime/test/external-thread-runtime.test.ts
+++ b/packages/host-runtime/test/external-thread-runtime.test.ts
@@ -8,7 +8,11 @@ import {
   hostThreadIdSchema,
   nativeSessionRefSchema,
 } from "@codexhost/shared-contracts";
-import { encodeGrokTransportModel } from "@codexhost/protocol-core";
+import {
+  encodeGrokTransportModel,
+  encodeOmpTransportModel,
+  type ExternalHarnessId,
+} from "@codexhost/protocol-core";
 import { describe, expect, it, vi } from "vitest";
 
 import type { ExternalThreadRepository } from "../src/external-thread-repository.js";
@@ -77,6 +81,125 @@ describe("ExternalThreadRuntime register", () => {
       effectiveModel: model,
       effectiveThinkingOptionId: thinkingOptionId,
     });
+  });
+
+  it("uses live OMP state instead of stale persisted model and Thinking selections", async () => {
+    const ompHarnessId = harnessIdSchema.parse("omp");
+    const adapter = new FakeHarnessAdapter(ompHarnessId);
+    const created = await adapter.open({ kind: "create", cwd: "/synthetic" });
+    if (!created.ok) throw new Error(created.error.message);
+
+    const nativeRef = created.value.initialState.nativeRef;
+    const actualModel = created.value.initialState.effectiveModel;
+    const actualThinking = created.value.initialState.effectiveThinkingOptionId;
+    const staleModel = adapter.catalog.models[1]?.ref;
+    if (!nativeRef || !actualModel || !actualThinking || !staleModel) {
+      throw new Error("Fake OMP Session did not expose the expected configuration state");
+    }
+
+    let stored: StoredThreadRecordV1 = {
+      ...record(),
+      harnessId: ompHarnessId,
+      nativeSessionRef: nativeRef,
+      transportModelId: encodeOmpTransportModel(
+        staleModel,
+        harnessThinkingOptionIdSchema.parse("low"),
+      ),
+      historyMode: "legacy",
+    };
+    const setTransportModelId = vi.fn(
+      async (_threadId: string, transportModelId: string): Promise<StoredThreadRecordV1> => {
+        stored = { ...stored, transportModelId };
+        return stored;
+      },
+    );
+    const repository = {
+      find: async () => stored,
+      alignSnapshot: async (current: StoredThreadRecordV1) => ({ record: current, turns: [] }),
+      sessionTreeId: async () => hostThreadId,
+      setTransportModelId,
+    } as unknown as ExternalThreadRepository;
+    const runtime = new ExternalThreadRuntime({
+      adapters: new Map<ExternalHarnessId, FakeHarnessAdapter>([["omp", adapter]]),
+      repository,
+      consumeOutputs: async () => undefined,
+      diagnose: () => undefined,
+    });
+
+    const resolved = await runtime.resolve(hostThreadId);
+
+    expect(resolved.kind).toBe("external");
+    if (resolved.kind !== "external") return;
+    expect(resolved.thread.stateObserver.state).toMatchObject({
+      effectiveModel: actualModel,
+      effectiveThinkingOptionId: actualThinking,
+    });
+    expect(resolved.thread.record.transportModelId).toBe(
+      encodeOmpTransportModel(actualModel, actualThinking),
+    );
+    expect(setTransportModelId).toHaveBeenCalledWith(
+      hostThreadId,
+      encodeOmpTransportModel(actualModel, actualThinking),
+    );
+
+    await adapter.close();
+  });
+
+  it("keeps OMP restore successful when live selection persistence fails", async () => {
+    const ompHarnessId = harnessIdSchema.parse("omp");
+    const adapter = new FakeHarnessAdapter(ompHarnessId);
+    const created = await adapter.open({ kind: "create", cwd: "/synthetic" });
+    if (!created.ok) throw new Error(created.error.message);
+
+    const nativeRef = created.value.initialState.nativeRef;
+    const actualModel = created.value.initialState.effectiveModel;
+    const actualThinking = created.value.initialState.effectiveThinkingOptionId;
+    const staleModel = adapter.catalog.models[1]?.ref;
+    if (!nativeRef || !actualModel || !actualThinking || !staleModel) {
+      throw new Error("Fake OMP Session did not expose the expected configuration state");
+    }
+
+    const staleTransportModelId = encodeOmpTransportModel(
+      staleModel,
+      harnessThinkingOptionIdSchema.parse("low"),
+    );
+    const setTransportModelId = vi.fn(async () => {
+      throw new Error("synthetic mapping persistence failure");
+    });
+    const diagnose = vi.fn();
+    const stored: StoredThreadRecordV1 = {
+      ...record(),
+      harnessId: ompHarnessId,
+      nativeSessionRef: nativeRef,
+      transportModelId: staleTransportModelId,
+      historyMode: "legacy",
+    } as StoredThreadRecordV1;
+    const repository = {
+      find: async () => stored,
+      alignSnapshot: async (current: StoredThreadRecordV1) => ({ record: current, turns: [] }),
+      sessionTreeId: async () => hostThreadId,
+      setTransportModelId,
+    } as unknown as ExternalThreadRepository;
+    const runtime = new ExternalThreadRuntime({
+      adapters: new Map<ExternalHarnessId, FakeHarnessAdapter>([["omp", adapter]]),
+      repository,
+      consumeOutputs: async () => undefined,
+      diagnose,
+    });
+
+    const resolved = await runtime.resolve(hostThreadId);
+
+    expect(resolved.kind).toBe("external");
+    if (resolved.kind !== "external") return;
+    expect(resolved.thread.stateObserver.state).toMatchObject({
+      effectiveModel: actualModel,
+      effectiveThinkingOptionId: actualThinking,
+    });
+    expect(resolved.thread.record.transportModelId).toBe(staleTransportModelId);
+    expect(setTransportModelId).toHaveBeenCalledOnce();
+    expect(diagnose).toHaveBeenCalledWith(expect.any(Error));
+
+    await adapter.close();
   });
 
   it("reapplies a persisted Grok Permission Mode before reading restored history", async () => {


### PR DESCRIPTION
## Context

This was reproduced with codexhost `v0.4.0` and an OMP External Thread whose persisted Model was no longer available. OMP fell back to a different Model but retained the old Thinking level, causing the strict codexhost resume invariant to reject the Thread.

## Summary

OMP can silently fall back from an unavailable Model while retaining the previous Session Thinking level. When that level is not supported by the fallback Model, codexhost rejects the otherwise recoverable External Thread during resume.

This change:

- Reconciles an unavailable OMP Thinking level after startup, resume, rollback, and Model selection.
- Prefers `high`, then the last available level, without fabricating a value when no level is available.
- Uses the live Native Session Model and Thinking state when restoring an OMP External Thread instead of stale persisted selections.
- Persists the effective OMP transport carrier so later restores do not reapply an obsolete Model.
- Keeps recovery successful when the best-effort mapping carrier update fails, while recording the diagnostic.
- Retains the reconciled carrier in the current-process Thread even if durable carrier persistence fails.
- Does not resurrect a persisted Thinking value when the live Snapshot explicitly omits Thinking.
- Adds regression coverage for stale Thinking recovery, stale carrier synchronization, absent live Thinking, and non-blocking persistence failure.

## Validation

- `npm run typecheck`
- `npx vitest run --config tests/vitest.config.js packages/adapters/omp/test/omp-adapter.test.ts packages/host-runtime/test/external-thread-runtime.test.ts` (`18 passed`)
- `npm run lint`
- `npx prettier --check` on changed files
- `cargo fmt --all --check`
- `git diff --check`
- Full TypeScript suite: `1477 passed`, `15 skipped`; the remaining failures are environment-related Windows symlink permission (`EPERM`) and a parallel 5-second release-bundle timeout. The bundle test passes serially with a 30-second timeout (`4 passed`).

No user Session data, mappings, transcripts, credentials, or installation files are included.