### PR TITLE
chore: restore repository format checks

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -6,6 +6,8 @@ node_modules/
 target/
 **/dist/
 build/
+# Generated visual preview bundle; formatting it creates a large non-semantic diff.
+packages/renderer-extension/src/settings/windows-update.preview.html
 coverage/
 playwright-report/
 test-results/

--- a/packages/host-runtime/test/remote-host-lifecycle.test.ts
+++ b/packages/host-runtime/test/remote-host-lifecycle.test.ts
@@ -150,12 +150,9 @@ describe("remote Host lifecycle", () => {
       startRemoteHost({ platform: "linux", environment: { HOME: home } }),
     ).rejects.toThrow("socket owner does not match");
     expect(launch).not.toHaveBeenCalled();
-    expect(terminate).toHaveBeenCalledWith(
-      expect.objectContaining(manifest),
-      socketPath,
-      "stock",
-      { HOME: home },
-    );
+    expect(terminate).toHaveBeenCalledWith(expect.objectContaining(manifest), socketPath, "stock", {
+      HOME: home,
+    });
   });
 
   it("stops only a protocol-verified managed Host", async () => {


### PR DESCRIPTION
## Summary

- apply the repository Prettier layout to `packages/host-runtime/test/remote-host-lifecycle.test.ts`
- exclude the exact generated `packages/renderer-extension/src/settings/windows-update.preview.html` artifact from Prettier
- restore the repository-wide `format:check` gate without changing runtime behavior or reformatting a 967 KB generated bundle

## Why ignore the preview artifact

The HTML file is an unreferenced visual preview containing bundled dependency/runtime JavaScript, is not shipped by `@codexhost/renderer-extension` (the package publishes only `dist`), and formatting it would create a large non-semantic diff. The ignore is intentionally file-specific rather than a broad HTML or preview glob.

The lifecycle test formatting overlaps the same Prettier normalization currently present in #71. It is included here so this standalone baseline PR passes CI against current `main`; if #71 lands first, this branch can be rebased and the now-redundant hunk will disappear.

This restores CI for existing PRs currently blocked before lint/typecheck/tests, including #91.

## Validation

- `npm run format:check`
- `npm run lint`
- `npm run typecheck`
- `npm run test:typescript` — 173 files passed, 1 skipped; 1491 tests passed, 15 skipped
- `npm run check:rust`
- `git diff --check`
- independent standards review — no findings
- independent spec review — no findings