### PR TITLE
feat: broker macOS Claude through the Aqua session

### DIFF
--- a/crates/launcher/src/main.rs
+++ b/crates/launcher/src/main.rs
@@ -4,6 +4,7 @@ mod active_update;
 mod compatibility;
 mod desktop_attachment;
 mod installation_layout;
+mod native_harness_broker;
 mod runtime_instance;
 #[cfg(target_os = "linux")]
 mod secure_storage;
@@ -50,6 +51,7 @@ use desktop_attachment::{
     endpoint_ready, publish_runtime_descriptor, stop_stale_launcher, wait_for_host_chain,
 };
 use installation_layout::InstalledResources;
+use native_harness_broker::run_native_harness_broker_cli;
 use runtime_instance::{
     StartupObservation, StartupState, classify_startup, default_descriptor_path, read_descriptor,
     remove_matching_descriptor,
@@ -120,7 +122,7 @@ impl Error for UnmanagedDesktopConflict {}
 
 fn usage() {
     eprintln!(
-        "usage:\n  codexhost\n  codexhost inspect [--custom-install <absolute-directory>]\n  codexhost launch [--shim <absolute-file>] [--node <absolute-file>] [--host-runtime <absolute-file>] [--desktop-controller <absolute-file>] [--renderer <absolute-file>] [--pi <absolute-file>] [--custom-install <absolute-directory>]\n  codexhost delegate --help\n  codexhost harness inspect ...\n  codexhost delegate start ...\n  codexhost thread send|cancel|read|wait|list ..."
+        "usage:\n  codexhost\n  codexhost inspect [--custom-install <absolute-directory>]\n  codexhost launch [--shim <absolute-file>] [--node <absolute-file>] [--host-runtime <absolute-file>] [--desktop-controller <absolute-file>] [--renderer <absolute-file>] [--pi <absolute-file>] [--custom-install <absolute-directory>]\n  codexhost broker install|status|stop|uninstall\n  codexhost delegate --help\n  codexhost harness inspect ...\n  codexhost delegate start ...\n  codexhost thread send|cancel|read|wait|list ..."
     );
 }
 
@@ -1158,6 +1160,7 @@ fn run(arguments: &[String]) -> Result<(), Box<dyn Error>> {
             inspect(custom_install_root.as_deref())
         }
         Some("launch") => launch(parse_launch_options(&arguments[1..])?, false),
+        Some("broker") => run_native_harness_broker_cli(&arguments[1..]),
         Some("harness") | Some("delegate") | Some("thread") => run_delegation_cli(arguments),
         _ => {
             usage();

--- a/crates/launcher/src/native_harness_broker.rs
+++ b/crates/launcher/src/native_harness_broker.rs
@@ -1,0 +1,232 @@
+use std::error::Error;
+use std::path::PathBuf;
+
+#[cfg(target_os = "macos")]
+use codexhost_platform::{
+    NativeHarnessBrokerInstallOutcome, NativeHarnessBrokerObservedState, NativeHarnessBrokerPaths,
+    inspect_native_harness_broker, install_native_harness_broker, stop_native_harness_broker,
+    uninstall_native_harness_broker,
+};
+
+#[cfg(target_os = "macos")]
+use crate::installation_layout::InstalledResources;
+#[cfg(target_os = "macos")]
+use crate::system_proxy_environment::launcher_proxy_environment;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum NativeHarnessBrokerCliCommand {
+    Install,
+    Status,
+    Stop,
+    Uninstall,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NativeHarnessBrokerCli {
+    pub command: NativeHarnessBrokerCliCommand,
+    pub node: Option<PathBuf>,
+    pub host_runtime: Option<PathBuf>,
+}
+
+fn macos_absolute_path(value: &str, option: &str) -> Result<PathBuf, String> {
+    if !value.starts_with('/') {
+        return Err(format!("{option} must be an absolute macOS path"));
+    }
+    Ok(PathBuf::from(value))
+}
+
+pub fn parse_native_harness_broker_cli(
+    arguments: &[String],
+) -> Result<NativeHarnessBrokerCli, String> {
+    let Some(command) = arguments.first() else {
+        return Err(
+            "usage: codexhost broker install|status|stop|uninstall [--node <absolute-file> --host-runtime <absolute-file>]".to_owned(),
+        );
+    };
+    let command = match command.as_str() {
+        "install" => NativeHarnessBrokerCliCommand::Install,
+        "status" => NativeHarnessBrokerCliCommand::Status,
+        "stop" => NativeHarnessBrokerCliCommand::Stop,
+        "uninstall" => NativeHarnessBrokerCliCommand::Uninstall,
+        unknown => Err(format!(
+            "unknown native Harness broker command '{unknown}'; expected install, status, stop, or uninstall"
+        ))?,
+    };
+    let mut node = None;
+    let mut host_runtime = None;
+    let mut index = 1;
+    while index < arguments.len() {
+        let option = arguments[index].as_str();
+        let value = arguments
+            .get(index + 1)
+            .ok_or_else(|| format!("{option} requires an absolute path"))?;
+        match option {
+            "--node" if node.is_none() => node = Some(macos_absolute_path(value, "--node")?),
+            "--host-runtime" if host_runtime.is_none() => {
+                host_runtime = Some(macos_absolute_path(value, "--host-runtime")?)
+            }
+            "--node" | "--host-runtime" => return Err(format!("duplicate option: {option}")),
+            unknown => return Err(format!("unknown native Harness broker option: {unknown}")),
+        }
+        index += 2;
+    }
+    if node.is_some() != host_runtime.is_some() {
+        return Err("--node and --host-runtime must be supplied together".to_owned());
+    }
+    Ok(NativeHarnessBrokerCli {
+        command,
+        node,
+        host_runtime,
+    })
+}
+
+#[cfg(target_os = "macos")]
+pub fn run_native_harness_broker_cli(arguments: &[String]) -> Result<(), Box<dyn Error>> {
+    let cli = parse_native_harness_broker_cli(arguments)?;
+    let bundled_resources = if cli.node.is_none() {
+        Some(InstalledResources::from_current_executable()?)
+    } else {
+        None
+    };
+    let home = std::env::var_os("HOME")
+        .map(std::path::PathBuf::from)
+        .ok_or("HOME is required to manage the current user's native Harness broker")?;
+    let node = cli
+        .node
+        .as_deref()
+        .or_else(|| {
+            bundled_resources
+                .as_ref()
+                .map(|resources| resources.node.as_path())
+        })
+        .ok_or("native Harness broker Node.js runtime is unavailable")?;
+    let host_runtime = cli
+        .host_runtime
+        .as_deref()
+        .or_else(|| {
+            bundled_resources
+                .as_ref()
+                .map(|resources| resources.host_runtime.as_path())
+        })
+        .ok_or("native Harness broker Host Runtime is unavailable")?;
+    let paths = NativeHarnessBrokerPaths {
+        home: &home,
+        node,
+        host_runtime,
+    };
+    let proxy_environment = launcher_proxy_environment()
+        .into_iter()
+        .map(|(name, value)| {
+            let name = name
+                .into_string()
+                .map_err(|_| "native Harness broker proxy variable name is not UTF-8")?;
+            let value = value.into_string().map_err(|_| {
+                format!("native Harness broker proxy value for {name} is not UTF-8")
+            })?;
+            Ok::<_, Box<dyn Error>>((name, value))
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+    match cli.command {
+        NativeHarnessBrokerCliCommand::Install => {
+            let outcome = install_native_harness_broker(paths, &proxy_environment)?;
+            let state = match outcome {
+                NativeHarnessBrokerInstallOutcome::AlreadyRunning => "already-running",
+                NativeHarnessBrokerInstallOutcome::Started => "restarted",
+                NativeHarnessBrokerInstallOutcome::Installed => "installed",
+                NativeHarnessBrokerInstallOutcome::Reinstalled => "reinstalled",
+            };
+            println!("state={state}");
+        }
+        NativeHarnessBrokerCliCommand::Status => {
+            let status = inspect_native_harness_broker(paths, &proxy_environment)?;
+            let state = match status.observed {
+                NativeHarnessBrokerObservedState::NotLoaded => "not-loaded",
+                NativeHarnessBrokerObservedState::LoadedStopped => "stopped",
+                NativeHarnessBrokerObservedState::Running => "running",
+            };
+            println!("state={state}");
+            println!("label={}", status.label);
+            println!("launchctl_target={}", status.launchctl_target);
+            println!("plist={}", status.plist_path.display());
+            println!("plist_matches={}", status.plist_matches);
+            println!("descriptor_ready={}", status.descriptor_ready);
+        }
+        NativeHarnessBrokerCliCommand::Stop => {
+            println!("stopped={}", stop_native_harness_broker(paths)?);
+        }
+        NativeHarnessBrokerCliCommand::Uninstall => {
+            println!("removed={}", uninstall_native_harness_broker(paths)?);
+        }
+    }
+    Ok(())
+}
+
+#[cfg(not(target_os = "macos"))]
+pub fn run_native_harness_broker_cli(arguments: &[String]) -> Result<(), Box<dyn Error>> {
+    let _ = parse_native_harness_broker_cli(arguments)?;
+    Err("the native Harness broker is available only on macOS".into())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::Path;
+
+    use super::{NativeHarnessBrokerCliCommand, parse_native_harness_broker_cli};
+
+    #[test]
+    fn parses_the_broker_lifecycle_commands_without_accepting_extra_arguments() {
+        for (argument, expected) in [
+            ("install", NativeHarnessBrokerCliCommand::Install),
+            ("status", NativeHarnessBrokerCliCommand::Status),
+            ("stop", NativeHarnessBrokerCliCommand::Stop),
+            ("uninstall", NativeHarnessBrokerCliCommand::Uninstall),
+        ] {
+            assert_eq!(
+                parse_native_harness_broker_cli(&[argument.to_owned()])
+                    .expect("valid command")
+                    .command,
+                expected
+            );
+        }
+        assert!(parse_native_harness_broker_cli(&["install".into(), "unexpected".into()]).is_err());
+    }
+
+    #[test]
+    fn accepts_only_a_complete_absolute_runtime_pair() {
+        let parsed = parse_native_harness_broker_cli(&[
+            "install".into(),
+            "--node".into(),
+            "/opt/codexhost/runtime/node".into(),
+            "--host-runtime".into(),
+            "/opt/codexhost/app/host-runtime.mjs".into(),
+        ])
+        .expect("absolute pair");
+        assert_eq!(
+            parsed.node.expect("node"),
+            Path::new("/opt/codexhost/runtime/node")
+        );
+        assert_eq!(
+            parsed.host_runtime.expect("runtime"),
+            Path::new("/opt/codexhost/app/host-runtime.mjs")
+        );
+
+        assert!(
+            parse_native_harness_broker_cli(&[
+                "install".into(),
+                "--node".into(),
+                "/opt/node".into(),
+            ])
+            .is_err()
+        );
+        assert!(
+            parse_native_harness_broker_cli(&[
+                "install".into(),
+                "--node".into(),
+                "relative/node".into(),
+                "--host-runtime".into(),
+                "/opt/host-runtime.mjs".into(),
+            ])
+            .is_err()
+        );
+    }
+}

--- a/crates/platform/Cargo.toml
+++ b/crates/platform/Cargo.toml
@@ -13,7 +13,7 @@ sha2 = "0.10.9"
 path = "src/lib.rs"
 
 [target.'cfg(any(target_os = "macos", target_os = "linux"))'.dependencies]
-nix = { version = "0.31.3", features = ["feature", "fs", "process", "signal"] }
+nix = { version = "0.31.3", features = ["feature", "fs", "process", "signal", "user"] }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 rustix = { version = "1.1.4", features = ["process"] }

--- a/crates/platform/src/lib.rs
+++ b/crates/platform/src/lib.rs
@@ -14,6 +14,7 @@ mod desktop_launch;
 mod installation;
 #[cfg(target_os = "linux")]
 mod linux_installation;
+mod macos_native_harness_broker;
 mod process;
 mod process_supervision;
 mod process_termination;
@@ -42,6 +43,18 @@ pub use installation::discover_codex_desktop;
 pub use installation::discover_codex_desktop_from_root;
 #[cfg(target_os = "linux")]
 pub use linux_installation::discover_codex_desktop;
+pub use macos_native_harness_broker::{
+    NATIVE_HARNESS_BROKER_LABEL, NativeHarnessBrokerCommand, NativeHarnessBrokerInstallStep,
+    NativeHarnessBrokerLaunchAgentPlan, NativeHarnessBrokerLaunchctlPlan,
+    NativeHarnessBrokerObservedState, NativeHarnessBrokerPaths, plan_native_harness_broker_install,
+    plan_native_harness_broker_launch_agent,
+    plan_native_harness_broker_launch_agent_with_environment, plan_native_harness_broker_launchctl,
+};
+#[cfg(target_os = "macos")]
+pub use macos_native_harness_broker::{
+    NativeHarnessBrokerInstallOutcome, NativeHarnessBrokerStatus, inspect_native_harness_broker,
+    install_native_harness_broker, stop_native_harness_broker, uninstall_native_harness_broker,
+};
 #[cfg(target_os = "macos")]
 pub use process::force_stop_desktop;
 pub use process::{

--- a/crates/platform/src/macos_native_harness_broker.rs
+++ b/crates/platform/src/macos_native_harness_broker.rs
@@ -1,0 +1,973 @@
+use std::path::{Path, PathBuf};
+
+#[cfg(target_os = "macos")]
+use std::fs::{self, OpenOptions};
+#[cfg(target_os = "macos")]
+use std::io::Write;
+#[cfg(target_os = "macos")]
+use std::os::unix::fs::{MetadataExt, OpenOptionsExt, PermissionsExt};
+#[cfg(target_os = "macos")]
+use std::process::{Command, Output};
+#[cfg(target_os = "macos")]
+use std::thread;
+#[cfg(target_os = "macos")]
+use std::time::{Duration, Instant};
+
+#[cfg(target_os = "macos")]
+use sha2::{Digest, Sha256};
+
+use crate::PlatformError;
+
+pub const NATIVE_HARNESS_BROKER_LABEL: &str = "ai.bytepioneer.codexhost.native-harness-broker";
+const NATIVE_HARNESS_BROKER_ARGUMENT: &str = "--codexhost-harness-broker";
+const NATIVE_HARNESS_BROKER_THROTTLE_SECONDS: u32 = 10;
+
+#[derive(Debug, Clone, Copy)]
+pub struct NativeHarnessBrokerPaths<'a> {
+    pub home: &'a Path,
+    pub node: &'a Path,
+    pub host_runtime: &'a Path,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NativeHarnessBrokerLaunchAgentPlan {
+    pub label: &'static str,
+    pub launchctl_domain: String,
+    pub launchctl_target: String,
+    pub plist_path: PathBuf,
+    pub broker_directory: PathBuf,
+    pub descriptor_path: PathBuf,
+    pub program_arguments: [String; 3],
+    pub plist_xml: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NativeHarnessBrokerCommand {
+    pub program: &'static str,
+    pub arguments: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NativeHarnessBrokerLaunchctlPlan {
+    pub print: NativeHarnessBrokerCommand,
+    pub bootstrap: NativeHarnessBrokerCommand,
+    pub bootout: NativeHarnessBrokerCommand,
+    pub kickstart: NativeHarnessBrokerCommand,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum NativeHarnessBrokerObservedState {
+    NotLoaded,
+    LoadedStopped,
+    Running,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum NativeHarnessBrokerInstallStep {
+    Bootout,
+    WritePlist,
+    Bootstrap,
+    Kickstart,
+}
+
+#[cfg(target_os = "macos")]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum NativeHarnessBrokerInstallOutcome {
+    AlreadyRunning,
+    Started,
+    Installed,
+    Reinstalled,
+}
+
+#[cfg(target_os = "macos")]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NativeHarnessBrokerStatus {
+    pub label: &'static str,
+    pub launchctl_target: String,
+    pub plist_path: PathBuf,
+    pub observed: NativeHarnessBrokerObservedState,
+    pub plist_matches: bool,
+    pub descriptor_ready: bool,
+}
+
+fn required_absolute_path(path: &Path, label: &str) -> Result<String, PlatformError> {
+    let value = path.to_str().ok_or_else(|| {
+        PlatformError::Invalid(format!(
+            "{label} must be valid UTF-8 for a LaunchAgent property list: {}",
+            path.display()
+        ))
+    })?;
+    if !value.starts_with('/') {
+        return Err(PlatformError::Invalid(format!(
+            "{label} must be an absolute path: {}",
+            path.display()
+        )));
+    }
+    Ok(value.to_owned())
+}
+
+fn xml_text(value: &str) -> String {
+    value
+        .replace('&', "&amp;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
+        .replace('"', "&quot;")
+        .replace('\'', "&apos;")
+}
+
+pub fn plan_native_harness_broker_launch_agent(
+    paths: NativeHarnessBrokerPaths<'_>,
+    console_uid: u32,
+) -> Result<NativeHarnessBrokerLaunchAgentPlan, PlatformError> {
+    plan_native_harness_broker_launch_agent_with_environment(paths, console_uid, &[])
+}
+
+fn launch_agent_environment_xml(environment: &[(String, String)]) -> Result<String, PlatformError> {
+    const ALLOWED: [&str; 9] = [
+        "HTTP_PROXY",
+        "http_proxy",
+        "HTTPS_PROXY",
+        "https_proxy",
+        "ALL_PROXY",
+        "all_proxy",
+        "NO_PROXY",
+        "no_proxy",
+        "NODE_USE_ENV_PROXY",
+    ];
+    if environment.is_empty() {
+        return Ok(String::new());
+    }
+    let mut values = environment.to_vec();
+    values.sort_by(|left, right| left.0.cmp(&right.0));
+    let mut prior: Option<String> = None;
+    let mut xml = String::from("<key>EnvironmentVariables</key>\n<dict>\n");
+    for (name, value) in values {
+        if !ALLOWED.contains(&name.as_str()) {
+            return Err(PlatformError::Invalid(format!(
+                "native Harness broker environment variable is not allowlisted: {name}"
+            )));
+        }
+        if prior.as_deref() == Some(name.as_str()) {
+            return Err(PlatformError::Invalid(format!(
+                "native Harness broker environment variable is duplicated: {name}"
+            )));
+        }
+        let proxy_variable = matches!(
+            name.as_str(),
+            "HTTP_PROXY" | "http_proxy" | "HTTPS_PROXY" | "https_proxy" | "ALL_PROXY" | "all_proxy"
+        );
+        if proxy_variable && value.contains('@') {
+            return Err(PlatformError::Invalid(format!(
+                "native Harness broker will not persist proxy credentials from {name}"
+            )));
+        }
+        if name == "NODE_USE_ENV_PROXY" && value != "0" && value != "1" {
+            return Err(PlatformError::Invalid(
+                "NODE_USE_ENV_PROXY must be either 0 or 1".to_owned(),
+            ));
+        }
+        xml.push_str(&format!(
+            "<key>{}</key>\n<string>{}</string>\n",
+            xml_text(&name),
+            xml_text(&value)
+        ));
+        prior = Some(name);
+    }
+    xml.push_str("</dict>\n");
+    Ok(xml)
+}
+
+pub fn plan_native_harness_broker_launch_agent_with_environment(
+    paths: NativeHarnessBrokerPaths<'_>,
+    console_uid: u32,
+    environment: &[(String, String)],
+) -> Result<NativeHarnessBrokerLaunchAgentPlan, PlatformError> {
+    if console_uid == 0 {
+        return Err(PlatformError::Invalid(
+            "the macOS Aqua console user must not be root".to_owned(),
+        ));
+    }
+    required_absolute_path(paths.home, "user home")?;
+    let node = required_absolute_path(paths.node, "packaged Node.js runtime")?;
+    let host_runtime = required_absolute_path(paths.host_runtime, "packaged Host Runtime")?;
+    let launchctl_domain = format!("gui/{console_uid}");
+    let launchctl_target = format!("{launchctl_domain}/{NATIVE_HARNESS_BROKER_LABEL}");
+    let plist_path = paths
+        .home
+        .join("Library/LaunchAgents")
+        .join(format!("{NATIVE_HARNESS_BROKER_LABEL}.plist"));
+    let broker_directory = paths.home.join(".codexhost/harness-broker");
+    let descriptor_path = broker_directory.join("claude-code-broker-v1.json");
+    let program_arguments = [
+        node,
+        host_runtime,
+        NATIVE_HARNESS_BROKER_ARGUMENT.to_owned(),
+    ];
+    let environment_xml = launch_agent_environment_xml(environment)?;
+    let plist_xml = format!(
+        "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n\
+<!DOCTYPE plist PUBLIC \"-//Apple//DTD PLIST 1.0//EN\" \"https://www.apple.com/DTDs/PropertyList-1.0.dtd\">\n\
+<plist version=\"1.0\">\n\
+<dict>\n\
+  <key>Label</key>\n\
+  <string>{}</string>\n\
+  <key>ProgramArguments</key>\n\
+  <array>\n\
+    <string>{}</string>\n\
+    <string>{}</string>\n\
+    <string>{}</string>\n\
+  </array>\n\
+  <key>LimitLoadToSessionType</key>\n\
+  <string>Aqua</string>\n\
+  <key>RunAtLoad</key>\n\
+  <true/>\n\
+  <key>ThrottleInterval</key>\n\
+  <integer>{NATIVE_HARNESS_BROKER_THROTTLE_SECONDS}</integer>\n\
+  <key>ProcessType</key>\n\
+  <string>Interactive</string>\n\
+{}\
+  <key>StandardOutPath</key>\n\
+  <string>/dev/null</string>\n\
+  <key>StandardErrorPath</key>\n\
+  <string>/dev/null</string>\n\
+</dict>\n\
+</plist>\n",
+        xml_text(NATIVE_HARNESS_BROKER_LABEL),
+        xml_text(&program_arguments[0]),
+        xml_text(&program_arguments[1]),
+        xml_text(&program_arguments[2]),
+        environment_xml,
+    );
+    Ok(NativeHarnessBrokerLaunchAgentPlan {
+        label: NATIVE_HARNESS_BROKER_LABEL,
+        launchctl_domain,
+        launchctl_target,
+        plist_path,
+        broker_directory,
+        descriptor_path,
+        program_arguments,
+        plist_xml,
+    })
+}
+
+pub fn plan_native_harness_broker_launchctl(
+    console_uid: u32,
+    plist_path: &Path,
+) -> Result<NativeHarnessBrokerLaunchctlPlan, PlatformError> {
+    if console_uid == 0 {
+        return Err(PlatformError::Invalid(
+            "the macOS Aqua console user must not be root".to_owned(),
+        ));
+    }
+    let plist_path = required_absolute_path(plist_path, "LaunchAgent property list")?;
+    let domain = format!("gui/{console_uid}");
+    let target = format!("{domain}/{NATIVE_HARNESS_BROKER_LABEL}");
+    let command = |arguments: Vec<String>| NativeHarnessBrokerCommand {
+        program: "/bin/launchctl",
+        arguments,
+    };
+    Ok(NativeHarnessBrokerLaunchctlPlan {
+        print: command(vec!["print".to_owned(), target.clone()]),
+        bootstrap: command(vec!["bootstrap".to_owned(), domain, plist_path]),
+        bootout: command(vec!["bootout".to_owned(), target.clone()]),
+        kickstart: command(vec!["kickstart".to_owned(), "-k".to_owned(), target]),
+    })
+}
+
+#[must_use]
+pub fn plan_native_harness_broker_install(
+    plist_matches: bool,
+    observed: NativeHarnessBrokerObservedState,
+) -> Vec<NativeHarnessBrokerInstallStep> {
+    match (plist_matches, observed) {
+        (true, NativeHarnessBrokerObservedState::Running) => {
+            vec![NativeHarnessBrokerInstallStep::Kickstart]
+        }
+        (true, NativeHarnessBrokerObservedState::LoadedStopped) => {
+            vec![NativeHarnessBrokerInstallStep::Kickstart]
+        }
+        (true, NativeHarnessBrokerObservedState::NotLoaded) => {
+            vec![NativeHarnessBrokerInstallStep::Bootstrap]
+        }
+        (false, NativeHarnessBrokerObservedState::NotLoaded) => vec![
+            NativeHarnessBrokerInstallStep::WritePlist,
+            NativeHarnessBrokerInstallStep::Bootstrap,
+        ],
+        (false, NativeHarnessBrokerObservedState::LoadedStopped)
+        | (false, NativeHarnessBrokerObservedState::Running) => vec![
+            NativeHarnessBrokerInstallStep::Bootout,
+            NativeHarnessBrokerInstallStep::WritePlist,
+            NativeHarnessBrokerInstallStep::Bootstrap,
+        ],
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn require_current_aqua_uid(home: &Path) -> Result<u32, PlatformError> {
+    use nix::unistd::Uid;
+
+    let effective_uid = Uid::effective().as_raw();
+    if effective_uid == 0 {
+        return Err(PlatformError::Invalid(
+            "the native Harness broker cannot be installed as root".to_owned(),
+        ));
+    }
+    let home_metadata = fs::symlink_metadata(home)?;
+    if home_metadata.file_type().is_symlink() || !home_metadata.is_dir() {
+        return Err(PlatformError::Invalid(format!(
+            "current user home must be a real directory, not a symlink: {}",
+            home.display()
+        )));
+    }
+    if home_metadata.uid() != effective_uid {
+        return Err(PlatformError::Invalid(format!(
+            "current user does not own the target home directory: {}",
+            home.display()
+        )));
+    }
+    let console_metadata = fs::metadata("/dev/console")?;
+    let console_uid = console_metadata.uid();
+    if console_uid == 0 || console_uid != effective_uid {
+        return Err(PlatformError::Invalid(format!(
+            "no Aqua console session is active for the current user (effective uid {effective_uid}, console uid {console_uid})"
+        )));
+    }
+    Ok(console_uid)
+}
+
+#[cfg(target_os = "macos")]
+fn require_regular_nonsymlink_file(path: &Path, label: &str) -> Result<(), PlatformError> {
+    let metadata = fs::symlink_metadata(path).map_err(|error| {
+        PlatformError::Invalid(format!(
+            "{label} is unavailable at '{}': {error}",
+            path.display()
+        ))
+    })?;
+    if metadata.file_type().is_symlink() || !metadata.is_file() {
+        return Err(PlatformError::Invalid(format!(
+            "{label} must be a regular file and not a symlink: {}",
+            path.display()
+        )));
+    }
+    Ok(())
+}
+
+#[cfg(target_os = "macos")]
+fn require_executable_file(path: &Path, label: &str) -> Result<(), PlatformError> {
+    require_regular_nonsymlink_file(path, label)?;
+    if fs::metadata(path)?.mode() & 0o111 == 0 {
+        return Err(PlatformError::Invalid(format!(
+            "{label} must have an executable permission bit: {}",
+            path.display()
+        )));
+    }
+    Ok(())
+}
+
+#[cfg(target_os = "macos")]
+fn ensure_owned_directory(
+    path: &Path,
+    uid: u32,
+    harden_to_owner_only: bool,
+) -> Result<(), PlatformError> {
+    if !path.exists() {
+        fs::create_dir(path)?;
+        fs::set_permissions(path, fs::Permissions::from_mode(0o700))?;
+    }
+    let mut metadata = fs::symlink_metadata(path)?;
+    if metadata.file_type().is_symlink() || !metadata.is_dir() || metadata.uid() != uid {
+        return Err(PlatformError::Invalid(format!(
+            "managed directory must be a current-user-owned real directory: {}",
+            path.display()
+        )));
+    }
+    if harden_to_owner_only && metadata.mode() & 0o777 != 0o700 {
+        fs::set_permissions(path, fs::Permissions::from_mode(0o700))?;
+        metadata = fs::symlink_metadata(path)?;
+    }
+    if metadata.file_type().is_symlink()
+        || !metadata.is_dir()
+        || metadata.uid() != uid
+        || if harden_to_owner_only {
+            metadata.mode() & 0o777 != 0o700
+        } else {
+            metadata.mode() & 0o022 != 0
+        }
+    {
+        return Err(PlatformError::Invalid(format!(
+            "managed directory permissions or ownership are unsafe: {}",
+            path.display()
+        )));
+    }
+    Ok(())
+}
+
+#[cfg(target_os = "macos")]
+fn ensure_managed_directories(
+    plan: &NativeHarnessBrokerLaunchAgentPlan,
+    uid: u32,
+) -> Result<(), PlatformError> {
+    let home =
+        plan.plist_path.ancestors().nth(3).ok_or_else(|| {
+            PlatformError::Invalid("LaunchAgent path has no user home".to_owned())
+        })?;
+    let library = home.join("Library");
+    let launch_agents = library.join("LaunchAgents");
+    ensure_owned_directory(&library, uid, false)?;
+    ensure_owned_directory(&launch_agents, uid, true)?;
+    let codexhost = home.join(".codexhost");
+    ensure_owned_directory(&codexhost, uid, true)?;
+    ensure_owned_directory(&plan.broker_directory, uid, true)
+}
+
+#[cfg(target_os = "macos")]
+fn plist_matches(
+    plan: &NativeHarnessBrokerLaunchAgentPlan,
+    uid: u32,
+) -> Result<bool, PlatformError> {
+    let metadata = match fs::symlink_metadata(&plan.plist_path) {
+        Ok(metadata) => metadata,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(false),
+        Err(error) => return Err(error.into()),
+    };
+    if metadata.file_type().is_symlink() || !metadata.is_file() {
+        return Err(PlatformError::Invalid(format!(
+            "managed LaunchAgent property list must be a regular file and not a symlink: {}",
+            plan.plist_path.display()
+        )));
+    }
+    if metadata.uid() != uid {
+        return Err(PlatformError::Invalid(format!(
+            "managed LaunchAgent property list belongs to another user: {}",
+            plan.plist_path.display()
+        )));
+    }
+    if metadata.mode() & 0o777 != 0o600 {
+        return Ok(false);
+    }
+    Ok(fs::read_to_string(&plan.plist_path)? == plan.plist_xml)
+}
+
+#[cfg(target_os = "macos")]
+fn validate_secure_plist(
+    plan: &NativeHarnessBrokerLaunchAgentPlan,
+    uid: u32,
+) -> Result<(), PlatformError> {
+    let parent = plan
+        .plist_path
+        .parent()
+        .ok_or_else(|| PlatformError::Invalid("LaunchAgent path has no parent".to_owned()))?;
+    ensure_owned_directory(parent, uid, true)?;
+    let metadata = fs::symlink_metadata(&plan.plist_path)?;
+    if metadata.file_type().is_symlink()
+        || !metadata.is_file()
+        || metadata.uid() != uid
+        || metadata.mode() & 0o777 != 0o600
+    {
+        return Err(PlatformError::Invalid(format!(
+            "managed LaunchAgent property list must be a current-user-owned 0600 regular file: {}",
+            plan.plist_path.display()
+        )));
+    }
+    Ok(())
+}
+
+#[cfg(target_os = "macos")]
+fn atomic_write_plist(
+    plan: &NativeHarnessBrokerLaunchAgentPlan,
+    uid: u32,
+) -> Result<(), PlatformError> {
+    if let Ok(metadata) = fs::symlink_metadata(&plan.plist_path) {
+        if metadata.file_type().is_symlink() || !metadata.is_file() {
+            return Err(PlatformError::Invalid(format!(
+                "refusing to replace a non-regular LaunchAgent property list: {}",
+                plan.plist_path.display()
+            )));
+        }
+        if metadata.uid() != uid {
+            return Err(PlatformError::Invalid(format!(
+                "refusing to replace a LaunchAgent property list owned by another user: {}",
+                plan.plist_path.display()
+            )));
+        }
+    }
+    let parent = plan
+        .plist_path
+        .parent()
+        .ok_or_else(|| PlatformError::Invalid("LaunchAgent path has no parent".to_owned()))?;
+    ensure_owned_directory(parent, uid, true)?;
+    let temporary_path = parent.join(format!(
+        ".{NATIVE_HARNESS_BROKER_LABEL}.{}.tmp",
+        std::process::id()
+    ));
+    let result = (|| -> Result<(), PlatformError> {
+        let mut temporary = OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .mode(0o600)
+            .open(&temporary_path)?;
+        temporary.write_all(plan.plist_xml.as_bytes())?;
+        temporary.sync_all()?;
+        fs::rename(&temporary_path, &plan.plist_path)?;
+        validate_secure_plist(plan, uid)?;
+        Ok(())
+    })();
+    if result.is_err() {
+        let _ = fs::remove_file(&temporary_path);
+    }
+    result
+}
+
+#[cfg(target_os = "macos")]
+fn run_launchctl(command: &NativeHarnessBrokerCommand) -> Result<Output, PlatformError> {
+    Command::new(command.program)
+        .args(&command.arguments)
+        .output()
+        .map_err(PlatformError::Io)
+}
+
+#[cfg(target_os = "macos")]
+fn command_failure(command: &NativeHarnessBrokerCommand, output: &Output) -> PlatformError {
+    let stderr = String::from_utf8_lossy(&output.stderr).trim().to_owned();
+    PlatformError::Invalid(format!(
+        "{} {} failed with {}{}",
+        command.program,
+        command.arguments.join(" "),
+        output.status,
+        if stderr.is_empty() {
+            String::new()
+        } else {
+            format!(": {stderr}")
+        }
+    ))
+}
+
+#[cfg(target_os = "macos")]
+fn observed_launchctl_state(
+    commands: &NativeHarnessBrokerLaunchctlPlan,
+) -> Result<NativeHarnessBrokerObservedState, PlatformError> {
+    let output = run_launchctl(&commands.print)?;
+    if output.status.success() {
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        return Ok(
+            if stdout.lines().any(|line| line.trim() == "state = running") {
+                NativeHarnessBrokerObservedState::Running
+            } else {
+                NativeHarnessBrokerObservedState::LoadedStopped
+            },
+        );
+    }
+    let stderr = String::from_utf8_lossy(&output.stderr).to_ascii_lowercase();
+    if stderr.contains("could not find service") || stderr.contains("service not found") {
+        Ok(NativeHarnessBrokerObservedState::NotLoaded)
+    } else {
+        Err(command_failure(&commands.print, &output))
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn descriptor_fingerprint(
+    plan: &NativeHarnessBrokerLaunchAgentPlan,
+    uid: u32,
+) -> Result<Option<[u8; 32]>, PlatformError> {
+    let metadata = match fs::symlink_metadata(&plan.descriptor_path) {
+        Ok(metadata) => metadata,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(error) => return Err(error.into()),
+    };
+    if metadata.file_type().is_symlink() || !metadata.is_file() {
+        return Err(PlatformError::Invalid(format!(
+            "native Harness broker descriptor must be a regular file and not a symlink: {}",
+            plan.descriptor_path.display()
+        )));
+    }
+    if metadata.uid() != uid {
+        return Err(PlatformError::Invalid(format!(
+            "native Harness broker descriptor belongs to another user: {}",
+            plan.descriptor_path.display()
+        )));
+    }
+    if metadata.mode() & 0o777 != 0o600 || metadata.len() == 0 {
+        return Ok(None);
+    }
+    let bytes = fs::read(&plan.descriptor_path)?;
+    if bytes.is_empty() {
+        return Ok(None);
+    }
+    Ok(Some(Sha256::digest(bytes).into()))
+}
+
+#[cfg(target_os = "macos")]
+fn wait_for_ready(
+    commands: &NativeHarnessBrokerLaunchctlPlan,
+    plan: &NativeHarnessBrokerLaunchAgentPlan,
+    uid: u32,
+    previous_descriptor: Option<[u8; 32]>,
+    timeout: Duration,
+) -> Result<bool, PlatformError> {
+    let started = Instant::now();
+    loop {
+        let descriptor = descriptor_fingerprint(plan, uid)?;
+        if observed_launchctl_state(commands)? == NativeHarnessBrokerObservedState::Running
+            && descriptor.is_some()
+            && descriptor != previous_descriptor
+        {
+            return Ok(true);
+        }
+        if started.elapsed() >= timeout {
+            return Ok(false);
+        }
+        thread::sleep(Duration::from_millis(50));
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn execute_required(command: &NativeHarnessBrokerCommand) -> Result<(), PlatformError> {
+    let output = run_launchctl(command)?;
+    if output.status.success() {
+        Ok(())
+    } else {
+        Err(command_failure(command, &output))
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn broker_context(
+    paths: NativeHarnessBrokerPaths<'_>,
+    environment: &[(String, String)],
+) -> Result<
+    (
+        NativeHarnessBrokerLaunchAgentPlan,
+        NativeHarnessBrokerLaunchctlPlan,
+    ),
+    PlatformError,
+> {
+    let uid = require_current_aqua_uid(paths.home)?;
+    require_executable_file(paths.node, "packaged Node.js runtime")?;
+    require_regular_nonsymlink_file(paths.host_runtime, "packaged Host Runtime")?;
+    let plan = plan_native_harness_broker_launch_agent_with_environment(paths, uid, environment)?;
+    let commands = plan_native_harness_broker_launchctl(uid, &plan.plist_path)?;
+    Ok((plan, commands))
+}
+
+#[cfg(target_os = "macos")]
+pub fn inspect_native_harness_broker(
+    paths: NativeHarnessBrokerPaths<'_>,
+    environment: &[(String, String)],
+) -> Result<NativeHarnessBrokerStatus, PlatformError> {
+    let uid = require_current_aqua_uid(paths.home)?;
+    let (plan, commands) = broker_context(paths, environment)?;
+    Ok(NativeHarnessBrokerStatus {
+        label: plan.label,
+        launchctl_target: plan.launchctl_target.clone(),
+        plist_path: plan.plist_path.clone(),
+        observed: observed_launchctl_state(&commands)?,
+        plist_matches: plist_matches(&plan, uid)?,
+        descriptor_ready: descriptor_fingerprint(&plan, require_current_aqua_uid(paths.home)?)?
+            .is_some(),
+    })
+}
+
+#[cfg(target_os = "macos")]
+pub fn install_native_harness_broker(
+    paths: NativeHarnessBrokerPaths<'_>,
+    environment: &[(String, String)],
+) -> Result<NativeHarnessBrokerInstallOutcome, PlatformError> {
+    let (plan, commands) = broker_context(paths, environment)?;
+    ensure_managed_directories(&plan, require_current_aqua_uid(paths.home)?)?;
+    let uid = require_current_aqua_uid(paths.home)?;
+    let matches = plist_matches(&plan, uid)?;
+    let observed = observed_launchctl_state(&commands)?;
+    let previous_descriptor = descriptor_fingerprint(&plan, require_current_aqua_uid(paths.home)?)?;
+    let steps = plan_native_harness_broker_install(matches, observed);
+    for step in &steps {
+        match step {
+            NativeHarnessBrokerInstallStep::Bootout => execute_required(&commands.bootout)?,
+            NativeHarnessBrokerInstallStep::WritePlist => atomic_write_plist(&plan, uid)?,
+            NativeHarnessBrokerInstallStep::Bootstrap => {
+                validate_secure_plist(&plan, uid)?;
+                execute_required(&commands.bootstrap)?;
+            }
+            NativeHarnessBrokerInstallStep::Kickstart => {
+                validate_secure_plist(&plan, uid)?;
+                execute_required(&commands.kickstart)?;
+            }
+        }
+    }
+    if !wait_for_ready(
+        &commands,
+        &plan,
+        require_current_aqua_uid(paths.home)?,
+        previous_descriptor,
+        Duration::from_secs(3),
+    )? {
+        return Err(PlatformError::Invalid(format!(
+            "native Harness broker did not enter the running state in {}",
+            plan.launchctl_target
+        )));
+    }
+    Ok(match steps.as_slice() {
+        [] => NativeHarnessBrokerInstallOutcome::AlreadyRunning,
+        [NativeHarnessBrokerInstallStep::Kickstart] => NativeHarnessBrokerInstallOutcome::Started,
+        [
+            NativeHarnessBrokerInstallStep::WritePlist,
+            NativeHarnessBrokerInstallStep::Bootstrap,
+        ] => NativeHarnessBrokerInstallOutcome::Installed,
+        _ => NativeHarnessBrokerInstallOutcome::Reinstalled,
+    })
+}
+
+#[cfg(target_os = "macos")]
+pub fn stop_native_harness_broker(
+    paths: NativeHarnessBrokerPaths<'_>,
+) -> Result<bool, PlatformError> {
+    let (_plan, commands) = broker_context(paths, &[])?;
+    if observed_launchctl_state(&commands)? == NativeHarnessBrokerObservedState::NotLoaded {
+        return Ok(false);
+    }
+    execute_required(&commands.bootout)?;
+    Ok(true)
+}
+
+#[cfg(target_os = "macos")]
+pub fn uninstall_native_harness_broker(
+    paths: NativeHarnessBrokerPaths<'_>,
+) -> Result<bool, PlatformError> {
+    let (plan, commands) = broker_context(paths, &[])?;
+    if observed_launchctl_state(&commands)? != NativeHarnessBrokerObservedState::NotLoaded {
+        execute_required(&commands.bootout)?;
+    }
+    let metadata = match fs::symlink_metadata(&plan.plist_path) {
+        Ok(metadata) => metadata,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(false),
+        Err(error) => return Err(error.into()),
+    };
+    if metadata.file_type().is_symlink() || !metadata.is_file() {
+        return Err(PlatformError::Invalid(format!(
+            "refusing to remove a non-regular LaunchAgent property list: {}",
+            plan.plist_path.display()
+        )));
+    }
+    fs::remove_file(&plan.plist_path)?;
+    Ok(true)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::Path;
+
+    use super::{
+        NATIVE_HARNESS_BROKER_LABEL, NativeHarnessBrokerInstallStep,
+        NativeHarnessBrokerObservedState, NativeHarnessBrokerPaths,
+        plan_native_harness_broker_install, plan_native_harness_broker_launch_agent,
+        plan_native_harness_broker_launch_agent_with_environment,
+        plan_native_harness_broker_launchctl,
+    };
+
+    #[test]
+    fn launch_agent_plan_runs_the_packaged_broker_only_in_aqua() {
+        let plan = plan_native_harness_broker_launch_agent(
+            NativeHarnessBrokerPaths {
+                home: Path::new("/Users/moka"),
+                node: Path::new("/Applications/codexhost.app/Contents/Resources/runtime/node"),
+                host_runtime: Path::new(
+                    "/Applications/codexhost.app/Contents/Resources/app/host-runtime.mjs",
+                ),
+            },
+            501,
+        )
+        .expect("valid plan");
+
+        assert_eq!(plan.label, NATIVE_HARNESS_BROKER_LABEL);
+        assert_eq!(plan.launchctl_domain, "gui/501");
+        assert_eq!(
+            plan.descriptor_path,
+            Path::new("/Users/moka/.codexhost/harness-broker/claude-code-broker-v1.json")
+        );
+        assert_eq!(
+            plan.program_arguments,
+            [
+                "/Applications/codexhost.app/Contents/Resources/runtime/node",
+                "/Applications/codexhost.app/Contents/Resources/app/host-runtime.mjs",
+                "--codexhost-harness-broker",
+            ]
+        );
+        assert!(plan.plist_xml.contains("<string>Aqua</string>"));
+        assert!(plan.plist_xml.contains("<key>RunAtLoad</key>\n<true/>"));
+        assert!(plan.plist_xml.contains("<key>ThrottleInterval</key>"));
+        assert!(!plan.plist_xml.contains("KeepAlive"));
+        assert!(!plan.plist_xml.contains("EnvironmentVariables"));
+        assert!(!plan.plist_xml.to_ascii_lowercase().contains("keychain"));
+        assert!(!plan.plist_xml.to_ascii_lowercase().contains("password"));
+    }
+
+    #[test]
+    fn launchctl_plan_targets_only_the_current_users_gui_domain() {
+        let plist = Path::new(
+            "/Users/moka/Library/LaunchAgents/ai.bytepioneer.codexhost.native-harness-broker.plist",
+        );
+        let commands = plan_native_harness_broker_launchctl(501, plist).expect("command plan");
+
+        assert_eq!(commands.print.program, "/bin/launchctl");
+        assert_eq!(
+            commands.print.arguments,
+            [
+                "print",
+                "gui/501/ai.bytepioneer.codexhost.native-harness-broker"
+            ]
+        );
+        assert_eq!(
+            commands.bootstrap.arguments,
+            ["bootstrap", "gui/501", plist.to_str().expect("UTF-8 plist")]
+        );
+        assert_eq!(
+            commands.bootout.arguments,
+            [
+                "bootout",
+                "gui/501/ai.bytepioneer.codexhost.native-harness-broker"
+            ]
+        );
+        assert_eq!(
+            commands.kickstart.arguments,
+            [
+                "kickstart",
+                "-k",
+                "gui/501/ai.bytepioneer.codexhost.native-harness-broker"
+            ]
+        );
+    }
+
+    #[test]
+    fn launch_agent_persists_only_the_normalized_proxy_allowlist() {
+        let paths = NativeHarnessBrokerPaths {
+            home: Path::new("/Users/moka"),
+            node: Path::new("/opt/codexhost/node"),
+            host_runtime: Path::new("/opt/codexhost/host-runtime.mjs"),
+        };
+        let plan = plan_native_harness_broker_launch_agent_with_environment(
+            paths,
+            501,
+            &[
+                ("HTTPS_PROXY".into(), "http://127.0.0.1:2080".into()),
+                ("NODE_USE_ENV_PROXY".into(), "1".into()),
+            ],
+        )
+        .expect("proxy allowlist");
+        assert!(plan.plist_xml.contains("<key>EnvironmentVariables</key>"));
+        assert!(plan.plist_xml.contains("<key>HTTPS_PROXY</key>"));
+        assert!(!plan.plist_xml.contains("ANTHROPIC"));
+
+        assert!(
+            plan_native_harness_broker_launch_agent_with_environment(
+                paths,
+                501,
+                &[("CLAUDE_TOKEN".into(), "secret".into())],
+            )
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn install_restarts_the_exact_agent_to_load_updated_runtime_code() {
+        assert_eq!(
+            plan_native_harness_broker_install(true, NativeHarnessBrokerObservedState::Running),
+            [NativeHarnessBrokerInstallStep::Kickstart]
+        );
+    }
+
+    #[test]
+    fn install_replaces_a_loaded_agent_when_its_plist_changed() {
+        assert_eq!(
+            plan_native_harness_broker_install(false, NativeHarnessBrokerObservedState::Running),
+            [
+                NativeHarnessBrokerInstallStep::Bootout,
+                NativeHarnessBrokerInstallStep::WritePlist,
+                NativeHarnessBrokerInstallStep::Bootstrap,
+            ]
+        );
+    }
+
+    #[test]
+    fn install_starts_an_exact_but_stopped_agent_without_rewriting_it() {
+        assert_eq!(
+            plan_native_harness_broker_install(
+                true,
+                NativeHarnessBrokerObservedState::LoadedStopped,
+            ),
+            [NativeHarnessBrokerInstallStep::Kickstart]
+        );
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn existing_managed_directory_is_hardened_and_revalidated() {
+        use std::fs;
+        use std::os::unix::fs::{MetadataExt, PermissionsExt};
+
+        use nix::unistd::Uid;
+
+        let root = crate::temporary_directory("codexhost-broker-directory-security");
+        let managed = root.join("LaunchAgents");
+        fs::create_dir(&managed).expect("managed directory");
+        fs::set_permissions(&managed, fs::Permissions::from_mode(0o777))
+            .expect("insecure fixture permissions");
+
+        super::ensure_owned_directory(&managed, Uid::effective().as_raw(), true)
+            .expect("harden current-user directory");
+        let metadata = fs::symlink_metadata(&managed).expect("hardened metadata");
+        assert_eq!(metadata.mode() & 0o777, 0o700);
+        assert_eq!(metadata.uid(), Uid::effective().as_raw());
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn managed_directory_rejects_symlinks_and_foreign_owners() {
+        use std::fs;
+        use std::os::unix::fs::symlink;
+
+        use nix::unistd::Uid;
+
+        let root = crate::temporary_directory("codexhost-broker-directory-identity");
+        let real = root.join("real");
+        let linked = root.join("linked");
+        fs::create_dir(&real).expect("real directory");
+        symlink(&real, &linked).expect("directory symlink");
+        let uid = Uid::effective().as_raw();
+
+        assert!(super::ensure_owned_directory(&linked, uid, true).is_err());
+        assert!(super::ensure_owned_directory(&real, uid.saturating_add(1), true).is_err());
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn atomic_plist_publish_finishes_with_current_user_and_0600_mode() {
+        use std::fs;
+        use std::os::unix::fs::{MetadataExt, PermissionsExt};
+
+        use nix::unistd::Uid;
+
+        let home = crate::temporary_directory("codexhost-broker-plist-security");
+        let uid = Uid::effective().as_raw();
+        let plan = plan_native_harness_broker_launch_agent(
+            NativeHarnessBrokerPaths {
+                home: &home,
+                node: Path::new("/opt/codexhost/node"),
+                host_runtime: Path::new("/opt/codexhost/host-runtime.mjs"),
+            },
+            uid,
+        )
+        .expect("LaunchAgent plan");
+        fs::create_dir(home.join("Library")).expect("Library fixture");
+        fs::set_permissions(home.join("Library"), fs::Permissions::from_mode(0o700))
+            .expect("Library permissions");
+
+        super::ensure_managed_directories(&plan, uid).expect("secure directories");
+        super::atomic_write_plist(&plan, uid).expect("atomic plist publish");
+
+        let metadata = fs::symlink_metadata(&plan.plist_path).expect("plist metadata");
+        assert!(metadata.is_file());
+        assert!(!metadata.file_type().is_symlink());
+        assert_eq!(metadata.uid(), uid);
+        assert_eq!(metadata.mode() & 0o777, 0o600);
+    }
+}

--- a/docs/remote-ssh-host.md
+++ b/docs/remote-ssh-host.md
@@ -39,6 +39,39 @@ The command:
 - records the installed native entrypoint digest so a later uninstall can still verify it after an older package runtime has been removed;
 - leaves the existing `codex` command and OpenCodex configuration untouched.
 
+On macOS, `remote install` also installs
+`ai.bytepioneer.codexhost.native-harness-broker` as a current-user LaunchAgent. The agent is
+restricted to the logged-in Aqua session and runs the packaged Node.js executable with the exact
+packaged `host-runtime.mjs --codexhost-harness-broker` arguments. A Background SSH Host talks to
+this local broker over its owner-only Unix socket; Claude Code remains the process that reads its
+native login from the Aqua session. codexhost never asks for a Keychain password, runs
+`security unlock-keychain`, reads OAuth material, or sends credentials over SSH.
+
+The LaunchAgent has `RunAtLoad` and bounded launchd throttling, but no `KeepAlive`: a persistent
+startup fault stays stopped instead of becoming a retry storm. Its descriptor and socket live in
+`~/.codexhost/harness-broker` with owner-only permissions. The property list persists only the
+normalized HTTP/HTTPS/SOCKS proxy variables already resolved by codexhost, plus `NO_PROXY` and
+`NODE_USE_ENV_PROXY`; Claude, Anthropic, OAuth, and arbitrary SSH environment variables are never
+copied. Proxy URLs containing embedded credentials are rejected rather than written to disk.
+
+The broker lifecycle is available directly for diagnosis:
+
+```bash
+codexhost broker install
+codexhost broker status
+codexhost broker stop
+codexhost broker uninstall
+```
+
+The npm wrapper supplies its current Node and packaged Host Runtime paths automatically. Re-running
+`remote install` deliberately restarts the exact LaunchAgent after updating the runtime, even when
+the property list did not change, so a broker cannot keep old JavaScript in memory. Active Claude
+Harness requests fail closed during that controlled restart; reconnect the remote workspace after
+the broker reports ready. Persistent Thread mappings and native history are preserved, but an
+in-memory broker Session is not reused across generations. If no Aqua console session exists for
+the current user, or launchd refuses `gui/$UID`,
+installation fails without falling back to a Background Claude process.
+
 The managed listener preserves Codex's native multi-client topology. One long-lived stock `app-server --listen unix://PATH` process owns a private sibling socket for the lifetime of the remote Host listener. Each Desktop SSH proxy connection still gets an isolated codexhost Host session, but that session opens its own WebSocket connection to the same stock app-server listener. Consequently, the stock app-server—not codexhost—owns the loaded Thread, per-connection subscriptions, and native writer/observer coordination. A second Desktop can resume and observe a Thread already loaded by the first connection instead of starting a competing app-server process that fails with `thread ... already has an active writer`. Closing one Desktop connection closes only its Host session; it does not stop the shared stock listener or the other subscribers.
 
 This composition follows the official [Codex app-server transport](https://learn.chatgpt.com/docs/app-server): Unix listeners use WebSockets over the Unix socket, each transport connection initializes independently, and `thread/start`/`thread/resume` manage that connection's Thread subscription. The internal sibling socket is created inside the same private control directory and is never exposed over the network.
@@ -69,5 +102,10 @@ codexhost remote uninstall
 ```
 
 `start` is idempotent and starts the installed headless Remote Host. `stop` stops only a verified codexhost listener and leaves unrelated Codex processes running. `status` reports runtime state and protocol identity in addition to a missing or modified native entrypoint, startup block, runtime, or data directory. A partially edited or otherwise malformed managed startup block is reported as degraded; install and uninstall still refuse to rewrite it automatically. Status also identifies the legacy blocking shell entrypoint and asks for a reinstall migration. `uninstall` verifies the recorded entrypoint digest before removing only the managed entrypoint, manifest, and startup block. It preserves profile backups and `~/.codexhost/remote/data` so Thread mappings remain recoverable. Reconnect the remote workspace after uninstalling.
+
+On macOS, `remote status` also verifies that the Aqua broker LaunchAgent is running, that its
+property list still matches the installed runtime, and that a non-empty owner-only descriptor is
+present. `remote uninstall` unloads and removes that managed LaunchAgent without touching Claude
+Code configuration, login state, Keychain data, or native Session history.
 
 Remote Host processes do not own the local codexhost Launcher or self-update controller. Update codexhost with the same package manager on both machines, then reconnect.

--- a/docs/remote-ssh-host.zh-CN.md
+++ b/docs/remote-ssh-host.zh-CN.md
@@ -39,6 +39,36 @@ codexhost remote install \
 - 记录已安装原生入口的摘要，因此旧版本包内 runtime 被清理后，后续卸载仍可校验该入口；
 - 保持原有 `codex` 命令和 OpenCodex 配置不变。
 
+在 macOS 上，`remote install` 还会为当前用户安装名为
+`ai.bytepioneer.codexhost.native-harness-broker` 的 LaunchAgent。该 Agent 只允许在已登录的
+Aqua 会话中加载，并以绝对路径执行打包的 Node.js 和
+`host-runtime.mjs --codexhost-harness-broker`。SSH Background Host 只通过用户私有的 Unix
+socket 与本机 broker 通信；仍由 Aqua 会话中的 Claude Code 原生进程读取自己的登录态。
+codexhost 不要求输入 Keychain 密码、不运行 `security unlock-keychain`、不读取 OAuth 材料，
+也不通过 SSH 传输凭据。
+
+LaunchAgent 使用 `RunAtLoad` 和有界的 launchd 节流，但不使用 `KeepAlive`：持续启动失败会
+保持停止，不会形成重试风暴。descriptor 与 socket 位于
+`~/.codexhost/harness-broker`，并限制为当前用户访问。plist 只保存 codexhost 已解析并规范化
+的 HTTP/HTTPS/SOCKS 代理变量，以及 `NO_PROXY` 和 `NODE_USE_ENV_PROXY`；不会复制 Claude、
+Anthropic、OAuth 或任意 SSH 环境变量。含内嵌账号密码的代理 URL 会被拒绝，不会落盘。
+
+可用以下命令单独诊断 broker 生命周期：
+
+```bash
+codexhost broker install
+codexhost broker status
+codexhost broker stop
+codexhost broker uninstall
+```
+
+npm 包装器会自动传入当前 Node 和打包 Host Runtime 的绝对路径。再次执行 `remote install`
+时，即使 plist 未变化，也会受控重启该 LaunchAgent，避免 broker 继续使用内存中的旧版
+JavaScript；正在执行的 Claude Harness 请求会在重启期间失败关闭，broker 恢复 ready 后需要
+重新连接远程工作区。持久化 Thread 映射与原生历史会保留，但不会跨 broker generation 复用
+内存 Session。若当前用户没有 Aqua 控制台会话，或 launchd 拒绝 `gui/$UID`，安装会直接失败，
+不会降级为由 Background SSH 进程启动 Claude。
+
 远程 Host 启动 Harness 时会重新解析开发机上的代理环境：已有的 `HTTP_PROXY`、`HTTPS_PROXY`、`ALL_PROXY` 等变量优先；macOS 再补充静态系统代理配置；Linux 保留其环境变量和 TUN 网络路径。codexhost 不识别具体代理软件，也不会猜测代理端口；没有可解析的代理时会按直连处理。
 
 如果早期候选版安装的是 Shell wrapper，再次运行 `remote install` 会原地迁移该入口。随后运行 `remote start` 即可启动无头 Host，不要求当前 Shell 重新加载 profile。如果目标 socket 被当前用户、安装清单中记录的官方 Codex 默认 listener 占用，该命令会精确终止这棵 listener 进程树后再启动 codexhost；未知 socket owner 绝不会被自动终止。
@@ -65,5 +95,9 @@ codexhost remote uninstall
 ```
 
 `start` 可重复执行并启动已安装的无头 Remote Host；`stop` 只停止经过校验的 codexhost listener，不影响其他 Codex 进程。`status` 除了报告运行状态和协议身份，也会报告原生入口、启动配置、runtime 或数据目录缺失/被修改；托管启动配置块只剩一侧标记或存在其他格式损坏时，会返回 degraded，而 install 与 uninstall 仍会拒绝自动改写；遇到会阻塞 bootstrap 的旧 Shell 入口时，也会明确提示重新安装迁移。`uninstall` 会先核对 manifest 中记录的入口摘要，再只移除托管入口、manifest 和启动配置块，并保留 profile 备份及 `~/.codexhost/remote/data`，便于恢复 Thread 映射。卸载后同样需要重新连接远程工作区。
+
+在 macOS 上，`remote status` 还会确认 Aqua broker LaunchAgent 正在运行、plist 仍指向当前安装的
+runtime，并且存在非空且仅当前用户可读的 descriptor。`remote uninstall` 会卸载并移除这个受管
+LaunchAgent，但不会修改 Claude Code 配置、登录态、Keychain 数据或原生 Session 历史。
 
 远程 Host 不拥有本机 codexhost Launcher 或自动更新控制器。请在两台机器上使用相同的包管理器更新到同一 codexhost 版本，然后重新连接。

--- a/package-lock.json
+++ b/package-lock.json
@@ -234,6 +234,10 @@
       "resolved": "packages/harness-adapter",
       "link": true
     },
+    "node_modules/@codexhost/harness-broker": {
+      "resolved": "packages/harness-broker",
+      "link": true
+    },
     "node_modules/@codexhost/harness-discovery": {
       "resolved": "packages/harness-discovery",
       "link": true
@@ -5453,6 +5457,15 @@
         "@codexhost/shared-contracts": "0.0.0"
       }
     },
+    "packages/harness-broker": {
+      "name": "@codexhost/harness-broker",
+      "version": "0.0.0",
+      "dependencies": {
+        "@codexhost/harness-adapter": "0.0.0",
+        "@codexhost/shared-contracts": "0.0.0",
+        "zod": "4.4.3"
+      }
+    },
     "packages/harness-discovery": {
       "name": "@codexhost/harness-discovery",
       "version": "0.0.0"
@@ -5469,6 +5482,7 @@
         "@codexhost/adapter-pi": "0.0.0",
         "@codexhost/desktop-control": "0.0.0",
         "@codexhost/harness-adapter": "0.0.0",
+        "@codexhost/harness-broker": "0.0.0",
         "@codexhost/mapping-store": "0.0.0",
         "@codexhost/protocol-core": "0.0.0",
         "@codexhost/shared-contracts": "0.0.0",

--- a/packages/harness-broker/package.json
+++ b/packages/harness-broker/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@codexhost/harness-broker",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "files": [
+    "dist"
+  ],
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "scripts": {
+    "build": "tsc -b"
+  },
+  "dependencies": {
+    "@codexhost/harness-adapter": "0.0.0",
+    "@codexhost/shared-contracts": "0.0.0",
+    "zod": "4.4.3"
+  }
+}

--- a/packages/harness-broker/src/client.ts
+++ b/packages/harness-broker/src/client.ts
@@ -1,0 +1,567 @@
+import { randomUUID } from "node:crypto";
+import { lstat, readFile } from "node:fs/promises";
+import net, { type Socket } from "node:net";
+
+import {
+  HarnessOutputChannel,
+  parseHostUsage,
+  type HarnessAdapter,
+  type HarnessCommandAccepted,
+  type HarnessCommandCapability,
+  type HarnessCommandInvocation,
+  type HarnessError,
+  type HarnessInspection,
+  type HarnessOutput,
+  type HarnessResult,
+  type HarnessSession,
+  type HarnessSessionCapabilities,
+  type HarnessSessionState,
+  type HostCommand,
+  type HostThreadSnapshot,
+  type HostUsage,
+  type InspectHarnessInput,
+  type InteractionRespondAccepted,
+  type InteractionRespondCommand,
+  type ModelSelectCommand,
+  type ModelSelectCompleted,
+  type OpenSessionInput,
+  type PermissionModeSelectCommand,
+  type PermissionModeSelectCompleted,
+  type ThinkingSelectCommand,
+  type ThinkingSelectCompleted,
+  type TurnCancelAccepted,
+  type TurnCancelCommand,
+  type TurnStartAccepted,
+  type TurnStartCommand,
+} from "@codexhost/harness-adapter";
+import {
+  harnessIdSchema,
+  harnessInspectionSchema,
+  harnessSessionCapabilitiesSchema,
+} from "@codexhost/shared-contracts";
+
+import { consumeBrokerFrames, writeBrokerFrame } from "./framing.js";
+import { defaultHarnessBrokerDescriptorPath } from "./paths.js";
+import {
+  HARNESS_BROKER_MAX_PENDING_REQUESTS,
+  HARNESS_BROKER_PROTOCOL_VERSION,
+  HARNESS_BROKER_REQUEST_TIMEOUT_MS,
+  harnessBrokerDescriptorSchema,
+  harnessBrokerServerFrameSchema,
+  type HarnessBrokerDescriptorV1,
+  type HarnessBrokerMethod,
+} from "./protocol.js";
+import {
+  harnessErrorSchema,
+  harnessOutputSchema,
+  harnessSessionStateSchema,
+} from "./validation.js";
+
+interface SessionMetadata {
+  sessionId: string;
+  sessionGeneration: number;
+  capabilities: HarnessSessionCapabilities;
+  initialState: HarnessSessionState;
+  initialUsage: HostUsage | null;
+  commands: boolean;
+}
+
+interface PendingRequest {
+  resolve(value: unknown): void;
+  reject(error: Error): void;
+  timeout: ReturnType<typeof setTimeout>;
+}
+
+function unavailable(message: string, retryable = true): HarnessError {
+  return { code: "unavailable", message, retryable, stage: "harnessBroker" };
+}
+
+function failedInspection(message: string): HarnessInspection {
+  return { status: "unavailable", error: unavailable(message) };
+}
+
+function isAuthenticationTerminal(output: HarnessOutput): boolean {
+  return (
+    output.kind === "event" &&
+    output.event.type === "turn.completed" &&
+    output.event.outcome.status === "failed" &&
+    output.event.outcome.error.code === "authenticationRequired"
+  );
+}
+
+function parseHarnessResult<T>(value: unknown): HarnessResult<T> {
+  if (!value || typeof value !== "object" || !("ok" in value)) {
+    return {
+      ok: false,
+      error: {
+        ...unavailable("Harness broker returned an invalid result", false),
+        code: "protocolError",
+      },
+    };
+  }
+  const result = value as { ok: boolean; value?: T; error?: unknown };
+  if (result.ok) return { ok: true, value: result.value as T };
+  const error = harnessErrorSchema.safeParse(result.error);
+  if (!error.success) {
+    return {
+      ok: false,
+      error: {
+        ...unavailable("Harness broker returned an invalid error", false),
+        code: "protocolError",
+      },
+    };
+  }
+  const parsed = error.data;
+  return {
+    ok: false,
+    error: {
+      code: parsed.code,
+      message: parsed.message,
+      retryable: parsed.retryable,
+      ...(parsed.diagnostic ? { diagnostic: parsed.diagnostic } : {}),
+      ...(parsed.stage ? { stage: parsed.stage } : {}),
+      ...(parsed.durationMs !== undefined ? { durationMs: parsed.durationMs } : {}),
+      ...(parsed.stderrTail ? { stderrTail: parsed.stderrTail } : {}),
+    },
+  };
+}
+
+function parseSessionMetadata(value: unknown): SessionMetadata {
+  if (!value || typeof value !== "object")
+    throw new Error("Harness broker Session metadata is invalid");
+  const candidate = value as Record<string, unknown>;
+  if (typeof candidate.sessionId !== "string" || typeof candidate.sessionGeneration !== "number") {
+    throw new Error("Harness broker Session identity is invalid");
+  }
+  const state = harnessSessionStateSchema.parse(candidate.initialState);
+  return {
+    sessionId: candidate.sessionId,
+    sessionGeneration: candidate.sessionGeneration,
+    capabilities: harnessSessionCapabilitiesSchema.parse(candidate.capabilities),
+    initialState: state,
+    initialUsage: candidate.initialUsage === null ? null : parseHostUsage(candidate.initialUsage),
+    commands: candidate.commands === true,
+  };
+}
+
+async function readDescriptor(descriptorPath: string): Promise<HarnessBrokerDescriptorV1> {
+  const metadata = await lstat(descriptorPath);
+  if (metadata.isSymbolicLink())
+    throw new Error("Claude Aqua broker descriptor must not be a symlink");
+  if (!metadata.isFile()) throw new Error("Claude Aqua broker descriptor is not a file");
+  if (process.platform !== "win32") {
+    if ((metadata.mode & 0o077) !== 0)
+      throw new Error("Claude Aqua broker descriptor is not owner-only");
+    if (process.getuid && metadata.uid !== process.getuid()) {
+      throw new Error("Claude Aqua broker descriptor belongs to another user");
+    }
+  }
+  const descriptor = harnessBrokerDescriptorSchema.parse(
+    JSON.parse(await readFile(descriptorPath, "utf8")),
+  );
+  if (process.platform === "darwin" && Buffer.byteLength(descriptor.socketPath) > 103) {
+    throw new Error("Claude Aqua broker socket path is too long for macOS");
+  }
+  if (process.platform !== "win32") {
+    const socket = await lstat(descriptor.socketPath);
+    if (socket.isSymbolicLink() || !socket.isSocket()) {
+      throw new Error("Claude Aqua broker endpoint is not a Unix socket");
+    }
+    if ((socket.mode & 0o077) !== 0 || (process.getuid && socket.uid !== process.getuid())) {
+      throw new Error("Claude Aqua broker endpoint is not owner-only");
+    }
+  }
+  try {
+    process.kill(descriptor.ownerPid, 0);
+  } catch {
+    throw new Error("Claude Aqua broker owner process is unavailable");
+  }
+  return descriptor;
+}
+
+class BrokerConnection {
+  readonly #descriptor: HarnessBrokerDescriptorV1;
+  readonly #socket: Socket;
+  readonly #pending = new Map<string, PendingRequest>();
+  readonly #sessions = new Map<string, BrokeredHarnessSession>();
+  #inputSequence = 1;
+  #outputSequence = 0;
+  #closed = false;
+  #failed = false;
+
+  private constructor(descriptor: HarnessBrokerDescriptorV1, socket: Socket) {
+    this.#descriptor = descriptor;
+    this.#socket = socket;
+    consumeBrokerFrames(
+      socket,
+      (raw) => this.#frame(raw),
+      (error) => this.#fail(error),
+    );
+    socket.once("close", () => this.#fail(new Error("Claude Aqua broker connection closed")));
+    socket.once("error", (error) => this.#fail(error));
+  }
+
+  static async connect(descriptorPath: string): Promise<BrokerConnection> {
+    const descriptor = await readDescriptor(descriptorPath);
+    const socket = net.createConnection(descriptor.socketPath);
+    await new Promise<void>((resolve, reject) => {
+      const timeout = setTimeout(
+        () => reject(new Error("Timed out connecting to Claude Aqua broker")),
+        HARNESS_BROKER_REQUEST_TIMEOUT_MS,
+      );
+      socket.once("connect", () => {
+        clearTimeout(timeout);
+        resolve();
+      });
+      socket.once("error", (error) => {
+        clearTimeout(timeout);
+        reject(error);
+      });
+    });
+    const connection = new BrokerConnection(descriptor, socket);
+    const hello = connection.#waitForHello();
+    await writeBrokerFrame(socket, {
+      version: HARNESS_BROKER_PROTOCOL_VERSION,
+      generation: descriptor.generation,
+      sequence: 1,
+      kind: "hello",
+      token: descriptor.token,
+    });
+    await hello;
+    return connection;
+  }
+
+  #waitForHello(): Promise<void> {
+    return new Promise<void>((resolve, reject) => {
+      const id = "__hello__";
+      const timeout = setTimeout(() => {
+        this.#pending.delete(id);
+        reject(new Error("Claude Aqua broker authentication timed out"));
+      }, HARNESS_BROKER_REQUEST_TIMEOUT_MS);
+      this.#pending.set(id, { resolve: () => resolve(), reject, timeout });
+    });
+  }
+
+  register(session: BrokeredHarnessSession): void {
+    this.#sessions.set(session.sessionId, session);
+  }
+
+  unregister(sessionId: string): void {
+    this.#sessions.delete(sessionId);
+  }
+
+  async request(method: HarnessBrokerMethod, params: unknown): Promise<unknown> {
+    if (this.#closed) throw new Error("Claude Aqua broker connection is closed");
+    if (this.#pending.size >= HARNESS_BROKER_MAX_PENDING_REQUESTS) {
+      throw new Error("Claude Aqua broker request limit exceeded");
+    }
+    this.#inputSequence += 1;
+    const id = randomUUID();
+    const response = new Promise<unknown>((resolve, reject) => {
+      const timeout = setTimeout(() => {
+        this.#pending.delete(id);
+        reject(new Error(`Claude Aqua broker ${method} timed out`));
+      }, HARNESS_BROKER_REQUEST_TIMEOUT_MS);
+      this.#pending.set(id, { resolve, reject, timeout });
+    });
+    await writeBrokerFrame(this.#socket, {
+      version: HARNESS_BROKER_PROTOCOL_VERSION,
+      generation: this.#descriptor.generation,
+      sequence: this.#inputSequence,
+      kind: "request",
+      id,
+      method,
+      params,
+    });
+    return response;
+  }
+
+  close(): void {
+    if (this.#closed) return;
+    this.#closed = true;
+    this.#socket.destroy();
+    this.#fail(new Error("Claude Aqua broker connection closed"));
+  }
+
+  #frame(raw: unknown): void {
+    const frame = harnessBrokerServerFrameSchema.parse(raw);
+    if (
+      frame.generation !== this.#descriptor.generation ||
+      frame.sequence !== this.#outputSequence + 1
+    ) {
+      this.#fail(new Error("Claude Aqua broker response generation or sequence is invalid"));
+      return;
+    }
+    this.#outputSequence = frame.sequence;
+    if (frame.kind === "output") {
+      this.#sessions.get(frame.sessionId)?.acceptOutput(frame.sessionGeneration, frame.output);
+      return;
+    }
+    if (this.#outputSequence === 1) {
+      const hello = this.#pending.get("__hello__");
+      if (hello) {
+        clearTimeout(hello.timeout);
+        this.#pending.delete("__hello__");
+        if (frame.ok) hello.resolve(frame.value);
+        else hello.reject(new Error(frame.error?.message ?? "Broker authentication failed"));
+      }
+      return;
+    }
+    const pending = this.#pending.get(frame.id);
+    if (!pending) {
+      this.#fail(new Error("Claude Aqua broker returned an unknown response ID"));
+      return;
+    }
+    clearTimeout(pending.timeout);
+    this.#pending.delete(frame.id);
+    if (frame.ok) pending.resolve(frame.value);
+    else pending.reject(new Error(frame.error?.message ?? "Broker request failed"));
+  }
+
+  #fail(error: Error): void {
+    if (this.#failed) return;
+    this.#failed = true;
+    if (!this.#closed) this.#closed = true;
+    for (const pending of this.#pending.values()) {
+      clearTimeout(pending.timeout);
+      pending.reject(error);
+    }
+    this.#pending.clear();
+    for (const session of this.#sessions.values()) session.connectionFault(error);
+  }
+}
+
+class BrokeredHarnessSession implements HarnessSession {
+  readonly harnessId = harnessIdSchema.parse("claude-code");
+  readonly outputs: AsyncIterable<HarnessOutput>;
+  readonly #channel = new HarnessOutputChannel<HarnessOutput>();
+  readonly #connection: BrokerConnection;
+  readonly commands?: HarnessCommandCapability;
+  #metadata: SessionMetadata;
+  #faulted = false;
+  #closed = false;
+
+  constructor(connection: BrokerConnection, metadata: SessionMetadata) {
+    this.#connection = connection;
+    this.#metadata = metadata;
+    this.outputs = this.#channel.outputs;
+    if (metadata.commands) {
+      this.commands = {
+        list: async () => {
+          try {
+            return parseHarnessResult(await this.#request("session.commands.list", {}));
+          } catch (error) {
+            return {
+              ok: false,
+              error: unavailable(error instanceof Error ? error.message : String(error)),
+            };
+          }
+        },
+        execute: async (
+          command: HarnessCommandInvocation,
+        ): Promise<HarnessResult<HarnessCommandAccepted>> => {
+          try {
+            return parseHarnessResult(await this.#request("session.commands.execute", { command }));
+          } catch (error) {
+            return {
+              ok: false,
+              error: unavailable(error instanceof Error ? error.message : String(error)),
+            };
+          }
+        },
+      };
+    }
+    connection.register(this);
+  }
+
+  get sessionId(): string {
+    return this.#metadata.sessionId;
+  }
+  get capabilities(): HarnessSessionCapabilities {
+    return this.#metadata.capabilities;
+  }
+  get initialState(): HarnessSessionState {
+    return this.#metadata.initialState;
+  }
+  get initialUsage(): HostUsage | null {
+    return this.#metadata.initialUsage;
+  }
+  acceptOutput(generation: number, output: unknown): void {
+    if (this.#closed || generation !== this.#metadata.sessionGeneration) return;
+    const value = harnessOutputSchema.parse(output);
+    if (
+      (value.kind === "event" && value.event.type === "session.faulted") ||
+      isAuthenticationTerminal(value)
+    ) {
+      this.#faulted = true;
+    }
+    this.#channel.emit(value);
+  }
+
+  connectionFault(error: Error): void {
+    if (this.#closed) return;
+    this.#faulted = true;
+    this.#channel.emit({
+      kind: "event",
+      event: { type: "session.faulted", error: unavailable(error.message) },
+    });
+  }
+
+  async refreshUsage(): Promise<void> {
+    await this.#request("session.refreshUsage", {});
+  }
+  async readSnapshot(): Promise<HarnessResult<HostThreadSnapshot>> {
+    try {
+      return parseHarnessResult(await this.#request("session.readSnapshot", {}));
+    } catch (error) {
+      return {
+        ok: false,
+        error: unavailable(error instanceof Error ? error.message : String(error)),
+      };
+    }
+  }
+
+  execute(command: TurnStartCommand): Promise<HarnessResult<TurnStartAccepted>>;
+  execute(command: TurnCancelCommand): Promise<HarnessResult<TurnCancelAccepted>>;
+  execute(command: InteractionRespondCommand): Promise<HarnessResult<InteractionRespondAccepted>>;
+  execute(command: ModelSelectCommand): Promise<HarnessResult<ModelSelectCompleted>>;
+  execute(command: ThinkingSelectCommand): Promise<HarnessResult<ThinkingSelectCompleted>>;
+  execute(
+    command: PermissionModeSelectCommand,
+  ): Promise<HarnessResult<PermissionModeSelectCompleted>>;
+  async execute(
+    command: HostCommand,
+  ): Promise<
+    HarnessResult<
+      | TurnStartAccepted
+      | TurnCancelAccepted
+      | InteractionRespondAccepted
+      | ModelSelectCompleted
+      | ThinkingSelectCompleted
+      | PermissionModeSelectCompleted
+    >
+  > {
+    if (this.#closed)
+      return { ok: false, error: unavailable("Claude Aqua broker Session is closed", false) };
+    if (this.#faulted && command.type === "turn.start") {
+      try {
+        const reopened = parseHarnessResult<SessionMetadata>(
+          await this.#request("session.reopen", {}),
+        );
+        if (!reopened.ok) return reopened;
+        this.#metadata = parseSessionMetadata(reopened.value);
+        this.#faulted = false;
+      } catch (error) {
+        return {
+          ok: false,
+          error: unavailable(error instanceof Error ? error.message : String(error)),
+        };
+      }
+    }
+    try {
+      return parseHarnessResult(await this.#request("session.execute", { command }));
+    } catch (error) {
+      return {
+        ok: false,
+        error: unavailable(error instanceof Error ? error.message : String(error)),
+      };
+    }
+  }
+
+  async close(): Promise<void> {
+    if (this.#closed) return;
+    this.#closed = true;
+    this.#connection.unregister(this.sessionId);
+    await this.#request("session.close", {}).catch(() => undefined);
+    this.#channel.end();
+  }
+
+  #request(method: HarnessBrokerMethod, extra: Record<string, unknown>): Promise<unknown> {
+    return this.#connection.request(method, {
+      sessionId: this.#metadata.sessionId,
+      sessionGeneration: this.#metadata.sessionGeneration,
+      ...extra,
+    });
+  }
+}
+
+export class BrokeredHarnessAdapter implements HarnessAdapter {
+  readonly harnessId = harnessIdSchema.parse("claude-code");
+  readonly #descriptorPath: string;
+  #connection: Promise<BrokerConnection> | null = null;
+  #closed = false;
+
+  readonly subagents = {
+    readSnapshot: async (
+      input: Parameters<NonNullable<HarnessAdapter["subagents"]>["readSnapshot"]>[0],
+    ) => {
+      try {
+        return parseHarnessResult<HostThreadSnapshot>(
+          await (await this.#connect()).request("adapter.subagent.readSnapshot", input),
+        );
+      } catch (error) {
+        return {
+          ok: false as const,
+          error: unavailable(error instanceof Error ? error.message : String(error)),
+        };
+      }
+    },
+  };
+
+  constructor(input: { descriptorPath?: string; environment?: NodeJS.ProcessEnv } = {}) {
+    this.#descriptorPath =
+      input.descriptorPath ?? defaultHarnessBrokerDescriptorPath(input.environment);
+  }
+
+  async inspect(input: InspectHarnessInput = {}): Promise<HarnessInspection> {
+    if (this.#closed) return failedInspection("Claude Aqua broker adapter is closed");
+    try {
+      return harnessInspectionSchema.parse(
+        await (await this.#connect()).request("adapter.inspect", input),
+      );
+    } catch (error) {
+      this.#connection = null;
+      return failedInspection(error instanceof Error ? error.message : String(error));
+    }
+  }
+
+  async open(input: OpenSessionInput): Promise<HarnessResult<HarnessSession>> {
+    if (this.#closed)
+      return { ok: false, error: unavailable("Claude Aqua broker adapter is closed", false) };
+    try {
+      const safeInput = { ...input } as OpenSessionInput & {
+        environment?: Record<string, string | undefined>;
+      };
+      delete safeInput.environment;
+      const result = parseHarnessResult<unknown>(
+        await (await this.#connect()).request("adapter.open", safeInput),
+      );
+      if (!result.ok) return result;
+      return {
+        ok: true,
+        value: new BrokeredHarnessSession(
+          await this.#connect(),
+          parseSessionMetadata(result.value),
+        ),
+      };
+    } catch (error) {
+      this.#connection = null;
+      return {
+        ok: false,
+        error: unavailable(error instanceof Error ? error.message : String(error)),
+      };
+    }
+  }
+
+  async close(): Promise<void> {
+    this.#closed = true;
+    const connection = await this.#connection?.catch(() => null);
+    connection?.close();
+    this.#connection = null;
+  }
+
+  #connect(): Promise<BrokerConnection> {
+    if (!this.#connection) this.#connection = BrokerConnection.connect(this.#descriptorPath);
+    return this.#connection;
+  }
+}

--- a/packages/harness-broker/src/framing.ts
+++ b/packages/harness-broker/src/framing.ts
@@ -1,0 +1,51 @@
+import type { Socket } from "node:net";
+
+import { HARNESS_BROKER_MAX_FRAME_BYTES } from "./protocol.js";
+
+export function writeBrokerFrame(socket: Socket, value: unknown): Promise<void> {
+  const frame = `${JSON.stringify(value)}\n`;
+  if (Buffer.byteLength(frame) > HARNESS_BROKER_MAX_FRAME_BYTES) {
+    return Promise.reject(new Error("Harness broker frame exceeds the maximum size"));
+  }
+  return new Promise((resolve, reject) => {
+    socket.write(frame, (error) => (error ? reject(error) : resolve()));
+  });
+}
+
+export function consumeBrokerFrames(
+  socket: Socket,
+  onFrame: (value: unknown) => void,
+  onError: (error: Error) => void,
+): void {
+  let buffered = Buffer.alloc(0);
+  socket.on("data", (chunk: Buffer) => {
+    buffered = Buffer.concat([buffered, chunk]);
+    if (buffered.length > HARNESS_BROKER_MAX_FRAME_BYTES) {
+      onError(new Error("Harness broker frame exceeds the maximum size"));
+      socket.destroy();
+      return;
+    }
+    let newline = buffered.indexOf(0x0a);
+    while (newline >= 0) {
+      const frame = buffered.subarray(0, newline);
+      buffered = buffered.subarray(newline + 1);
+      if (frame.length > 0) {
+        try {
+          const value = JSON.parse(frame.toString("utf8")) as unknown;
+          onFrame(value);
+        } catch (error) {
+          onError(
+            error instanceof SyntaxError
+              ? new Error("Harness broker received invalid JSON")
+              : error instanceof Error
+                ? error
+                : new Error(String(error)),
+          );
+          socket.destroy();
+          return;
+        }
+      }
+      newline = buffered.indexOf(0x0a);
+    }
+  });
+}

--- a/packages/harness-broker/src/index.ts
+++ b/packages/harness-broker/src/index.ts
@@ -1,0 +1,18 @@
+export { BrokeredHarnessAdapter } from "./client.js";
+export {
+  HARNESS_BROKER_DESCRIPTOR_ENV,
+  HARNESS_BROKER_DESCRIPTOR_FILE,
+  HARNESS_BROKER_SOCKET_FILE,
+  defaultHarnessBrokerDescriptorPath,
+  defaultHarnessBrokerDirectory,
+  defaultHarnessBrokerSocketPath,
+} from "./paths.js";
+export {
+  HARNESS_BROKER_MAX_FRAME_BYTES,
+  HARNESS_BROKER_MAX_PENDING_REQUESTS,
+  HARNESS_BROKER_PROTOCOL_VERSION,
+} from "./protocol.js";
+export { startHarnessBrokerServer } from "./server.js";
+export type { HarnessBrokerServer } from "./server.js";
+
+export const packageMetadata = { name: "@codexhost/harness-broker", protocolVersion: 1 } as const;

--- a/packages/harness-broker/src/paths.ts
+++ b/packages/harness-broker/src/paths.ts
@@ -1,0 +1,28 @@
+import os from "node:os";
+import path from "node:path";
+
+export const HARNESS_BROKER_DESCRIPTOR_ENV = "CODEXHOST_CLAUDE_BROKER_DESCRIPTOR";
+export const HARNESS_BROKER_DESCRIPTOR_FILE = "claude-code-broker-v1.json";
+export const HARNESS_BROKER_SOCKET_FILE = "claude-code-broker-v1.sock";
+
+export function defaultHarnessBrokerDirectory(
+  environment: NodeJS.ProcessEnv = process.env,
+): string {
+  const home = environment.HOME || os.homedir();
+  return path.join(home, ".codexhost", "harness-broker");
+}
+
+export function defaultHarnessBrokerDescriptorPath(
+  environment: NodeJS.ProcessEnv = process.env,
+): string {
+  return (
+    environment[HARNESS_BROKER_DESCRIPTOR_ENV] ??
+    path.join(defaultHarnessBrokerDirectory(environment), HARNESS_BROKER_DESCRIPTOR_FILE)
+  );
+}
+
+export function defaultHarnessBrokerSocketPath(
+  environment: NodeJS.ProcessEnv = process.env,
+): string {
+  return path.join(defaultHarnessBrokerDirectory(environment), HARNESS_BROKER_SOCKET_FILE);
+}

--- a/packages/harness-broker/src/protocol.ts
+++ b/packages/harness-broker/src/protocol.ts
@@ -1,0 +1,112 @@
+import { z } from "zod";
+
+export const HARNESS_BROKER_PROTOCOL_VERSION = 1 as const;
+export const HARNESS_BROKER_MAX_FRAME_BYTES = 8 * 1024 * 1024;
+export const HARNESS_BROKER_MAX_PENDING_REQUESTS = 32;
+export const HARNESS_BROKER_REQUEST_TIMEOUT_MS = 15_000;
+
+export const harnessBrokerMethodSchema = z.enum([
+  "adapter.inspect",
+  "adapter.open",
+  "adapter.subagent.readSnapshot",
+  "session.readSnapshot",
+  "session.refreshUsage",
+  "session.execute",
+  "session.commands.list",
+  "session.commands.execute",
+  "session.reopen",
+  "session.close",
+]);
+export type HarnessBrokerMethod = z.infer<typeof harnessBrokerMethodSchema>;
+
+export const harnessBrokerHelloSchema = z
+  .object({
+    version: z.literal(HARNESS_BROKER_PROTOCOL_VERSION),
+    generation: z.string().uuid(),
+    sequence: z.literal(1),
+    kind: z.literal("hello"),
+    token: z.string().regex(/^[a-f0-9]{64}$/u),
+  })
+  .strict();
+
+export const harnessBrokerRequestSchema = z
+  .object({
+    version: z.literal(HARNESS_BROKER_PROTOCOL_VERSION),
+    generation: z.string().uuid(),
+    sequence: z.number().int().min(2).max(Number.MAX_SAFE_INTEGER),
+    kind: z.literal("request"),
+    id: z.string().uuid(),
+    method: harnessBrokerMethodSchema,
+    params: z.unknown(),
+  })
+  .strict();
+export type HarnessBrokerRequest = z.infer<typeof harnessBrokerRequestSchema>;
+
+export const harnessBrokerResponseSchema = z
+  .object({
+    version: z.literal(HARNESS_BROKER_PROTOCOL_VERSION),
+    generation: z.string().uuid(),
+    sequence: z.number().int().positive().max(Number.MAX_SAFE_INTEGER),
+    kind: z.literal("response"),
+    id: z.string().uuid(),
+    ok: z.boolean(),
+    value: z.unknown().optional(),
+    error: z
+      .object({ code: z.string(), message: z.string(), retryable: z.boolean() })
+      .strict()
+      .optional(),
+  })
+  .strict()
+  .superRefine((frame, context) => {
+    if (frame.ok === Boolean(frame.error)) {
+      context.addIssue({ code: "custom", message: "Response must contain value or error" });
+    }
+  });
+
+export const harnessBrokerOutputSchema = z
+  .object({
+    version: z.literal(HARNESS_BROKER_PROTOCOL_VERSION),
+    generation: z.string().uuid(),
+    sequence: z.number().int().positive().max(Number.MAX_SAFE_INTEGER),
+    kind: z.literal("output"),
+    sessionId: z.string().uuid(),
+    sessionGeneration: z.number().int().positive(),
+    output: z.unknown(),
+  })
+  .strict();
+
+export const harnessBrokerServerFrameSchema = z.union([
+  harnessBrokerResponseSchema,
+  harnessBrokerOutputSchema,
+]);
+export type HarnessBrokerServerFrame = z.infer<typeof harnessBrokerServerFrameSchema>;
+
+export interface HarnessBrokerDescriptorV1 {
+  schemaVersion: 1;
+  protocolVersion: 1;
+  harnessId: "claude-code";
+  generation: string;
+  ownerPid: number;
+  socketPath: string;
+  token: string;
+}
+
+export const harnessBrokerDescriptorSchema = z
+  .object({
+    schemaVersion: z.literal(1),
+    protocolVersion: z.literal(HARNESS_BROKER_PROTOCOL_VERSION),
+    harnessId: z.literal("claude-code"),
+    generation: z.string().uuid(),
+    ownerPid: z.number().int().positive(),
+    socketPath: z.string().min(1).max(512),
+    token: z.string().regex(/^[a-f0-9]{64}$/u),
+  })
+  .strict();
+
+export function protocolError(message: string): {
+  code: string;
+  message: string;
+  retryable: false;
+} {
+  return { code: "protocolError", message, retryable: false };
+}

--- a/packages/harness-broker/src/server.ts
+++ b/packages/harness-broker/src/server.ts
@@ -1,0 +1,884 @@
+import { randomBytes, randomUUID } from "node:crypto";
+import { chmod, lstat, mkdir, open, readFile, rename, rm } from "node:fs/promises";
+import net, { type Server, type Socket } from "node:net";
+import path from "node:path";
+
+import type {
+  HarnessAdapter,
+  HarnessError,
+  HarnessOutput,
+  HarnessSession,
+  OpenSessionInput,
+} from "@codexhost/harness-adapter";
+
+import { consumeBrokerFrames, writeBrokerFrame } from "./framing.js";
+import {
+  HARNESS_BROKER_MAX_PENDING_REQUESTS,
+  HARNESS_BROKER_PROTOCOL_VERSION,
+  harnessBrokerHelloSchema,
+  harnessBrokerDescriptorSchema,
+  harnessBrokerRequestSchema,
+  protocolError,
+  type HarnessBrokerDescriptorV1,
+  type HarnessBrokerRequest,
+} from "./protocol.js";
+import {
+  brokerCommandInvocationSchema,
+  brokerHostCommandSchema,
+  brokerInspectInputSchema,
+  brokerOpenInputSchema,
+  sessionCommandExecuteParamsSchema,
+  sessionExecuteParamsSchema,
+  sessionParamsSchema,
+  subagentReadSnapshotSchema,
+} from "./validation.js";
+
+interface ServerSession {
+  id: string;
+  generation: number;
+  owner: string;
+  cwd: string;
+  nativeId?: string;
+  nativeRef?: HarnessSession["initialState"]["nativeRef"];
+  writerKey?: string;
+  awaitingNativeIdentity: boolean;
+  provisionalWriterLease: boolean;
+  bootstrapTurnId?: string;
+  session: HarnessSession;
+  outputTask: Promise<void>;
+  forwarderEpoch: number;
+  faulted: boolean;
+  selection: {
+    model?: HarnessSession["initialState"]["effectiveModel"];
+    thinkingOptionId?: HarnessSession["initialState"]["effectiveThinkingOptionId"];
+    permissionModeId?: HarnessSession["initialState"]["effectivePermissionModeId"];
+  };
+}
+
+interface ConnectionState {
+  id: string;
+  socket: Socket;
+  authenticated: boolean;
+  inputSequence: number;
+  outputSequence: number;
+  sessions: Set<string>;
+  queue: Promise<void>;
+  queuedFrames: number;
+  closed: boolean;
+}
+
+export interface HarnessBrokerServer {
+  readonly descriptor: HarnessBrokerDescriptorV1;
+  close(): Promise<void>;
+}
+
+function harnessError(message: string, retryable = true): HarnessError {
+  return { code: "unavailable", message, retryable, stage: "harnessBroker" };
+}
+
+function isAuthenticationTerminal(output: HarnessOutput): boolean {
+  return (
+    output.kind === "event" &&
+    output.event.type === "turn.completed" &&
+    output.event.outcome.status === "failed" &&
+    output.event.outcome.error.code === "authenticationRequired"
+  );
+}
+
+function nativeWriterKey(nativeSessionId: string): string {
+  return nativeSessionId;
+}
+
+async function privateDirectory(directory: string): Promise<void> {
+  await mkdir(directory, { recursive: true, mode: 0o700 });
+  if (process.platform === "win32") return;
+  const metadata = await lstat(directory);
+  if (metadata.isSymbolicLink() || !metadata.isDirectory()) {
+    throw new Error("Harness broker directory must be a real directory");
+  }
+  if (process.getuid && metadata.uid !== process.getuid()) {
+    throw new Error("Harness broker directory belongs to another user");
+  }
+  await chmod(directory, 0o700);
+  const hardened = await lstat(directory);
+  if ((hardened.mode & 0o077) !== 0) {
+    throw new Error("Harness broker directory must be owner-only");
+  }
+}
+
+function processIsAlive(processId: number): boolean {
+  try {
+    process.kill(processId, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function assertNoLiveDescriptor(descriptorPath: string): Promise<void> {
+  try {
+    const metadata = await lstat(descriptorPath);
+    if (metadata.isSymbolicLink() || !metadata.isFile()) {
+      throw new Error("Harness broker descriptor path must be a regular file");
+    }
+    if (process.platform !== "win32") {
+      if ((metadata.mode & 0o077) !== 0 || (process.getuid && metadata.uid !== process.getuid())) {
+        throw new Error("Harness broker descriptor is not owner-only");
+      }
+    }
+    const descriptor = harnessBrokerDescriptorSchema.parse(
+      JSON.parse(await readFile(descriptorPath, "utf8")),
+    );
+    if (processIsAlive(descriptor.ownerPid)) {
+      throw new Error("Harness broker descriptor already has a live owner");
+    }
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+  }
+}
+
+async function publishDescriptor(
+  descriptorPath: string,
+  descriptor: HarnessBrokerDescriptorV1,
+): Promise<void> {
+  const temporary = `${descriptorPath}.${process.pid}.${randomUUID()}.tmp`;
+  const handle = await open(temporary, "wx", 0o600);
+  try {
+    await handle.writeFile(`${JSON.stringify(descriptor)}\n`, "utf8");
+    await handle.sync();
+  } finally {
+    await handle.close();
+  }
+  await rename(temporary, descriptorPath);
+  if (process.platform !== "win32") await chmod(descriptorPath, 0o600);
+}
+
+function sessionMetadata(record: ServerSession): object {
+  const initialState = { ...record.session.initialState };
+  if (record.selection.model && initialState.effectiveModel?.id !== record.selection.model.id) {
+    delete initialState.resolvedModelLabel;
+  }
+  if (
+    record.selection.thinkingOptionId &&
+    initialState.effectiveThinkingOptionId !== record.selection.thinkingOptionId
+  ) {
+    delete initialState.availableThinkingOptions;
+  }
+  return {
+    sessionId: record.id,
+    sessionGeneration: record.generation,
+    capabilities: record.session.capabilities,
+    initialState: {
+      ...initialState,
+      ...(record.nativeRef ? { nativeRef: record.nativeRef } : {}),
+      ...(record.selection.model ? { effectiveModel: record.selection.model } : {}),
+      ...(record.selection.thinkingOptionId
+        ? { effectiveThinkingOptionId: record.selection.thinkingOptionId }
+        : {}),
+      ...(record.selection.permissionModeId
+        ? { effectivePermissionModeId: record.selection.permissionModeId }
+        : {}),
+    },
+    initialUsage: record.session.initialUsage,
+    commands: record.session.commands !== undefined,
+  };
+}
+
+async function socketAcceptsConnections(socketPath: string): Promise<boolean> {
+  return new Promise<boolean>((resolve) => {
+    const socket = net.createConnection(socketPath);
+    const finish = (value: boolean): void => {
+      socket.destroy();
+      resolve(value);
+    };
+    socket.once("connect", () => finish(true));
+    socket.once("error", () => finish(false));
+  });
+}
+
+async function prepareUnixSocketPath(socketPath: string): Promise<void> {
+  try {
+    const metadata = await lstat(socketPath);
+    if (metadata.isSymbolicLink() || !metadata.isSocket()) {
+      throw new Error("Harness broker socket path must not replace a non-socket entry");
+    }
+    if (process.getuid && metadata.uid !== process.getuid()) {
+      throw new Error("Harness broker socket belongs to another user");
+    }
+    if (await socketAcceptsConnections(socketPath)) {
+      throw new Error("Harness broker socket is already active");
+    }
+    await rm(socketPath);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+  }
+}
+
+export async function startHarnessBrokerServer(input: {
+  descriptorPath: string;
+  socketPath: string;
+  adapter: HarnessAdapter;
+  generation?: string;
+  token?: string;
+}): Promise<HarnessBrokerServer> {
+  if (input.adapter.harnessId !== "claude-code") {
+    throw new Error("Harness broker accepts only the claude-code adapter");
+  }
+  if (
+    process.platform !== "win32" &&
+    path.dirname(input.descriptorPath) !== path.dirname(input.socketPath)
+  ) {
+    throw new Error("Harness broker descriptor and socket must share one private directory");
+  }
+  if (process.platform === "darwin" && Buffer.byteLength(input.socketPath) > 103) {
+    throw new Error("Harness broker Unix socket path is too long for macOS");
+  }
+  await privateDirectory(path.dirname(input.descriptorPath));
+  await assertNoLiveDescriptor(input.descriptorPath);
+  if (process.platform !== "win32") await prepareUnixSocketPath(input.socketPath);
+
+  const generation = input.generation ?? randomUUID();
+  const token = input.token ?? randomBytes(32).toString("hex");
+  const descriptor: HarnessBrokerDescriptorV1 = {
+    schemaVersion: 1,
+    protocolVersion: HARNESS_BROKER_PROTOCOL_VERSION,
+    harnessId: "claude-code",
+    generation,
+    ownerPid: process.pid,
+    socketPath: input.socketPath,
+    token,
+  };
+  const sessions = new Map<string, ServerSession>();
+  const nativeWriters = new Map<string, string>();
+  let provisionalNativeWriter: string | undefined;
+  const connections = new Set<ConnectionState>();
+  let closed = false;
+
+  const server: Server = net.createServer((socket) => {
+    const state: ConnectionState = {
+      id: randomUUID(),
+      socket,
+      authenticated: false,
+      inputSequence: 0,
+      outputSequence: 0,
+      sessions: new Set(),
+      queue: Promise.resolve(),
+      queuedFrames: 0,
+      closed: false,
+    };
+    connections.add(state);
+
+    const send = async (frame: object): Promise<void> => {
+      state.outputSequence += 1;
+      await writeBrokerFrame(socket, {
+        version: HARNESS_BROKER_PROTOCOL_VERSION,
+        generation,
+        sequence: state.outputSequence,
+        ...frame,
+      });
+    };
+    const respond = async (
+      request: HarnessBrokerRequest,
+      result: { ok: true; value: unknown } | { ok: false; error: ReturnType<typeof protocolError> },
+    ): Promise<void> => {
+      await send({ kind: "response", id: request.id, ...result });
+    };
+
+    const releaseProvisionalWriter = (record: ServerSession): void => {
+      if (record.provisionalWriterLease && provisionalNativeWriter === record.id) {
+        provisionalNativeWriter = undefined;
+      }
+      record.provisionalWriterLease = false;
+      record.awaitingNativeIdentity = false;
+    };
+
+    const forwardOutputs = async (
+      record: ServerSession,
+      nativeSession: HarnessSession,
+      sessionGeneration: number,
+      forwarderEpoch: number,
+    ): Promise<void> => {
+      const isCurrent = (): boolean =>
+        sessions.get(record.id) === record &&
+        record.session === nativeSession &&
+        record.generation === sessionGeneration &&
+        record.forwarderEpoch === forwarderEpoch;
+      try {
+        for await (const output of nativeSession.outputs) {
+          if (!isCurrent()) break;
+          if (output.kind === "event" && output.event.type === "session.state.changed") {
+            const state = output.event.state;
+            const observedNativeId = state.nativeRef?.nativeSessionId;
+            if (
+              state.nativeRef &&
+              record.nativeRef &&
+              (record.nativeRef.harnessId !== state.nativeRef.harnessId ||
+                record.nativeRef.nativeSessionId !== state.nativeRef.nativeSessionId ||
+                record.nativeRef.formatVersion !== state.nativeRef.formatVersion)
+            ) {
+              record.faulted = true;
+              await send({
+                kind: "output",
+                sessionId: record.id,
+                sessionGeneration,
+                output: {
+                  kind: "event",
+                  event: {
+                    type: "session.faulted",
+                    error: {
+                      code: "protocolError",
+                      message: "Native Claude Session identity changed after open",
+                      retryable: false,
+                      stage: "harnessBroker.identity",
+                    },
+                  },
+                },
+              });
+              await nativeSession.close().catch(() => undefined);
+              break;
+            }
+            if (observedNativeId && !record.writerKey) {
+              const writerKey = nativeWriterKey(observedNativeId);
+              const owner = nativeWriters.get(writerKey);
+              if (owner && owner !== record.id) {
+                record.faulted = true;
+                releaseProvisionalWriter(record);
+                await send({
+                  kind: "output",
+                  sessionId: record.id,
+                  sessionGeneration,
+                  output: {
+                    kind: "event",
+                    event: {
+                      type: "session.faulted",
+                      error: {
+                        code: "sessionBusy",
+                        message: "Native Claude Session already has an active writer",
+                        retryable: true,
+                        stage: "harnessBroker.identity",
+                      },
+                    },
+                  },
+                });
+                await nativeSession.close().catch(() => undefined);
+                break;
+              }
+              nativeWriters.set(writerKey, record.id);
+              record.nativeId = observedNativeId;
+              record.nativeRef = state.nativeRef;
+              record.writerKey = writerKey;
+              releaseProvisionalWriter(record);
+            }
+            if (state.effectiveModel) record.selection.model = state.effectiveModel;
+            if (state.effectiveThinkingOptionId) {
+              record.selection.thinkingOptionId = state.effectiveThinkingOptionId;
+            }
+            if (state.effectivePermissionModeId) {
+              record.selection.permissionModeId = state.effectivePermissionModeId;
+            }
+          }
+          const authenticationTerminal = isAuthenticationTerminal(output);
+          if (output.kind === "event" && output.event.type === "session.faulted") {
+            record.faulted = true;
+            releaseProvisionalWriter(record);
+          }
+          if (authenticationTerminal) {
+            record.faulted = true;
+            releaseProvisionalWriter(record);
+          }
+          await send({
+            kind: "output",
+            sessionId: record.id,
+            sessionGeneration,
+            output,
+          });
+          if (authenticationTerminal) {
+            await nativeSession.close().catch(() => undefined);
+            break;
+          }
+        }
+      } catch {
+        if (isCurrent()) {
+          record.faulted = true;
+          releaseProvisionalWriter(record);
+        }
+      }
+    };
+
+    const closeRecord = async (record: ServerSession): Promise<void> => {
+      if (sessions.get(record.id) !== record) return;
+      sessions.delete(record.id);
+      state.sessions.delete(record.id);
+      record.forwarderEpoch += 1;
+      const nativeSession = record.session;
+      const outputTask = record.outputTask;
+      await nativeSession.close().catch(() => undefined);
+      await outputTask.catch(() => undefined);
+      if (record.writerKey && nativeWriters.get(record.writerKey) === record.id) {
+        nativeWriters.delete(record.writerKey);
+      }
+      releaseProvisionalWriter(record);
+    };
+
+    const requireSession = (params: unknown): ServerSession => {
+      const candidate = params as { sessionId?: unknown; sessionGeneration?: unknown };
+      const parsed = sessionParamsSchema.parse({
+        sessionId: candidate.sessionId,
+        sessionGeneration: candidate.sessionGeneration,
+      });
+      const record = sessions.get(parsed.sessionId);
+      if (!record || record.owner !== state.id)
+        throw new Error("Harness broker Session is unavailable");
+      if (record.generation !== parsed.sessionGeneration) {
+        throw new Error("Harness broker Session generation is stale");
+      }
+      return record;
+    };
+
+    const handleRequest = async (request: HarnessBrokerRequest): Promise<unknown> => {
+      if (closed || state.closed) throw new Error("Harness broker connection is closed");
+      if (request.method === "adapter.inspect") {
+        const parsed = brokerInspectInputSchema.parse(request.params);
+        return input.adapter.inspect({
+          ...(parsed.cwd ? { cwd: parsed.cwd } : {}),
+          ...(parsed.refresh !== undefined ? { refresh: parsed.refresh } : {}),
+        });
+      }
+      if (request.method === "adapter.subagent.readSnapshot") {
+        const subagents = input.adapter.subagents;
+        if (!subagents)
+          return { ok: false, error: harnessError("Claude subagents are unavailable", false) };
+        return subagents.readSnapshot(subagentReadSnapshotSchema.parse(request.params));
+      }
+      if (request.method === "adapter.open") {
+        const openInput = brokerOpenInputSchema.parse(request.params) as OpenSessionInput;
+        const sourceRef =
+          openInput.kind === "create"
+            ? undefined
+            : openInput.kind === "resume"
+              ? openInput.nativeRef
+              : openInput.sourceRef;
+        const sourceNativeId = sourceRef?.nativeSessionId;
+        const sourceKey = sourceNativeId ? nativeWriterKey(sourceNativeId) : undefined;
+        if (sourceKey && nativeWriters.has(sourceKey)) {
+          return {
+            ok: false,
+            error: {
+              code: "sessionBusy",
+              message: "Native Claude Session already has an active writer",
+              retryable: true,
+              stage: "harnessBroker.open",
+            },
+          };
+        }
+        if (provisionalNativeWriter) {
+          return {
+            ok: false,
+            error: {
+              code: "sessionBusy",
+              message: "Native Claude Session identity claim is already pending",
+              retryable: true,
+              stage: "harnessBroker.open",
+            },
+          };
+        }
+        const openReservation = randomUUID();
+        if (sourceKey) nativeWriters.set(sourceKey, openReservation);
+        const provisionalReservation = openInput.kind === "create" ? openReservation : undefined;
+        if (provisionalReservation) provisionalNativeWriter = provisionalReservation;
+        const releaseOpenReservations = (): void => {
+          if (sourceKey && nativeWriters.get(sourceKey) === openReservation) {
+            nativeWriters.delete(sourceKey);
+          }
+          if (provisionalReservation && provisionalNativeWriter === provisionalReservation) {
+            provisionalNativeWriter = undefined;
+          }
+        };
+        const opened = await input.adapter.open(openInput).catch((error: unknown) => {
+          releaseOpenReservations();
+          throw error;
+        });
+        if (!opened.ok) {
+          releaseOpenReservations();
+          return opened;
+        }
+        if (closed || state.closed) {
+          releaseOpenReservations();
+          await opened.value.close().catch(() => undefined);
+          return { ok: false, error: harnessError("Harness broker connection closed") };
+        }
+        const openedRef = opened.value.initialState.nativeRef;
+        if (
+          sourceRef &&
+          (!openedRef ||
+            openedRef.harnessId !== sourceRef.harnessId ||
+            openedRef.formatVersion !== sourceRef.formatVersion ||
+            (openInput.kind === "resume" &&
+              openedRef.nativeSessionId !== sourceRef.nativeSessionId))
+        ) {
+          releaseOpenReservations();
+          await opened.value.close().catch(() => undefined);
+          return {
+            ok: false,
+            error: {
+              code: "protocolError",
+              message: "Native Claude Session identity did not match the requested open",
+              retryable: false,
+              stage: "harnessBroker.open",
+            },
+          };
+        }
+        const nativeId = openedRef?.nativeSessionId;
+        const nativeKey = nativeId ? nativeWriterKey(nativeId) : undefined;
+        const nativeOwner = nativeKey ? nativeWriters.get(nativeKey) : undefined;
+        if (nativeOwner && nativeOwner !== openReservation) {
+          releaseOpenReservations();
+          await opened.value.close().catch(() => undefined);
+          return {
+            ok: false,
+            error: {
+              code: "sessionBusy",
+              message: "Native Claude Session already has an active writer",
+              retryable: true,
+              stage: "harnessBroker.open",
+            },
+          };
+        }
+        const delayedCreateIdentity = openInput.kind === "create" && !nativeKey;
+        const record: ServerSession = {
+          id: openReservation,
+          generation: 1,
+          owner: state.id,
+          cwd: openInput.cwd,
+          ...(nativeId ? { nativeId } : {}),
+          ...(opened.value.initialState.nativeRef
+            ? { nativeRef: opened.value.initialState.nativeRef }
+            : {}),
+          ...(nativeKey ? { writerKey: nativeKey } : {}),
+          awaitingNativeIdentity: delayedCreateIdentity,
+          provisionalWriterLease: delayedCreateIdentity,
+          session: opened.value,
+          outputTask: Promise.resolve(),
+          forwarderEpoch: 1,
+          faulted: false,
+          selection: {
+            ...(opened.value.initialState.effectiveModel
+              ? { model: opened.value.initialState.effectiveModel }
+              : {}),
+            ...(opened.value.initialState.effectiveThinkingOptionId
+              ? { thinkingOptionId: opened.value.initialState.effectiveThinkingOptionId }
+              : {}),
+            ...(opened.value.initialState.effectivePermissionModeId
+              ? { permissionModeId: opened.value.initialState.effectivePermissionModeId }
+              : {}),
+          },
+        };
+        sessions.set(record.id, record);
+        state.sessions.add(record.id);
+        if (nativeKey) nativeWriters.set(nativeKey, record.id);
+        if (sourceKey && sourceKey !== nativeKey && nativeWriters.get(sourceKey) === record.id) {
+          nativeWriters.delete(sourceKey);
+        }
+        if (!record.provisionalWriterLease && provisionalNativeWriter === provisionalReservation) {
+          provisionalNativeWriter = undefined;
+        }
+        record.outputTask = forwardOutputs(
+          record,
+          opened.value,
+          record.generation,
+          record.forwarderEpoch,
+        );
+        return { ok: true, value: sessionMetadata(record) };
+      }
+      if (request.method === "session.execute") {
+        const parsed = sessionExecuteParamsSchema.parse(request.params);
+        const record = requireSession(parsed);
+        const command = brokerHostCommandSchema.parse(parsed.command);
+        if (record.awaitingNativeIdentity && !record.writerKey) {
+          const isBootstrapTurn =
+            command.type === "turn.start" &&
+            record.provisionalWriterLease &&
+            record.bootstrapTurnId === undefined;
+          const isBootstrapTurnContinuation =
+            record.bootstrapTurnId !== undefined &&
+            ((command.type === "turn.cancel" && command.turnId === record.bootstrapTurnId) ||
+              command.type === "interaction.respond");
+          if (!isBootstrapTurn && !isBootstrapTurnContinuation) {
+            return {
+              ok: false,
+              error: {
+                code: "sessionBusy",
+                message: "Native Claude Session identity has not been claimed yet",
+                retryable: true,
+                stage: "harnessBroker.identity",
+              },
+            };
+          }
+          if (command.type === "turn.start") record.bootstrapTurnId = command.turnId;
+        }
+        let result;
+        if (command.type === "turn.start") result = await record.session.execute(command);
+        else if (command.type === "turn.cancel") result = await record.session.execute(command);
+        else if (command.type === "interaction.respond") {
+          result = await record.session.execute({
+            type: command.type,
+            interactionId: command.interactionId,
+            response:
+              command.response.type === "question"
+                ? {
+                    type: "question",
+                    answers: command.response.answers,
+                    ...(command.response.cancelled !== undefined
+                      ? { cancelled: command.response.cancelled }
+                      : {}),
+                  }
+                : command.response,
+          });
+        } else if (command.type === "model.select") result = await record.session.execute(command);
+        else if (command.type === "thinking.select") result = await record.session.execute(command);
+        else result = await record.session.execute(command);
+        if (
+          !result.ok &&
+          command.type === "turn.start" &&
+          record.awaitingNativeIdentity &&
+          record.bootstrapTurnId === command.turnId
+        ) {
+          delete record.bootstrapTurnId;
+        }
+        if (result.ok) {
+          if (command.type === "model.select") record.selection.model = command.model;
+          if (command.type === "thinking.select")
+            record.selection.thinkingOptionId = command.thinkingOptionId;
+          if (command.type === "permissionMode.select")
+            record.selection.permissionModeId = command.permissionModeId;
+        }
+        return result;
+      }
+      if (request.method === "session.readSnapshot") {
+        return requireSession(request.params).session.readSnapshot();
+      }
+      if (request.method === "session.refreshUsage") {
+        const record = requireSession(request.params);
+        const refreshUsage = (
+          record.session as HarnessSession & { refreshUsage?: () => Promise<void> }
+        ).refreshUsage;
+        if (refreshUsage) await refreshUsage.call(record.session);
+        return null;
+      }
+      if (request.method === "session.commands.list") {
+        const commands = requireSession(request.params).session.commands;
+        return commands
+          ? commands.list()
+          : { ok: false, error: harnessError("Commands unavailable", false) };
+      }
+      if (request.method === "session.commands.execute") {
+        const parsed = sessionCommandExecuteParamsSchema.parse(request.params);
+        const commands = requireSession(parsed).session.commands;
+        const command = brokerCommandInvocationSchema.parse(parsed.command);
+        return commands
+          ? commands.execute({
+              turnId: command.turnId,
+              commandId: command.commandId,
+              ...(command.arguments ? { arguments: command.arguments } : {}),
+            })
+          : { ok: false, error: harnessError("Commands unavailable", false) };
+      }
+      if (request.method === "session.reopen") {
+        const record = requireSession(request.params);
+        if (!record.faulted) {
+          return { ok: true, value: sessionMetadata(record) };
+        }
+        if (!record.nativeRef) {
+          return {
+            ok: false,
+            error: {
+              code: "sessionBusy",
+              message: "Faulted Claude Session has no authoritative native identity",
+              retryable: false,
+              stage: "harnessBroker.reopen",
+            },
+          };
+        }
+        const nativeRef = record.nativeRef;
+        const oldSession = record.session;
+        const oldOutputTask = record.outputTask;
+        record.forwarderEpoch += 1;
+        await oldSession.close().catch(() => undefined);
+        await oldOutputTask.catch(() => undefined);
+        const reopened = await input.adapter.open({ kind: "resume", cwd: record.cwd, nativeRef });
+        if (!reopened.ok) return reopened;
+        const reopenedRef = reopened.value.initialState.nativeRef;
+        if (
+          !reopenedRef ||
+          reopenedRef.harnessId !== nativeRef.harnessId ||
+          reopenedRef.nativeSessionId !== nativeRef.nativeSessionId ||
+          reopenedRef.formatVersion !== nativeRef.formatVersion
+        ) {
+          await reopened.value.close().catch(() => undefined);
+          return {
+            ok: false,
+            error: {
+              code: "protocolError",
+              message: "Claude Aqua broker reopen changed the native Session identity",
+              retryable: false,
+              stage: "harnessBroker.reopen",
+            },
+          };
+        }
+        if (record.selection.model && reopened.value.capabilities.configuration.selectModel) {
+          const selected = await reopened.value.execute({
+            type: "model.select",
+            model: record.selection.model,
+          });
+          if (!selected.ok) {
+            await reopened.value.close().catch(() => undefined);
+            return selected;
+          }
+        }
+        if (
+          record.selection.thinkingOptionId &&
+          reopened.value.capabilities.configuration.selectThinkingOption
+        ) {
+          const selected = await reopened.value.execute({
+            type: "thinking.select",
+            thinkingOptionId: record.selection.thinkingOptionId,
+          });
+          if (!selected.ok) {
+            await reopened.value.close().catch(() => undefined);
+            return selected;
+          }
+        }
+        if (
+          record.selection.permissionModeId &&
+          reopened.value.capabilities.configuration.selectPermissionMode
+        ) {
+          const selected = await reopened.value.execute({
+            type: "permissionMode.select",
+            permissionModeId: record.selection.permissionModeId,
+          });
+          if (!selected.ok) {
+            await reopened.value.close().catch(() => undefined);
+            return selected;
+          }
+        }
+        record.session = reopened.value;
+        record.generation += 1;
+        record.faulted = false;
+        record.outputTask = forwardOutputs(
+          record,
+          reopened.value,
+          record.generation,
+          record.forwarderEpoch,
+        );
+        return { ok: true, value: sessionMetadata(record) };
+      }
+      const record = requireSession(request.params);
+      await closeRecord(record);
+      return null;
+    };
+
+    consumeBrokerFrames(
+      socket,
+      (raw) => {
+        state.queuedFrames += 1;
+        if (state.queuedFrames > HARNESS_BROKER_MAX_PENDING_REQUESTS) {
+          state.closed = true;
+          socket.destroy();
+          return;
+        }
+        state.queue = state.queue
+          .then(async () => {
+            if (state.closed) return;
+            if (!state.authenticated) {
+              const hello = harnessBrokerHelloSchema.safeParse(raw);
+              if (
+                !hello.success ||
+                hello.data.generation !== generation ||
+                hello.data.token !== token
+              ) {
+                socket.destroy();
+                return;
+              }
+              state.authenticated = true;
+              state.inputSequence = 1;
+              await send({ kind: "response", id: randomUUID(), ok: true, value: { ready: true } });
+              return;
+            }
+            const parsed = harnessBrokerRequestSchema.safeParse(raw);
+            if (
+              !parsed.success ||
+              parsed.data.generation !== generation ||
+              parsed.data.sequence !== state.inputSequence + 1
+            ) {
+              socket.destroy();
+              return;
+            }
+            state.inputSequence = parsed.data.sequence;
+            try {
+              await respond(parsed.data, { ok: true, value: await handleRequest(parsed.data) });
+            } catch (error) {
+              await respond(parsed.data, {
+                ok: false,
+                error: protocolError(error instanceof Error ? error.message : String(error)),
+              });
+            } finally {
+              // One authenticated connection intentionally serializes requests. This bounds
+              // native Harness concurrency at one while the client bounds queued requests.
+            }
+          })
+          .finally(() => {
+            state.queuedFrames -= 1;
+          })
+          .catch(() => {
+            socket.destroy();
+          });
+      },
+      () => socket.destroy(),
+    );
+
+    socket.once("close", () => {
+      state.closed = true;
+      connections.delete(state);
+      for (const sessionId of [...state.sessions]) {
+        const record = sessions.get(sessionId);
+        if (record) void closeRecord(record);
+      }
+    });
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(input.socketPath, () => {
+      server.removeListener("error", reject);
+      resolve();
+    });
+  });
+  try {
+    if (process.platform !== "win32") await chmod(input.socketPath, 0o600);
+    await publishDescriptor(input.descriptorPath, descriptor);
+  } catch (error) {
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+    if (process.platform !== "win32") await rm(input.socketPath, { force: true });
+    throw error;
+  }
+
+  return {
+    descriptor,
+    async close(): Promise<void> {
+      if (closed) return;
+      closed = true;
+      for (const connection of connections) connection.socket.destroy();
+      for (const record of sessions.values()) record.forwarderEpoch += 1;
+      await Promise.all(
+        [...sessions.values()].map((record) => record.session.close().catch(() => undefined)),
+      );
+      await Promise.all(
+        [...sessions.values()].map((record) => record.outputTask.catch(() => undefined)),
+      );
+      await input.adapter.close().catch(() => undefined);
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+      if (process.platform !== "win32") await rm(input.socketPath, { force: true });
+      await rm(input.descriptorPath, { force: true });
+    },
+  };
+}

--- a/packages/harness-broker/src/validation.ts
+++ b/packages/harness-broker/src/validation.ts
@@ -1,0 +1,263 @@
+import { z } from "zod";
+
+import {
+  harnessConfigurationStateSchema,
+  harnessModelRefSchema,
+  harnessPermissionModeIdSchema,
+  harnessThinkingOptionIdSchema,
+  hostInteractionIdSchema,
+  hostTurnIdSchema,
+  jsonObjectSchema,
+  nativeCheckpointRefSchema,
+  nativeSessionRefSchema,
+  nativeTurnRefSchema,
+} from "@codexhost/shared-contracts";
+import type { HarnessError, HarnessOutput, HarnessSessionState } from "@codexhost/harness-adapter";
+
+const cwdSchema = z.string().min(1).max(16_384);
+
+const createSchema = z
+  .object({
+    kind: z.literal("create"),
+    cwd: cwdSchema,
+    executionPolicy: z.enum(["default", "unattended-full-access"]).optional(),
+    model: harnessModelRefSchema.optional(),
+    thinkingOptionId: harnessThinkingOptionIdSchema.optional(),
+    permissionModeId: harnessPermissionModeIdSchema.optional(),
+  })
+  .strict();
+const resumeSchema = z
+  .object({
+    kind: z.literal("resume"),
+    nativeRef: nativeSessionRefSchema,
+    cwd: cwdSchema,
+    knownTurnRefs: z.array(nativeTurnRefSchema).max(100_000).optional(),
+  })
+  .strict();
+const forkSchema = z
+  .object({
+    kind: z.literal("fork"),
+    sourceRef: nativeSessionRefSchema,
+    checkpoint: nativeCheckpointRefSchema,
+    cwd: cwdSchema,
+  })
+  .strict();
+const rollbackSchema = z
+  .object({
+    kind: z.literal("rollbackLastTurn"),
+    sourceRef: nativeSessionRefSchema,
+    cwd: cwdSchema,
+  })
+  .strict();
+
+export const brokerOpenInputSchema = z.discriminatedUnion("kind", [
+  createSchema,
+  resumeSchema,
+  forkSchema,
+  rollbackSchema,
+]);
+
+export const brokerInspectInputSchema = z
+  .object({ cwd: cwdSchema.optional(), refresh: z.boolean().optional() })
+  .strict();
+
+const textInputSchema = z
+  .object({ type: z.literal("text"), text: z.string().max(4_000_000) })
+  .strict();
+const turnStartSchema = z
+  .object({
+    type: z.literal("turn.start"),
+    turnId: hostTurnIdSchema,
+    input: z.array(textInputSchema),
+  })
+  .strict();
+const turnCancelSchema = z
+  .object({ type: z.literal("turn.cancel"), turnId: hostTurnIdSchema })
+  .strict();
+const interactionResponseSchema = z.union([
+  z
+    .object({
+      type: z.literal("question"),
+      answers: z.record(z.string(), z.array(z.string())),
+      cancelled: z.boolean().optional(),
+    })
+    .strict(),
+  z.object({ type: z.literal("approval"), actionId: z.string().min(1).max(1_024) }).strict(),
+]);
+const interactionRespondSchema = z
+  .object({
+    type: z.literal("interaction.respond"),
+    interactionId: hostInteractionIdSchema,
+    response: interactionResponseSchema,
+  })
+  .strict();
+const modelSelectSchema = z
+  .object({ type: z.literal("model.select"), model: harnessModelRefSchema })
+  .strict();
+const thinkingSelectSchema = z
+  .object({
+    type: z.literal("thinking.select"),
+    thinkingOptionId: harnessThinkingOptionIdSchema,
+  })
+  .strict();
+const permissionSelectSchema = z
+  .object({
+    type: z.literal("permissionMode.select"),
+    permissionModeId: harnessPermissionModeIdSchema,
+  })
+  .strict();
+
+export const brokerHostCommandSchema = z.discriminatedUnion("type", [
+  turnStartSchema,
+  turnCancelSchema,
+  interactionRespondSchema,
+  modelSelectSchema,
+  thinkingSelectSchema,
+  permissionSelectSchema,
+]);
+
+export const brokerCommandInvocationSchema = z
+  .object({
+    turnId: hostTurnIdSchema,
+    commandId: z.string().min(1).max(1_024),
+    arguments: jsonObjectSchema.optional(),
+  })
+  .strict();
+
+export const sessionParamsSchema = z
+  .object({ sessionId: z.string().uuid(), sessionGeneration: z.number().int().positive() })
+  .strict();
+
+export const sessionExecuteParamsSchema = sessionParamsSchema.extend({
+  command: brokerHostCommandSchema,
+});
+
+export const sessionCommandExecuteParamsSchema = sessionParamsSchema.extend({
+  command: brokerCommandInvocationSchema,
+});
+
+export const subagentReadSnapshotSchema = z
+  .object({
+    parent: nativeSessionRefSchema,
+    nativeSubagentId: z.string().min(1).max(4_096),
+    cwd: cwdSchema,
+  })
+  .strict();
+
+export const harnessErrorSchema = z
+  .object({
+    code: z.enum([
+      "notInstalled",
+      "unavailable",
+      "authenticationRequired",
+      "sessionNotFound",
+      "sessionBusy",
+      "checkpointNotFound",
+      "unsupported",
+      "invalidRequest",
+      "invalidState",
+      "protocolError",
+      "processExited",
+      "nativeFailure",
+      "internalError",
+    ]),
+    message: z.string().max(65_536),
+    retryable: z.boolean(),
+    diagnostic: z.string().max(65_536).optional(),
+    stage: z.string().max(1_024).optional(),
+    durationMs: z.number().finite().nonnegative().optional(),
+    stderrTail: z.string().max(65_536).optional(),
+  })
+  .strict();
+
+export const harnessSessionStateSchema = z.custom<HarnessSessionState>((value) => {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+  const record = value as Record<string, unknown>;
+  const allowed = new Set([
+    "nativeRef",
+    "effectiveModel",
+    "resolvedModelLabel",
+    "effectiveThinkingOptionId",
+    "availableThinkingOptions",
+    "effectivePermissionModeId",
+  ]);
+  if (Object.keys(record).some((key) => !allowed.has(key))) return false;
+  if (
+    record.nativeRef !== undefined &&
+    !nativeSessionRefSchema.safeParse(record.nativeRef).success
+  ) {
+    return false;
+  }
+  const { nativeRef: _nativeRef, ...configuration } = record;
+  void _nativeRef;
+  return harnessConfigurationStateSchema.safeParse(configuration).success;
+});
+
+const eventKeys = new Map<string, ReadonlySet<string>>([
+  ["session.state.changed", new Set(["type", "state"])],
+  ["session.usage.changed", new Set(["type", "usage", "observedForTurnId"])],
+  ["subagent.state.changed", new Set(["type", "nativeSubagentId", "status", "resultSummary"])],
+  ["subagent.transcript.changed", new Set(["type", "nativeSubagentId"])],
+  ["turn.started", new Set(["type", "turnId"])],
+  ["turn.autonomous.started", new Set(["type", "turnId", "input"])],
+  ["item.started", new Set(["type", "turnId", "item"])],
+  ["item.updated", new Set(["type", "turnId", "itemId", "update"])],
+  ["item.completed", new Set(["type", "turnId", "snapshot"])],
+  ["interaction.closed", new Set(["type", "interactionId", "turnId", "reason"])],
+  ["turn.completed", new Set(["type", "turnId", "nativeTurnRef", "outcome"])],
+  ["session.faulted", new Set(["type", "error"])],
+]);
+const interactionKeys = new Map<string, ReadonlySet<string>>([
+  [
+    "question",
+    new Set(["type", "interactionId", "turnId", "itemId", "title", "questions", "expiresAt"]),
+  ],
+  [
+    "approval",
+    new Set([
+      "type",
+      "interactionId",
+      "turnId",
+      "title",
+      "description",
+      "subject",
+      "actions",
+      "expiresAt",
+    ]),
+  ],
+]);
+
+function strictKeys(
+  value: unknown,
+  allowed: ReadonlySet<string> | undefined,
+): value is Record<string, unknown> {
+  return Boolean(
+    allowed &&
+    value &&
+    typeof value === "object" &&
+    !Array.isArray(value) &&
+    Object.keys(value).every((key) => allowed.has(key)),
+  );
+}
+
+export const harnessOutputSchema = z.custom<HarnessOutput>((value) => {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+  const output = value as Record<string, unknown>;
+  if (output.kind === "event") {
+    if (Object.keys(output).some((key) => key !== "kind" && key !== "event")) return false;
+    const event = output.event as Record<string, unknown> | undefined;
+    if (!strictKeys(event, eventKeys.get(String(event?.type)))) return false;
+    if (event.type === "session.state.changed")
+      return harnessSessionStateSchema.safeParse(event.state).success;
+    if (event.type === "session.faulted") return harnessErrorSchema.safeParse(event.error).success;
+    return true;
+  }
+  if (output.kind === "interaction") {
+    if (Object.keys(output).some((key) => key !== "kind" && key !== "interaction")) return false;
+    const interaction = output.interaction as Record<string, unknown> | undefined;
+    return strictKeys(interaction, interactionKeys.get(String(interaction?.type)));
+  }
+  return false;
+});
+
+export type ValidatedHarnessError = z.infer<typeof harnessErrorSchema> & HarnessError;

--- a/packages/harness-broker/test/harness-broker.test.ts
+++ b/packages/harness-broker/test/harness-broker.test.ts
@@ -1,0 +1,617 @@
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import net from "node:net";
+import os from "node:os";
+import path from "node:path";
+
+import { randomUUID } from "node:crypto";
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  HarnessOutputChannel,
+  type HarnessAdapter,
+  type HarnessOutput,
+  type HarnessSession,
+  type HostCommand,
+} from "@codexhost/harness-adapter";
+import { FakeHarnessAdapter, FakeHarnessSession } from "@codexhost/harness-adapter/testing";
+import {
+  harnessIdSchema,
+  harnessPermissionModeCatalogSchema,
+  hostTurnIdSchema,
+} from "@codexhost/shared-contracts";
+import {
+  BrokeredHarnessAdapter,
+  HARNESS_BROKER_MAX_PENDING_REQUESTS,
+  startHarnessBrokerServer,
+} from "../src/index.js";
+
+const roots: string[] = [];
+
+function deferred(): { promise: Promise<void>; resolve(): void } {
+  let resolve = (): void => undefined;
+  const promise = new Promise<void>((done) => {
+    resolve = done;
+  });
+  return { promise, resolve };
+}
+
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
+});
+
+describe("macOS Aqua Harness broker", () => {
+  it.skipIf(process.platform === "win32")(
+    "refuses to replace a non-socket entry at the broker socket path",
+    async () => {
+      const root = await mkdtemp(path.join(os.tmpdir(), "codexhost-harness-broker-"));
+      roots.push(root);
+      const descriptorPath = path.join(root, "broker-v1.json");
+      const socketPath = path.join(root, "broker.sock");
+      await writeFile(socketPath, "user-owned-content", "utf8");
+      const native = new FakeHarnessAdapter(harnessIdSchema.parse("claude-code"));
+
+      await expect(
+        startHarnessBrokerServer({ descriptorPath, socketPath, adapter: native }),
+      ).rejects.toThrow("must not replace a non-socket entry");
+      await expect(readFile(socketPath, "utf8")).resolves.toBe("user-owned-content");
+      await native.close();
+    },
+  );
+
+  it("round-trips inspect, open, execute, streamed output, and close", async () => {
+    const root = await mkdtemp(path.join(os.tmpdir(), "codexhost-harness-broker-"));
+    roots.push(root);
+    const descriptorPath = path.join(root, "broker-v1.json");
+    const socketPath =
+      process.platform === "win32"
+        ? `\\\\.\\pipe\\codexhost-harness-broker-${process.pid}-${randomUUID()}`
+        : path.join(root, "broker.sock");
+    const native = new FakeHarnessAdapter(harnessIdSchema.parse("claude-code"));
+    const nativeOpen = vi.spyOn(native, "open");
+    const server = await startHarnessBrokerServer({ descriptorPath, socketPath, adapter: native });
+    const adapter = new BrokeredHarnessAdapter({ descriptorPath });
+
+    await expect(adapter.inspect({ cwd: root })).resolves.toMatchObject({
+      status: "ready",
+    });
+    const opened = await adapter.open({
+      kind: "create",
+      cwd: root,
+      environment: { ANTHROPIC_API_KEY: "must-not-cross-the-broker" },
+    });
+    expect(opened.ok).toBe(true);
+    if (!opened.ok) throw new Error(opened.error.message);
+    const output = opened.value.outputs[Symbol.asyncIterator]();
+    const accepted = await opened.value.execute({
+      type: "turn.start",
+      turnId: hostTurnIdSchema.parse("broker-turn-1"),
+      input: [{ type: "text", text: "ping" }],
+    });
+    expect(accepted).toEqual({ ok: true, value: { turnId: "broker-turn-1" } });
+    await expect(output.next()).resolves.toMatchObject({
+      done: false,
+      value: { kind: "event", event: { type: "turn.started", turnId: "broker-turn-1" } },
+    });
+    await expect(output.next()).resolves.toMatchObject({
+      done: false,
+      value: { kind: "event", event: { type: "item.started", turnId: "broker-turn-1" } },
+    });
+
+    expect(native.sessions).toHaveLength(1);
+    expect(native.sessions[0]?.cwd).toBe(root);
+    expect(nativeOpen).toHaveBeenCalledWith({ kind: "create", cwd: root });
+    await opened.value.close();
+    await adapter.close();
+    await server.close();
+  });
+
+  it.each([
+    ["token", (descriptor: Record<string, unknown>) => ({ ...descriptor, token: "0".repeat(64) })],
+    ["protocol", (descriptor: Record<string, unknown>) => ({ ...descriptor, protocolVersion: 2 })],
+    [
+      "generation",
+      (descriptor: Record<string, unknown>) => ({ ...descriptor, generation: randomUUID() }),
+    ],
+  ])("fails closed for a descriptor with the wrong %s", async (_field, mutate) => {
+    const root = await mkdtemp(path.join(os.tmpdir(), "codexhost-harness-broker-"));
+    roots.push(root);
+    const descriptorPath = path.join(root, "broker-v1.json");
+    const socketPath =
+      process.platform === "win32"
+        ? `\\\\.\\pipe\\codexhost-harness-broker-${process.pid}-${randomUUID()}`
+        : path.join(root, "broker.sock");
+    const native = new FakeHarnessAdapter(harnessIdSchema.parse("claude-code"));
+    const server = await startHarnessBrokerServer({ descriptorPath, socketPath, adapter: native });
+    const descriptor = JSON.parse(await readFile(descriptorPath, "utf8")) as Record<
+      string,
+      unknown
+    >;
+    await writeFile(descriptorPath, `${JSON.stringify(mutate(descriptor))}\n`, "utf8");
+    const adapter = new BrokeredHarnessAdapter({ descriptorPath });
+
+    const inspection = await adapter.inspect();
+    expect(inspection).toMatchObject({
+      status: "unavailable",
+      error: { code: "unavailable", stage: "harnessBroker" },
+    });
+    if (inspection.status === "unavailable") {
+      expect(inspection.error.message).not.toContain(String(descriptor.token));
+      expect(inspection.error.message).not.toContain("0".repeat(64));
+    }
+    await adapter.close();
+    await server.close();
+  });
+
+  it("fail-closes before processing a packed frame batch beyond the server queue cap", async () => {
+    const root = await mkdtemp(path.join(os.tmpdir(), "codexhost-harness-broker-"));
+    roots.push(root);
+    const descriptorPath = path.join(root, "broker-v1.json");
+    const socketPath =
+      process.platform === "win32"
+        ? `\\\\.\\pipe\\codexhost-harness-broker-${process.pid}-${randomUUID()}`
+        : path.join(root, "broker.sock");
+    const native = new FakeHarnessAdapter(harnessIdSchema.parse("claude-code"));
+    const inspect = vi.spyOn(native, "inspect");
+    const server = await startHarnessBrokerServer({ descriptorPath, socketPath, adapter: native });
+    const socket = net.createConnection(socketPath);
+    await new Promise<void>((resolve, reject) => {
+      socket.once("connect", resolve);
+      socket.once("error", reject);
+    });
+    const closed = new Promise<void>((resolve) => socket.once("close", () => resolve()));
+    const frames = [
+      {
+        version: 1,
+        generation: server.descriptor.generation,
+        sequence: 1,
+        kind: "hello",
+        token: server.descriptor.token,
+      },
+      ...Array.from({ length: HARNESS_BROKER_MAX_PENDING_REQUESTS + 1 }, (_, index) => ({
+        version: 1,
+        generation: server.descriptor.generation,
+        sequence: index + 2,
+        kind: "request",
+        id: randomUUID(),
+        method: "adapter.inspect",
+        params: {},
+      })),
+    ];
+    socket.write(`${frames.map((frame) => JSON.stringify(frame)).join("\n")}\n`);
+
+    await closed;
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    expect(inspect).not.toHaveBeenCalled();
+    await server.close();
+  });
+
+  it("rejects a second writer before opening the same native Session", async () => {
+    const root = await mkdtemp(path.join(os.tmpdir(), "codexhost-harness-broker-"));
+    roots.push(root);
+    const descriptorPath = path.join(root, "broker-v1.json");
+    const socketPath =
+      process.platform === "win32"
+        ? `\\\\.\\pipe\\codexhost-harness-broker-${process.pid}-${randomUUID()}`
+        : path.join(root, "broker.sock");
+    const native = new FakeHarnessAdapter(harnessIdSchema.parse("claude-code"));
+    const otherCwd = path.join(root, "other-cwd");
+    await mkdir(otherCwd);
+    const nativeOpen = vi.spyOn(native, "open");
+    const server = await startHarnessBrokerServer({ descriptorPath, socketPath, adapter: native });
+    const firstAdapter = new BrokeredHarnessAdapter({ descriptorPath });
+    const first = await firstAdapter.open({ kind: "create", cwd: root });
+    if (!first.ok || !first.value.initialState.nativeRef) throw new Error("fixture failed to open");
+    const secondAdapter = new BrokeredHarnessAdapter({ descriptorPath });
+
+    await expect(
+      secondAdapter.open({
+        kind: "resume",
+        cwd: otherCwd,
+        nativeRef: first.value.initialState.nativeRef,
+      }),
+    ).resolves.toMatchObject({ ok: false, error: { code: "sessionBusy" } });
+    expect(nativeOpen).toHaveBeenCalledTimes(1);
+
+    await first.value.close();
+    await firstAdapter.close();
+    await secondAdapter.close();
+    await server.close();
+  });
+
+  it("reserves a known native writer before awaiting the native open", async () => {
+    const root = await mkdtemp(path.join(os.tmpdir(), "codexhost-harness-broker-"));
+    roots.push(root);
+    const otherCwd = path.join(root, "other-cwd");
+    await mkdir(otherCwd);
+    const descriptorPath = path.join(root, "broker-v1.json");
+    const socketPath =
+      process.platform === "win32"
+        ? `\\\\.\\pipe\\codexhost-harness-broker-${process.pid}-${randomUUID()}`
+        : path.join(root, "broker.sock");
+    const native = new FakeHarnessAdapter(harnessIdSchema.parse("claude-code"));
+    const seeded = await native.open({ kind: "create", cwd: root });
+    const nativeRef = seeded.ok ? seeded.value.initialState.nativeRef : undefined;
+    if (!nativeRef) throw new Error("fixture failed to seed a Native Session");
+    const originalOpen = native.open.bind(native);
+    const openStarted = deferred();
+    const releaseOpen = deferred();
+    const nativeOpen = vi.spyOn(native, "open").mockImplementation(async (input) => {
+      if (input.kind === "resume") {
+        openStarted.resolve();
+        await releaseOpen.promise;
+      }
+      return originalOpen(input);
+    });
+    const server = await startHarnessBrokerServer({ descriptorPath, socketPath, adapter: native });
+    const firstAdapter = new BrokeredHarnessAdapter({ descriptorPath });
+    const secondAdapter = new BrokeredHarnessAdapter({ descriptorPath });
+
+    const firstOpen = firstAdapter.open({ kind: "resume", cwd: root, nativeRef });
+    await openStarted.promise;
+    const secondOpen = secondAdapter.open({ kind: "resume", cwd: otherCwd, nativeRef });
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    expect(nativeOpen).toHaveBeenCalledTimes(1);
+    releaseOpen.resolve();
+
+    const first = await firstOpen;
+    if (!first.ok) throw new Error(first.error.message);
+    await expect(secondOpen).resolves.toMatchObject({
+      ok: false,
+      error: { code: "sessionBusy" },
+    });
+    expect(nativeOpen).toHaveBeenCalledTimes(1);
+
+    await first.value.close();
+    await firstAdapter.close();
+    await secondAdapter.close();
+    await server.close();
+  });
+
+  it("fail-closes delayed create writes until the bootstrap turn claims native identity", async () => {
+    const root = await mkdtemp(path.join(os.tmpdir(), "codexhost-harness-broker-"));
+    roots.push(root);
+    const otherCwd = path.join(root, "other-cwd");
+    await mkdir(otherCwd);
+    const descriptorPath = path.join(root, "broker-v1.json");
+    const socketPath =
+      process.platform === "win32"
+        ? `\\\\.\\pipe\\codexhost-harness-broker-${process.pid}-${randomUUID()}`
+        : path.join(root, "broker.sock");
+    const harnessId = harnessIdSchema.parse("claude-code");
+    const fixture = new FakeHarnessAdapter(harnessId);
+    const model = fixture.catalog.defaultModel ?? fixture.catalog.models[0]?.ref;
+    if (!model) throw new Error("fixture Model is unavailable");
+    const nativeRef = {
+      harnessId,
+      nativeSessionId: "delayed-create-native-session",
+      formatVersion: 1 as const,
+    };
+    const channel = new HarnessOutputChannel<HarnessOutput>();
+    const baseline = new FakeHarnessSession(
+      harnessId,
+      fixture.catalog,
+      model,
+      nativeRef,
+      { turns: [] },
+      true,
+      root,
+    );
+    const execute = vi.fn(async (command: HostCommand) => {
+      if (command.type === "turn.start") {
+        channel.emit({
+          kind: "event",
+          event: {
+            type: "session.state.changed",
+            state: { nativeRef, effectiveModel: model },
+          },
+        });
+        channel.emit({ kind: "event", event: { type: "turn.started", turnId: command.turnId } });
+        return { ok: true, value: { turnId: command.turnId } };
+      }
+      if (command.type === "turn.cancel") {
+        return { ok: true, value: { cancellationRequested: true } };
+      }
+      if (command.type === "interaction.respond") {
+        return { ok: true, value: { accepted: true } };
+      }
+      return { ok: true, value: { completed: true } };
+    });
+    const nativeSession: HarnessSession = {
+      harnessId,
+      capabilities: baseline.capabilities,
+      initialState: {},
+      initialUsage: null,
+      outputs: channel.outputs,
+      execute: execute as HarnessSession["execute"],
+      readSnapshot: async () => ({ ok: true, value: { turns: [], state: { nativeRef } } }),
+      close: async () => channel.end(),
+    };
+    const openStarted = deferred();
+    const releaseOpen = deferred();
+    const open = vi.fn(async () => {
+      openStarted.resolve();
+      await releaseOpen.promise;
+      return { ok: true as const, value: nativeSession };
+    });
+    const native: HarnessAdapter = {
+      harnessId,
+      inspect: (input) => fixture.inspect(input),
+      open,
+      close: () => nativeSession.close(),
+    };
+    const server = await startHarnessBrokerServer({ descriptorPath, socketPath, adapter: native });
+    const firstAdapter = new BrokeredHarnessAdapter({ descriptorPath });
+    const firstOpen = firstAdapter.open({ kind: "create", cwd: root });
+    await openStarted.promise;
+    const secondAdapter = new BrokeredHarnessAdapter({ descriptorPath });
+    const resumeWhileNativeOpenIsPending = secondAdapter.open({
+      kind: "resume",
+      cwd: otherCwd,
+      nativeRef,
+    });
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    expect(open).toHaveBeenCalledTimes(1);
+    releaseOpen.resolve();
+    const first = await firstOpen;
+    if (!first.ok) throw new Error(first.error.message);
+    expect(first.value.initialState.nativeRef).toBeUndefined();
+    const output = first.value.outputs[Symbol.asyncIterator]();
+    await expect(first.value.execute({ type: "model.select", model })).resolves.toMatchObject({
+      ok: false,
+      error: { code: "sessionBusy", stage: "harnessBroker.identity" },
+    });
+    expect(execute).not.toHaveBeenCalled();
+
+    await expect(resumeWhileNativeOpenIsPending).resolves.toMatchObject({
+      ok: false,
+      error: { code: "sessionBusy" },
+    });
+    await expect(secondAdapter.open({ kind: "create", cwd: otherCwd })).resolves.toMatchObject({
+      ok: false,
+      error: { code: "sessionBusy" },
+    });
+    expect(open).toHaveBeenCalledTimes(1);
+
+    await expect(
+      first.value.execute({
+        type: "turn.start",
+        turnId: hostTurnIdSchema.parse("bootstrap-identity-turn"),
+        input: [{ type: "text", text: "claim identity" }],
+      }),
+    ).resolves.toEqual({ ok: true, value: { turnId: "bootstrap-identity-turn" } });
+    await expect(output.next()).resolves.toMatchObject({
+      value: {
+        kind: "event",
+        event: { type: "session.state.changed", state: { nativeRef } },
+      },
+    });
+    await expect(
+      secondAdapter.open({ kind: "resume", cwd: otherCwd, nativeRef }),
+    ).resolves.toMatchObject({ ok: false, error: { code: "sessionBusy" } });
+    expect(open).toHaveBeenCalledTimes(1);
+    await expect(first.value.execute({ type: "model.select", model })).resolves.toEqual({
+      ok: true,
+      value: { completed: true },
+    });
+
+    await first.value.close();
+    await firstAdapter.close();
+    await secondAdapter.close();
+    await server.close();
+  });
+
+  it("drops delayed output from the retired generation without closing its replacement", async () => {
+    const root = await mkdtemp(path.join(os.tmpdir(), "codexhost-harness-broker-"));
+    roots.push(root);
+    const descriptorPath = path.join(root, "broker-v1.json");
+    const socketPath =
+      process.platform === "win32"
+        ? `\\\\.\\pipe\\codexhost-harness-broker-${process.pid}-${randomUUID()}`
+        : path.join(root, "broker.sock");
+    const harnessId = harnessIdSchema.parse("claude-code");
+    const fixture = new FakeHarnessAdapter(harnessId);
+    const nativeRef = {
+      harnessId,
+      nativeSessionId: "generation-race-native-session",
+      formatVersion: 1 as const,
+    };
+    const staleGate = deferred();
+    const sessions: FakeHarnessSession[] = [];
+    const open = vi.fn(async () => {
+      const session = new FakeHarnessSession(
+        harnessId,
+        fixture.catalog,
+        undefined,
+        nativeRef,
+        { turns: [] },
+        true,
+        root,
+      );
+      if (sessions.length === 0) {
+        const originalOutputs = session.outputs;
+        const delayedOutputs: AsyncIterable<HarnessOutput> = {
+          async *[Symbol.asyncIterator]() {
+            for await (const output of originalOutputs) yield output;
+            await staleGate.promise;
+            yield {
+              kind: "event",
+              event: {
+                type: "session.faulted",
+                error: {
+                  code: "nativeFailure",
+                  message: "stale output from retired native child",
+                  retryable: true,
+                },
+              },
+            };
+          },
+        };
+        Object.defineProperty(session, "outputs", { value: delayedOutputs, configurable: true });
+      }
+      sessions.push(session);
+      return { ok: true as const, value: session };
+    });
+    const native: HarnessAdapter = {
+      harnessId,
+      inspect: (input) => fixture.inspect(input),
+      open,
+      close: async () =>
+        Promise.all(sessions.map((session) => session.close())).then(() => undefined),
+    };
+    const server = await startHarnessBrokerServer({ descriptorPath, socketPath, adapter: native });
+    const adapter = new BrokeredHarnessAdapter({ descriptorPath });
+    const opened = await adapter.open({ kind: "create", cwd: root });
+    if (!opened.ok) throw new Error(opened.error.message);
+    const output = opened.value.outputs[Symbol.asyncIterator]();
+    const firstNativeSession = sessions[0];
+    if (!firstNativeSession) throw new Error("first native Session is unavailable");
+    firstNativeSession.fault({
+      code: "authenticationRequired",
+      message: "native login changed",
+      retryable: true,
+    });
+    await expect(output.next()).resolves.toMatchObject({
+      value: { kind: "event", event: { type: "session.faulted" } },
+    });
+
+    const secondTurn = opened.value.execute({
+      type: "turn.start",
+      turnId: hostTurnIdSchema.parse("generation-race-second-turn"),
+      input: [{ type: "text", text: "explicit reopen" }],
+    });
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    expect(open).toHaveBeenCalledTimes(1);
+    staleGate.resolve();
+    await expect(secondTurn).resolves.toMatchObject({ ok: true });
+    expect(open).toHaveBeenCalledTimes(2);
+    const replacement = sessions[1];
+    if (!replacement) throw new Error("replacement native Session is unavailable");
+    replacement.succeedTurn();
+
+    await expect(
+      opened.value.execute({
+        type: "turn.start",
+        turnId: hostTurnIdSchema.parse("generation-race-third-turn"),
+        input: [{ type: "text", text: "replacement remains active" }],
+      }),
+    ).resolves.toMatchObject({ ok: true });
+    expect(open).toHaveBeenCalledTimes(2);
+
+    await opened.value.close();
+    await adapter.close();
+    await server.close();
+  });
+
+  it("reopens once after a terminal authentication failure and restores selection", async () => {
+    const root = await mkdtemp(path.join(os.tmpdir(), "codexhost-harness-broker-"));
+    roots.push(root);
+    const descriptorPath = path.join(root, "broker-v1.json");
+    const socketPath =
+      process.platform === "win32"
+        ? `\\\\.\\pipe\\codexhost-harness-broker-${process.pid}-${randomUUID()}`
+        : path.join(root, "broker.sock");
+    const harnessId = harnessIdSchema.parse("claude-code");
+    const permissionModes = harnessPermissionModeCatalogSchema.parse({
+      modes: [
+        { id: "ask", label: "Ask", description: "Ask before native actions" },
+        { id: "bypass", label: "Bypass", description: "Use native bypass mode" },
+      ],
+      defaultModeId: "ask",
+    });
+    const fixture = new FakeHarnessAdapter(harnessId, undefined, true, true, null, permissionModes);
+    const nativeRef = {
+      harnessId,
+      nativeSessionId: "native-session-preserved",
+      formatVersion: 1 as const,
+    };
+    const sessions: FakeHarnessSession[] = [];
+    const open = vi.fn(async () => {
+      const session = new FakeHarnessSession(
+        harnessId,
+        fixture.catalog,
+        undefined,
+        nativeRef,
+        { turns: [] },
+        true,
+        root,
+        true,
+        undefined,
+        null,
+        permissionModes,
+        permissionModes.defaultModeId,
+      );
+      sessions.push(session);
+      return { ok: true as const, value: session };
+    });
+    const native: HarnessAdapter = {
+      harnessId,
+      inspect: (input) => fixture.inspect(input),
+      open,
+      close: async () =>
+        Promise.all(sessions.map((session) => session.close())).then(() => undefined),
+    };
+    const server = await startHarnessBrokerServer({ descriptorPath, socketPath, adapter: native });
+    const adapter = new BrokeredHarnessAdapter({ descriptorPath });
+    const opened = await adapter.open({ kind: "create", cwd: root });
+    if (!opened.ok) throw new Error(opened.error.message);
+    const outputs = opened.value.outputs[Symbol.asyncIterator]();
+    const selectedModel = fixture.catalog.models[1];
+    const selectedThinking = fixture.catalog.thinkingOptions[1];
+    const selectedPermission = permissionModes.modes[1];
+    const firstNativeSession = sessions[0];
+    if (!selectedModel || !selectedThinking || !selectedPermission || !firstNativeSession) {
+      throw new Error("fixture selection is unavailable");
+    }
+    await opened.value.execute({ type: "model.select", model: selectedModel.ref });
+    await opened.value.execute({
+      type: "thinking.select",
+      thinkingOptionId: selectedThinking.id,
+    });
+    await opened.value.execute({
+      type: "permissionMode.select",
+      permissionModeId: selectedPermission.id,
+    });
+    const failedTurnId = hostTurnIdSchema.parse("broker-auth-failed-turn");
+    await opened.value.execute({
+      type: "turn.start",
+      turnId: failedTurnId,
+      input: [{ type: "text", text: "first turn sees expired OAuth" }],
+    });
+    firstNativeSession.failTurn({
+      code: "authenticationRequired",
+      message: "OAuth session expired and could not be refreshed",
+      retryable: true,
+    });
+    let observedAuthenticationTerminal = false;
+    for (let index = 0; index < 10 && !observedAuthenticationTerminal; index += 1) {
+      const next = await outputs.next();
+      observedAuthenticationTerminal =
+        !next.done &&
+        next.value.kind === "event" &&
+        next.value.event.type === "turn.completed" &&
+        next.value.event.turnId === failedTurnId &&
+        next.value.event.outcome.status === "failed" &&
+        next.value.event.outcome.error.code === "authenticationRequired";
+    }
+    expect(observedAuthenticationTerminal).toBe(true);
+
+    await expect(
+      opened.value.execute({
+        type: "turn.start",
+        turnId: hostTurnIdSchema.parse("broker-reopen-turn"),
+        input: [{ type: "text", text: "resume after login" }],
+      }),
+    ).resolves.toEqual({ ok: true, value: { turnId: "broker-reopen-turn" } });
+    expect(open).toHaveBeenCalledTimes(2);
+    expect(sessions[1]?.state.nativeRef).toEqual(nativeRef);
+    expect(sessions[1]?.state.effectiveModel).toEqual(selectedModel.ref);
+    expect(sessions[1]?.state.effectiveThinkingOptionId).toBe(selectedThinking.id);
+    expect(sessions[1]?.state.effectivePermissionModeId).toBe(selectedPermission.id);
+    expect(opened.value.initialState.nativeRef).toEqual(nativeRef);
+
+    await opened.value.close();
+    await adapter.close();
+    await server.close();
+  });
+});

--- a/packages/harness-broker/tsconfig.json
+++ b/packages/harness-broker/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "composite": true,
+    "types": ["node"],
+    "rootDir": "src",
+    "outDir": "dist",
+    "tsBuildInfoFile": "dist/tsconfig.tsbuildinfo"
+  },
+  "references": [
+    { "path": "../shared-contracts/tsconfig.json" },
+    { "path": "../harness-adapter/tsconfig.json" }
+  ],
+  "include": ["src/**/*.ts"]
+}

--- a/packages/host-runtime/package.json
+++ b/packages/host-runtime/package.json
@@ -25,6 +25,7 @@
     "@codexhost/adapter-omp": "0.0.0",
     "@codexhost/desktop-control": "0.0.0",
     "@codexhost/harness-adapter": "0.0.0",
+    "@codexhost/harness-broker": "0.0.0",
     "@codexhost/mapping-store": "0.0.0",
     "@codexhost/protocol-core": "0.0.0",
     "@codexhost/shared-contracts": "0.0.0",

--- a/packages/host-runtime/scripts/build-release.mjs
+++ b/packages/host-runtime/scripts/build-release.mjs
@@ -52,6 +52,7 @@ export function auditHostBundleMetafile(metafile) {
     "/packages/host-runtime/src/remote-app-server.ts/",
     "/packages/host-runtime/src/remote-control-app-server.ts/",
     "/packages/host-runtime/src/remote-socket-lock.ts/",
+    "/packages/harness-broker/",
     "/packages/adapters/pi/",
     "/packages/adapters/claude-code/",
     "/packages/adapters/deepseek-harness/",

--- a/packages/host-runtime/src/adapter-composition.ts
+++ b/packages/host-runtime/src/adapter-composition.ts
@@ -4,6 +4,7 @@ import { GrokAdapter } from "@codexhost/adapter-grok";
 import { OpenCodeAdapter } from "@codexhost/adapter-opencode";
 import { PiAdapter } from "@codexhost/adapter-pi";
 import { OmpAdapter } from "@codexhost/adapter-omp";
+import { BrokeredHarnessAdapter } from "@codexhost/harness-broker";
 import type { HarnessAdapter } from "@codexhost/harness-adapter";
 import type { ExternalHarnessId } from "@codexhost/protocol-core";
 
@@ -29,7 +30,24 @@ export async function prefetchClaudeCodeModelCatalog(
 
 export function createExternalHarnessAdapters(
   environment: NodeJS.ProcessEnv,
+  options: {
+    platform?: NodeJS.Platform;
+    managedRemoteHost?: boolean;
+    brokerDescriptorPath?: string;
+  } = {},
 ): ReadonlyMap<ExternalHarnessId, HarnessAdapter> {
+  const claudeAdapter =
+    (options.platform ?? process.platform) === "darwin" && options.managedRemoteHost === true
+      ? new BrokeredHarnessAdapter({
+          environment,
+          ...(options.brokerDescriptorPath ? { descriptorPath: options.brokerDescriptorPath } : {}),
+        })
+      : new ClaudeCodeAdapter({
+          ...(environment[CLAUDE_CODE_COMMAND_ENV]
+            ? { command: environment[CLAUDE_CODE_COMMAND_ENV] }
+            : {}),
+          environment,
+        });
   return new Map<ExternalHarnessId, HarnessAdapter>([
     [
       "pi",
@@ -38,15 +56,7 @@ export function createExternalHarnessAdapters(
         environment,
       }),
     ],
-    [
-      "claude-code",
-      new ClaudeCodeAdapter({
-        ...(environment[CLAUDE_CODE_COMMAND_ENV]
-          ? { command: environment[CLAUDE_CODE_COMMAND_ENV] }
-          : {}),
-        environment,
-      }),
-    ],
+    ["claude-code", claudeAdapter],
     [
       "deepseek-harness",
       new DeepSeekHarnessAdapter({

--- a/packages/host-runtime/src/aqua-harness-broker.ts
+++ b/packages/host-runtime/src/aqua-harness-broker.ts
@@ -1,0 +1,56 @@
+import { ClaudeCodeAdapter } from "@codexhost/adapter-claude-code";
+import {
+  defaultHarnessBrokerDescriptorPath,
+  defaultHarnessBrokerSocketPath,
+  startHarnessBrokerServer,
+  type HarnessBrokerServer,
+} from "@codexhost/harness-broker";
+
+import { CLAUDE_CODE_COMMAND_ENV } from "./adapter-composition.js";
+
+export async function runClaudeAquaHarnessBroker(
+  environment: NodeJS.ProcessEnv = process.env,
+): Promise<number> {
+  if (process.platform !== "darwin") {
+    throw new Error("Claude Aqua Harness broker is available only on macOS");
+  }
+  const adapter = new ClaudeCodeAdapter({
+    ...(environment[CLAUDE_CODE_COMMAND_ENV]
+      ? { command: environment[CLAUDE_CODE_COMMAND_ENV] }
+      : {}),
+    environment,
+  });
+  let server: HarnessBrokerServer;
+  try {
+    server = await startHarnessBrokerServer({
+      descriptorPath: defaultHarnessBrokerDescriptorPath(environment),
+      socketPath: defaultHarnessBrokerSocketPath(environment),
+      adapter,
+    });
+  } catch (error) {
+    await adapter.close().catch(() => undefined);
+    throw error;
+  }
+  process.title = "codexhost claude-code Aqua harness broker";
+  process.stdout.write(
+    `${JSON.stringify({
+      method: "codexhost/harness-broker/ready",
+      params: { protocolVersion: 1, harnessId: "claude-code" },
+    })}\n`,
+  );
+  let stop: (() => void) | undefined;
+  try {
+    await new Promise<void>((resolve) => {
+      stop = resolve;
+      process.once("SIGINT", resolve);
+      process.once("SIGTERM", resolve);
+    });
+    return 0;
+  } finally {
+    if (stop) {
+      process.removeListener("SIGINT", stop);
+      process.removeListener("SIGTERM", stop);
+    }
+    await server.close();
+  }
+}

--- a/packages/host-runtime/src/index.ts
+++ b/packages/host-runtime/src/index.ts
@@ -6,6 +6,7 @@ import { packageMetadata as piAdapter } from "@codexhost/adapter-pi";
 import { packageMetadata as ompAdapter } from "@codexhost/adapter-omp";
 import { packageMetadata as desktopControl } from "@codexhost/desktop-control";
 import { packageMetadata as harnessAdapter } from "@codexhost/harness-adapter";
+import { packageMetadata as harnessBroker } from "@codexhost/harness-broker";
 import { packageMetadata as mappingStore } from "@codexhost/mapping-store";
 import { packageMetadata as protocolCore } from "@codexhost/protocol-core";
 import { packageMetadata as sharedContracts } from "@codexhost/shared-contracts";
@@ -62,6 +63,7 @@ export type {
   ThreadWaitInput,
 } from "./delegation-types.js";
 export { hasLauncherManagedUpdateRuntime, runHostRuntime } from "./run-host-runtime.js";
+export { runClaudeAquaHarnessBroker } from "./aqua-harness-broker.js";
 export {
   REMOTE_CONTROL_BRIDGE_DESCRIPTOR_FILE,
   createRemoteControlAppServerPlan,
@@ -117,6 +119,7 @@ export const packageMetadata = {
     deepSeekHarnessAdapter.name,
     desktopControl.name,
     harnessAdapter.name,
+    harnessBroker.name,
     grokAdapter.name,
     mappingStore.name,
     piAdapter.name,

--- a/packages/host-runtime/src/main.ts
+++ b/packages/host-runtime/src/main.ts
@@ -2,13 +2,16 @@ import { runDelegationCli } from "./delegation-cli.js";
 import { runHostRuntime } from "./run-host-runtime.js";
 import { runRemoteControlAppServerBridge } from "./remote-control-app-server.js";
 import { runRemoteHostCli } from "./remote-host-cli.js";
+import { runClaudeAquaHarnessBroker } from "./aqua-harness-broker.js";
 
 const arguments_ = process.argv.slice(2);
 process.exitCode =
   arguments_[0] === "--codexhost-delegation-cli"
     ? await runDelegationCli({ arguments: arguments_.slice(1), environment: process.env })
-    : arguments_[0] === "--codexhost-remote"
-      ? await runRemoteHostCli({ arguments: arguments_.slice(1), environment: process.env })
-      : arguments_[0] === "--codexhost-remote-control-bridge"
-        ? await runRemoteControlAppServerBridge()
-        : await runHostRuntime({ arguments: arguments_, environment: process.env });
+    : arguments_[0] === "--codexhost-harness-broker"
+      ? await runClaudeAquaHarnessBroker(process.env)
+      : arguments_[0] === "--codexhost-remote"
+        ? await runRemoteHostCli({ arguments: arguments_.slice(1), environment: process.env })
+        : arguments_[0] === "--codexhost-remote-control-bridge"
+          ? await runRemoteControlAppServerBridge()
+          : await runHostRuntime({ arguments: arguments_, environment: process.env });

--- a/packages/host-runtime/src/release-main.ts
+++ b/packages/host-runtime/src/release-main.ts
@@ -2,17 +2,20 @@ import { runDelegationCli } from "./delegation-cli.js";
 import { runHostRuntime } from "./run-host-runtime.js";
 import { runRemoteControlAppServerBridge } from "./remote-control-app-server.js";
 import { runRemoteHostCli } from "./remote-host-cli.js";
+import { runClaudeAquaHarnessBroker } from "./aqua-harness-broker.js";
 
 const arguments_ = process.argv.slice(2);
 process.exitCode =
   arguments_[0] === "--codexhost-delegation-cli"
     ? await runDelegationCli({ arguments: arguments_.slice(1), environment: process.env })
-    : arguments_[0] === "--codexhost-remote"
-      ? await runRemoteHostCli({ arguments: arguments_.slice(1), environment: process.env })
-      : arguments_[0] === "--codexhost-remote-control-bridge"
-        ? await runRemoteControlAppServerBridge()
-        : await runHostRuntime({
-            arguments: arguments_,
-            environment: process.env,
-            hostRuntimeUrl: import.meta.url,
-          });
+    : arguments_[0] === "--codexhost-harness-broker"
+      ? await runClaudeAquaHarnessBroker(process.env)
+      : arguments_[0] === "--codexhost-remote"
+        ? await runRemoteHostCli({ arguments: arguments_.slice(1), environment: process.env })
+        : arguments_[0] === "--codexhost-remote-control-bridge"
+          ? await runRemoteControlAppServerBridge()
+          : await runHostRuntime({
+              arguments: arguments_,
+              environment: process.env,
+              hostRuntimeUrl: import.meta.url,
+            });

--- a/packages/host-runtime/src/run-host-runtime.ts
+++ b/packages/host-runtime/src/run-host-runtime.ts
@@ -284,7 +284,9 @@ export async function runHostRuntime(input: {
         socketPath,
         diagnosticOutput: process.stderr,
         createSession: ({ input: desktopInput, output: desktopOutput, diagnosticOutput }) => {
-          const externalAdapters = createExternalHarnessAdapters(delegationEnvironment);
+          const externalAdapters = createExternalHarnessAdapters(delegationEnvironment, {
+            managedRemoteHost: true,
+          });
           void prefetchClaudeCodeModelCatalog(externalAdapters);
           return new AppServerHost({
             stockCodexPath,

--- a/packages/host-runtime/test/adapter-composition.test.ts
+++ b/packages/host-runtime/test/adapter-composition.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
+import path from "node:path";
 
 import type { HarnessInspection } from "@codexhost/harness-adapter";
 import {
@@ -90,6 +91,24 @@ describe("Host external Harness composition", () => {
     await expect(adapters.get("opencode")?.inspect()).resolves.toMatchObject({
       status: "notInstalled",
       error: { code: "notInstalled" },
+    });
+    await Promise.all([...adapters.values()].map((adapter) => adapter.close()));
+  });
+
+  it("fails closed when a managed macOS SSH Host cannot reach the Aqua broker", async () => {
+    const descriptorPath = path.join(
+      process.cwd(),
+      ".missing-fixture",
+      "claude-code-broker-v1.json",
+    );
+    const adapters = createExternalHarnessAdapters(
+      { PATH: "", CODEXHOST_CLAUDE_COMMAND: "/must/not/spawn/in/background" },
+      { platform: "darwin", managedRemoteHost: true, brokerDescriptorPath: descriptorPath },
+    );
+
+    await expect(adapters.get("claude-code")?.inspect()).resolves.toMatchObject({
+      status: "unavailable",
+      error: { code: "unavailable", stage: "harnessBroker" },
     });
     await Promise.all([...adapters.values()].map((adapter) => adapter.close()));
   });

--- a/packages/host-runtime/test/index.test.ts
+++ b/packages/host-runtime/test/index.test.ts
@@ -5,7 +5,7 @@ import { classifyCreateRequestRoute, packageMetadata } from "../src/index.js";
 
 describe("host-runtime package", () => {
   it("declares the composition-root dependencies", () => {
-    expect(packageMetadata.dependencies).toHaveLength(12);
+    expect(packageMetadata.dependencies).toHaveLength(13);
     expect(packageMetadata.dependencies).toContain("@codexhost/protocol-core");
     expect(packageMetadata.dependencies).toContain("@codexhost/adapter-claude-code");
     expect(packageMetadata.dependencies).toContain("@codexhost/adapter-deepseek-harness");
@@ -13,6 +13,7 @@ describe("host-runtime package", () => {
     expect(packageMetadata.dependencies).toContain("@codexhost/adapter-opencode");
     expect(packageMetadata.dependencies).toContain("@codexhost/adapter-omp");
     expect(packageMetadata.dependencies).toContain("@codexhost/harness-adapter");
+    expect(packageMetadata.dependencies).toContain("@codexhost/harness-broker");
     expect(packageMetadata.dependencies).toContain("@codexhost/shared-contracts");
     expect(packageMetadata.dependencies).toContain("@codexhost/update-manager");
   });

--- a/packages/host-runtime/tsconfig.json
+++ b/packages/host-runtime/tsconfig.json
@@ -10,6 +10,7 @@
   "references": [
     { "path": "../desktop-control/tsconfig.json" },
     { "path": "../harness-adapter/tsconfig.json" },
+    { "path": "../harness-broker/tsconfig.json" },
     { "path": "../mapping-store/tsconfig.json" },
     { "path": "../protocol-core/tsconfig.json" },
     { "path": "../shared-contracts/tsconfig.json" },

--- a/scripts/release/prepare-npm-meta.mjs
+++ b/scripts/release/prepare-npm-meta.mjs
@@ -58,9 +58,13 @@ npm automatically installs the matching macOS, Windows, or Linux platform packag
 \`\`\`bash
 codexhost --version
 codexhost
+codexhost remote install
+codexhost remote status
 \`\`\`
 
 The \`codexhost\` command starts Codex Desktop. On macOS and Linux it returns immediately while the packaged Launcher keeps supervising in the background. On Windows, the command remains attached until Codex Desktop exits so shells that clean up process trees of completed commands cannot discard the supervisor. Re-running \`codexhost\` attaches to the same controlled instance.
+
+On macOS, \`remote install\` installs a current-user Aqua Harness broker so Background SSH Hosts can use native Claude Code login without reading, copying, or unlocking Keychain credentials.
 
 If installation used \`--omit=optional\`, reinstall without that option so npm can select the native package for the current architecture.
 `;

--- a/scripts/release/prepare-npm.mjs
+++ b/scripts/release/prepare-npm.mjs
@@ -430,6 +430,7 @@ if (updateEnvironment.CODEXHOST_REMOTE_SSH_MANAGED === "1") {
 
 let launchArguments;
 let remoteArguments = null;
+let brokerArguments = null;
 let delegationArguments = null;
 if (userArguments.length === 0) {
   launchArguments = ["launch"];
@@ -440,6 +441,9 @@ if (userArguments.length === 0) {
 } else if (userArguments[0] === "remote") {
   launchArguments = null;
   remoteArguments = userArguments.slice(1);
+} else if (userArguments[0] === "broker") {
+  launchArguments = null;
+  brokerArguments = userArguments.slice(1);
 } else if (
   userArguments[0] === "harness" ||
   userArguments[0] === "delegate" ||
@@ -456,6 +460,7 @@ if (userArguments.length === 0) {
       "  codexhost inspect",
       "  codexhost launch [launcher options]",
       "  codexhost remote install|start|stop|status|uninstall",
+      "  codexhost broker install|status|stop|uninstall",
       "  codexhost delegate --help",
       "  codexhost harness inspect ...",
       "  codexhost delegate start ...",
@@ -519,7 +524,50 @@ if (delegationArguments !== null) {
     }
     process.exit(code ?? 1);
   });
+} else if (brokerArguments !== null) {
+  const child = spawn(
+    launcher,
+    [
+      "broker",
+      ...brokerArguments,
+      "--node", process.execPath, "--host-runtime", hostRuntime,
+    ],
+    {
+      env: updateEnvironment,
+      stdio: "inherit",
+      windowsHide: true,
+    },
+  );
+  child.on("error", (error) => fail(error.message));
+  child.on("exit", (code, signal) => {
+    if (signal) {
+      process.kill(process.pid, signal);
+      return;
+    }
+    process.exit(code ?? 1);
+  });
 } else if (remoteArguments !== null) {
+  const runNativeBroker = (command) => {
+    const broker = spawn(
+      launcher,
+      ["broker", command, "--node", process.execPath, "--host-runtime", hostRuntime],
+      {
+        env: updateEnvironment,
+        // remote status is a stable JSON stdout surface. Keep the broker's
+        // human-readable status beside it on stderr instead of corrupting JSON.
+        stdio: command === "status" ? ["inherit", process.stderr, "inherit"] : "inherit",
+        windowsHide: true,
+      },
+    );
+    broker.on("error", (error) => fail(error.message));
+    broker.on("exit", (code, signal) => {
+      if (signal) {
+        process.kill(process.pid, signal);
+        return;
+      }
+      process.exit(code ?? 1);
+    });
+  };
   const child = spawn(
     process.execPath,
     [
@@ -544,6 +592,20 @@ if (delegationArguments !== null) {
     if (signal) {
       process.kill(process.pid, signal);
       return;
+    }
+    if (code === 0 && process.platform === "darwin") {
+      if (remoteArguments[0] === "install") {
+        runNativeBroker("install");
+        return;
+      }
+      if (remoteArguments[0] === "status") {
+        runNativeBroker("status");
+        return;
+      }
+      if (remoteArguments[0] === "uninstall") {
+        runNativeBroker("uninstall");
+        return;
+      }
     }
     process.exit(code ?? 1);
   });
@@ -644,6 +706,7 @@ codexhost remote start
 codexhost remote stop
 codexhost remote status
 codexhost remote uninstall
+codexhost broker status
 \`\`\`
 
 The \`codexhost\` command launches the packaged Rust launcher with:
@@ -661,6 +724,7 @@ The \`codexhost\` command launches the packaged Rust launcher with:
 ## Notes
 
 - This npm package does **not** embed a private Node.js runtime.
+- On macOS, \`remote install\` manages the current-user Aqua Harness broker; it never asks for a Keychain password or copies Claude credentials.
 - Installer packages (DMG/EXE) remain the zero-dependency desktop distribution path.
 - Prefer \`npm install -g ${NPM_PACKAGE_NAME}\` over installing the monorepo root.
 `;

--- a/tests/release/host-bundle.test.mjs
+++ b/tests/release/host-bundle.test.mjs
@@ -46,6 +46,7 @@ function validMetafile(extraInputs = {}) {
       "packages/host-runtime/src/remote-app-server.ts": {},
       "packages/host-runtime/src/remote-control-app-server.ts": {},
       "packages/host-runtime/src/remote-socket-lock.ts": {},
+      "packages/harness-broker/dist/index.js": {},
       "packages/adapters/pi/dist/index.js": {},
       "packages/adapters/claude-code/dist/index.js": {},
       "packages/adapters/deepseek-harness/dist/index.js": {},
@@ -118,6 +119,12 @@ describe("release Host Bundle", () => {
       "missing required input: /packages/adapters/pi/",
     );
 
+    const withoutHarnessBroker = { ...validMetafile().inputs };
+    delete withoutHarnessBroker["packages/harness-broker/dist/index.js"];
+    expect(() => auditHostBundleMetafile({ inputs: withoutHarnessBroker })).toThrow(
+      "missing required input: /packages/harness-broker/",
+    );
+
     const withoutClaude = { ...validMetafile().inputs };
     delete withoutClaude["packages/adapters/claude-code/dist/index.js"];
     expect(() => auditHostBundleMetafile({ inputs: withoutClaude })).toThrow(
@@ -168,6 +175,7 @@ describe("release Host Bundle", () => {
       expect(source).toContain("Claude Code is not installed");
       expect(source).toContain("CODEXHOST_DEEPSEEK_HARNESS_ENDPOINT");
       expect(source).toContain("CODEXHOST_OPENCODE_COMMAND");
+      expect(source).toContain("--codexhost-harness-broker");
       expect(source).not.toContain("claude-agent-sdk-darwin-arm64");
       expect(source).not.toContain("dsh-jsonrpc-agent");
       expect(source).not.toContain("runtime/cordis.yml");

--- a/tests/release/npm-package.test.mjs
+++ b/tests/release/npm-package.test.mjs
@@ -251,6 +251,64 @@ async function runLauncherLifecycle(platform) {
   }
 }
 
+async function runGeneratedWrapperLifecycle(platform, userArguments, exitCodes) {
+  const root = await temporaryDirectory();
+  try {
+    const { launcherPath, npmCliPath } = await createLauncherLifecycleFixture(root, platform);
+    const preloadPath = path.join(root, "remote-broker-preload.mjs");
+    const callsPath = path.join(root, "spawn-calls.jsonl");
+    await writeFile(
+      preloadPath,
+      `import childProcess from "node:child_process";
+import { appendFileSync } from "node:fs";
+import { EventEmitter } from "node:events";
+import { syncBuiltinESMExports } from "node:module";
+
+Object.defineProperty(process, "platform", { configurable: true, value: process.env.CODEXHOST_TEST_PLATFORM });
+Object.defineProperty(process, "arch", { configurable: true, value: "x64" });
+const exitCodes = JSON.parse(process.env.CODEXHOST_TEST_EXIT_CODES);
+let call = 0;
+childProcess.spawn = (command, args, options) => {
+  appendFileSync(process.env.CODEXHOST_TEST_CALLS, JSON.stringify({
+    command,
+    args,
+    stdoutFd: Array.isArray(options?.stdio) ? options.stdio[1]?.fd : null,
+  }) + "\\n");
+  const child = new EventEmitter();
+  const exitCode = exitCodes[call++] ?? 1;
+  setTimeout(() => child.emit("exit", exitCode, null), 5);
+  return child;
+};
+syncBuiltinESMExports();
+`,
+    );
+    const result = spawnSync(
+      process.execPath,
+      ["--import", pathToFileURL(preloadPath).href, launcherPath, ...userArguments],
+      {
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          CODEXHOST_TEST_PLATFORM: platform,
+          CODEXHOST_TEST_CALLS: callsPath,
+          CODEXHOST_TEST_EXIT_CODES: JSON.stringify(exitCodes),
+          npm_execpath: npmCliPath,
+        },
+        timeout: 2_000,
+        windowsHide: true,
+      },
+    );
+    const calls = (await readFile(callsPath, "utf8"))
+      .trim()
+      .split("\n")
+      .filter(Boolean)
+      .map((line) => JSON.parse(line));
+    return { result, calls };
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+}
+
 describe("npm package release", () => {
   it("maps the current host to a release target id", () => {
     expect(hostReleaseTargetId("darwin", "arm64")).toBe("macos-arm64");
@@ -390,6 +448,13 @@ describe("npm package release", () => {
     expect(source).toContain('extras.push("--renderer", rendererExtension)');
     expect(source).toContain('if (launchArguments?.[0] === "launch")');
     expect(source).toContain('userArguments[0] === "remote"');
+    expect(source).toContain('userArguments[0] === "broker"');
+    expect(source).toContain("brokerArguments = userArguments.slice(1)");
+    expect(source).toContain('"--node", process.execPath, "--host-runtime", hostRuntime');
+    expect(source).toContain('remoteArguments[0] === "install"');
+    expect(source).toContain('remoteArguments[0] === "uninstall"');
+    expect(source).toContain('runNativeBroker("install"');
+    expect(source).toContain('runNativeBroker("uninstall"');
     expect(source).toContain('userArguments[0] === "delegate"');
     expect(source).toContain('userArguments[0] === "thread"');
     expect(source).toContain('"--codexhost-delegation-cli"');
@@ -400,6 +465,78 @@ describe("npm package release", () => {
     expect(source).toContain('const readyMarker = "ready\\n"');
     expect(source).toContain("path.dirname(path.dirname(path.resolve(process.argv[1])))");
     expect(source).not.toContain("runtime/node");
+  });
+
+  it("installs the Aqua broker after a successful macOS remote install", async () => {
+    const { result, calls } = await runGeneratedWrapperLifecycle(
+      "darwin",
+      ["remote", "install"],
+      [0, 0],
+    );
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(calls).toHaveLength(2);
+    expect(calls[1].args).toEqual([
+      "broker",
+      "install",
+      "--node",
+      process.execPath,
+      "--host-runtime",
+      expect.stringMatching(/host-runtime\.mjs$/u),
+    ]);
+  });
+
+  it("reports a macOS broker status failure after remote status succeeds", async () => {
+    const { result, calls } = await runGeneratedWrapperLifecycle(
+      "darwin",
+      ["remote", "status"],
+      [0, 9],
+    );
+
+    expect(result.status).toBe(9);
+    expect(calls[1].args.slice(0, 2)).toEqual(["broker", "status"]);
+    expect(calls[1].stdoutFd).toBe(2);
+  });
+
+  it("does not manage an Aqua broker for Linux remote installs", async () => {
+    const { result, calls } = await runGeneratedWrapperLifecycle(
+      "linux",
+      ["remote", "install"],
+      [0],
+    );
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(calls).toHaveLength(1);
+  });
+
+  it("does not install the Aqua broker when remote installation fails", async () => {
+    const { result, calls } = await runGeneratedWrapperLifecycle(
+      "darwin",
+      ["remote", "install"],
+      [7],
+    );
+
+    expect(result.status).toBe(7);
+    expect(calls).toHaveLength(1);
+  });
+
+  it("injects the npm Node and Host Runtime into direct broker status", async () => {
+    const { result, calls } = await runGeneratedWrapperLifecycle(
+      "darwin",
+      ["broker", "status"],
+      [0],
+    );
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(calls).toHaveLength(1);
+    expect(calls[0].args).toEqual([
+      "broker",
+      "status",
+      "--node",
+      process.execPath,
+      "--host-runtime",
+      expect.stringMatching(/host-runtime\.mjs$/u),
+    ]);
   });
 
   it("keeps Windows launcher supervision alive after the ready handshake", async () => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,6 +3,7 @@
   "references": [
     { "path": "./packages/shared-contracts/tsconfig.json" },
     { "path": "./packages/harness-adapter/tsconfig.json" },
+    { "path": "./packages/harness-broker/tsconfig.json" },
     { "path": "./packages/harness-discovery/tsconfig.json" },
     { "path": "./packages/mapping-store/tsconfig.json" },
     { "path": "./packages/protocol-core/tsconfig.json" },


### PR DESCRIPTION
## Summary

Managed macOS SSH Hosts run in a detached Background audit session, while native Claude Code login and Keychain access belong to the logged-in Aqua session. Launching Claude directly from the remote Host therefore makes a valid native login appear expired.

This change adds a current-user Aqua Harness broker and routes Claude Code through it only for managed macOS remote Hosts.

## Design

- installs `ai.bytepioneer.codexhost.native-harness-broker` in the current non-root `gui/<uid>` Aqua domain;
- runs the packaged Host Runtime with the caller's explicit npm Node path, so npm packages do not assume a bundled Node runtime;
- exposes an owner-only Unix socket and owner-only descriptor with a fresh generation and 256-bit capability;
- rejects symlinks, foreign ownership, unsafe file modes, stale endpoints, replayed/out-of-sequence frames, oversized frames, and overfull request queues;
- strips remote per-session environment data and persists only the reviewed proxy allowlist, never Claude/OAuth/Keychain values;
- keeps native Claude session identity, model, thinking, permission mode, and writer ownership across bounded authentication recovery;
- retires and awaits old output forwarders before reopen so stale output cannot be relabeled as the replacement generation;
- reserves known and delayed native writers before awaiting native open, closing cross-cwd and concurrent-open races;
- adds `codexhost broker install|status|stop|uninstall` and composes broker lifecycle with macOS `remote install|status|uninstall`;
- keeps `remote status` machine-readable JSON on stdout and sends broker status diagnostics to stderr.

The Background Host never unlocks Keychain, asks for a password, copies Claude credentials, changes `~/.claude`, or proxies Claude through OpenCodex.

## Validation

- `npm run check`
  - formatting, lint, boundary checks, and typecheck passed;
  - TypeScript: 174 files passed, 1 skipped; 1507 tests passed, 16 skipped;
  - Clippy with `-D warnings` passed;
  - full Rust workspace tests passed.
- Focused broker/release tests include:
  - stale output after reopen;
  - same native session across different cwd values;
  - pre-await known-native open reservation;
  - delayed create identity and bootstrap-turn reservation;
  - packed-frame queue overflow;
  - descriptor/socket mode and replacement checks;
  - macOS LaunchAgent directory/plist hardening;
  - npm wrapper lifecycle and JSON stdout compatibility.
- Live macOS arm64 candidate `0.4.0-main.38dbcbb.1`:
  - LaunchAgent, descriptor, plist, and socket ownership/modes verified;
  - broker ran in Aqua ASID `100015` while the managed SSH Host ran in Background ASID `305362`;
  - exactly one managed remote Host chain survived the reconnect and an 8-second stability window;
  - Host-level `codexhost/harness/inspect` returned 5 native Claude models and 5 native permission modes;
  - an ephemeral Host-routed Claude thread completed with exact reply `HOST_BROKER_OK`;
  - no Keychain prompt or Claude configuration change was used.

## Rollback

The candidate is versioned independently. `broker uninstall` removes the LaunchAgent, and the prior `0.4.0` candidate plus pre-switch remote shim/manifest backup remain available for a controlled rollback.