### PR TITLE
fix(host-runtime): encode official Codex model refs

### DIFF
--- a/packages/host-runtime/src/app-server-host.ts
+++ b/packages/host-runtime/src/app-server-host.ts
@@ -25,7 +25,6 @@ import {
   harnessInspectParamsSchema,
   harnessConfigurationStateSchema,
   harnessInspectionSchema,
-  harnessModelRefSchema,
   harnessModelSelectionStateSchema,
   harnessThinkingOptionIdSchema,
   hostItemIdSchema,
@@ -97,6 +96,11 @@ import type {
 } from "./delegation-types.js";
 import { projectDelegationThreadSnapshot } from "./delegation-snapshot.js";
 import { OfficialRequestBroker } from "./official-request-broker.js";
+import {
+  canonicalizeOfficialCodexModelRef,
+  decodeOfficialCodexModelRef,
+  encodeOfficialCodexModelRef,
+} from "./official-codex-model-ref.js";
 import {
   spawnOfficialAppServerConnection,
   type OfficialAppServerConnection,
@@ -1102,7 +1106,7 @@ export class AppServerHost {
         : [];
       return [
         {
-          ref: harnessModelRefSchema.parse({ id: candidate.model }),
+          ref: encodeOfficialCodexModelRef(candidate.model),
           label:
             typeof candidate.displayName === "string" && candidate.displayName.trim()
               ? candidate.displayName
@@ -1116,7 +1120,7 @@ export class AppServerHost {
     );
     const defaultModel =
       isRecord(defaultEntry) && typeof defaultEntry.model === "string"
-        ? harnessModelRefSchema.parse({ id: defaultEntry.model })
+        ? encodeOfficialCodexModelRef(defaultEntry.model)
         : undefined;
     return {
       harnessId: input.harnessId,
@@ -1142,12 +1146,19 @@ export class AppServerHost {
   async #startOfficialDelegation(
     input: DelegationStartInput & { parentThreadId: string },
   ): Promise<DelegationStartResult> {
+    let requestedModel: HarnessModelRef | undefined;
+    try {
+      requestedModel = input.model ? canonicalizeOfficialCodexModelRef(input.model) : undefined;
+    } catch {
+      throw new DelegationControlError("INVALID_ARGUMENT", "Official Model Ref is invalid");
+    }
+    const nativeModelId = requestedModel ? decodeOfficialCodexModelRef(requestedModel) : undefined;
     const digest = createHash("sha256")
       .update(
         JSON.stringify({
           task: input.task,
           cwd: input.cwd,
-          modelId: input.model?.id ?? null,
+          modelId: requestedModel?.id ?? null,
           thinkingOptionId: input.thinkingOptionId ?? null,
         }),
       )
@@ -1185,7 +1196,7 @@ export class AppServerHost {
         },
       };
     }
-    if (input.model || input.thinkingOptionId) {
+    if (requestedModel || input.thinkingOptionId) {
       const inspected = await this.#inspectOfficialDelegationTarget({
         harnessId: "codex",
         cwd: input.cwd,
@@ -1197,9 +1208,9 @@ export class AppServerHost {
         );
       }
       if (
-        input.model &&
+        requestedModel &&
         !inspected.inspection.catalog.models.some(
-          (candidate) => candidate.ref.id === input.model?.id,
+          (candidate) => candidate.ref.id === requestedModel.id,
         )
       ) {
         throw new DelegationControlError("INVALID_ARGUMENT", "Official Model is unavailable", {
@@ -1207,7 +1218,7 @@ export class AppServerHost {
         });
       }
       if (input.thinkingOptionId) {
-        const selectedModel = input.model ?? inspected.inspection.catalog.defaultModel;
+        const selectedModel = requestedModel ?? inspected.inspection.catalog.defaultModel;
         const selectedEntry = selectedModel
           ? inspected.inspection.catalog.models.find(
               (candidate) => candidate.ref.id === selectedModel.id,
@@ -1225,7 +1236,7 @@ export class AppServerHost {
     }
     const started = await this.#officialRequestBroker.request("thread/start", {
       cwd: input.cwd,
-      ...(input.model ? { model: input.model.id } : {}),
+      ...(nativeModelId ? { model: nativeModelId } : {}),
       approvalPolicy: "never",
       sandbox: "danger-full-access",
       ephemeral: false,
@@ -1241,7 +1252,7 @@ export class AppServerHost {
       const turn = await this.#officialRequestBroker.request("turn/start", {
         threadId,
         input: [{ type: "text", text: input.task }],
-        ...(input.model ? { model: input.model.id } : {}),
+        ...(nativeModelId ? { model: nativeModelId } : {}),
         ...(input.thinkingOptionId ? { effort: input.thinkingOptionId } : {}),
       });
       const turnResult = isRecord(turn.result) ? turn.result : null;
@@ -1279,16 +1290,16 @@ export class AppServerHost {
         harnessId: "codex",
         deepLink: `codex://threads/${threadId}`,
         status: pendingTerminal ?? "running",
-        ...(input.model || input.thinkingOptionId
+        ...(requestedModel || input.thinkingOptionId
           ? {
               configuration: {
                 requested: {
-                  ...(input.model ? { model: input.model } : {}),
+                  ...(requestedModel ? { model: requestedModel } : {}),
                   ...(input.thinkingOptionId ? { thinkingOptionId: input.thinkingOptionId } : {}),
                 },
                 effective: {
                   ...(startedResult && typeof startedResult.model === "string"
-                    ? { effectiveModel: harnessModelRefSchema.parse({ id: startedResult.model }) }
+                    ? { effectiveModel: encodeOfficialCodexModelRef(startedResult.model) }
                     : {}),
                 },
               },

--- a/packages/host-runtime/src/official-codex-model-ref.ts
+++ b/packages/host-runtime/src/official-codex-model-ref.ts
@@ -1,0 +1,43 @@
+import { Buffer } from "node:buffer";
+
+import {
+  HARNESS_MODEL_REF_MAX_LENGTH,
+  harnessModelRefSchema,
+  type HarnessModelRef,
+} from "@codexhost/shared-contracts";
+
+export const OFFICIAL_CODEX_MODEL_REF_PREFIX = "codex-model-v1.";
+
+export function encodeOfficialCodexModelRef(nativeModelId: string): HarnessModelRef {
+  if (!nativeModelId.trim()) throw new Error("Official Codex Model id must not be empty");
+  const encoded = Buffer.from(nativeModelId, "utf8").toString("base64url");
+  const id = `${OFFICIAL_CODEX_MODEL_REF_PREFIX}${encoded}`;
+  if (id.length > HARNESS_MODEL_REF_MAX_LENGTH) {
+    throw new Error("Official Codex Model id is too long for a Model Ref");
+  }
+  return harnessModelRefSchema.parse({ id });
+}
+
+export function decodeOfficialCodexModelRef(ref: HarnessModelRef): string {
+  const parsed = harnessModelRefSchema.parse(ref);
+  if (!parsed.id.startsWith(OFFICIAL_CODEX_MODEL_REF_PREFIX)) {
+    return parsed.id;
+  }
+  const encoded = parsed.id.slice(OFFICIAL_CODEX_MODEL_REF_PREFIX.length);
+  if (!encoded) throw new Error("Official Codex Model Ref is empty");
+  const nativeModelId = Buffer.from(encoded, "base64url").toString("utf8");
+  if (!nativeModelId.trim()) throw new Error("Official Codex Model Ref is malformed");
+  if (encodeOfficialCodexModelRef(nativeModelId).id !== parsed.id) {
+    throw new Error("Official Codex Model Ref is not canonical");
+  }
+  return nativeModelId;
+}
+
+export function canonicalizeOfficialCodexModelRef(ref: HarnessModelRef): HarnessModelRef {
+  const parsed = harnessModelRefSchema.parse(ref);
+  try {
+    return encodeOfficialCodexModelRef(decodeOfficialCodexModelRef(parsed));
+  } catch {
+    return encodeOfficialCodexModelRef(parsed.id);
+  }
+}

--- a/packages/host-runtime/test/app-server-host.test.ts
+++ b/packages/host-runtime/test/app-server-host.test.ts
@@ -1146,6 +1146,12 @@ describe("AppServerHost HarnessAdapter projection", () => {
   });
 
   it("inspects native Codex Models and starts with explicit Model and Thinking", async () => {
+    const xaiModel = harnessModelRefSchema.parse({
+      id: "codex-model-v1.eGFpL2dyb2stNC42",
+    });
+    const kimiModel = harnessModelRefSchema.parse({
+      id: "codex-model-v1.a2ltaS9rM1sxbV0",
+    });
     let delegationApi: DelegationControlApi | undefined;
     const fixture = createFixture({
       onDelegationApi: (api) => {
@@ -1166,9 +1172,14 @@ describe("AppServerHost HarnessAdapter projection", () => {
         result: {
           data: [
             {
-              model: "gpt-5.6-luna",
-              displayName: "GPT Luna",
+              model: "xai/grok-4.6",
+              displayName: "Grok 4.6",
               isDefault: true,
+              supportedReasoningEfforts: [{ reasoningEffort: "high", description: "High" }],
+            },
+            {
+              model: "kimi/k3[1m]",
+              displayName: "Kimi K3",
               supportedReasoningEfforts: [{ reasoningEffort: "high", description: "High" }],
             },
           ],
@@ -1180,7 +1191,11 @@ describe("AppServerHost HarnessAdapter projection", () => {
       inspection: {
         status: "ready",
         catalog: {
-          defaultModel: { id: "gpt-5.6-luna" },
+          models: [
+            { ref: xaiModel, label: "Grok 4.6" },
+            { ref: kimiModel, label: "Kimi K3" },
+          ],
+          defaultModel: xaiModel,
           thinkingOptions: [{ id: "high", label: "High" }],
         },
       },
@@ -1191,7 +1206,7 @@ describe("AppServerHost HarnessAdapter projection", () => {
       task: "review auth",
       cwd: "/synthetic",
       parentThreadId: "parent-thread",
-      model: harnessModelRefSchema.parse({ id: "gpt-5.6-luna" }),
+      model: kimiModel,
       thinkingOptionId: harnessThinkingOptionIdSchema.parse("high"),
     });
     const validationList = await readJsonLine(fixture.official.stdin);
@@ -1202,7 +1217,11 @@ describe("AppServerHost HarnessAdapter projection", () => {
         result: {
           data: [
             {
-              model: "gpt-5.6-luna",
+              model: "xai/grok-4.6",
+              supportedReasoningEfforts: [{ reasoningEffort: "high", description: "High" }],
+            },
+            {
+              model: "kimi/k3[1m]",
               isDefault: true,
               supportedReasoningEfforts: [{ reasoningEffort: "high", description: "High" }],
             },
@@ -1213,7 +1232,7 @@ describe("AppServerHost HarnessAdapter projection", () => {
     const threadStart = await readJsonLine(fixture.official.stdin);
     expect(threadStart).toMatchObject({
       method: "thread/start",
-      params: { model: "gpt-5.6-luna" },
+      params: { model: "kimi/k3[1m]" },
     });
     expect(threadStart.params).not.toHaveProperty("reasoningEffort");
     fixture.official.stdout.write(
@@ -1221,6 +1240,70 @@ describe("AppServerHost HarnessAdapter projection", () => {
         id: threadStart.id,
         result: {
           thread: { id: "native-configured" },
+          model: "kimi/k3[1m]",
+        },
+      })}\n`,
+    );
+    const turnStart = await readJsonLine(fixture.official.stdin);
+    expect(turnStart).toMatchObject({
+      method: "turn/start",
+      params: { model: "kimi/k3[1m]", effort: "high" },
+    });
+    fixture.official.stdout.write(
+      `${JSON.stringify({ id: turnStart.id, result: { turn: { id: "native-turn" } } })}\n`,
+    );
+    await expect(pending).resolves.toMatchObject({
+      configuration: {
+        requested: { model: kimiModel, thinkingOptionId: "high" },
+        effective: {
+          effectiveModel: kimiModel,
+        },
+      },
+    });
+    await stopFixture(fixture);
+  });
+
+  it("canonicalizes legacy transport-safe Codex Model refs before delegation", async () => {
+    const legacyModel = harnessModelRefSchema.parse({ id: "gpt-5.6-luna" });
+    const canonicalModel = harnessModelRefSchema.parse({
+      id: "codex-model-v1.Z3B0LTUuNi1sdW5h",
+    });
+    let delegationApi: DelegationControlApi | undefined;
+    const fixture = createFixture({
+      onDelegationApi: (api) => {
+        delegationApi = api;
+        return undefined;
+      },
+    });
+    await vi.waitFor(() => expect(delegationApi).toBeDefined());
+    await vi.waitFor(async () => expect(await fixture.mappingStore.listThreads()).toEqual([]));
+    if (!delegationApi) throw new Error("Delegation API was not registered");
+
+    const pending = delegationApi.start({
+      harnessId: "codex",
+      task: "review auth",
+      cwd: "/synthetic",
+      parentThreadId: "parent-thread",
+      model: legacyModel,
+    });
+    const modelList = await readJsonLine(fixture.official.stdin);
+    expect(modelList).toMatchObject({ method: "model/list", params: {} });
+    fixture.official.stdout.write(
+      `${JSON.stringify({
+        id: modelList.id,
+        result: { data: [{ model: "gpt-5.6-luna", isDefault: true }] },
+      })}\n`,
+    );
+    const threadStart = await readJsonLine(fixture.official.stdin);
+    expect(threadStart).toMatchObject({
+      method: "thread/start",
+      params: { model: "gpt-5.6-luna" },
+    });
+    fixture.official.stdout.write(
+      `${JSON.stringify({
+        id: threadStart.id,
+        result: {
+          thread: { id: "native-legacy-configured" },
           model: "gpt-5.6-luna",
         },
       })}\n`,
@@ -1228,17 +1311,15 @@ describe("AppServerHost HarnessAdapter projection", () => {
     const turnStart = await readJsonLine(fixture.official.stdin);
     expect(turnStart).toMatchObject({
       method: "turn/start",
-      params: { model: "gpt-5.6-luna", effort: "high" },
+      params: { model: "gpt-5.6-luna" },
     });
     fixture.official.stdout.write(
-      `${JSON.stringify({ id: turnStart.id, result: { turn: { id: "native-turn" } } })}\n`,
+      `${JSON.stringify({ id: turnStart.id, result: { turn: { id: "native-legacy-turn" } } })}\n`,
     );
     await expect(pending).resolves.toMatchObject({
       configuration: {
-        requested: { model: { id: "gpt-5.6-luna" }, thinkingOptionId: "high" },
-        effective: {
-          effectiveModel: { id: "gpt-5.6-luna" },
-        },
+        requested: { model: canonicalModel },
+        effective: { effectiveModel: canonicalModel },
       },
     });
     await stopFixture(fixture);

--- a/packages/host-runtime/test/official-codex-model-ref.test.ts
+++ b/packages/host-runtime/test/official-codex-model-ref.test.ts
@@ -1,0 +1,55 @@
+import { HARNESS_MODEL_REF_MAX_LENGTH, harnessModelRefSchema } from "@codexhost/shared-contracts";
+import { describe, expect, it } from "vitest";
+
+import {
+  canonicalizeOfficialCodexModelRef,
+  decodeOfficialCodexModelRef,
+  encodeOfficialCodexModelRef,
+} from "../src/official-codex-model-ref.js";
+
+describe("official Codex Model refs", () => {
+  it.each([
+    ["gpt-5.6-luna", "codex-model-v1.Z3B0LTUuNi1sdW5h"],
+    ["xai/grok-4.6", "codex-model-v1.eGFpL2dyb2stNC42"],
+    ["kimi/k3[1m]", "codex-model-v1.a2ltaS9rM1sxbV0"],
+  ])("round-trips %s through a canonical opaque ref", (nativeModelId, opaqueId) => {
+    const ref = encodeOfficialCodexModelRef(nativeModelId);
+    expect(ref).toEqual({ id: opaqueId });
+    expect(decodeOfficialCodexModelRef(ref)).toBe(nativeModelId);
+  });
+
+  it("canonicalizes legacy transport-safe native IDs", () => {
+    const legacy = harnessModelRefSchema.parse({ id: "gpt-5.6-luna" });
+    expect(decodeOfficialCodexModelRef(legacy)).toBe("gpt-5.6-luna");
+    expect(canonicalizeOfficialCodexModelRef(legacy)).toEqual({
+      id: "codex-model-v1.Z3B0LTUuNi1sdW5h",
+    });
+  });
+
+  it("rejects empty, malformed, non-canonical, and overlong refs", () => {
+    expect(() =>
+      decodeOfficialCodexModelRef(harnessModelRefSchema.parse({ id: "codex-model-v1.empty" })),
+    ).toThrow();
+    expect(() =>
+      decodeOfficialCodexModelRef(
+        harnessModelRefSchema.parse({ id: "codex-model-v1.Z3B0LTUuNi1sdW5h." }),
+      ),
+    ).toThrow("not canonical");
+    expect(() => encodeOfficialCodexModelRef(" ")).toThrow("must not be empty");
+    expect(() => encodeOfficialCodexModelRef("x".repeat(HARNESS_MODEL_REF_MAX_LENGTH))).toThrow(
+      "too long",
+    );
+  });
+
+  it("canonicalizes legacy native IDs that collide with the opaque namespace", () => {
+    const nativeModelId = "codex-model-v1.literal";
+    expect(decodeOfficialCodexModelRef(encodeOfficialCodexModelRef(nativeModelId))).toBe(
+      nativeModelId,
+    );
+    const legacy = harnessModelRefSchema.parse({ id: nativeModelId });
+    expect(() => decodeOfficialCodexModelRef(legacy)).toThrow();
+    expect(decodeOfficialCodexModelRef(canonicalizeOfficialCodexModelRef(legacy))).toBe(
+      nativeModelId,
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- encode official Codex `model/list` IDs as canonical `codex-model-v1.<base64url>` Harness Model refs
- keep the native model ID separate and restore it only at the official `thread/start` / `turn/start` boundary
- canonicalize legacy transport-safe refs, including native IDs that collide with the opaque prefix
- add unit and host-runtime integration coverage for `xai/grok-4.6`, `kimi/k3[1m]`, legacy refs, selection, and effective state

## Root cause

The official Codex inspection path parsed native model IDs directly as `HarnessModelRef`. Provider-qualified and long-context IDs can contain `/`, `[` or `]`, so schema validation failed before the catalog reached the renderer.

## Validation

- `npm run lint`
- `npm run typecheck`
- `npm run test:typescript` (173 files passed, 1 skipped; 1482 tests passed, 15 skipped)
- `npm run check:rust`
- Prettier check on all four changed files
- focused host-runtime tests: 118 passed

The aggregate `npm run check` currently stops in its repository-wide format phase on unchanged upstream file `packages/renderer-extension/src/settings/windows-update.preview.html` (blob `83ac03d60433bb3be11a20a4018a7b900d92c8e0`). The remaining lint, typecheck, TypeScript, and Rust gates were run separately and passed; this PR does not include unrelated formatting churn.