### PR TITLE
fix: strip ANSI and control characters from delegation Thread title

### DIFF
--- a/packages/host-runtime/src/harness-delegation-coordinator.ts
+++ b/packages/host-runtime/src/harness-delegation-coordinator.ts
@@ -47,6 +47,23 @@ import type { ExternalThread, ExternalThreadRuntime } from "./external-thread-ru
 
 const IMPLICIT_DEDUPLICATION_MS = 30_000;
 const NATIVE_REF_TIMEOUT_MS = 10_000;
+const DELEGATION_TITLE_MAX_LENGTH = 120;
+const DELEGATION_TITLE_ELLIPSIS = "...";
+const ANSI_CSI_PATTERN = /\u001B\[[0-9;]*[a-zA-Z]/gu;
+const C0_AND_DEL_CONTROL_CHARACTERS = /[\u0000-\u001F\u007F]/gu;
+const CONSECUTIVE_WHITESPACE = /\s+/gu;
+
+export function sanitizeDelegationTitle(task: string): string {
+  const withoutAnsi = task.replace(ANSI_CSI_PATTERN, "");
+  const withoutControls = withoutAnsi.replace(C0_AND_DEL_CONTROL_CHARACTERS, " ");
+  const collapsed = withoutControls.replace(CONSECUTIVE_WHITESPACE, " ");
+  const trimmed = collapsed.trim();
+  if (trimmed.length <= DELEGATION_TITLE_MAX_LENGTH) {
+    return trimmed;
+  }
+  const cutLength = Math.max(0, DELEGATION_TITLE_MAX_LENGTH - DELEGATION_TITLE_ELLIPSIS.length);
+  return `${trimmed.slice(0, cutLength)}${DELEGATION_TITLE_ELLIPSIS}`;
+}
 
 function delay(milliseconds: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, milliseconds));
@@ -252,7 +269,7 @@ export class HarnessDelegationCoordinator {
         createRequestId,
         harnessId: harnessIdSchema.parse(targetHarnessId),
         cwd: path.resolve(input.cwd),
-        title: input.task.trim().slice(0, 120),
+        title: sanitizeDelegationTitle(input.task),
         transportModelId:
           input.model || input.thinkingOptionId
             ? encodeExternalTransportSelection(targetHarnessId, {

--- a/packages/host-runtime/test/harness-delegation-coordinator.test.ts
+++ b/packages/host-runtime/test/harness-delegation-coordinator.test.ts
@@ -8,7 +8,10 @@ import { MappingStore } from "@codexhost/mapping-store";
 import { harnessIdSchema, hostThreadIdSchema, hostTurnIdSchema } from "@codexhost/shared-contracts";
 import { describe, expect, it, vi } from "vitest";
 
-import { HarnessDelegationCoordinator } from "../src/harness-delegation-coordinator.js";
+import {
+  HarnessDelegationCoordinator,
+  sanitizeDelegationTitle,
+} from "../src/harness-delegation-coordinator.js";
 import { ExternalThreadRepository } from "../src/external-thread-repository.js";
 import { ExternalThreadRuntime } from "../src/external-thread-runtime.js";
 
@@ -353,5 +356,69 @@ describe("HarnessDelegationCoordinator", () => {
     } finally {
       await value.close();
     }
+  });
+  it("sanitizes task text when creating child Thread title", async () => {
+    const adapter = new RecordingAdapter(harnessIdSchema.parse("pi"));
+    const value = await fixture(adapter);
+    try {
+      const longSuffix = "x".repeat(150);
+      await value.coordinator.start({
+        harnessId: "pi",
+        task: `\u001B[32mdeploy\u001B[0m\n\tcoordinator\r\n${longSuffix}`,
+        cwd: "/synthetic",
+        parentThreadId: "parent-thread",
+      });
+      const records = await value.repository.list();
+      expect(records).toHaveLength(1);
+      const title = records[0]?.title ?? "";
+      expect(title).not.toContain("\n");
+      expect(title).not.toContain("\u001B");
+      expect(title).not.toContain("32m");
+      expect(title).not.toContain("0m");
+      expect(title.startsWith("deploy coordinator ")).toBe(true);
+      expect(title.length).toBeLessThanOrEqual(120);
+      expect(title.endsWith("...")).toBe(true);
+      expect(title).toBe(
+        sanitizeDelegationTitle(`\u001B[32mdeploy\u001B[0m\n\tcoordinator\r\n${longSuffix}`),
+      );
+    } finally {
+      await value.close();
+    }
+  });
+});
+
+describe("sanitizeDelegationTitle", () => {
+  it("strips ANSI CSI sequences without leaving visible parameter or terminator artifacts", () => {
+    const input =
+      "\u001B[32mdeploy\u001B[0m \u001B[1;31mwith colors\u001B[0m and \u001B[2K\u001B[1Gclear";
+    const result = sanitizeDelegationTitle(input);
+    expect(result).toBe("deploy with colors and clear");
+    expect(result).not.toMatch(/32m|31m|2K|1G/);
+  });
+
+  it("replaces C0 control characters and DEL with spaces, collapses whitespace, and trims", () => {
+    const input =
+      "\u0000\u0001\u0002Hello\u001F\t\nworld\u007F\r\nfrom \u001B[31mcodexhost\u001B[0m\u0000";
+    expect(sanitizeDelegationTitle(input)).toBe("Hello world from codexhost");
+    expect(sanitizeDelegationTitle(input)).not.toContain("31m");
+  });
+
+  it("handles multi-line tasks with newlines and tabs", () => {
+    const input = "\n\tFix the login authentication flow\r\n\t  and update unit tests.\n";
+    expect(sanitizeDelegationTitle(input)).toBe(
+      "Fix the login authentication flow and update unit tests.",
+    );
+  });
+
+  it("does not truncate strings within the maximum length", () => {
+    const input = "a".repeat(120);
+    expect(sanitizeDelegationTitle(input)).toBe("a".repeat(120));
+  });
+
+  it("truncates strings exceeding maximum length and appends an ellipsis keeping total length within limit", () => {
+    const input = "a".repeat(121);
+    const sanitized = sanitizeDelegationTitle(input);
+    expect(sanitized).toBe(`${"a".repeat(117)}...`);
+    expect(sanitized).toHaveLength(120);
   });
 });


### PR DESCRIPTION
## What

Sanitizes the delegated task text before it becomes an External Thread title.

## Why

`HarnessDelegationCoordinator.start` derived the child Thread title with `input.task.trim().slice(0, 120)`. The task text is free-form user input, so a task containing ANSI escape sequences, newlines, or tabs carried those bytes straight into the Thread title — which is then rendered in the Desktop Thread list and echoed in CLI output, where it can garble the surrounding display.

## How

`sanitizeDelegationTitle` applies four steps, in this order:

1. remove complete ANSI CSI sequences (`ESC [ params letter`)
2. replace remaining C0 controls and DEL with a space
3. collapse consecutive whitespace
4. trim, then truncate to 120 chars with an ellipsis

Step 1 has to precede step 2: stripping `ESC` alone leaves the still-visible `[32m` remainder behind, which defeats the purpose.

## Verification

Rebased onto current `main` (`df334f4`) and re-run there:

| Check | Result |
| --- | --- |
| `npm run lint` | pass |
| `npm run typecheck` | pass |
| `packages/host-runtime/` | 279 passed, 2 skipped (28 files) |

`npm run test:rust` was not run — this change does not touch the Rust crates.

Tests cover ANSI colour and erase sequences, mixed C0/DEL with newlines and tabs, whitespace collapsing, the 120/121 truncation boundary, and one integration case asserting the persisted record title is clean. Assertions check for the absence of the visible remainder (`31m`, `2K`, …), not just the absence of `ESC`.