### PR TITLE
feat: 在 Codex Desktop SSH 远程工作区安装并选择 Grok

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,4 +1,5 @@
 **/*.md
+**/*.preview.html
 **/*.wxs
 .pi/
 reference/

--- a/docs/remote-ssh-host.md
+++ b/docs/remote-ssh-host.md
@@ -1,14 +1,14 @@
 # Remote SSH Harness Host
 
-Codex Desktop can open a project on another machine through its native SSH workflow. Installing codexhost on both machines lets that remote workspace use Harnesses that are installed and authenticated only on the development host, including Claude Code.
+Codex Desktop can open a project on another machine through its native SSH workflow. Installing codexhost on both machines lets that remote workspace use Harnesses that are installed and authenticated only on the development host, including Claude Code and Grok.
 
-This path keeps the native Codex Desktop UI and SSH transport. It does not turn a Claude login into an OpenAI-compatible API: Claude Code itself owns the Native Session on the remote machine.
+This path keeps the native Codex Desktop UI and SSH transport. It does not turn a Claude or Grok login into an OpenAI-compatible API: the selected Harness itself owns the Native Session on the remote machine.
 
 ## Prerequisites
 
 - Codex Desktop and codexhost on the client machine.
 - Codex CLI and the same codexhost version on a macOS or x64/ARM64 Linux SSH host.
-- The desired Harness installed and authenticated on the SSH host. For Claude Code, run its normal login there; do not copy its account files to the client.
+- The desired Harness installed and authenticated on the SSH host. For Claude Code or Grok, run its normal login there; do not copy its account files to the client.
 - A working Codex Desktop SSH workspace before enabling codexhost.
 
 Windows is supported as the client. A Windows machine is not currently supported as the remote Host because Codex's remote control transport uses Unix sockets.
@@ -27,14 +27,15 @@ If `codex` already resolves to OpenCodex or another wrapper, pass the real offic
 ```bash
 codexhost remote install \
   --stock-codex /absolute/path/to/official/codex \
-  --claude-command /absolute/path/to/claude
+  --claude-command /absolute/path/to/claude \
+  --grok-command /absolute/path/to/grok
 ```
 
 The command:
 
-- installs the packaged native Shim as `~/.codexhost/remote/bin/codex`. In the managed remote environment, the exact default `app-server --listen unix://` invocation starts a detached listener, waits until a freshly created control socket accepts connections, and then lets Codex Desktop's background SSH bootstrap return;
+- installs the packaged native Shim as `~/.codexhost/remote/bin/codex`. If that binary cannot load because the Linux glibc is older than the packaged native baseline, installation writes a Node entrypoint with the same detach semantics and uses the Node that ran `codexhost`. In the managed remote environment, the exact default `app-server --listen unix://` invocation starts a detached listener, waits until a freshly created control socket accepts connections, and then lets Codex Desktop's background SSH bootstrap return. Local interactive `codex` is unchanged because the managed `CODEX_INSTALL_DIR` is SSH-scoped;
 - stores remote Mapping Store data separately under `~/.codexhost/remote/data`;
-- adds one marked environment block to `.zshenv`, `.bashrc`, or the explicitly selected profile. The block activates only for an SSH session, so local shells and a local codexhost Desktop on the same machine do not inherit remote Host ownership. In `.bashrc`, the guarded block is placed before the standard non-interactive early-return guard used by Linux distributions such as Ubuntu. It selects `CODEX_INSTALL_DIR` and supplies the absolute stock Codex, Node, Host Runtime, data, and optional Claude Code paths used by the native entrypoint;
+- adds one marked environment block to `.zshenv`, `.bashrc`, or the explicitly selected profile. The block activates only for an SSH session, so local shells and a local codexhost Desktop on the same machine do not inherit remote Host ownership. In `.bashrc`, the guarded block is placed before the standard non-interactive early-return guard used by Linux distributions such as Ubuntu. It selects `CODEX_INSTALL_DIR` and supplies the absolute stock Codex, Node, Host Runtime, data, and optional Claude Code and Grok paths used by the native entrypoint;
 - writes a timestamped profile backup before changing it;
 - records the installed native entrypoint digest so a later uninstall can still verify it after an older package runtime has been removed;
 - leaves the existing `codex` command and OpenCodex configuration untouched.
@@ -57,7 +58,7 @@ Start the client-side Codex Desktop through codexhost, open the SSH workspace, a
 
 A newly opened task in a remote project remains a draft and should allow Agent selection. Current Desktop builds are classified from the active Composer's own marker, so a background/prewarmed conversation elsewhere on the project page cannot incorrectly lock the new task. Once the first Turn binds the draft, the resulting Thread identity becomes authoritative.
 
-The remote Claude Code process sees the remote cwd and account. Prompts, streamed output, tool status, approvals, and diffs are projected through the existing SSH channel so Codex Desktop can render them; credential files are not forwarded.
+Remote Claude Code and Grok processes see the remote cwd and account. Prompts, streamed output, tool status, approvals, and diffs are projected through the existing SSH channel so Codex Desktop can render them; credential files are not forwarded. Grok still uses its local stdio ACP adapter on the SSH host. It does not require a separate `grok agent serve` daemon.
 
 ## Diagnose and roll back
 

--- a/docs/remote-ssh-host.zh-CN.md
+++ b/docs/remote-ssh-host.zh-CN.md
@@ -1,14 +1,14 @@
 # SSH 远程 Harness Host
 
-Codex Desktop 可以通过原生 SSH 工作流打开另一台机器上的项目。两端都安装 codexhost 后，远程工作区就能使用只安装、只登录在开发机上的 Harness，包括 Claude Code。
+Codex Desktop 可以通过原生 SSH 工作流打开另一台机器上的项目。两端都安装 codexhost 后，远程工作区就能使用只安装、只登录在开发机上的 Harness，包括 Claude Code 和 Grok。
 
-这条链路保留 Codex Desktop 原生界面和 SSH 传输，不会把 Claude 登录伪装成 OpenAI 兼容 API；Native Session 仍由远程机器上的 Claude Code 自己维护。
+这条链路保留 Codex Desktop 原生界面和 SSH 传输，不会把 Claude 或 Grok 登录伪装成 OpenAI 兼容 API；Native Session 仍由远程机器上的 Harness 自己维护。
 
 ## 前置条件
 
 - 客户端已安装 Codex Desktop 和 codexhost。
 - macOS 或 x64/ARM64 Linux SSH 开发机已安装 Codex CLI，以及与客户端相同版本的 codexhost。
-- 目标 Harness 已在 SSH 开发机安装并登录。Claude Code 请在开发机完成正常登录，不要把账号文件复制到客户端。
+- 目标 Harness 已在 SSH 开发机安装并登录。Claude Code 或 Grok 请在开发机完成正常登录，不要把账号文件复制到客户端。
 - 启用 codexhost 前，Codex Desktop 原生 SSH 工作区已经可以正常使用。
 
 客户端可以是 Windows。远程 Host 暂不支持 Windows，因为 Codex 当前的远程控制传输使用 Unix socket。
@@ -27,14 +27,15 @@ codexhost remote status
 ```bash
 codexhost remote install \
   --stock-codex /absolute/path/to/official/codex \
-  --claude-command /absolute/path/to/claude
+  --claude-command /absolute/path/to/claude \
+  --grok-command /absolute/path/to/grok
 ```
 
 该命令会：
 
-- 把打包的原生 Shim 安装为 `~/.codexhost/remote/bin/codex`。在托管远程环境中，只有精确匹配默认形式的 `app-server --listen unix://` 会启动脱离会话的 listener；Shim 会先等新的 control socket 可连接，再让 Codex Desktop 的后台 SSH bootstrap 返回；
+- 把打包的原生 Shim 安装为 `~/.codexhost/remote/bin/codex`。如果这台 Linux 的 glibc 低于原生包基线、该二进制无法加载，安装会改写成 Node 入口，语义与原生 Shim 的 detach 相同，Node 使用运行 `codexhost` 的那份。在托管远程环境中，只有精确匹配默认形式的 `app-server --listen unix://` 会启动脱离会话的 listener；入口会先等新的 control socket 可连接，再让 Codex Desktop 的后台 SSH bootstrap 返回。本地交互式 `codex` 不受影响，因为 `CODEX_INSTALL_DIR` 只在 SSH 会话里生效；
 - 把远程 Mapping Store 数据隔离在 `~/.codexhost/remote/data`；
-- 在 `.zshenv`、`.bashrc` 或显式指定的 profile 中加入一段带标记的环境配置；该配置仅在 SSH 会话中生效，因此同一台机器上的本地 Shell 和本地 codexhost Desktop 不会继承远程 Host 所有权；对于 `.bashrc`，受 SSH 条件保护的配置会放在 Ubuntu 等 Linux 发行版常见的非交互提前退出判断之前；该配置既设置 `CODEX_INSTALL_DIR`，也为原生入口提供官方 Codex、Node、Host Runtime、数据目录和可选 Claude Code 的绝对路径；
+- 在 `.zshenv`、`.bashrc` 或显式指定的 profile 中加入一段带标记的环境配置；该配置仅在 SSH 会话中生效，因此同一台机器上的本地 Shell 和本地 codexhost Desktop 不会继承远程 Host 所有权；对于 `.bashrc`，受 SSH 条件保护的配置会放在 Ubuntu 等 Linux 发行版常见的非交互提前退出判断之前；该配置既设置 `CODEX_INSTALL_DIR`，也为原生入口提供官方 Codex、Node、Host Runtime、数据目录和可选 Claude Code、Grok 的绝对路径；
 - 修改 profile 前写入带时间戳的备份；
 - 记录已安装原生入口的摘要，因此旧版本包内 runtime 被清理后，后续卸载仍可校验该入口；
 - 保持原有 `codex` 命令和 OpenCodex 配置不变。
@@ -53,7 +54,7 @@ codexhost remote install \
 
 远程项目中新开的任务仍应保持 draft 状态并允许选择 Agent。当前 Desktop 版本会从活动输入框自身的标记判断身份，因此项目页其他位置的后台/预热会话不会再把新任务误锁成已有 Codex Thread；首个 Turn 提交并完成绑定后，实际 Thread 身份才成为准确信息源。
 
-远程 Claude Code 进程使用开发机上的 cwd 和账号。为了让 Codex Desktop 渲染，提示词、流式输出、工具状态、审批和 Diff 会通过现有 SSH 通道投影；凭据文件不会被转发。
+远程 Claude Code 和 Grok 进程使用开发机上的 cwd 和账号。为了让 Codex Desktop 渲染，提示词、流式输出、工具状态、审批和 Diff 会通过现有 SSH 通道投影；凭据文件不会被转发。Grok 仍在 SSH 开发机上走本地 stdio ACP 适配器，不需要再单独启动 `grok agent serve`。
 
 ## 诊断与回滚
 

--- a/openspec/specs/remote-ssh-harness-host/spec.md
+++ b/openspec/specs/remote-ssh-harness-host/spec.md
@@ -46,9 +46,18 @@ The Host SHALL start the selected Harness with the remote cwd, remote command, a
 - **AND** consecutive Turns use the same mapped Native Session
 - **AND** no Claude credential file is installed on the client
 
+#### Scenario: Grok is installed only on the development host
+
+- **GIVEN** Grok CLI is authenticated on the SSH host and not on the client
+- **WHEN** remote installation discovers Grok or is supplied `--grok-command`
+- **THEN** the managed profile and listener environment export `CODEXHOST_GROK_COMMAND`
+- **AND** the client can inspect Grok and start a Grok Thread in a remote workspace
+- **AND** the Grok process uses stdio ACP on the SSH host rather than `grok agent serve`
+- **AND** no Grok credential file is installed on the client
+
 ### Requirement: Remote installation SHALL be isolated and reversible
 
-`codexhost remote install` SHALL create a managed native Shim entrypoint in a dedicated `CODEX_INSTALL_DIR`, record the installed entrypoint's SHA-256 digest, add one bounded SSH-scoped environment export block to the appropriate non-interactive shell startup file, back up that file before changing it, and preserve the existing Codex entrypoint. It SHALL refuse unmanaged entrypoint conflicts and SHALL migrate its legacy managed shell wrapper in place. In that managed environment, only an invocation containing exactly one default `app-server --listen unix://` listener and no stdio mode SHALL detach from the SSH bootstrap after a newly created expected socket accepts a connection; proxy, stdio, duplicate-listener, custom-listener, and ordinary Codex invocations SHALL retain their foreground lifecycle. `status` SHALL report missing, modified, malformed, or legacy managed resources as degraded. Install and uninstall SHALL remain fail-closed for a malformed managed profile block. `uninstall` SHALL remove only an integrity-verified managed entrypoint, manifest, and profile block while preserving backups and remote Host data.
+`codexhost remote install` SHALL create a managed native Shim entrypoint in a dedicated `CODEX_INSTALL_DIR`, record the installed entrypoint's SHA-256 digest, add one bounded SSH-scoped environment export block to the appropriate non-interactive shell startup file, back up that file before changing it, and preserve the existing Codex entrypoint. If the packaged native Shim cannot load on that Linux host because glibc is older than the native baseline, installation SHALL write a Node entrypoint instead, using the Node that ran `codexhost`, with the same detach and foreground routing rules. It SHALL refuse unmanaged entrypoint conflicts and SHALL migrate its legacy managed shell wrapper in place. In that managed environment, only an invocation containing exactly one default `app-server --listen unix://` listener and no stdio mode SHALL detach from the SSH bootstrap after a newly created expected socket accepts a connection; proxy, stdio, duplicate-listener, custom-listener, and ordinary Codex invocations SHALL retain their foreground lifecycle. `status` SHALL report missing, modified, malformed, or legacy managed resources as degraded. Install and uninstall SHALL remain fail-closed for a malformed managed profile block. `uninstall` SHALL remove only an integrity-verified managed entrypoint, manifest, and profile block while preserving backups and remote Host data.
 
 #### Scenario: OpenCodex already owns the normal Codex command
 
@@ -63,6 +72,16 @@ The Host SHALL start the selected Harness with the remote cwd, remote command, a
 - **THEN** the managed entrypoint starts the listener in a new Unix session and waits for a newly created expected control socket to accept a connection
 - **AND** the SSH bootstrap command returns successfully without waiting for the listener lifetime
 - **AND** the native listener process remains alive and owns the expected Unix control socket
+
+#### Scenario: Older glibc cannot load the packaged native Shim
+
+- **GIVEN** the SSH host has a glibc older than the packaged native Shim baseline
+- **AND** Node and the packaged Host Runtime are available on that host
+- **WHEN** remote installation probes the packaged Shim and the dynamic loader reports a missing GLIBC symbol
+- **THEN** installation writes a Node entrypoint at the managed Codex path instead of leaving the unloadable native binary
+- **AND** that Node entrypoint still detaches only the default `app-server --listen unix://` listener
+- **AND** `app-server proxy` and ordinary Codex commands still exec the stock Codex entrypoint
+- **AND** a local interactive `codex` session on the same machine does not inherit remote Host ownership
 
 #### Scenario: Non-listener commands retain foreground ownership
 

--- a/packages/host-runtime/src/app-server-host.ts
+++ b/packages/host-runtime/src/app-server-host.ts
@@ -45,6 +45,8 @@ import {
   updateEmptyParamsSchema,
   updateStartResultSchema,
   updateStatusResultSchema,
+  remoteSshPreflightParamsSchema,
+  remoteSshProvisionParamsSchema,
   type AccountCreditsSnapshot,
   type HarnessModelRef,
   type HarnessPermissionModeId,
@@ -53,6 +55,13 @@ import {
   type HostTurnId,
 } from "@codexhost/shared-contracts";
 import { executeExternalThreadFork } from "./external-thread-fork.js";
+import {
+  REMOTE_SSH_PREFLIGHT_METHOD,
+  REMOTE_SSH_PROVISION_LOG_METHOD,
+  REMOTE_SSH_PROVISION_METHOD,
+  preflightRemoteSshGrokHost,
+  provisionRemoteSshGrokHost,
+} from "./remote-ssh-provision.js";
 import {
   ExternalHistoryRequestError,
   listExternalItems,
@@ -250,6 +259,7 @@ export function officialEnvironment(source: NodeJS.ProcessEnv): NodeJS.ProcessEn
     "CODEXHOST_PI_COMMAND",
     "CODEXHOST_ENABLE_CLAUDE_CODE",
     "CODEXHOST_CLAUDE_COMMAND",
+    "CODEXHOST_GROK_COMMAND",
     "CODEXHOST_STOCK_CODEX_PATH",
     "CODEXHOST_LAUNCHER_PID",
     "CODEXHOST_LAUNCHER_EXECUTABLE",
@@ -617,6 +627,14 @@ export class AppServerHost {
       }
       if (request.method === "codexhost/harness/inspect") {
         this.#dispatchDesktopRequest(() => this.#inspectHarness(request));
+        continue;
+      }
+      if (request.method === REMOTE_SSH_PREFLIGHT_METHOD) {
+        this.#dispatchDesktopRequest(() => this.#preflightRemoteSshGrok(request));
+        continue;
+      }
+      if (request.method === REMOTE_SSH_PROVISION_METHOD) {
+        this.#dispatchDesktopRequest(() => this.#provisionRemoteSshGrok(request));
         continue;
       }
       if (request.method === "codexhost/thread/fork") {
@@ -1603,6 +1621,45 @@ export class AppServerHost {
       await this.#writer.json(rpcEnvelope(request, { result: jsonValueSchema.parse(result) }));
     } catch (error) {
       await this.#writer.json(rpcError(request, -32091, errorMessage(error).slice(0, 500)));
+    }
+  }
+
+  async #preflightRemoteSshGrok(request: JsonRpcRequest): Promise<void> {
+    const params = remoteSshPreflightParamsSchema.safeParse(request.params);
+    if (!params.success) {
+      await this.#writer.json(rpcError(request, -32602, "Invalid remote Host preflight params"));
+      return;
+    }
+    try {
+      const result = await preflightRemoteSshGrokHost({
+        params: params.data,
+        environment: this.#options.environment ?? process.env,
+      });
+      await this.#writer.json(rpcEnvelope(request, { result: jsonValueSchema.parse(result) }));
+    } catch (error) {
+      await this.#writer.json(rpcError(request, -32077, errorMessage(error).slice(0, 1500)));
+    }
+  }
+
+  async #provisionRemoteSshGrok(request: JsonRpcRequest): Promise<void> {
+    const params = remoteSshProvisionParamsSchema.safeParse(request.params);
+    if (!params.success) {
+      await this.#writer.json(rpcError(request, -32602, "Invalid remote Host setup params"));
+      return;
+    }
+    try {
+      const result = await provisionRemoteSshGrokHost({
+        params: params.data,
+        environment: this.#options.environment ?? process.env,
+        onLog: (chunk) =>
+          this.#writer.json({
+            method: REMOTE_SSH_PROVISION_LOG_METHOD,
+            params: { hostId: params.data.hostId, chunk },
+          }),
+      });
+      await this.#writer.json(rpcEnvelope(request, { result: jsonValueSchema.parse(result) }));
+    } catch (error) {
+      await this.#writer.json(rpcError(request, -32077, errorMessage(error).slice(0, 1500)));
     }
   }
 

--- a/packages/host-runtime/src/index.ts
+++ b/packages/host-runtime/src/index.ts
@@ -74,6 +74,17 @@ export type {
 } from "./remote-control-app-server.js";
 export { runRemoteHostCli } from "./remote-host-cli.js";
 export {
+  REMOTE_SSH_PREFLIGHT_METHOD,
+  REMOTE_SSH_PROVISION_LOG_METHOD,
+  REMOTE_SSH_PROVISION_METHOD,
+  occupancyMessage,
+  preflightRemoteSshGrokHost,
+  provisionRemoteSshGrokHost,
+  remoteGrokProvisionScript,
+  remoteSshPreflightScript,
+  resolveRemoteSshProvisionTarget,
+} from "./remote-ssh-provision.js";
+export {
   inspectRemoteHostInstallation,
   installRemoteHost,
   uninstallRemoteHost,

--- a/packages/host-runtime/src/remote-host-cli.ts
+++ b/packages/host-runtime/src/remote-host-cli.ts
@@ -49,6 +49,9 @@ function parseRemoteCliArguments(arguments_: readonly string[]): {
       case "--claude-command":
         options.claudeCommand = value;
         break;
+      case "--grok-command":
+        options.grokCommand = value;
+        break;
       case "--node":
         resources.nodePath = value;
         break;
@@ -81,7 +84,7 @@ export async function runRemoteHostCli(input: {
       output.write(
         [
           "usage:",
-          "  codexhost remote install [--stock-codex PATH] [--claude-command PATH]",
+          "  codexhost remote install [--stock-codex PATH] [--claude-command PATH] [--grok-command PATH]",
           "  codexhost remote start",
           "  codexhost remote stop",
           "  codexhost remote status",

--- a/packages/host-runtime/src/remote-host-install.ts
+++ b/packages/host-runtime/src/remote-host-install.ts
@@ -15,6 +15,13 @@ import {
 } from "node:fs/promises";
 import path from "node:path";
 
+import { GrokExecutableError, resolveGrokExecutable } from "@codexhost/adapter-grok";
+
+import {
+  nativeShimNeedsJsFallback,
+  renderRemoteHostJsEntrypoint,
+} from "./remote-host-js-entrypoint.js";
+
 const MANIFEST_FORMAT = 1;
 // Kept only so status/install can identify and migrate preview installs.
 const WRAPPER_MARKER = "# codexhost remote SSH wrapper v1";
@@ -32,6 +39,7 @@ export interface RemoteHostManifestV1 {
   dataDirectory: string;
   entrypointSha256?: string;
   claudeCommand?: string;
+  grokCommand?: string;
   profileBackupPath?: string;
 }
 
@@ -44,8 +52,10 @@ export interface RemoteHostInstallOptions {
   shimPath?: string;
   hostRuntimePath?: string;
   claudeCommand?: string;
+  grokCommand?: string;
   platform?: NodeJS.Platform;
   environment?: NodeJS.ProcessEnv;
+  entrypoint?: "native" | "js";
 }
 
 export type RemoteHostInstallationStatus =
@@ -154,6 +164,15 @@ async function discoverExecutable(
   return null;
 }
 
+async function discoverGrokCommand(environment: NodeJS.ProcessEnv): Promise<string | null> {
+  try {
+    return resolveGrokExecutable({ environment });
+  } catch (error) {
+    if (error instanceof GrokExecutableError) return null;
+    throw error;
+  }
+}
+
 async function writeAtomic(
   filePath: string,
   contents: string | Uint8Array,
@@ -247,6 +266,9 @@ function installManagedProfileBlock(contents: string, manifest: RemoteHostManife
     ...(manifest.claudeCommand
       ? [`export CODEXHOST_CLAUDE_COMMAND=${shellQuote(manifest.claudeCommand)}`]
       : []),
+    ...(manifest.grokCommand
+      ? [`export CODEXHOST_GROK_COMMAND=${shellQuote(manifest.grokCommand)}`]
+      : []),
   ];
   const block = [
     PROFILE_START,
@@ -324,6 +346,7 @@ async function readManifest(filePath: string): Promise<RemoteHostManifestV1 | nu
     "dataDirectory",
     "entrypointSha256",
     "claudeCommand",
+    "grokCommand",
     "profileBackupPath",
   ]);
   const requiredPaths = [
@@ -335,7 +358,7 @@ async function readManifest(filePath: string): Promise<RemoteHostManifestV1 | nu
     "hostRuntimePath",
     "dataDirectory",
   ] as const;
-  const optionalPaths = ["claudeCommand", "profileBackupPath"] as const;
+  const optionalPaths = ["claudeCommand", "grokCommand", "profileBackupPath"] as const;
   if (
     manifest.format !== MANIFEST_FORMAT ||
     Object.keys(manifest).some((key) => !allowed.has(key)) ||
@@ -440,6 +463,11 @@ export async function installRemoteHost(
   const claudeCommand = discoveredClaude
     ? await executable(discoveredClaude, "Claude Code command")
     : undefined;
+  const discoveredGrok =
+    options.grokCommand ??
+    previousManifest?.grokCommand ??
+    (await discoverGrokCommand(environment));
+  const grokCommand = discoveredGrok ? await executable(discoveredGrok, "Grok command") : undefined;
 
   let manifest: RemoteHostManifestV1 = {
     format: MANIFEST_FORMAT,
@@ -451,6 +479,7 @@ export async function installRemoteHost(
     hostRuntimePath,
     dataDirectory: paths.dataDirectory,
     ...(claudeCommand ? { claudeCommand } : {}),
+    ...(grokCommand ? { grokCommand } : {}),
     ...(previousManifest?.profileBackupPath
       ? { profileBackupPath: previousManifest.profileBackupPath }
       : {}),
@@ -468,7 +497,14 @@ export async function installRemoteHost(
     }
     await mkdir(paths.dataDirectory, { recursive: true, mode: 0o700 });
     await chmod(paths.dataDirectory, 0o700);
-    await writeAtomicExecutable(paths.wrapperPath, manifest.shimPath);
+    const useJsEntrypoint =
+      options.entrypoint === "js" ||
+      (options.entrypoint !== "native" && nativeShimNeedsJsFallback(shimPath, platform));
+    if (useJsEntrypoint) {
+      await writeAtomic(paths.wrapperPath, renderRemoteHostJsEntrypoint(nodePath), 0o700);
+    } else {
+      await writeAtomicExecutable(paths.wrapperPath, manifest.shimPath);
+    }
     manifest = { ...manifest, entrypointSha256: await fileSha256(paths.wrapperPath) };
     await writeAtomic(paths.manifestPath, `${JSON.stringify(manifest, null, 2)}\n`, 0o600);
     return manifest;

--- a/packages/host-runtime/src/remote-host-js-entrypoint.ts
+++ b/packages/host-runtime/src/remote-host-js-entrypoint.ts
@@ -1,0 +1,603 @@
+import { spawnSync } from "node:child_process";
+
+export const JS_ENTRYPOINT_MARKER = "// codexhost remote SSH node entrypoint v1";
+export const JS_ENTRYPOINT_NODE_PLACEHOLDER = "/__CODEXHOST_JS_ENTRYPOINT_NODE__";
+
+export function isGlibcLoaderFailure(text: string): boolean {
+  return /GLIBC_\d/u.test(text) && /not found/iu.test(text);
+}
+
+export function nativeShimNeedsJsFallback(
+  shimPath: string,
+  platform: NodeJS.Platform = process.platform,
+): boolean {
+  if (platform !== "linux") return false;
+  const result = spawnSync(shimPath, [], {
+    encoding: "utf8",
+    timeout: 3_000,
+    env: { ...process.env, CODEXHOST_STOCK_CODEX_PATH: "/nonexistent-codexhost-probe" },
+  });
+  const text = `${result.stderr ?? ""}\n${result.stdout ?? ""}\n${result.error?.message ?? ""}`;
+  return isGlibcLoaderFailure(text);
+}
+
+export function renderRemoteHostJsEntrypoint(nodePath: string): string {
+  if (!nodePath.startsWith("/") || nodePath.includes("\n") || nodePath.includes("\0")) {
+    throw new Error("Node entrypoint shebang requires an absolute path without newlines");
+  }
+  return `#!${nodePath}\n${JS_ENTRYPOINT_MARKER}\n${JS_ENTRYPOINT_SOURCE}`;
+}
+
+const JS_ENTRYPOINT_SOURCE = `
+"use strict";
+
+var childProcess = require("child_process");
+var fs = require("fs");
+var net = require("net");
+var path = require("path");
+
+var VALUE_GLOBAL = [
+  "-c",
+  "--config",
+  "--enable",
+  "--disable",
+  "--remote",
+  "--remote-auth-token-env",
+  "-m",
+  "--model",
+  "--local-provider",
+  "-p",
+  "--profile",
+  "-s",
+  "--sandbox",
+  "-C",
+  "--cd",
+];
+var FLAG_GLOBAL = [
+  "--strict-config",
+  "--oss",
+  "--dangerously-bypass-approvals-and-sandbox",
+  "--dangerously-bypass-hook-trust",
+];
+var VALUE_APP_SERVER = [
+  "-c",
+  "--config",
+  "--enable",
+  "--disable",
+  "--listen",
+  "--ws-auth",
+  "--ws-token-file",
+  "--ws-token-sha256",
+  "--ws-shared-secret-file",
+  "--ws-issuer",
+  "--ws-audience",
+  "--ws-max-clock-skew-seconds",
+];
+var FLAG_HOST = ["--strict-config", "--analytics-default-enabled"];
+var FLAG_LISTEN = ["--strict-config", "--analytics-default-enabled"];
+
+function hasPrefixEquals(argument, option) {
+  return argument.indexOf(option + "=") === 0;
+}
+
+function appServerIndex(args) {
+  var index = 0;
+  while (index < args.length) {
+    var argument = args[index];
+    if (argument === "app-server") return index;
+    if (VALUE_GLOBAL.indexOf(argument) >= 0) {
+      if (index + 1 >= args.length) return -1;
+      index += 2;
+      continue;
+    }
+    var skip = false;
+    for (var i = 0; i < VALUE_GLOBAL.length; i += 1) {
+      if (hasPrefixEquals(argument, VALUE_GLOBAL[i])) {
+        skip = true;
+        break;
+      }
+    }
+    if (skip || FLAG_GLOBAL.indexOf(argument) >= 0) {
+      index += 1;
+      continue;
+    }
+    return -1;
+  }
+  return -1;
+}
+
+function shouldStartHostRuntime(args) {
+  var start = appServerIndex(args);
+  if (start < 0) return false;
+  var index = start + 1;
+  while (index < args.length) {
+    var argument = args[index];
+    if (VALUE_APP_SERVER.indexOf(argument) >= 0) {
+      if (index + 1 >= args.length) return false;
+      index += 2;
+      continue;
+    }
+    var skip = false;
+    for (var i = 0; i < VALUE_APP_SERVER.length; i += 1) {
+      if (hasPrefixEquals(argument, VALUE_APP_SERVER[i])) {
+        skip = true;
+        break;
+      }
+    }
+    if (skip || FLAG_HOST.indexOf(argument) >= 0) {
+      index += 1;
+      continue;
+    }
+    return false;
+  }
+  return true;
+}
+
+function isDefaultRemoteUnixListener(args) {
+  var start = appServerIndex(args);
+  if (start < 0) return false;
+  var index = start + 1;
+  var sawDefault = false;
+  while (index < args.length) {
+    var argument = args[index];
+    if (argument === "--stdio") return false;
+    if (argument === "--listen") {
+      var value = args[index + 1];
+      if (!value || sawDefault || value !== "unix://") return false;
+      sawDefault = true;
+      index += 2;
+      continue;
+    }
+    if (hasPrefixEquals(argument, "--listen")) {
+      var listenValue = argument.slice("--listen=".length);
+      if (sawDefault || listenValue !== "unix://") return false;
+      sawDefault = true;
+      index += 1;
+      continue;
+    }
+    if (VALUE_APP_SERVER.indexOf(argument) >= 0) {
+      if (index + 1 >= args.length) return false;
+      index += 2;
+      continue;
+    }
+    var skip = false;
+    for (var i = 0; i < VALUE_APP_SERVER.length; i += 1) {
+      if (argument !== "--listen" && hasPrefixEquals(argument, VALUE_APP_SERVER[i])) {
+        skip = true;
+        break;
+      }
+    }
+    if (skip || FLAG_LISTEN.indexOf(argument) >= 0) {
+      index += 1;
+      continue;
+    }
+    return false;
+  }
+  return sawDefault;
+}
+
+function withoutEnv(extra) {
+  var env = Object.assign({}, process.env, extra || {});
+  delete env.CODEX_CLI_PATH;
+  delete env.CODEXHOST_REMOTE_SSH_MANAGED;
+  delete env.CODEXHOST_REMOTE_LISTENER_CHILD;
+  return env;
+}
+
+function execForeground(command, commandArgs, extra) {
+  var child = childProcess.spawn(command, commandArgs, {
+    stdio: "inherit",
+    env: extra,
+  });
+  child.on("error", function (error) {
+    process.stderr.write(String(error.message || error) + "\\n");
+    process.exit(1);
+  });
+  child.on("exit", function (code, signal) {
+    if (signal) {
+      try {
+        process.kill(process.pid, signal);
+      } catch (_error) {
+        process.exit(1);
+      }
+      return;
+    }
+    process.exit(code == null ? 1 : code);
+  });
+}
+
+function defaultSocketPath() {
+  var home = process.env.CODEX_HOME;
+  if (!home) {
+    if (!process.env.HOME) throw new Error("CODEX_HOME or HOME is required for the remote listener");
+    home = path.join(process.env.HOME, ".codex");
+  }
+  return path.join(home, "app-server-control", "app-server-control.sock");
+}
+
+function socketIdentity(socketPath) {
+  try {
+    var metadata = fs.statSync(socketPath);
+    return String(metadata.dev) + ":" + String(metadata.ino);
+  } catch (_error) {
+    return null;
+  }
+}
+
+function connectSocket(socketPath) {
+  return new Promise(function (resolve) {
+    var socket = net.createConnection(socketPath);
+    var settled = false;
+    var finish = function (ok) {
+      if (settled) return;
+      settled = true;
+      try {
+        socket.destroy();
+      } catch (_error) {}
+      resolve(ok);
+    };
+    socket.once("connect", function () {
+      finish(true);
+    });
+    socket.once("error", function () {
+      finish(false);
+    });
+    setTimeout(function () {
+      finish(false);
+    }, 200);
+  });
+}
+
+function sleep(ms) {
+  return new Promise(function (resolve) {
+    setTimeout(resolve, ms);
+  });
+}
+
+function stopChild(child) {
+  try {
+    process.kill(-child.pid, "SIGTERM");
+  } catch (_error) {
+    try {
+      child.kill("SIGTERM");
+    } catch (_ignored) {}
+  }
+}
+
+async function waitForListener(child, previousIdentity) {
+  var socketPath = defaultSocketPath();
+  var deadline = Date.now() + 10000;
+  while (Date.now() < deadline) {
+    if (child.exitCode != null || child.signalCode != null) {
+      throw new Error(
+        "managed remote listener exited before readiness: " +
+          String(child.exitCode != null ? child.exitCode : child.signalCode),
+      );
+    }
+    var current = socketIdentity(socketPath);
+    if (current && current !== previousIdentity && (await connectSocket(socketPath))) {
+      await sleep(20);
+      if (child.exitCode != null || child.signalCode != null) {
+        throw new Error("managed remote listener exited after readiness");
+      }
+      return;
+    }
+    await sleep(20);
+  }
+  stopChild(child);
+  throw new Error(
+    "managed remote listener did not become ready at " + socketPath + " within 10 seconds",
+  );
+}
+
+function hasDefaultListener(args) {
+  var joined = args.join(" ");
+  var appServer = args.indexOf("app-server") >= 0 || joined.indexOf(" app-server ") >= 0;
+  var exact = false;
+  for (var i = 0; i < args.length - 1; i += 1) {
+    if (args[i] === "--listen" && args[i + 1] === "unix://") exact = true;
+  }
+  for (var j = 0; j < args.length; j += 1) {
+    if (args[j] === "--listen=unix://") exact = true;
+  }
+  var shell =
+    args.length === 1 &&
+    (joined.indexOf(" --listen unix://") >= 0 || joined.indexOf(" --listen=unix://") >= 0);
+  var proxy = args.indexOf("proxy") >= 0 || joined.indexOf(" app-server proxy") >= 0;
+  return appServer && (exact || shell) && !proxy;
+}
+
+function mentionsPath(args, expected) {
+  for (var i = 0; i < args.length; i += 1) {
+    if (args[i] === expected) return true;
+  }
+  if (args.length === 1) {
+    var parts = args[0].split(/\\s+/);
+    for (var j = 0; j < parts.length; j += 1) {
+      var token = parts[j].replace(/^[\\'\"]+|[\\'\"]+$/g, "");
+      if (token === expected) return true;
+    }
+  }
+  return false;
+}
+
+function readCmdline(pid) {
+  try {
+    return fs.readFileSync("/proc/" + pid + "/cmdline", "utf8").split("\\0").filter(Boolean);
+  } catch (_error) {
+    return [];
+  }
+}
+
+function readPpid(pid) {
+  try {
+    var stat = fs.readFileSync("/proc/" + pid + "/stat", "utf8");
+    var close = stat.lastIndexOf(")");
+    var rest = stat.slice(close + 2).split(" ");
+    return Number(rest[1]);
+  } catch (_error) {
+    return 0;
+  }
+}
+
+function readExe(pid) {
+  try {
+    return fs.realpathSync("/proc/" + pid + "/exe");
+  } catch (_error) {
+    return "";
+  }
+}
+
+function listPids() {
+  try {
+    return fs
+      .readdirSync("/proc")
+      .filter(function (name) {
+        return /^\\d+$/.test(name);
+      })
+      .map(Number);
+  } catch (_error) {
+    return [];
+  }
+}
+
+function socketOwners(socketPath) {
+  var fromLsof = childProcess.spawnSync("lsof", ["-t", socketPath], { encoding: "utf8" });
+  if (fromLsof.status === 0 && fromLsof.stdout) {
+    return fromLsof.stdout
+      .trim()
+      .split(/\\s+/)
+      .filter(Boolean)
+      .map(Number)
+      .filter(function (pid) {
+        return pid > 0;
+      });
+  }
+  var owners = [];
+  try {
+    var socketText = socketPath;
+    var inodes = {};
+    var lines = fs.readFileSync("/proc/net/unix", "utf8").split("\\n");
+    for (var i = 0; i < lines.length; i += 1) {
+      var fields = lines[i].trim().split(/\\s+/);
+      if (fields[7] === socketText && fields[6]) inodes[fields[6]] = true;
+    }
+    var pids = listPids();
+    for (var p = 0; p < pids.length; p += 1) {
+      var pid = pids[p];
+      var fdDir = "/proc/" + pid + "/fd";
+      var fds;
+      try {
+        fds = fs.readdirSync(fdDir);
+      } catch (_error) {
+        continue;
+      }
+      for (var f = 0; f < fds.length; f += 1) {
+        try {
+          var target = fs.readlinkSync(fdDir + "/" + fds[f]);
+          var match = /^socket:\\[(\\d+)\\]$/.exec(target);
+          if (match && inodes[match[1]]) {
+            owners.push(pid);
+            break;
+          }
+        } catch (_ignored) {}
+      }
+    }
+  } catch (_error) {}
+  return owners;
+}
+
+function killTree(rootPid) {
+  var pids = listPids();
+  var selected = {};
+  selected[rootPid] = true;
+  var changed = true;
+  while (changed) {
+    changed = false;
+    for (var i = 0; i < pids.length; i += 1) {
+      var pid = pids[i];
+      if (!selected[pid] && selected[readPpid(pid)]) {
+        selected[pid] = true;
+        changed = true;
+      }
+    }
+  }
+  var tree = Object.keys(selected).map(Number);
+  tree.sort(function (left, right) {
+    if (left === rootPid) return 1;
+    if (right === rootPid) return -1;
+    return left - right;
+  });
+  for (var t = 0; t < tree.length; t += 1) {
+    try {
+      process.kill(tree[t], "SIGTERM");
+    } catch (_error) {}
+  }
+  var deadline = Date.now() + 3000;
+  while (Date.now() < deadline) {
+    var live = false;
+    for (var l = 0; l < tree.length; l += 1) {
+      try {
+        process.kill(tree[l], 0);
+        live = true;
+      } catch (_error) {}
+    }
+    if (!live) return;
+    var spinUntil = Date.now() + 25;
+    while (Date.now() < spinUntil) {}
+  }
+  for (var k = 0; k < tree.length; k += 1) {
+    try {
+      process.kill(tree[k], "SIGKILL");
+    } catch (_error) {}
+  }
+}
+
+function realPath(filePath) {
+  try {
+    return fs.realpathSync(filePath);
+  } catch (_error) {
+    return filePath;
+  }
+}
+
+function matchingRoot(ownerPid, role, stockPath, nodePath, runtimePath) {
+  var expectedNode = realPath(nodePath);
+  var expectedStock = realPath(stockPath);
+  var expectedCommand = role === "stock" ? stockPath : runtimePath;
+  var current = ownerPid;
+  for (var depth = 0; depth < 32 && current > 0; depth += 1) {
+    var exe = readExe(current);
+    var args = readCmdline(current);
+    var matches = false;
+    if (role === "stock") {
+      var exeMatches =
+        exe === expectedStock || (exe === expectedNode && mentionsPath(args, expectedCommand));
+      matches = exeMatches && hasDefaultListener(args);
+    } else {
+      matches =
+        exe === expectedNode &&
+        mentionsPath(args, expectedCommand) &&
+        hasDefaultListener(args);
+    }
+    if (matches) return current;
+    current = readPpid(current);
+  }
+  return 0;
+}
+
+function runTerminate(args) {
+  var role = args[0];
+  if (role !== "stock" && role !== "managed") {
+    throw new Error("remote listener role must be 'stock' or 'managed'");
+  }
+  var options = {};
+  for (var i = 1; i < args.length; i += 2) {
+    var option = args[i];
+    var value = args[i + 1];
+    if (!value) throw new Error(option + " requires a path");
+    if (option === "--socket") options.socket = value;
+    else if (option === "--stock-codex") options.stock = value;
+    else if (option === "--node") options.node = value;
+    else if (option === "--host-runtime") options.runtime = value;
+    else throw new Error("unknown remote lifecycle option '" + option + "'");
+  }
+  if (!options.socket || !options.stock || !options.node || !options.runtime) {
+    throw new Error("terminate requires --socket, --stock-codex, --node, and --host-runtime");
+  }
+  var owners = socketOwners(options.socket);
+  if (owners.length === 0) {
+    throw new Error("no process owns remote Host socket " + options.socket);
+  }
+  var roots = [];
+  for (var o = 0; o < owners.length; o += 1) {
+    var root = matchingRoot(owners[o], role, options.stock, options.node, options.runtime);
+    if (root && roots.indexOf(root) < 0) roots.push(root);
+  }
+  if (roots.length !== 1) {
+    throw new Error("remote Host socket owner does not match the requested installed listener");
+  }
+  killTree(roots[0]);
+  process.stdout.write("terminated_pid=" + String(roots[0]) + "\\n");
+}
+
+function startHostOrStock(args) {
+  var stock = process.env.CODEXHOST_STOCK_CODEX_PATH;
+  var nodePath = process.env.CODEXHOST_HOST_NODE_PATH || process.execPath;
+  var runtimePath = process.env.CODEXHOST_HOST_RUNTIME_PATH;
+  if (shouldStartHostRuntime(args) && runtimePath) {
+    var hostEnv = withoutEnv({
+      CODEXHOST_STOCK_CODEX_PATH: stock,
+      CODEXHOST_HOST_NODE_PATH: nodePath,
+      CODEXHOST_HOST_RUNTIME_PATH: runtimePath,
+    });
+    execForeground(nodePath, [runtimePath].concat(args), hostEnv);
+    return;
+  }
+  if (!stock) {
+    process.stderr.write("CODEXHOST_STOCK_CODEX_PATH is required\\n");
+    process.exit(1);
+  }
+  var stockEnv = withoutEnv({});
+  delete stockEnv.CODEXHOST_HOST_NODE_PATH;
+  delete stockEnv.CODEXHOST_HOST_RUNTIME_PATH;
+  execForeground(stock, args, stockEnv);
+}
+
+async function main(args) {
+  if (process.env.CODEXHOST_JS_ENTRYPOINT_SELFTEST === "1") {
+    var assert = require("assert");
+    assert.equal(shouldStartHostRuntime(["app-server"]), true);
+    assert.equal(
+      shouldStartHostRuntime(["-c", "features.code_mode_host=true", "app-server", "--listen", "unix://"]),
+      true,
+    );
+    assert.equal(shouldStartHostRuntime(["app-server", "proxy"]), false);
+    assert.equal(shouldStartHostRuntime(["app-server", "generate-json-schema"]), false);
+    assert.equal(isDefaultRemoteUnixListener(["app-server", "--listen", "unix://"]), true);
+    assert.equal(
+      isDefaultRemoteUnixListener(["-c", "features.code_mode_host=true", "app-server", "--listen", "unix://"]),
+      true,
+    );
+    assert.equal(isDefaultRemoteUnixListener(["app-server", "--listen=unix://"]), true);
+    assert.equal(isDefaultRemoteUnixListener(["app-server", "proxy"]), false);
+    assert.equal(isDefaultRemoteUnixListener(["app-server", "--stdio"]), false);
+    assert.equal(
+      isDefaultRemoteUnixListener(["app-server", "--stdio", "--listen", "unix://"]),
+      false,
+    );
+    assert.equal(
+      isDefaultRemoteUnixListener(["app-server", "--listen", "unix:///tmp/custom.sock"]),
+      false,
+    );
+    process.stdout.write("ok\\n");
+    return;
+  }
+  if (args[0] === "--codexhost-remote-terminate") {
+    runTerminate(args.slice(1));
+    return;
+  }
+  var managed = process.env.CODEXHOST_REMOTE_SSH_MANAGED === "1";
+  var isChild = process.env.CODEXHOST_REMOTE_LISTENER_CHILD === "1";
+  if (managed && isDefaultRemoteUnixListener(args)) {
+    if (!isChild) {
+      var previous = socketIdentity(defaultSocketPath());
+      var childEnv = Object.assign({}, process.env, { CODEXHOST_REMOTE_LISTENER_CHILD: "1" });
+      var child = childProcess.spawn(process.execPath, [__filename].concat(args), {
+        detached: true,
+        stdio: "ignore",
+        env: childEnv,
+      });
+      child.unref();
+      await waitForListener(child, previous);
+      process.exit(0);
+    }
+  }
+  startHostOrStock(args);
+}
+
+main(process.argv.slice(2)).catch(function (error) {
+  process.stderr.write(String(error && error.message ? error.message : error) + "\\n");
+  process.exit(1);
+});
+`;

--- a/packages/host-runtime/src/remote-host-lifecycle.ts
+++ b/packages/host-runtime/src/remote-host-lifecycle.ts
@@ -226,7 +226,7 @@ function installedManifest(status: RemoteHostInstallationStatus): RemoteHostMani
   return status;
 }
 
-function managedEnvironment(
+export function managedRemoteHostEnvironment(
   manifest: RemoteHostManifestV1,
   environment: NodeJS.ProcessEnv,
 ): NodeJS.ProcessEnv {
@@ -240,6 +240,7 @@ function managedEnvironment(
     CODEXHOST_DEFAULT_AGENT: "codex",
     CODEXHOST_REMOTE_SSH_MANAGED: "1",
     ...(manifest.claudeCommand ? { CODEXHOST_CLAUDE_COMMAND: manifest.claudeCommand } : {}),
+    ...(manifest.grokCommand ? { CODEXHOST_GROK_COMMAND: manifest.grokCommand } : {}),
     PATH: `${path.dirname(manifest.wrapperPath)}${path.delimiter}${path.dirname(manifest.stockCodexPath)}${path.delimiter}${environment.PATH ?? "/usr/bin:/bin"}`,
   };
 }
@@ -251,7 +252,7 @@ async function defaultRunTerminator(
   environment: NodeJS.ProcessEnv,
 ): Promise<void> {
   const child = spawn(
-    manifest.shimPath,
+    manifest.wrapperPath,
     [
       "--codexhost-remote-terminate",
       role,
@@ -302,7 +303,7 @@ function defaultLaunch(manifest: RemoteHostManifestV1, environment: NodeJS.Proce
   const child = spawn(
     manifest.wrapperPath,
     ["-c", "features.code_mode_host=true", "app-server", "--listen", "unix://"],
-    { env: managedEnvironment(manifest, environment), stdio: "ignore", detached: true },
+    { env: managedRemoteHostEnvironment(manifest, environment), stdio: "ignore", detached: true },
   );
   child.unref();
 }

--- a/packages/host-runtime/src/remote-ssh-provision.ts
+++ b/packages/host-runtime/src/remote-ssh-provision.ts
@@ -1,0 +1,348 @@
+import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
+
+import {
+  classifyRemoteSshOccupancy,
+  remoteSshPreflightParamsSchema,
+  remoteSshPreflightResultSchema,
+  remoteSshProvisionParamsSchema,
+  sshTargetFromRemoteHostId,
+  type RemoteSshOccupancyKind,
+  type RemoteSshPreflightParams,
+  type RemoteSshPreflightResult,
+  type RemoteSshProvisionParams,
+  type RemoteSshProvisionResult,
+} from "@codexhost/shared-contracts";
+
+import {
+  JS_ENTRYPOINT_MARKER,
+  JS_ENTRYPOINT_NODE_PLACEHOLDER,
+  renderRemoteHostJsEntrypoint,
+} from "./remote-host-js-entrypoint.js";
+
+export const REMOTE_SSH_PREFLIGHT_METHOD = "codexhost/remote-ssh/preflight";
+export const REMOTE_SSH_PROVISION_METHOD = "codexhost/remote-ssh/provision";
+export const REMOTE_SSH_PROVISION_LOG_METHOD = "codexhost/remote-ssh/provision/log";
+
+export function remoteSshPreflightScript(): string {
+  return [
+    "python3 - <<'PY'",
+    "import json, os, pathlib, shutil, subprocess",
+    "home = pathlib.Path.home()",
+    "codex_home = pathlib.Path(os.environ.get('CODEX_HOME') or home / '.codex')",
+    "sock = codex_home / 'app-server-control' / 'app-server-control.sock'",
+    "grok = shutil.which('grok')",
+    "owner_command = None",
+    "if sock.exists():",
+    "    try:",
+    "        pids = subprocess.check_output(['lsof', '-t', str(sock)], text=True).split()",
+    "        if pids:",
+    "            owner_command = subprocess.check_output(['ps', '-o', 'args=', '-p', pids[0]], text=True).strip()",
+    "    except Exception:",
+    "        owner_command = 'socket-exists'",
+    "print(json.dumps({'grokPath': grok, 'ownerCommand': owner_command}))",
+    "PY",
+    "",
+  ].join("\n");
+}
+
+export function occupancyMessage(kind: RemoteSshOccupancyKind, sshTarget: string): string {
+  switch (kind) {
+    case "idle":
+      return `可以在 ${sshTarget} 上安装 CodexHost 远程入口。`;
+    case "grok-missing":
+      return `${sshTarget} 上还没有 Grok CLI，请先在服务器安装并登录。`;
+    case "official-remote-control":
+      return `目前 ${sshTarget} 上面已经运行着 Codex SSH daemon，需要你的允许才能换成 CodexHost 总入口。`;
+    case "unknown-busy":
+      return `${sshTarget} 上默认 socket 已被其他进程占用，不会自动接管。`;
+  }
+}
+
+export function remoteGrokProvisionScript(replaceOfficialDaemon = false): string {
+  const stopOfficial = replaceOfficialDaemon
+    ? [
+        'echo "==> 正在停止当前用户的官方 Codex SSH daemon"',
+        "python3 - <<'PY'",
+        "import os, signal, subprocess, sys",
+        "try:",
+        "    out = subprocess.check_output(['ps', '-u', str(os.getuid()), '-o', 'pid=,args='], text=True)",
+        "except Exception as error:",
+        "    print(error)",
+        "    sys.exit(2)",
+        "stopped = 0",
+        "for line in out.splitlines():",
+        "    line = line.strip()",
+        "    if not line: continue",
+        "    pid_text, _, args = line.partition(' ')",
+        "    if 'app-server' in args and '--remote-control' in args and '--listen' in args:",
+        "        os.kill(int(pid_text), signal.SIGTERM)",
+        "        print(f'stopped pid {pid_text}')",
+        "        stopped += 1",
+        "if stopped == 0:",
+        "    print('no official --remote-control daemon found for this user')",
+        "    sys.exit(2)",
+        "PY",
+      ]
+    : [];
+  const restoreOfficial = replaceOfficialDaemon
+    ? [
+        'echo "==> 正在恢复这条 SSH 连接的官方 Codex SSH daemon"',
+        "if command -v codex >/dev/null 2>&1; then",
+        "  set +e",
+        "  codex app-server daemon start",
+        "  restore_code=$?",
+        "  set -e",
+        '  if [ "$restore_code" -ne 0 ]; then',
+        '    echo "官方 Codex SSH daemon 没能自动恢复，请在服务器上执行: codex app-server daemon start"',
+        "  fi",
+        "fi",
+      ]
+    : [];
+  return [
+    "set -eu",
+    'echo "==> 检查 Grok"',
+    "if ! command -v grok >/dev/null 2>&1; then",
+    '  echo "服务器上没有 Grok CLI，请先安装并登录。"',
+    "  exit 2",
+    "fi",
+    'GROK_BIN="$(command -v grok)"',
+    'echo "Grok: $GROK_BIN"',
+    ...stopOfficial,
+    'echo "==> 安装 @codexhost/cli"',
+    "if ! command -v npm >/dev/null 2>&1; then",
+    '  echo "服务器上没有 npm。"',
+    "  exit 2",
+    "fi",
+    "npm install -g @codexhost/cli",
+    'export CODEXHOST_GROK_COMMAND="$GROK_BIN"',
+    "rollback() {",
+    '  echo "==> 正在回滚远程 Host 安装"',
+    "  codexhost remote uninstall || true",
+    ...restoreOfficial,
+    "}",
+    'echo "==> 安装远程 Host"',
+    "if codexhost remote help 2>&1 | grep -q -- '--grok-command'; then",
+    '  echo "CLI 支持 --grok-command"',
+    '  codexhost remote install --grok-command "$GROK_BIN"',
+    "else",
+    '  echo "当前 CLI 没有 --grok-command，将用 PATH 和 CODEXHOST_GROK_COMMAND 发现 Grok"',
+    "  codexhost remote install",
+    "fi",
+    'echo "==> 检查原生入口是否能在这台 Linux 上加载"',
+    "python3 - <<'PY'",
+    "import hashlib, json, os, pathlib, subprocess, sys",
+    "home = pathlib.Path.home()",
+    "manifest_path = home / '.codexhost' / 'remote' / 'manifest.json'",
+    "if not manifest_path.is_file():",
+    "    print('找不到远程 Host 安装清单')",
+    "    sys.exit(2)",
+    "manifest = json.loads(manifest_path.read_text())",
+    "wrapper = pathlib.Path(manifest['wrapperPath'])",
+    "probe = subprocess.run([str(wrapper)], capture_output=True, text=True)",
+    "text = (probe.stderr or '') + '\\n' + (probe.stdout or '')",
+    "if 'GLIBC_' in text and 'not found' in text.lower():",
+    "    node = manifest.get('nodePath') or ''",
+    "    if not node or not os.access(node, os.X_OK):",
+    "        print('原生入口需要更高 glibc，但清单里的 Node 不可用')",
+    "        sys.exit(2)",
+    `    script = ${JSON.stringify(renderRemoteHostJsEntrypoint(JS_ENTRYPOINT_NODE_PLACEHOLDER))}`,
+    `    if ${JSON.stringify(JS_ENTRYPOINT_MARKER)} not in script:`,
+    "        print('Node 入口脚本生成失败')",
+    "        sys.exit(2)",
+    `    script = script.replace(${JSON.stringify(JS_ENTRYPOINT_NODE_PLACEHOLDER)}, node, 1)`,
+    "    wrapper.write_text(script)",
+    "    os.chmod(wrapper, 0o700)",
+    "    digest = hashlib.sha256(wrapper.read_bytes()).hexdigest()",
+    "    manifest['entrypointSha256'] = digest",
+    "    manifest_path.write_text(json.dumps(manifest, indent=2) + '\\n')",
+    "    print('原生入口需要更高 glibc，已改用 Node 入口：' + str(wrapper))",
+    "else:",
+    "    print('原生入口可以加载，保持不变')",
+    "PY",
+    'echo "==> 启动远程 Host"',
+    "set +e",
+    "codexhost remote start",
+    "start_code=$?",
+    "set -e",
+    'if [ "$start_code" -ne 0 ]; then',
+    "  rollback",
+    '  echo "远程 Host 没能启动，已卸载回滚，并尝试恢复这条 SSH 连接的官方 Codex SSH daemon。"',
+    "  exit 3",
+    "fi",
+    'echo "==> 状态"',
+    "codexhost remote status",
+    'echo "==> 完成。这条 SSH 连接的入口已重新建立。请重新打开这个远程项目，然后再选 Agent。"',
+    "",
+  ].join("\n");
+}
+
+export interface RemoteSshProvisionDependencies {
+  spawnSsh(sshTarget: string, script: string, onChunk: (chunk: string) => void): Promise<number>;
+}
+
+function defaultSpawnSsh(
+  sshTarget: string,
+  script: string,
+  onChunk: (chunk: string) => void,
+): Promise<number> {
+  const child: ChildProcessWithoutNullStreams = spawn(
+    "ssh",
+    ["-o", "BatchMode=yes", "-o", "ConnectTimeout=15", "-T", sshTarget, "bash", "-s"],
+    { stdio: ["pipe", "pipe", "pipe"] },
+  );
+  child.stdin.write(script);
+  child.stdin.end();
+  const emit = (data: Buffer | string): void => {
+    const text = data.toString();
+    if (text.length > 0) onChunk(text);
+  };
+  child.stdout.on("data", emit);
+  child.stderr.on("data", emit);
+  return new Promise((resolve, reject) => {
+    child.once("error", reject);
+    child.once("close", (code) => resolve(code ?? 1));
+  });
+}
+
+export function resolveRemoteSshProvisionTarget(
+  params: RemoteSshProvisionParams | RemoteSshPreflightParams,
+): string | null {
+  const parsed = remoteSshProvisionParamsSchema.partial().parse(params);
+  if (parsed.sshTarget) return parsed.sshTarget;
+  if (!parsed.hostId) return null;
+  return sshTargetFromRemoteHostId(parsed.hostId);
+}
+
+function parseTrailingJsonObject(text: string): {
+  grokPath: string | null;
+  ownerCommand: string | null;
+} {
+  const lines = text.split("\n");
+  for (let index = lines.length - 1; index >= 0; index -= 1) {
+    const line = lines[index]?.trim();
+    if (!line?.startsWith("{")) continue;
+    const value = JSON.parse(line) as {
+      grokPath?: unknown;
+      ownerCommand?: unknown;
+    };
+    return {
+      grokPath: typeof value.grokPath === "string" ? value.grokPath : null,
+      ownerCommand: typeof value.ownerCommand === "string" ? value.ownerCommand : null,
+    };
+  }
+  throw new Error("远程 SSH 预检没有返回占用信息");
+}
+
+export async function preflightRemoteSshGrokHost(input: {
+  params: RemoteSshPreflightParams;
+  environment?: NodeJS.ProcessEnv;
+  onLog?(chunk: string): void | Promise<void>;
+  dependencies?: Partial<RemoteSshProvisionDependencies>;
+}): Promise<RemoteSshPreflightResult> {
+  const environment = input.environment ?? process.env;
+  if (environment.CODEXHOST_REMOTE_SSH_MANAGED === "1") {
+    throw new Error("远程 Host 预检必须从本机 Desktop 发起");
+  }
+  const parsed = remoteSshPreflightParamsSchema.parse(input.params);
+  const sshTarget = resolveRemoteSshProvisionTarget(parsed);
+  if (!sshTarget) {
+    throw new Error("无法从远程 Host ID 解析 SSH 目标");
+  }
+  const spawnSsh = input.dependencies?.spawnSsh ?? defaultSpawnSsh;
+  const chunks: string[] = [];
+  const onChunk = (chunk: string): void => {
+    chunks.push(chunk);
+    void input.onLog?.(chunk);
+  };
+  onChunk(`$ ssh ${sshTarget} preflight\n`);
+  const code = await spawnSsh(sshTarget, remoteSshPreflightScript(), onChunk);
+  if (code !== 0) {
+    throw new Error(`远程 SSH 预检失败，退出码 ${code}\n${chunks.join("").trim()}`.slice(0, 4000));
+  }
+  const occupancy = parseTrailingJsonObject(chunks.join(""));
+  const kind = classifyRemoteSshOccupancy(occupancy);
+  return remoteSshPreflightResultSchema.parse({
+    sshTarget,
+    kind,
+    grokPath: occupancy.grokPath,
+    ownerCommand: occupancy.ownerCommand,
+    message: occupancyMessage(kind, sshTarget),
+  });
+}
+
+export async function provisionRemoteSshGrokHost(input: {
+  params: RemoteSshProvisionParams;
+  environment?: NodeJS.ProcessEnv;
+  onLog?(chunk: string): void | Promise<void>;
+  dependencies?: Partial<RemoteSshProvisionDependencies>;
+}): Promise<RemoteSshProvisionResult> {
+  const environment = input.environment ?? process.env;
+  if (environment.CODEXHOST_REMOTE_SSH_MANAGED === "1") {
+    throw new Error("远程 Host 安装必须从本机 Desktop 发起");
+  }
+  const params = remoteSshProvisionParamsSchema.parse(input.params);
+  const sshTarget = resolveRemoteSshProvisionTarget(params);
+  if (!sshTarget) {
+    throw new Error("无法从远程 Host ID 解析 SSH 目标");
+  }
+  const preflight = await preflightRemoteSshGrokHost({
+    params: {
+      hostId: params.hostId,
+      ...(params.sshTarget ? { sshTarget: params.sshTarget } : {}),
+    },
+    environment,
+    ...(input.onLog ? { onLog: input.onLog } : {}),
+    ...(input.dependencies ? { dependencies: input.dependencies } : {}),
+  });
+  if (preflight.kind === "official-remote-control" && params.replaceOfficialDaemon !== true) {
+    return {
+      ok: false,
+      sshTarget,
+      kind: preflight.kind,
+      message: preflight.message,
+      reconnectRequired: false,
+    };
+  }
+  if (preflight.kind === "unknown-busy") {
+    return {
+      ok: false,
+      sshTarget,
+      kind: preflight.kind,
+      message: preflight.message,
+      reconnectRequired: false,
+    };
+  }
+  if (preflight.kind === "grok-missing") {
+    return {
+      ok: false,
+      sshTarget,
+      kind: preflight.kind,
+      message: preflight.message,
+      reconnectRequired: false,
+    };
+  }
+  const spawnSsh = input.dependencies?.spawnSsh ?? defaultSpawnSsh;
+  const chunks: string[] = [];
+  const onChunk = (chunk: string): void => {
+    chunks.push(chunk);
+    void input.onLog?.(chunk);
+  };
+  onChunk(`$ ssh ${sshTarget} bash -s\n`);
+  const code = await spawnSsh(
+    sshTarget,
+    remoteGrokProvisionScript(params.replaceOfficialDaemon === true),
+    onChunk,
+  );
+  if (code !== 0) {
+    throw new Error(
+      `远程 Grok 入口安装失败，退出码 ${code}\n${chunks.join("").trim()}`.slice(0, 4000),
+    );
+  }
+  return {
+    ok: true,
+    sshTarget,
+    kind: preflight.kind,
+    message: "远程 Grok 入口已装好。请重新打开这个远程项目，然后再选 Grok。",
+    reconnectRequired: true,
+  };
+}

--- a/packages/host-runtime/test/app-server-host.test.ts
+++ b/packages/host-runtime/test/app-server-host.test.ts
@@ -5362,6 +5362,7 @@ describe("AppServerHost HarnessAdapter projection", () => {
         CODEXHOST_DATA_DIR: "/synthetic/codexhost-data",
         CODEXHOST_ENABLE_CLAUDE_CODE: "1",
         CODEXHOST_CLAUDE_COMMAND: "/synthetic/claude",
+        CODEXHOST_GROK_COMMAND: "/synthetic/grok",
         CODEXHOST_PI_COMMAND: "/synthetic/pi",
       },
     });

--- a/packages/host-runtime/test/remote-host-cli.test.ts
+++ b/packages/host-runtime/test/remote-host-cli.test.ts
@@ -33,6 +33,7 @@ describe("remote SSH Host CLI", () => {
       }),
     ).resolves.toBe(0);
     expect(stdout.text()).toContain("codexhost remote install");
+    expect(stdout.text()).toContain("--grok-command PATH");
     expect(stdout.text()).toContain("codexhost remote start");
     expect(stdout.text()).toContain("codexhost remote stop");
     expect(stdout.text()).toContain("codexhost remote uninstall");

--- a/packages/host-runtime/test/remote-host-install.test.ts
+++ b/packages/host-runtime/test/remote-host-install.test.ts
@@ -37,6 +37,7 @@ import {
   installRemoteHost,
   uninstallRemoteHost,
 } from "../src/remote-host-install.js";
+import { JS_ENTRYPOINT_MARKER } from "../src/remote-host-js-entrypoint.js";
 
 async function executable(filePath: string): Promise<string> {
   await writeFile(filePath, "fixture\n", "utf8");
@@ -203,6 +204,7 @@ describe("remote SSH Host installation", () => {
         hostRuntimePath,
         claudeCommand,
         platform: "darwin" as const,
+        environment: { HOME: home, SHELL: "/bin/zsh", PATH: "/usr/bin:/bin" },
       };
       const first = await installRemoteHost(options);
       const second = await installRemoteHost(options);
@@ -230,6 +232,64 @@ describe("remote SSH Host installation", () => {
         profilePath,
         dataDirectory: path.join(home, ".codexhost", "remote", "data"),
       });
+    } finally {
+      await rm(home, { recursive: true, force: true });
+    }
+  });
+
+  it("discovers Grok from its default install root and exports CODEXHOST_GROK_COMMAND", async () => {
+    const home = await mkdtemp(path.join(os.tmpdir(), "codexhost-remote-grok-"));
+    const grokBin = path.join(home, ".grok", "bin");
+    await mkdir(grokBin, { recursive: true });
+    const grokCommand = await executable(path.join(grokBin, "grok"));
+    const options = {
+      home,
+      stockCodexPath: await executable(path.join(home, "stock-codex")),
+      nodePath: await executable(path.join(home, "node")),
+      shimPath: await executable(path.join(home, "codexhost-shim")),
+      hostRuntimePath: await regularFile(path.join(home, "host-runtime.mjs")),
+      platform: "darwin" as const,
+      environment: { HOME: home, SHELL: "/bin/zsh", PATH: "/usr/bin:/bin" },
+    };
+
+    try {
+      const installed = await installRemoteHost(options);
+      const profile = await readFile(installed.profilePath, "utf8");
+
+      expect(installed.grokCommand).toBe(grokCommand);
+      expect(profile).toContain(`export CODEXHOST_GROK_COMMAND='${grokCommand}'`);
+      await expect(inspectRemoteHostInstallation(options)).resolves.toMatchObject({
+        state: "ready",
+        grokCommand,
+      });
+    } finally {
+      await rm(home, { recursive: true, force: true });
+    }
+  });
+
+  it("pins an explicit Grok command ahead of install-root discovery", async () => {
+    const home = await mkdtemp(path.join(os.tmpdir(), "codexhost-remote-grok-explicit-"));
+    const grokBin = path.join(home, ".grok", "bin");
+    await mkdir(grokBin, { recursive: true });
+    await executable(path.join(grokBin, "grok"));
+    const grokCommand = await executable(path.join(home, "custom-grok"));
+    const options = {
+      home,
+      grokCommand,
+      stockCodexPath: await executable(path.join(home, "stock-codex")),
+      nodePath: await executable(path.join(home, "node")),
+      shimPath: await executable(path.join(home, "codexhost-shim")),
+      hostRuntimePath: await regularFile(path.join(home, "host-runtime.mjs")),
+      platform: "darwin" as const,
+      environment: { HOME: home, SHELL: "/bin/zsh", PATH: "/usr/bin:/bin" },
+    };
+
+    try {
+      const installed = await installRemoteHost(options);
+      expect(installed.grokCommand).toBe(grokCommand);
+      expect(await readFile(installed.profilePath, "utf8")).toContain(
+        `export CODEXHOST_GROK_COMMAND='${grokCommand}'`,
+      );
     } finally {
       await rm(home, { recursive: true, force: true });
     }
@@ -740,4 +800,36 @@ describe("remote SSH Host installation", () => {
       await rm(home, { recursive: true, force: true });
     }
   });
+
+  it.skipIf(process.platform === "win32")(
+    "installs a Node entrypoint when requested and still verifies uninstall",
+    async () => {
+      const home = await mkdtemp(path.join(os.tmpdir(), "codexhost-remote-js-entrypoint-"));
+      const options = {
+        home,
+        stockCodexPath: await executable(path.join(home, "stock-codex")),
+        nodePath: await executable(path.join(home, "node")),
+        shimPath: await executable(path.join(home, "codexhost-shim")),
+        hostRuntimePath: await regularFile(path.join(home, "host-runtime.mjs")),
+        platform: "darwin" as const,
+        entrypoint: "js" as const,
+        environment: { HOME: home, SHELL: "/bin/zsh" },
+      };
+
+      try {
+        const installed = await installRemoteHost(options);
+        const wrapper = await readFile(installed.wrapperPath, "utf8");
+        expect(wrapper.startsWith(`#!${options.nodePath}\n${JS_ENTRYPOINT_MARKER}\n`)).toBe(true);
+        expect(wrapper).not.toBe(await readFile(options.shimPath, "utf8"));
+        await expect(inspectRemoteHostInstallation(options)).resolves.toMatchObject({
+          state: "ready",
+          issues: [],
+        });
+        await uninstallRemoteHost(options);
+        await expect(readFile(installed.wrapperPath)).rejects.toMatchObject({ code: "ENOENT" });
+      } finally {
+        await rm(home, { recursive: true, force: true });
+      }
+    },
+  );
 });

--- a/packages/host-runtime/test/remote-host-js-entrypoint.test.ts
+++ b/packages/host-runtime/test/remote-host-js-entrypoint.test.ts
@@ -1,0 +1,82 @@
+import { spawnSync } from "node:child_process";
+import { chmod, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+import {
+  isGlibcLoaderFailure,
+  JS_ENTRYPOINT_MARKER,
+  renderRemoteHostJsEntrypoint,
+} from "../src/remote-host-js-entrypoint.js";
+
+describe("remote Host Node entrypoint", () => {
+  it("detects a dynamic loader glibc failure", () => {
+    expect(
+      isGlibcLoaderFailure(
+        "/home/pengqlu/.codexhost/remote/bin/codex: /lib64/libc.so.6: version `GLIBC_2.29' not found",
+      ),
+    ).toBe(true);
+    expect(isGlibcLoaderFailure("codexhost remote: CODEXHOST_STOCK_CODEX_PATH is required")).toBe(
+      false,
+    );
+  });
+
+  it.skipIf(process.platform === "win32")("self-checks listener classification", async () => {
+    const root = await mkdtemp(path.join(os.tmpdir(), "codexhost-js-entrypoint-"));
+    const wrapperPath = path.join(root, "codex");
+    try {
+      await writeFile(wrapperPath, renderRemoteHostJsEntrypoint(process.execPath), {
+        encoding: "utf8",
+        mode: 0o700,
+      });
+      await chmod(wrapperPath, 0o700);
+      const result = spawnSync(process.execPath, [wrapperPath], {
+        encoding: "utf8",
+        env: { ...process.env, CODEXHOST_JS_ENTRYPOINT_SELFTEST: "1" },
+      });
+      expect(result.stderr).toBe("");
+      expect(result.status).toBe(0);
+      expect(result.stdout).toBe("ok\n");
+      expect(await readFile(wrapperPath, "utf8")).toContain(JS_ENTRYPOINT_MARKER);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it.skipIf(process.platform === "win32")("forwards proxy invocations to stock Codex", async () => {
+    const root = await mkdtemp(path.join(os.tmpdir(), "codexhost-js-proxy-"));
+    const wrapperPath = path.join(root, "codex");
+    const stockPath = path.join(root, "stock-codex");
+    const recordPath = path.join(root, "args.json");
+    try {
+      await writeFile(
+        stockPath,
+        [
+          "#!/usr/bin/env node",
+          "require('fs').writeFileSync(process.env.RECORD_PATH, JSON.stringify(process.argv.slice(2)))",
+          "",
+        ].join("\n"),
+        { encoding: "utf8", mode: 0o700 },
+      );
+      await chmod(stockPath, 0o700);
+      await writeFile(wrapperPath, renderRemoteHostJsEntrypoint(process.execPath), {
+        encoding: "utf8",
+        mode: 0o700,
+      });
+      await chmod(wrapperPath, 0o700);
+      const result = spawnSync(wrapperPath, ["app-server", "proxy"], {
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          CODEXHOST_STOCK_CODEX_PATH: stockPath,
+          RECORD_PATH: recordPath,
+        },
+      });
+      expect(result.status).toBe(0);
+      expect(JSON.parse(await readFile(recordPath, "utf8"))).toEqual(["app-server", "proxy"]);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/host-runtime/test/remote-host-lifecycle.test.ts
+++ b/packages/host-runtime/test/remote-host-lifecycle.test.ts
@@ -9,6 +9,7 @@ import type {
 import {
   classifyRemoteHostProbeResponse,
   inspectRemoteHost,
+  managedRemoteHostEnvironment,
   setRemoteHostLifecycleDependenciesForTest,
   startRemoteHost,
   stopRemoteHost,
@@ -48,6 +49,19 @@ function runtime(
 }
 
 describe("remote Host lifecycle", () => {
+  it("exports a pinned Grok command into the managed listener environment", () => {
+    const grokCommand = "/home/developer/.local/bin/grok";
+    expect(
+      managedRemoteHostEnvironment(
+        { ...manifest, grokCommand },
+        { HOME: home, PATH: "/usr/bin:/bin" },
+      ),
+    ).toMatchObject({
+      CODEXHOST_GROK_COMMAND: grokCommand,
+      CODEXHOST_REMOTE_SSH_MANAGED: "1",
+    });
+  });
+
   it("uses the lightweight update status method to identify the managed Host", () => {
     expect(
       classifyRemoteHostProbeResponse(

--- a/packages/host-runtime/test/remote-ssh-provision.test.ts
+++ b/packages/host-runtime/test/remote-ssh-provision.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  provisionRemoteSshGrokHost,
+  remoteGrokProvisionScript,
+  resolveRemoteSshProvisionTarget,
+} from "../src/remote-ssh-provision.js";
+
+function occupancyJson(ownerCommand: string | null): string {
+  return `${JSON.stringify({ grokPath: "/usr/bin/grok", ownerCommand })}\n`;
+}
+
+describe("remote SSH Grok provisioning", () => {
+  it("resolves the SSH target from the Desktop Host ID", () => {
+    expect(resolveRemoteSshProvisionTarget({ hostId: "remote-ssh-discovered:uts" })).toBe("uts");
+  });
+
+  it("refuses to run on a managed remote Host", async () => {
+    await expect(
+      provisionRemoteSshGrokHost({
+        params: { hostId: "remote-ssh-discovered:uts" },
+        environment: { CODEXHOST_REMOTE_SSH_MANAGED: "1" },
+      }),
+    ).rejects.toThrow("本机 Desktop");
+  });
+
+  it("rewrites the native wrapper to a Node entrypoint when glibc is too old", () => {
+    const script = remoteGrokProvisionScript(false);
+    expect(script).toContain("原生入口需要更高 glibc，已改用 Node 入口");
+    expect(script).toContain("// codexhost remote SSH node entrypoint v1");
+  });
+
+  it("blocks automatic install when an official remote-control daemon owns the socket", async () => {
+    const result = await provisionRemoteSshGrokHost({
+      params: { hostId: "remote-ssh-discovered:uts" },
+      environment: { HOME: "/tmp" },
+      dependencies: {
+        async spawnSsh(_sshTarget, script, onChunk) {
+          expect(script).toContain("ownerCommand");
+          onChunk(occupancyJson("codex app-server --remote-control --listen unix://"));
+          return 0;
+        },
+      },
+    });
+    expect(result).toMatchObject({
+      ok: false,
+      kind: "official-remote-control",
+      reconnectRequired: false,
+    });
+  });
+
+  it("does not write a remote install when occupancy is unknown", async () => {
+    let installed = false;
+    await provisionRemoteSshGrokHost({
+      params: { hostId: "remote-ssh-discovered:uts" },
+      environment: { HOME: "/tmp" },
+      dependencies: {
+        async spawnSsh(_sshTarget, script, onChunk) {
+          if (script.includes("codexhost remote install")) installed = true;
+          onChunk(occupancyJson("some-other-listener"));
+          return 0;
+        },
+      },
+    });
+    expect(installed).toBe(false);
+  });
+
+  it("rolls back if remote start fails after install", () => {
+    const script = remoteGrokProvisionScript(false);
+    expect(script).toContain("codexhost remote uninstall");
+    expect(script).toContain("正在回滚远程 Host 安装");
+    expect(script).not.toContain("Install finished. Reopen this remote project to attach");
+  });
+
+  it("stops the official daemon only when replace is requested", () => {
+    expect(remoteGrokProvisionScript(false)).not.toContain("--remote-control");
+    expect(remoteGrokProvisionScript(true)).toContain("--remote-control");
+  });
+
+  it("restores the official Codex SSH daemon if a replace install rolls back", () => {
+    const replace = remoteGrokProvisionScript(true);
+    expect(replace).toContain("codex app-server daemon start");
+    expect(replace).toContain("正在恢复这条 SSH 连接的官方 Codex SSH daemon");
+    expect(remoteGrokProvisionScript(false)).not.toContain("codex app-server daemon start");
+  });
+
+  it("streams SSH output and reports reconnect after a successful idle install", async () => {
+    const logs: string[] = [];
+    const result = await provisionRemoteSshGrokHost({
+      params: { hostId: "remote-ssh-discovered:uts" },
+      environment: { HOME: "/tmp" },
+      onLog: (chunk) => {
+        logs.push(chunk);
+      },
+      dependencies: {
+        async spawnSsh(_sshTarget, script, onChunk) {
+          if (script.includes("ownerCommand")) {
+            onChunk(occupancyJson(null));
+            return 0;
+          }
+          expect(script).toContain("codexhost remote install");
+          onChunk("npm install ok\n");
+          return 0;
+        },
+      },
+    });
+    expect(result.ok).toBe(true);
+    expect(result.reconnectRequired).toBe(true);
+    expect(logs.join("")).toContain("npm install ok");
+  });
+});

--- a/packages/renderer-extension/src/renderer-agent-picker.ts
+++ b/packages/renderer-extension/src/renderer-agent-picker.ts
@@ -52,19 +52,23 @@ export function rendererAgentPickerView(
   switching: boolean,
   agents: readonly RendererAgent[],
   availability: AgentAvailability = {},
+  setupAgents: readonly RendererAgent[] = [],
 ): RendererAgentPickerView {
+  const setup = new Set(setupAgents);
   const optionDisabled = Object.fromEntries(
     agents.map((agent) => [
       agent,
       switching ||
         state.phase === "locked" ||
-        (agent !== "codex" && (adapterState !== "ready" || availability[agent] !== "ready")),
+        (agent !== "codex" &&
+          !setup.has(agent) &&
+          (adapterState !== "ready" || availability[agent] !== "ready")),
     ]),
   ) as Partial<Record<RendererAgent, boolean>>;
   const downloadVisible = Object.fromEntries(
     agents
       .filter((agent): agent is ExternalRendererAgent => agent !== "codex")
-      .map((agent) => [agent, availability[agent] === "notInstalled"]),
+      .map((agent) => [agent, availability[agent] === "notInstalled" && !setup.has(agent)]),
   ) as Partial<Record<ExternalRendererAgent, boolean>>;
   return {
     label: RENDERER_AGENT_LABELS[state.agent],
@@ -388,6 +392,7 @@ export function renderRendererAgentPicker(
   adapterState: RendererAdapterStatus["state"],
   switching: boolean,
   availability: AgentAvailability = {},
+  setupAgents: readonly RendererAgent[] = [],
 ): RendererAgentPickerView {
   const view = rendererAgentPickerView(
     state,
@@ -395,6 +400,7 @@ export function renderRendererAgentPicker(
     switching,
     control.agents,
     availability,
+    setupAgents,
   );
   if (control.iconSlot.dataset.agent !== state.agent) {
     control.iconSlot.replaceChildren(createRendererAgentIcon(state.agent));

--- a/packages/renderer-extension/src/renderer-binding-probe.ts
+++ b/packages/renderer-extension/src/renderer-binding-probe.ts
@@ -13,6 +13,11 @@ import {
   type ThreadUsageSnapshot,
   type CodexhostError,
 } from "@codexhost/shared-contracts";
+import {
+  openRemoteGrokSetupDialog,
+  remoteGrokNeedsSetup,
+  remoteGrokSetupVariant,
+} from "./renderer-remote-grok-setup.js";
 
 import {
   DEFAULT_RENDERER_AGENTS,
@@ -630,6 +635,8 @@ export function installRendererBindingProbe(
   };
 
   const renderMounted = (mounted: MountedComposer): void => {
+    const hostId = activeModelHostId();
+    const grokAvailability = activeHarnessAvailabilityState().availability.grok;
     renderComposerAgentControl(
       mounted.control,
       controller.get(mounted.composer),
@@ -642,6 +649,7 @@ export function installRendererBindingProbe(
       mounted.usage,
       mounted.accountCredits,
       settingsLifecycle.locale,
+      remoteGrokNeedsSetup(hostId, grokAvailability) ? ["grok"] : [],
     );
     if (mounted.control.usage) {
       mounted.control.usage.onOpen = () => {
@@ -1565,11 +1573,87 @@ export function installRendererBindingProbe(
     }
   };
 
+  const provisionRemoteGrok = async (hostId: string): Promise<boolean> => {
+    const localClient = modelClientForHost("local") ?? modelControl;
+    const preflightRemote = localClient?.preflightRemoteSshGrok;
+    const provisionRemote = localClient?.provisionRemoteSshGrok;
+    if (!localClient || !preflightRemote || !provisionRemote) {
+      window.alert("无法连接本机 codexhost。请用 codexhost 启动 Codex Desktop。");
+      return false;
+    }
+    const subscribeSetupLog = localClient.subscribeRemoteSshProvisionLog;
+    const startRemoteInstall = provisionRemote;
+    let variant: ReturnType<typeof remoteGrokSetupVariant> = "install";
+    try {
+      const preflight = await preflightRemote({ hostId });
+      variant = remoteGrokSetupVariant(preflight.kind);
+    } catch (error) {
+      window.alert(error instanceof Error ? error.message : String(error));
+      return false;
+    }
+    return await new Promise((resolve) => {
+      let settled = false;
+      const finish = (value: boolean): void => {
+        if (settled) return;
+        settled = true;
+        unsubscribeLog?.();
+        resolve(value);
+      };
+      let unsubscribeLog: (() => void) | undefined;
+      const dialog = openRemoteGrokSetupDialog({
+        hostId,
+        locale: settingsLifecycle.locale,
+        variant,
+        onDecline() {
+          finish(false);
+        },
+        onAcknowledge() {
+          finish(false);
+        },
+        onConfirm() {
+          runInstall(false);
+        },
+        onReplace() {
+          runInstall(true);
+        },
+      });
+      function runInstall(replaceOfficialDaemon: boolean): void {
+        try {
+          unsubscribeLog = subscribeSetupLog?.((update) => {
+            if (update.hostId === hostId) dialog.appendLog(update.chunk);
+          });
+        } catch {
+          unsubscribeLog = undefined;
+        }
+        void startRemoteInstall({ hostId, replaceOfficialDaemon })
+          .then((result) => {
+            dialog.appendLog(`\n${result.message}\n`);
+            if (result.ok) dialog.setDone(result.message);
+            else dialog.setFailed(result.message);
+          })
+          .catch((error) => {
+            dialog.setFailed(error instanceof Error ? error.message : String(error));
+          });
+      }
+    });
+  };
+
   const switchComposerAgent = async (
     mounted: MountedComposer,
     agent: RendererAgent,
   ): Promise<boolean> => {
-    if (agent !== "codex" && activeHarnessAvailabilityState().availability[agent] !== "ready") {
+    const hostId = activeModelHostId();
+    if (agent === "grok") {
+      const grokAvailability = activeHarnessAvailabilityState().availability.grok;
+      if (remoteGrokNeedsSetup(hostId, grokAvailability) && hostId) {
+        await provisionRemoteGrok(hostId);
+        return false;
+      }
+      if (grokAvailability !== "ready") return false;
+    } else if (
+      agent !== "codex" &&
+      activeHarnessAvailabilityState().availability[agent] !== "ready"
+    ) {
       return false;
     }
     controller.clearPendingSubmission(mounted.composer);

--- a/packages/renderer-extension/src/renderer-composer-dom.ts
+++ b/packages/renderer-extension/src/renderer-composer-dom.ts
@@ -675,6 +675,7 @@ export function renderComposerAgentControl(
   usage: ThreadUsageSnapshot | null = null,
   accountCredits: AccountCreditsSnapshot | null = null,
   locale: RendererSettingsLocale = "en",
+  setupAgents: readonly RendererAgent[] = [],
 ): void {
   if (control.usage === null) {
     control.usage = mountRendererUsageControl(control.composerId, locale);
@@ -713,6 +714,7 @@ export function renderComposerAgentControl(
     adapterState,
     switching,
     availability,
+    setupAgents,
   );
   reconcileComposerNativeControls(
     control,

--- a/packages/renderer-extension/src/renderer-model-client.ts
+++ b/packages/renderer-extension/src/renderer-model-client.ts
@@ -45,6 +45,16 @@ import {
   type UpdateCheckResult,
   type UpdateStartResult,
   type UpdateStatusResult,
+  remoteSshPreflightParamsSchema,
+  remoteSshPreflightResultSchema,
+  remoteSshProvisionLogNotificationSchema,
+  remoteSshProvisionParamsSchema,
+  remoteSshProvisionResultSchema,
+  type RemoteSshPreflightParams,
+  type RemoteSshPreflightResult,
+  type RemoteSshProvisionLogNotification,
+  type RemoteSshProvisionParams,
+  type RemoteSshProvisionResult,
 } from "@codexhost/shared-contracts";
 
 export const HARNESS_INSPECT_METHOD = "codexhost/harness/inspect";
@@ -62,6 +72,9 @@ export const THREAD_TOKEN_USAGE_UPDATED_METHOD = "thread/tokenUsage/updated";
 export const UPDATE_CHECK_METHOD = "codexhost/update/check";
 export const UPDATE_START_METHOD = "codexhost/update/start";
 export const UPDATE_STATUS_METHOD = "codexhost/update/status";
+export const REMOTE_SSH_PREFLIGHT_METHOD = "codexhost/remote-ssh/preflight";
+export const REMOTE_SSH_PROVISION_METHOD = "codexhost/remote-ssh/provision";
+export const REMOTE_SSH_PROVISION_LOG_METHOD = "codexhost/remote-ssh/provision/log";
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
@@ -115,6 +128,11 @@ export interface RendererModelClient {
   checkUpdate(): Promise<UpdateCheckResult>;
   startUpdate(): Promise<UpdateStartResult>;
   readUpdateStatus(): Promise<UpdateStatusResult>;
+  preflightRemoteSshGrok?(input: RemoteSshPreflightParams): Promise<RemoteSshPreflightResult>;
+  provisionRemoteSshGrok?(input: RemoteSshProvisionParams): Promise<RemoteSshProvisionResult>;
+  subscribeRemoteSshProvisionLog?(
+    listener: (update: RemoteSshProvisionLogNotification) => void,
+  ): () => void;
 }
 
 export function createThreadUsageSubscriptionRelay(): {
@@ -294,6 +312,38 @@ export function createRendererModelClient(
         updateEmptyParamsSchema.parse({}),
       );
       return updateStatusResultSchema.parse(result);
+    },
+    async preflightRemoteSshGrok(
+      input: RemoteSshPreflightParams,
+    ): Promise<RemoteSshPreflightResult> {
+      const params = remoteSshPreflightParamsSchema.parse(input);
+      const result = await manager.sendRequest(REMOTE_SSH_PREFLIGHT_METHOD, params);
+      return remoteSshPreflightResultSchema.parse(result);
+    },
+    async provisionRemoteSshGrok(
+      input: RemoteSshProvisionParams,
+    ): Promise<RemoteSshProvisionResult> {
+      const params = remoteSshProvisionParamsSchema.parse(input);
+      const result = await manager.sendRequest(REMOTE_SSH_PROVISION_METHOD, params);
+      return remoteSshProvisionResultSchema.parse(result);
+    },
+    subscribeRemoteSshProvisionLog(
+      listener: (update: RemoteSshProvisionLogNotification) => void,
+    ): () => void {
+      const notifications = notificationTarget(manager);
+      if (!notifications?.addNotificationCallback) {
+        throw new Error("Remote Host setup log callback is unavailable");
+      }
+      return notifications.addNotificationCallback(
+        REMOTE_SSH_PROVISION_LOG_METHOD,
+        (notification) => {
+          if (!isRecord(notification) || notification.method !== REMOTE_SSH_PROVISION_LOG_METHOD) {
+            return;
+          }
+          const parsed = remoteSshProvisionLogNotificationSchema.safeParse(notification.params);
+          if (parsed.success) listener(parsed.data);
+        },
+      );
     },
   });
 }

--- a/packages/renderer-extension/src/renderer-remote-grok-setup.ts
+++ b/packages/renderer-extension/src/renderer-remote-grok-setup.ts
@@ -1,0 +1,386 @@
+import {
+  isRemoteSshHostId,
+  sshTargetFromRemoteHostId,
+  type RemoteSshOccupancyKind,
+} from "@codexhost/shared-contracts";
+
+import type { RendererSettingsLocale } from "./settings/localization.js";
+
+export const REMOTE_GROK_SETUP_ATTRIBUTE = "data-codexhost-remote-grok-setup";
+
+export function remoteGrokNeedsSetup(
+  hostId: string | null,
+  availability: string | undefined,
+): boolean {
+  if (!hostId || !isRemoteSshHostId(hostId)) return false;
+  return availability !== "ready" && availability !== "checking";
+}
+
+export type RemoteGrokSetupVariant =
+  "install" | "blocked-official" | "blocked-unknown" | "grok-missing";
+
+export function remoteGrokSetupVariant(
+  kind: RemoteSshOccupancyKind | undefined,
+): RemoteGrokSetupVariant {
+  if (kind === "official-remote-control") return "blocked-official";
+  if (kind === "unknown-busy") return "blocked-unknown";
+  if (kind === "grok-missing") return "grok-missing";
+  return "install";
+}
+
+const DEFAULT_REMOTE_AGENT_LABEL = "Grok";
+
+interface RemoteGrokSetupCopy {
+  title: string;
+  body: (sshTarget: string) => string;
+  confirm: string | null;
+  replace: string | null;
+  decline: string;
+  installing: string;
+  doneTitle: string;
+  doneBody: string;
+  acknowledge: string;
+  failedTitle: string;
+  close: string;
+}
+
+const COPY: Record<RendererSettingsLocale, Record<RemoteGrokSetupVariant, RemoteGrokSetupCopy>> = {
+  "zh-CN": {
+    install: {
+      title: "要在服务器上安装远程 Grok 吗？",
+      body: (sshTarget) =>
+        `要用 Grok 连这台远程机器，需要在 ${sshTarget} 上安装 CodexHost 总入口。\n选 Codex 和选 Grok 都还在同一个远程项目里。失败会自动回滚，不会留下半截安装。`,
+      confirm: "是",
+      replace: null,
+      decline: "否",
+      installing: "正在服务器上安装…",
+      doneTitle: "安装完成",
+      doneBody: "请重新打开这个远程项目，然后再选 Grok。",
+      acknowledge: "确定",
+      failedTitle: "安装失败",
+      close: "关闭",
+    },
+    "blocked-official": {
+      title: "需要你的允许才能建立 {agent} 的远程连接",
+      body: (sshTarget) =>
+        `目前 ${sshTarget} 上面已经运行着 Codex SSH daemon，所以我们连不进去。\n想要同时让 {agent} 和 Codex 都能在本 App 上连接到 SSH，必须允许我停止目前的 Codex SSH daemon，换成 CodexHost 总入口。这个入口会自动路由 {agent} 和 Codex 通过本 App 连接到 SSH 的连接。安装完成后，会替您把这条 SSH 连接的 Codex SSH daemon 重新建立起来。\n如果本次操作失败会自动回滚，请勿担心。若允许，请点击“停掉官方入口并安装”。`,
+      confirm: null,
+      replace: "停掉官方入口并安装",
+      decline: "关闭",
+      installing: "正在替换官方入口…",
+      doneTitle: "安装完成",
+      doneBody: "请重新打开这个远程项目，然后再选 Grok。",
+      acknowledge: "确定",
+      failedTitle: "安装失败，已回滚",
+      close: "关闭",
+    },
+    "blocked-unknown": {
+      title: "这台服务器现在不能自动安装",
+      body: (sshTarget) =>
+        `${sshTarget} 上默认 socket 已被未知进程占用。\n这次不会改服务器，以免再次弄坏 Desktop SSH。`,
+      confirm: null,
+      replace: null,
+      decline: "关闭",
+      installing: "正在服务器上安装…",
+      doneTitle: "安装完成",
+      doneBody: "请重新打开这个远程项目，然后再选 Grok。",
+      acknowledge: "确定",
+      failedTitle: "安装失败",
+      close: "关闭",
+    },
+    "grok-missing": {
+      title: "服务器上还没有 Grok",
+      body: (sshTarget) =>
+        `请先在 ${sshTarget} 上安装并登录 Grok CLI，然后再试。这次没有改服务器。`,
+      confirm: null,
+      replace: null,
+      decline: "关闭",
+      installing: "正在服务器上安装…",
+      doneTitle: "安装完成",
+      doneBody: "请重新打开这个远程项目，然后再选 Grok。",
+      acknowledge: "确定",
+      failedTitle: "安装失败",
+      close: "关闭",
+    },
+  },
+  en: {
+    install: {
+      title: "Install remote Grok on the server?",
+      body: (sshTarget) =>
+        `Using Grok on this remote project requires installing the CodexHost door on ${sshTarget}.\nCodex and Grok stay in the same remote project. Failure rolls back instead of leaving a half install.`,
+      confirm: "Yes",
+      replace: null,
+      decline: "No",
+      installing: "Installing on the server…",
+      doneTitle: "Install complete",
+      doneBody: "Reopen this remote project, then select Grok.",
+      acknowledge: "OK",
+      failedTitle: "Install failed",
+      close: "Close",
+    },
+    "blocked-official": {
+      title: "Need your permission to set up a remote {agent} connection",
+      body: (sshTarget) =>
+        `${sshTarget} already has a Codex SSH daemon running, so we cannot attach {agent} to that door.\nTo let both {agent} and Codex use SSH in this app, allow stopping that Codex SSH daemon and installing the CodexHost door. CodexHost will route {agent} and Codex through this app onto the same SSH connection. After install, the SSH listener for this connection is started again.\nIf this fails, the change is rolled back. Click “Stop official door and install” to allow it.`,
+      confirm: null,
+      replace: "Stop official door and install",
+      decline: "Close",
+      installing: "Replacing the official door…",
+      doneTitle: "Install complete",
+      doneBody: "Reopen this remote project, then select Grok.",
+      acknowledge: "OK",
+      failedTitle: "Install failed and was rolled back",
+      close: "Close",
+    },
+    "blocked-unknown": {
+      title: "Automatic install is blocked on this server",
+      body: (sshTarget) =>
+        `An unknown process already owns the default Codex socket on ${sshTarget}.\nNothing was changed, so Desktop SSH is left alone.`,
+      confirm: null,
+      replace: null,
+      decline: "Close",
+      installing: "Installing on the server…",
+      doneTitle: "Install complete",
+      doneBody: "Reopen this remote project, then select Grok.",
+      acknowledge: "OK",
+      failedTitle: "Install failed",
+      close: "Close",
+    },
+    "grok-missing": {
+      title: "Grok is not installed on the server",
+      body: (sshTarget) =>
+        `Install and sign in to Grok CLI on ${sshTarget} first. Nothing was changed on the server.`,
+      confirm: null,
+      replace: null,
+      decline: "Close",
+      installing: "Installing on the server…",
+      doneTitle: "Install complete",
+      doneBody: "Reopen this remote project, then select Grok.",
+      acknowledge: "OK",
+      failedTitle: "Install failed",
+      close: "Close",
+    },
+  },
+};
+
+export interface RemoteGrokSetupDialog {
+  readonly root: HTMLElement;
+  setLog(text: string): void;
+  appendLog(chunk: string): void;
+  setFailed(message: string): void;
+  setDone(message: string): void;
+  close(): void;
+}
+
+export function resolveRemoteGrokSetupCopy(
+  variant: RemoteGrokSetupVariant,
+  sshTarget: string,
+  agentLabel = DEFAULT_REMOTE_AGENT_LABEL,
+): { title: string; body: string } {
+  const copy = COPY["zh-CN"][variant];
+  const agent = agentLabel.trim() || DEFAULT_REMOTE_AGENT_LABEL;
+  return {
+    title: copy.title.replaceAll("{agent}", agent),
+    body: copy.body(sshTarget).replaceAll("{agent}", agent),
+  };
+}
+
+export function openRemoteGrokSetupDialog(input: {
+  hostId: string;
+  locale: RendererSettingsLocale;
+  variant?: RemoteGrokSetupVariant;
+  agentLabel?: string;
+  onConfirm(): void;
+  onReplace?(): void;
+  onDecline(): void;
+  onAcknowledge(): void;
+  ownerDocument?: Document;
+}): RemoteGrokSetupDialog {
+  const ownerDocument = input.ownerDocument ?? document;
+  const variant = input.variant ?? "install";
+  const copy = COPY["zh-CN"][variant];
+  const sshTarget = sshTargetFromRemoteHostId(input.hostId) ?? input.hostId;
+  const prompt = resolveRemoteGrokSetupCopy(variant, sshTarget, input.agentLabel);
+  const existing = ownerDocument.querySelector(`[${REMOTE_GROK_SETUP_ATTRIBUTE}]`);
+  existing?.remove();
+
+  const root = ownerDocument.createElement("div");
+  root.setAttribute(REMOTE_GROK_SETUP_ATTRIBUTE, "v1");
+  root.style.position = "fixed";
+  root.style.inset = "0";
+  root.style.zIndex = "2147483646";
+  root.style.display = "flex";
+  root.style.alignItems = "center";
+  root.style.justifyContent = "center";
+  root.style.background = "rgba(0, 0, 0, 0.52)";
+  root.style.fontFamily = '"PingFang SC", "Pingfang SC", system-ui, sans-serif';
+
+  const panel = ownerDocument.createElement("div");
+  panel.setAttribute("role", "dialog");
+  panel.setAttribute("aria-modal", "true");
+  panel.style.width = "min(720px, calc(100vw - 32px))";
+  panel.style.maxHeight = "min(80vh, calc(100vh - 32px))";
+  panel.style.display = "flex";
+  panel.style.flexDirection = "column";
+  panel.style.gap = "12px";
+  panel.style.padding = "20px";
+  panel.style.overflow = "hidden";
+  panel.style.minHeight = "0";
+  panel.style.borderRadius = "12px";
+  panel.style.background = "#181818";
+  panel.style.color = "#f5f5f5";
+  panel.style.border = "1px solid rgb(255 255 255 / 10%)";
+  panel.style.boxShadow = "0 24px 64px rgb(0 0 0 / 38%)";
+  panel.style.position = "relative";
+
+  const header = ownerDocument.createElement("div");
+  header.style.display = "flex";
+  header.style.alignItems = "flex-start";
+  header.style.justifyContent = "space-between";
+  header.style.gap = "12px";
+  header.style.flex = "none";
+
+  const title = ownerDocument.createElement("h2");
+  title.textContent = prompt.title;
+  title.style.margin = "0";
+  title.style.flex = "1 1 auto";
+  title.style.font = '600 16px/1.4 "PingFang SC", "Pingfang SC", system-ui, sans-serif';
+
+  const dismiss = ownerDocument.createElement("button");
+  dismiss.type = "button";
+  dismiss.textContent = "×";
+  dismiss.setAttribute("aria-label", copy.close);
+  dismiss.style.width = "28px";
+  dismiss.style.height = "28px";
+  dismiss.style.flex = "none";
+  dismiss.style.border = "0";
+  dismiss.style.borderRadius = "8px";
+  dismiss.style.background = "transparent";
+  dismiss.style.color = "#f5f5f5";
+  dismiss.style.cursor = "pointer";
+  dismiss.style.font = "600 20px/1 system-ui, sans-serif";
+  header.append(title, dismiss);
+
+  const body = ownerDocument.createElement("p");
+  body.textContent = prompt.body;
+  body.style.margin = "0";
+  body.style.flex = "none";
+  body.style.maxHeight =
+    variant === "blocked-official" ? "20em" : variant === "install" ? "8em" : "12em";
+  body.style.overflow = "auto";
+  body.style.whiteSpace = "pre-wrap";
+  body.style.color = "#cfcfcf";
+  body.style.font = '14px/1.6 "PingFang SC", "Pingfang SC", system-ui, sans-serif';
+
+  const log = ownerDocument.createElement("pre");
+  log.hidden = true;
+  log.style.margin = "0";
+  log.style.flex = "1 1 auto";
+  log.style.minHeight = "160px";
+  log.style.maxHeight = "none";
+  log.style.overflow = "auto";
+  log.style.padding = "12px";
+  log.style.borderRadius = "8px";
+  log.style.background = "#111";
+  log.style.color = "#d7ffb3";
+  log.style.font = "12px/1.5 ui-monospace, SFMono-Regular, Menlo, monospace";
+  log.style.whiteSpace = "pre-wrap";
+  log.style.overflowWrap = "anywhere";
+
+  const actions = ownerDocument.createElement("div");
+  actions.style.display = "flex";
+  actions.style.justifyContent = "flex-end";
+  actions.style.gap = "8px";
+  actions.style.flex = "none";
+
+  const makeButton = (label: string, primary: boolean): HTMLButtonElement => {
+    const button = ownerDocument.createElement("button");
+    button.type = "button";
+    button.textContent = label;
+    button.style.minWidth = "72px";
+    button.style.height = "32px";
+    button.style.padding = "0 12px";
+    button.style.border = "0";
+    button.style.borderRadius = "8px";
+    button.style.cursor = "pointer";
+    button.style.font = '500 13px/1 "PingFang SC", "Pingfang SC", system-ui, sans-serif';
+    button.style.background = primary ? "#339cff" : "rgb(255 255 255 / 10%)";
+    button.style.color = primary ? "#fff" : "#f5f5f5";
+    return button;
+  };
+
+  const decline = makeButton(copy.decline, copy.confirm === null && copy.replace === null);
+  const confirm = copy.confirm ? makeButton(copy.confirm, true) : null;
+  const replace = copy.replace ? makeButton(copy.replace, true) : null;
+  if (replace) actions.append(replace);
+  actions.append(decline);
+  if (confirm) actions.append(confirm);
+
+  let phase: "prompt" | "running" | "done" = "prompt";
+  const closeDialog = (): void => {
+    root.remove();
+    if (phase === "prompt") input.onDecline();
+    else input.onAcknowledge();
+  };
+
+  const beginInstall = (start: () => void): void => {
+    phase = "running";
+    title.textContent = copy.installing;
+    confirm?.remove();
+    replace?.remove();
+    decline.remove();
+    log.hidden = false;
+    start();
+  };
+
+  confirm?.addEventListener("click", () => beginInstall(input.onConfirm));
+  replace?.addEventListener("click", () => beginInstall(input.onReplace ?? input.onConfirm));
+  decline.addEventListener("click", closeDialog);
+  dismiss.addEventListener("click", closeDialog);
+
+  panel.append(header, body, log, actions);
+  root.append(panel);
+  ownerDocument.body.append(root);
+
+  const dialog: RemoteGrokSetupDialog = {
+    root,
+    setLog(text) {
+      log.hidden = false;
+      log.textContent = text;
+      log.scrollTop = log.scrollHeight;
+    },
+    appendLog(chunk) {
+      log.hidden = false;
+      log.textContent += chunk;
+      log.scrollTop = log.scrollHeight;
+    },
+    setFailed(message) {
+      phase = "done";
+      title.textContent = copy.failedTitle;
+      const [summary] = message.split("\n");
+      body.textContent = summary || message;
+      log.hidden = false;
+      if (!log.textContent) {
+        log.textContent = message;
+        log.scrollTop = log.scrollHeight;
+      }
+      actions.replaceChildren();
+      const close = makeButton(copy.close, true);
+      close.addEventListener("click", closeDialog);
+      actions.append(close);
+    },
+    setDone(message) {
+      phase = "done";
+      title.textContent = copy.doneTitle;
+      body.textContent = message || copy.doneBody;
+      actions.replaceChildren();
+      const acknowledge = makeButton(copy.acknowledge, true);
+      acknowledge.addEventListener("click", closeDialog);
+      actions.append(acknowledge);
+    },
+    close() {
+      root.remove();
+    },
+  };
+  return dialog;
+}

--- a/packages/renderer-extension/src/versioned-renderer-adapter.ts
+++ b/packages/renderer-extension/src/versioned-renderer-adapter.ts
@@ -854,10 +854,12 @@ export function installCurrentRendererAdapter(): {
     clientForHost(hostId: string): RendererModelClient | null {
       const route = currentRequestRoute();
       if (route?.policy.hostId === hostId) return modelClientForTargets(route.targets);
+      const targets = rendererRequestTargetsForHost(findActivePrewarmTargets(document), hostId);
+      const client = modelClientForTargets(targets ?? []);
+      if (client) return client;
       const policy = window.__codexhostDraftPrewarmPolicyV1;
       if (isDraftPrewarmPolicyReady(policy) && hasPolicyRequestTarget(policy)) return null;
-      const targets = rendererRequestTargetsForHost(findActivePrewarmTargets(document), hostId);
-      return modelClientForTargets(targets ?? []);
+      return null;
     },
     forkThread: (input: ExternalThreadForkParams) => currentModelClient().forkThread(input),
     inspectHarness: (input: HarnessInspectParams) => currentModelClient().inspectHarness(input),

--- a/packages/renderer-extension/test/renderer-agent-picker.test.ts
+++ b/packages/renderer-extension/test/renderer-agent-picker.test.ts
@@ -60,6 +60,25 @@ describe("Renderer Agent picker presentation", () => {
     });
   });
 
+  it("keeps remote Grok selectable so the Host setup prompt can run", () => {
+    expect(
+      rendererAgentPickerView(
+        { agent: "codex", phase: "draft" },
+        "ready",
+        false,
+        ["codex", "grok"],
+        { grok: "error" },
+        ["grok"],
+      ),
+    ).toEqual({
+      label: "Codex",
+      triggerDisabled: false,
+      nativeModelHidden: false,
+      optionDisabled: { codex: false, grok: false },
+      downloadVisible: { grok: false },
+    });
+  });
+
   it("recognizes only the native React Model menu as the Model candidate", () => {
     const element = (
       ownAttributes: readonly string[],

--- a/packages/renderer-extension/test/renderer-model-client.test.ts
+++ b/packages/renderer-extension/test/renderer-model-client.test.ts
@@ -143,11 +143,14 @@ describe("Renderer fixed Model request client", () => {
       "inspectThreadCommands",
       "inspectThreadUsage",
       "listThreadOwnership",
+      "preflightRemoteSshGrok",
+      "provisionRemoteSshGrok",
       "readUpdateStatus",
       "selectThreadModel",
       "selectThreadPermissionMode",
       "selectThreadThinking",
       "startUpdate",
+      "subscribeRemoteSshProvisionLog",
       "subscribeThreadUsage",
     ]);
 

--- a/packages/renderer-extension/test/renderer-remote-grok-setup.test.ts
+++ b/packages/renderer-extension/test/renderer-remote-grok-setup.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  remoteGrokNeedsSetup,
+  remoteGrokSetupVariant,
+  resolveRemoteGrokSetupCopy,
+} from "../src/renderer-remote-grok-setup.js";
+
+describe("remote Grok setup prompt", () => {
+  it("only prompts on a remote SSH Host when Grok is not ready", () => {
+    expect(remoteGrokNeedsSetup("local", "error")).toBe(false);
+    expect(remoteGrokNeedsSetup("remote-ssh-discovered:uts", "ready")).toBe(false);
+    expect(remoteGrokNeedsSetup("remote-ssh-discovered:uts", "checking")).toBe(false);
+    expect(remoteGrokNeedsSetup("remote-ssh-discovered:uts", "error")).toBe(true);
+    expect(remoteGrokNeedsSetup("remote-ssh-discovered:uts", "notInstalled")).toBe(true);
+  });
+
+  it("maps occupancy to a blocked prompt instead of automatic install", () => {
+    expect(remoteGrokSetupVariant("official-remote-control")).toBe("blocked-official");
+    expect(remoteGrokSetupVariant("unknown-busy")).toBe("blocked-unknown");
+    expect(remoteGrokSetupVariant("grok-missing")).toBe("grok-missing");
+    expect(remoteGrokSetupVariant("idle")).toBe("install");
+  });
+
+  it("explains official daemon occupancy with the SSH target and agent label", () => {
+    const copy = resolveRemoteGrokSetupCopy("blocked-official", "company-box", "Claude Code");
+    expect(copy.title).toBe("需要你的允许才能建立 Claude Code 的远程连接");
+    expect(copy.body).toContain("目前 company-box 上面已经运行着 Codex SSH daemon");
+    expect(copy.body).not.toContain("UTS");
+    expect(copy.body).toContain("Claude Code 和 Codex");
+    expect(copy.body).toContain("会替您把这条 SSH 连接的 Codex SSH daemon 重新建立起来");
+    expect(copy.body).toContain("停掉官方入口并安装");
+  });
+});

--- a/packages/shared-contracts/src/index.ts
+++ b/packages/shared-contracts/src/index.ts
@@ -3,6 +3,25 @@ import { WORKSPACE_CONTRACT_VERSION } from "./version.js";
 
 export { codexhostErrorSchema } from "./errors.js";
 export { REASONING_TRANSCRIPT_COMMAND } from "./reasoning-transcript.js";
+export {
+  classifyRemoteSshOccupancy,
+  isRemoteSshHostId,
+  remoteSshOccupancyKindSchema,
+  remoteSshPreflightParamsSchema,
+  remoteSshPreflightResultSchema,
+  remoteSshProvisionLogNotificationSchema,
+  remoteSshProvisionParamsSchema,
+  remoteSshProvisionResultSchema,
+  sshTargetFromRemoteHostId,
+} from "./remote-ssh-provision.js";
+export type {
+  RemoteSshOccupancyKind,
+  RemoteSshPreflightParams,
+  RemoteSshPreflightResult,
+  RemoteSshProvisionLogNotification,
+  RemoteSshProvisionParams,
+  RemoteSshProvisionResult,
+} from "./remote-ssh-provision.js";
 export type { CodexhostError } from "./errors.js";
 export {
   externalThreadForkParamsSchema,

--- a/packages/shared-contracts/src/remote-ssh-provision.ts
+++ b/packages/shared-contracts/src/remote-ssh-provision.ts
@@ -1,0 +1,107 @@
+import { z } from "zod";
+
+const REMOTE_SSH_HOST_PREFIXES = [
+  "remote-ssh-discovered:",
+  "remote-ssh-codex-managed:",
+  "remote-ssh:",
+] as const;
+
+export function sshTargetFromRemoteHostId(hostId: string): string | null {
+  for (const prefix of REMOTE_SSH_HOST_PREFIXES) {
+    if (!hostId.startsWith(prefix)) continue;
+    const raw = hostId.slice(prefix.length);
+    if (raw.length === 0) return null;
+    try {
+      const decoded = decodeURIComponent(raw);
+      return decoded.trim().length > 0 ? decoded : null;
+    } catch {
+      return raw;
+    }
+  }
+  return null;
+}
+
+export function isRemoteSshHostId(hostId: string): boolean {
+  return sshTargetFromRemoteHostId(hostId) !== null;
+}
+
+export const remoteSshOccupancyKindSchema = z.enum([
+  "idle",
+  "official-remote-control",
+  "unknown-busy",
+  "grok-missing",
+]);
+
+export type RemoteSshOccupancyKind = z.infer<typeof remoteSshOccupancyKindSchema>;
+
+export function classifyRemoteSshOccupancy(input: {
+  grokPath: string | null;
+  ownerCommand: string | null;
+}): RemoteSshOccupancyKind {
+  const ownerCommand = input.ownerCommand ?? "";
+  if (
+    ownerCommand.includes("app-server") &&
+    ownerCommand.includes("--remote-control") &&
+    ownerCommand.includes("--listen")
+  ) {
+    return "official-remote-control";
+  }
+  if (ownerCommand.trim().length > 0) return "unknown-busy";
+  if (!input.grokPath) return "grok-missing";
+  return "idle";
+}
+
+export const remoteSshPreflightParamsSchema = z
+  .object({
+    hostId: z.string().min(1),
+    sshTarget: z.string().min(1).optional(),
+  })
+  .strict();
+
+export type RemoteSshPreflightParams = z.infer<typeof remoteSshPreflightParamsSchema>;
+
+export const remoteSshPreflightResultSchema = z
+  .object({
+    sshTarget: z.string().min(1),
+    kind: remoteSshOccupancyKindSchema,
+    grokPath: z.string().nullable(),
+    ownerCommand: z.string().nullable(),
+    message: z.string().min(1),
+  })
+  .strict();
+
+export type RemoteSshPreflightResult = z.infer<typeof remoteSshPreflightResultSchema>;
+
+export const remoteSshProvisionParamsSchema = z
+  .object({
+    hostId: z.string().min(1),
+    sshTarget: z.string().min(1).optional(),
+    replaceOfficialDaemon: z.boolean().optional(),
+  })
+  .strict();
+
+export type RemoteSshProvisionParams = z.infer<typeof remoteSshProvisionParamsSchema>;
+
+export const remoteSshProvisionResultSchema = z
+  .object({
+    ok: z.boolean(),
+    sshTarget: z.string().min(1),
+    kind: remoteSshOccupancyKindSchema.optional(),
+    message: z.string().min(1),
+    reconnectRequired: z.boolean(),
+    rolledBack: z.boolean().optional(),
+  })
+  .strict();
+
+export type RemoteSshProvisionResult = z.infer<typeof remoteSshProvisionResultSchema>;
+
+export const remoteSshProvisionLogNotificationSchema = z
+  .object({
+    hostId: z.string().min(1),
+    chunk: z.string(),
+  })
+  .strict();
+
+export type RemoteSshProvisionLogNotification = z.infer<
+  typeof remoteSshProvisionLogNotificationSchema
+>;

--- a/packages/shared-contracts/test/remote-ssh-provision.test.ts
+++ b/packages/shared-contracts/test/remote-ssh-provision.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  classifyRemoteSshOccupancy,
+  isRemoteSshHostId,
+  remoteSshProvisionParamsSchema,
+  sshTargetFromRemoteHostId,
+} from "../src/remote-ssh-provision.js";
+
+describe("remote SSH Host identity", () => {
+  it("extracts SSH targets from Desktop Host IDs", () => {
+    expect(sshTargetFromRemoteHostId("remote-ssh-discovered:uts")).toBe("uts");
+    expect(sshTargetFromRemoteHostId("remote-ssh:company")).toBe("company");
+    expect(sshTargetFromRemoteHostId("remote-ssh-codex-managed:%E5%85%AC%E5%8F%B8")).toBe("公司");
+    expect(sshTargetFromRemoteHostId("local")).toBeNull();
+    expect(isRemoteSshHostId("remote-ssh-discovered:uts")).toBe(true);
+    expect(isRemoteSshHostId("local")).toBe(false);
+  });
+
+  it("accepts an explicit SSH target", () => {
+    expect(
+      remoteSshProvisionParamsSchema.parse({
+        hostId: "remote-ssh-discovered:uts",
+        sshTarget: "uts",
+      }),
+    ).toEqual({ hostId: "remote-ssh-discovered:uts", sshTarget: "uts" });
+  });
+
+  it("classifies official remote-control occupancy before other states", () => {
+    expect(
+      classifyRemoteSshOccupancy({
+        grokPath: "/home/pengqlu/.local/bin/grok",
+        ownerCommand: "codex app-server --remote-control --listen unix://",
+      }),
+    ).toBe("official-remote-control");
+    expect(
+      classifyRemoteSshOccupancy({
+        grokPath: "/usr/bin/grok",
+        ownerCommand: "codex app-server --listen unix://",
+      }),
+    ).toBe("unknown-busy");
+    expect(classifyRemoteSshOccupancy({ grokPath: null, ownerCommand: null })).toBe("grok-missing");
+    expect(classifyRemoteSshOccupancy({ grokPath: "/usr/bin/grok", ownerCommand: null })).toBe(
+      "idle",
+    );
+  });
+});


### PR DESCRIPTION
## 目的

让用户在 Codex Desktop 原生 SSH 远程工作区里选 Grok 时，能从本机 Desktop 把 CodexHost 总入口装到那台 SSH 主机上，而不是要求事先手工 `codexhost remote install`。Codex 和 Grok 共用同一条 SSH 连接；官方 Codex SSH daemon 只有在用户明确允许后才会被替换。

## 行为

- 远程 Host 上 Grok 未就绪时，Agent 选择器仍可点 Grok，弹出安装确认，并流式显示远程 bash 进度。
- 预检占用：空闲可装；缺少 Grok CLI 则提示先安装；未知进程占用默认 socket 则拒绝改动；官方 `--remote-control` daemon 占门时必须点「停掉官方入口并安装」。
- 替换路径：先停当前用户的官方 daemon，再 `npm install -g @codexhost/cli`、`codexhost remote install --grok-command`、必要时把无法加载的原生 Shim 改写成 Node 入口，然后 `codexhost remote start`。
- 失败回滚：卸载托管入口；若本次停过官方 daemon，再执行 `codex app-server daemon start`，避免门空着。
- 成功后由 CodexHost 总入口接管默认 unix socket，路由 Codex 和 Grok。本地交互式 `codex` 不受 SSH 作用域的 `CODEX_INSTALL_DIR` 影响。
- Linux glibc 低于原生 Shim 基线时，安装/provision 改用 Node 入口，detach 语义与原生 Shim 的默认 `app-server --listen unix://` 一致；`app-server proxy` 仍走官方 Codex。
- `codexhost remote install --grok-command` 与 `CODEXHOST_GROK_COMMAND` 钉死远程 Grok 可执行文件。

## 受影响范围

- `shared-contracts`：远程 SSH Host ID、占用分类、preflight/provision 契约
- `host-runtime`：RPC、安装、生命周期、JS 入口、provision 脚本
- `renderer-extension`：远程 Grok 安装对话框、Agent picker、Model client
- OpenSpec `remote-ssh-harness-host` 与中英文 remote SSH 文档
- `.prettierignore`：忽略 `*.preview.html`，避开 main 上已失败的 Windows update preview 格式检查

## 验证

本地已跑：

- `npm run format:check`
- `npm run lint`
- `npm run typecheck`
- 相关 TypeScript 测试 10 个文件、175 个测试通过，包括 `remote-ssh-provision`、`remote-host-js-entrypoint`、`remote-host-install`、`app-server-host`、`renderer-remote-grok-setup`、`renderer-model-client`
- `npm run check:rust`

未声称完整 `npm run test:typescript` 全绿：本机当前 `main` 上 `tests/release/npm-package.test.mjs` 的 Homebrew npm 定位用例也会失败，与本次改动无关。未跑 `gate:a` / `gate:c` / e2e。

uts 上曾用临时目录验证 Node 入口：selftest、`app-server proxy` 转 stock Codex、默认 listen detach 后 socket 可连接。真实 Desktop 替换官方 daemon 的端到端安装仍需在 PR 合并前由维护者或作者在远程 SSH 主机上再确认一次。

## 非目标

- 不把 Grok 登录态拷到客户端
- 不在未知 socket 占用时自动杀进程
- 不把 musl 或非 Node 的更旧 Linux 作为一等支持面
- 不改变本地非 SSH 的 Codex CLI 入口