### PR TITLE
fix: restore Windows launcher and remote Host startup

### DIFF
--- a/crates/launcher/src/main.rs
+++ b/crates/launcher/src/main.rs
@@ -128,7 +128,7 @@ fn run_delegation_cli(arguments: &[String]) -> Result<(), Box<dyn Error>> {
     let executable = env::current_exe()?.canonicalize()?;
     let resources = InstalledResources::from_executable(&executable)?;
     let status = Command::new(&resources.node)
-        .arg(&resources.host_runtime)
+        .arg(node_entrypoint_path(&resources.host_runtime))
         .arg("--codexhost-delegation-cli")
         .args(arguments)
         .env(CODEXHOST_CLI_PATH_ENV, &executable)

--- a/crates/platform/src/windows_desktop.rs
+++ b/crates/platform/src/windows_desktop.rs
@@ -397,9 +397,14 @@ pub fn activate_packaged_desktop(
     let _apartment = ComApartment::initialize()?;
     let environment = windows_environment_block(environment)?;
     let mut package_environment = PackageEnvironment::enable(package_full_name, &environment)?;
-    let manager: IApplicationActivationManager =
-        unsafe { CoCreateInstance(&ApplicationActivationManager, None, CLSCTX_LOCAL_SERVER) }
-            .map_err(|error| windows_error("cannot initialize AppX activation manager", error))?;
+    let manager: IApplicationActivationManager = unsafe {
+        CoCreateInstance(
+            &ApplicationActivationManager,
+            None,
+            CLSCTX_INPROC_SERVER | CLSCTX_LOCAL_SERVER,
+        )
+    }
+    .map_err(|error| windows_error("cannot initialize AppX activation manager", error))?;
     let activation_process_id = unsafe {
         manager.ActivateApplication(
             &HSTRING::from(app_user_model_id),
@@ -446,9 +451,14 @@ pub fn activate_stock_desktop(
     } {
         let _ = unsafe { settings.DisableDebugging(&HSTRING::from(package_full_name)) };
     }
-    let manager: IApplicationActivationManager =
-        unsafe { CoCreateInstance(&ApplicationActivationManager, None, CLSCTX_LOCAL_SERVER) }
-            .map_err(|error| windows_error("cannot initialize AppX activation manager", error))?;
+    let manager: IApplicationActivationManager = unsafe {
+        CoCreateInstance(
+            &ApplicationActivationManager,
+            None,
+            CLSCTX_INPROC_SERVER | CLSCTX_LOCAL_SERVER,
+        )
+    }
+    .map_err(|error| windows_error("cannot initialize AppX activation manager", error))?;
     let activation_process_id = unsafe {
         manager.ActivateApplication(
             &HSTRING::from(app_user_model_id),

--- a/packages/host-runtime/src/remote-host-install.ts
+++ b/packages/host-runtime/src/remote-host-install.ts
@@ -238,6 +238,7 @@ function installManagedProfileBlock(contents: string, manifest: RemoteHostManife
   const base = removeManagedProfileBlock(contents);
   const environment = [
     `export CODEX_INSTALL_DIR=${shellQuote(path.dirname(manifest.wrapperPath))}`,
+    `export PATH=${shellQuote(path.dirname(manifest.wrapperPath))}:${shellQuote(path.dirname(manifest.nodePath))}:${shellQuote(path.dirname(manifest.stockCodexPath))}:"\${PATH:-/usr/local/bin:/usr/bin:/bin}"`,
     `export CODEXHOST_STOCK_CODEX_PATH=${shellQuote(manifest.stockCodexPath)}`,
     `export CODEXHOST_HOST_NODE_PATH=${shellQuote(manifest.nodePath)}`,
     `export CODEXHOST_HOST_RUNTIME_PATH=${shellQuote(manifest.hostRuntimePath)}`,

--- a/packages/host-runtime/src/remote-host-lifecycle.ts
+++ b/packages/host-runtime/src/remote-host-lifecycle.ts
@@ -361,9 +361,6 @@ export async function startRemoteHost(
   }
   let replacedStockCodex = false;
   if (current.state !== "stopped") {
-    if (current.protocol !== "stock-codex") {
-      throw new Error(current.message ?? `Unknown process owns Remote Host socket ${socketPath}`);
-    }
     await lifecycle.runTerminator(manifest, socketPath, "stock", environment);
     replacedStockCodex = true;
   }

--- a/packages/host-runtime/test/remote-host-install.test.ts
+++ b/packages/host-runtime/test/remote-host-install.test.ts
@@ -144,7 +144,7 @@ describe("remote SSH Host installation", () => {
           "--noprofile",
           "--norc",
           "-c",
-          `. ${shellQuote(profilePath)}; printf '%s\\n%s\\n' "$CODEXHOST_REMOTE_SSH_MANAGED" "$CODEX_INSTALL_DIR"`,
+          `unset PATH; . ${shellQuote(profilePath)}; printf '%s\\n%s\\n%s\\n' "$CODEXHOST_REMOTE_SSH_MANAGED" "$CODEX_INSTALL_DIR" "$PATH"`,
         ];
         const localProbe = spawnSync("/bin/bash", probeArguments, {
           encoding: "utf8",
@@ -155,7 +155,7 @@ describe("remote SSH Host installation", () => {
           signal: localProbe.signal,
           stderr: localProbe.stderr,
           stdout: localProbe.stdout,
-        }).toEqual({ status: 0, signal: null, stderr: "", stdout: "\n\n" });
+        }).toEqual({ status: 0, signal: null, stderr: "", stdout: "\n\n\n" });
 
         const sshProbe = spawnSync("/bin/bash", probeArguments, {
           encoding: "utf8",
@@ -170,7 +170,9 @@ describe("remote SSH Host installation", () => {
           signal: null,
           stderr: "",
         });
-        expect(sshProbe.stdout).toBe(`1\n${path.dirname(installed.wrapperPath)}\n`);
+        expect(sshProbe.stdout).toBe(
+          `1\n${path.dirname(installed.wrapperPath)}\n${path.dirname(installed.wrapperPath)}:${home}:${home}:/usr/local/bin:/usr/bin:/bin\n`,
+        );
         await expect(inspectRemoteHostInstallation(options)).resolves.toMatchObject({
           state: "ready",
         });
@@ -214,6 +216,9 @@ describe("remote SSH Host installation", () => {
       expect(await readFile(first.wrapperPath)).toEqual(await readFile(shimPath));
       expect(profile).toContain(`export CODEXHOST_STOCK_CODEX_PATH='${stockCodexPath}'`);
       expect(profile).toContain(`export CODEXHOST_HOST_NODE_PATH='${nodePath}'`);
+      expect(profile).toContain(
+        `export PATH='${path.dirname(first.wrapperPath)}':'${path.dirname(nodePath)}':'${path.dirname(stockCodexPath)}':\"\${PATH:-/usr/local/bin:/usr/bin:/bin}\"`,
+      );
       expect(profile).toContain(`export CODEXHOST_HOST_RUNTIME_PATH='${hostRuntimePath}'`);
       expect(profile).toContain("export CODEXHOST_REMOTE_SSH_MANAGED='1'");
       expect(profile).toContain(`export CODEXHOST_CLAUDE_COMMAND='${claudeCommand}'`);

--- a/packages/host-runtime/test/remote-host-lifecycle.test.ts
+++ b/packages/host-runtime/test/remote-host-lifecycle.test.ts
@@ -104,11 +104,11 @@ describe("remote Host lifecycle", () => {
     expect(terminate).not.toHaveBeenCalled();
   });
 
-  it("replaces a verified stock listener before launching the managed Host", async () => {
+  it("uses process verification when an active listener cannot be classified", async () => {
     const operations: string[] = [];
     restore = setRemoteHostLifecycleDependenciesForTest({
       inspectInstallation: vi.fn().mockResolvedValue(readyInstallation),
-      probeProtocol: vi.fn().mockResolvedValue(runtime("conflict", "stock-codex")),
+      probeProtocol: vi.fn().mockResolvedValue(runtime("unknown", "unknown")),
       runTerminator: vi.fn(async (_manifest, _socket, role) => {
         operations.push(`terminate:${role}`);
       }),
@@ -132,7 +132,11 @@ describe("remote Host lifecycle", () => {
 
   it("fails closed for an unknown active socket", async () => {
     const launch = vi.fn();
-    const terminate = vi.fn();
+    const terminate = vi
+      .fn()
+      .mockRejectedValue(
+        new Error("remote Host socket owner does not match the requested installed listener"),
+      );
     restore = setRemoteHostLifecycleDependenciesForTest({
       inspectInstallation: vi.fn().mockResolvedValue(readyInstallation),
       probeProtocol: vi
@@ -144,9 +148,14 @@ describe("remote Host lifecycle", () => {
 
     await expect(
       startRemoteHost({ platform: "linux", environment: { HOME: home } }),
-    ).rejects.toThrow("unknown owner");
+    ).rejects.toThrow("socket owner does not match");
     expect(launch).not.toHaveBeenCalled();
-    expect(terminate).not.toHaveBeenCalled();
+    expect(terminate).toHaveBeenCalledWith(
+      expect.objectContaining(manifest),
+      socketPath,
+      "stock",
+      { HOME: home },
+    );
   });
 
   it("stops only a protocol-verified managed Host", async () => {


### PR DESCRIPTION
## Purpose

Fix startup failures across the packaged Windows launcher and Remote SSH Host bootstrap.

## Changes

- allow the Windows AppX activation manager to resolve through in-process or local-server COM contexts
- normalize Windows verbatim paths before passing packaged Host entrypoints to Node
- add managed binaries to the Remote SSH profile PATH with a safe system fallback
- use the native process verifier when an active Remote Host listener cannot be classified by protocol probing
- preserve fail-closed behavior when the socket owner does not match the installed listener

## Validation

- `npm run release:package -- --target windows-x64`
- packaged `codexhost.exe delegate --help` and `codexhost.exe inspect`
- Remote Host Vitest files: 22 passed, 2 Unix-shell tests skipped on Windows
- `npm run build --workspace=@codexhost/host-runtime`
- `npx tsc -p tests/tsconfig.json --noEmit --pretty false`
- targeted Rust path-normalization tests
- `cargo fmt --all --check`

## Notes

The native Linux/macOS terminator still verifies socket ownership, executable identity, and listener arguments before terminating any process.