### PR TITLE
fix: retry transient Windows process identity reads

### DIFF
--- a/crates/platform/src/lib.rs
+++ b/crates/platform/src/lib.rs
@@ -50,7 +50,7 @@ pub use process::{
     process_exists, process_snapshot, terminate_process_by_id,
 };
 #[cfg(target_os = "windows")]
-pub use process::{desktop_process_ids, desktop_root_process_ids};
+pub use process::{desktop_process_ids, desktop_root_process_ids, process_started_at_micros};
 #[cfg(any(target_os = "macos", target_os = "linux"))]
 pub use process::{
     desktop_process_tree, desktop_root_snapshots_for_installation, process_snapshots,
@@ -145,6 +145,11 @@ pub enum PlatformError {
     NotFound(String),
     UnmanagedDesktopConflict,
     Invalid(String),
+    ProcessInspection {
+        process_id: u32,
+        operation: &'static str,
+        source: io::Error,
+    },
     Io(io::Error),
 }
 
@@ -157,12 +162,27 @@ impl Display for PlatformError {
                 "Codex Desktop is already running outside codexhost; completely quit it before starting codexhost",
             ),
             Self::Invalid(message) => write!(formatter, "{message}"),
+            Self::ProcessInspection {
+                process_id,
+                operation,
+                source,
+            } => write!(
+                formatter,
+                "{operation} while inspecting PID {process_id}: {source}"
+            ),
             Self::Io(error) => Display::fmt(error, formatter),
         }
     }
 }
 
-impl Error for PlatformError {}
+impl Error for PlatformError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match self {
+            Self::ProcessInspection { source, .. } | Self::Io(source) => Some(source),
+            _ => None,
+        }
+    }
+}
 
 impl From<io::Error> for PlatformError {
     fn from(error: io::Error) -> Self {

--- a/crates/platform/src/process.rs
+++ b/crates/platform/src/process.rs
@@ -135,18 +135,20 @@ pub fn process_snapshot(process_id: u32) -> Result<ProcessSnapshot, PlatformErro
         .find(|process| process.id == process_id)
         .ok_or_else(|| PlatformError::NotFound(format!("cannot inspect PID {process_id}")))?
         .parent_id;
-    let executable = windows_process::process_image_path(process_id).map_err(|error| {
-        PlatformError::Io(std::io::Error::new(
-            error.kind(),
-            format!("read executable while inspecting PID {process_id}: {error}"),
-        ))
+    let executable = windows_process::process_image_path(process_id).map_err(|source| {
+        PlatformError::ProcessInspection {
+            process_id,
+            operation: "read executable",
+            source,
+        }
     })?;
     let started_at_micros =
-        windows_process::process_started_at_micros(process_id).map_err(|error| {
-            PlatformError::Io(std::io::Error::new(
-                error.kind(),
-                format!("read start time while inspecting PID {process_id}: {error}"),
-            ))
+        windows_process::process_started_at_micros(process_id).map_err(|source| {
+            PlatformError::ProcessInspection {
+                process_id,
+                operation: "read start time",
+                source,
+            }
         })?;
     Ok(ProcessSnapshot {
         id: process_id,
@@ -774,6 +776,17 @@ pub fn parent_process_id(_process_id: u32) -> Result<Option<u32>, PlatformError>
 #[cfg(target_os = "windows")]
 pub fn process_executable_path(process_id: u32) -> Result<PathBuf, PlatformError> {
     windows_process::process_image_path(process_id).map_err(PlatformError::Io)
+}
+
+#[cfg(target_os = "windows")]
+pub fn process_started_at_micros(process_id: u32) -> Result<u64, PlatformError> {
+    windows_process::process_started_at_micros(process_id).map_err(|source| {
+        PlatformError::ProcessInspection {
+            process_id,
+            operation: "read start time",
+            source,
+        }
+    })
 }
 
 #[cfg(any(target_os = "macos", target_os = "linux"))]

--- a/crates/shim/src/lib.rs
+++ b/crates/shim/src/lib.rs
@@ -16,6 +16,7 @@ use codexhost_platform::{
 };
 
 mod local_runtime_lease;
+mod process_identity;
 #[cfg(any(target_os = "macos", target_os = "linux"))]
 mod remote_lifecycle;
 

--- a/crates/shim/src/local_runtime_lease.rs
+++ b/crates/shim/src/local_runtime_lease.rs
@@ -13,6 +13,11 @@ use codexhost_platform::{
 };
 use fs2::FileExt;
 
+use crate::process_identity::{
+    RecordedProcessObservation, current_process_snapshot, recorded_process_identity,
+    recorded_process_snapshot,
+};
+
 const OWNER_DIRECTORY_NAME: &str = "local-host-runtime-owner-v1";
 const OWNER_LOCK_NAME: &str = "local-host-runtime-owner.lock";
 const OWNER_RECORD_NAME: &str = "owner";
@@ -582,12 +587,12 @@ fn migrated_owner_record(
 }
 
 fn owner_shim_state(owner: &OwnerRecord) -> Result<OwnerShimState, Box<dyn Error>> {
-    let Some(owner_snapshot) = current_process_snapshot(owner.process_id)? else {
-        return Ok(OwnerShimState::Missing);
-    };
-    if owner_snapshot.started_at_micros != owner.process_started_at_micros {
-        return Ok(OwnerShimState::Reused);
-    }
+    let owner_snapshot =
+        match recorded_process_identity(owner.process_id, owner.process_started_at_micros)? {
+            RecordedProcessObservation::Matching(snapshot) => snapshot,
+            RecordedProcessObservation::Missing => return Ok(OwnerShimState::Missing),
+            RecordedProcessObservation::Reused => return Ok(OwnerShimState::Reused),
+        };
     let current_executable = env::current_exe()?;
     // npm upgrades and candidate packages can move the same Shim to another absolute path.
     // PID plus start time is the process-instance identity. The basename additionally rejects a
@@ -613,10 +618,8 @@ fn retire_legacy_mapping_store_owner(
     let Some(runtime_process_id) = legacy_lock_process_id(&lock_path) else {
         return Ok(());
     };
-    let runtime_snapshot = match process_snapshot(runtime_process_id) {
-        Ok(snapshot) => snapshot,
-        Err(_) if !process_exists(runtime_process_id) => return Ok(()),
-        Err(error) => return Err(error.into()),
+    let Some(runtime_snapshot) = current_process_snapshot(runtime_process_id)? else {
+        return Ok(());
     };
     if !runtime_snapshot
         .executable
@@ -627,10 +630,8 @@ fn retire_legacy_mapping_store_owner(
     }
 
     let shim_process_id = runtime_snapshot.parent_id;
-    let shim_snapshot = match process_snapshot(shim_process_id) {
-        Ok(snapshot) => snapshot,
-        Err(_) if !process_exists(shim_process_id) => return Ok(()),
-        Err(error) => return Err(error.into()),
+    let Some(shim_snapshot) = current_process_snapshot(shim_process_id)? else {
+        return Ok(());
     };
     let current_executable = env::current_exe()?;
     if !executable_file_name_matches(&shim_snapshot.executable, &current_executable) {
@@ -751,27 +752,6 @@ fn wait_for_owner_exit(owner: &OwnerRecord, timeout: Duration) -> Result<bool, B
             return Ok(false);
         }
         thread::sleep(POLL_INTERVAL);
-    }
-}
-
-fn current_process_snapshot(process_id: u32) -> Result<Option<ProcessSnapshot>, Box<dyn Error>> {
-    match process_snapshot(process_id) {
-        Ok(snapshot) => Ok(Some(snapshot)),
-        Err(PlatformError::NotFound(_)) => Ok(None),
-        Err(_) if !process_exists(process_id) => Ok(None),
-        Err(error) => Err(error.into()),
-    }
-}
-
-fn recorded_process_snapshot(
-    process_id: u32,
-    started_at_micros: u64,
-) -> Result<Option<ProcessSnapshot>, Box<dyn Error>> {
-    match process_snapshot(process_id) {
-        Ok(snapshot) if snapshot.started_at_micros == started_at_micros => Ok(Some(snapshot)),
-        Ok(_) | Err(PlatformError::NotFound(_)) => Ok(None),
-        Err(_) if !process_exists(process_id) => Ok(None),
-        Err(error) => Err(error.into()),
     }
 }
 

--- a/crates/shim/src/process_identity.rs
+++ b/crates/shim/src/process_identity.rs
@@ -1,0 +1,453 @@
+use std::error::Error;
+#[cfg(target_os = "windows")]
+use std::thread;
+#[cfg(target_os = "windows")]
+use std::time::Duration;
+
+#[cfg(not(target_os = "windows"))]
+use codexhost_platform::process_exists;
+#[cfg(target_os = "windows")]
+use codexhost_platform::process_started_at_micros;
+use codexhost_platform::{PlatformError, ProcessSnapshot, process_snapshot};
+
+#[cfg(target_os = "windows")]
+// Four waits plus the initial observation cap transient exit-state retries at 80 ms.
+const WINDOWS_SNAPSHOT_ATTEMPTS: usize = 5;
+#[cfg(target_os = "windows")]
+const WINDOWS_SNAPSHOT_RETRY_INTERVAL: Duration = Duration::from_millis(20);
+
+#[cfg(any(target_os = "windows", test))]
+const ERROR_ACCESS_DENIED: i32 = 5;
+#[cfg(any(target_os = "windows", test))]
+const ERROR_GEN_FAILURE: i32 = 31;
+#[cfg(any(target_os = "windows", test))]
+const ERROR_INVALID_PARAMETER: i32 = 87;
+
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) enum RecordedProcessObservation {
+    Matching(ProcessSnapshot),
+    Missing,
+    Reused,
+}
+
+#[cfg(any(target_os = "windows", test))]
+fn process_query_raw_os_error(error: &PlatformError) -> Option<i32> {
+    match error {
+        PlatformError::ProcessInspection { source, .. } | PlatformError::Io(source) => {
+            source.raw_os_error()
+        }
+        _ => None,
+    }
+}
+
+#[cfg(any(target_os = "windows", test))]
+fn is_transient_windows_process_query_error(error: &PlatformError) -> bool {
+    // Windows can report either code while a process observed by Toolhelp is exiting before
+    // OpenProcess or QueryFullProcessImageNameW completes. Retry only these evidenced codes.
+    matches!(
+        process_query_raw_os_error(error),
+        Some(ERROR_ACCESS_DENIED | ERROR_GEN_FAILURE)
+    )
+}
+
+#[cfg(any(target_os = "windows", test))]
+fn is_missing_windows_process_error(error: &PlatformError) -> bool {
+    // OpenProcess reports ERROR_INVALID_PARAMETER when a previously observed non-zero PID has
+    // exited before the identity query begins.
+    process_query_raw_os_error(error) == Some(ERROR_INVALID_PARAMETER)
+}
+
+#[cfg(any(target_os = "windows", test))]
+fn observe_process_snapshot_with<I, W>(
+    process_id: u32,
+    expected_started_at_micros: Option<u64>,
+    attempts: usize,
+    mut inspect: I,
+    mut wait: W,
+) -> Result<Option<ProcessSnapshot>, PlatformError>
+where
+    I: FnMut(u32) -> Result<ProcessSnapshot, PlatformError>,
+    W: FnMut(),
+{
+    assert!(attempts > 0, "process snapshot attempts must be positive");
+    for attempt in 0..attempts {
+        match inspect(process_id) {
+            Ok(snapshot)
+                if expected_started_at_micros
+                    .is_none_or(|expected| snapshot.started_at_micros == expected) =>
+            {
+                return Ok(Some(snapshot));
+            }
+            Ok(_) | Err(PlatformError::NotFound(_)) => return Ok(None),
+            Err(error) if process_id != 0 && is_missing_windows_process_error(&error) => {
+                return Ok(None);
+            }
+            Err(error)
+                if is_transient_windows_process_query_error(&error) && attempt + 1 < attempts =>
+            {
+                wait();
+            }
+            Err(error) => return Err(error),
+        }
+    }
+    unreachable!("positive process snapshot attempts always return")
+}
+
+#[cfg(any(target_os = "windows", test))]
+fn observe_recorded_process_with<S, I, W>(
+    process_id: u32,
+    expected_started_at_micros: u64,
+    attempts: usize,
+    mut inspect_started_at: S,
+    mut inspect: I,
+    mut wait: W,
+) -> Result<RecordedProcessObservation, PlatformError>
+where
+    S: FnMut(u32) -> Result<u64, PlatformError>,
+    I: FnMut(u32) -> Result<ProcessSnapshot, PlatformError>,
+    W: FnMut(),
+{
+    assert!(attempts > 0, "recorded process attempts must be positive");
+    for attempt in 0..attempts {
+        match inspect_started_at(process_id) {
+            Ok(started_at_micros) if started_at_micros != expected_started_at_micros => {
+                return Ok(RecordedProcessObservation::Reused);
+            }
+            Ok(_) => {}
+            Err(PlatformError::NotFound(_)) => return Ok(RecordedProcessObservation::Missing),
+            Err(error) if process_id != 0 && is_missing_windows_process_error(&error) => {
+                return Ok(RecordedProcessObservation::Missing);
+            }
+            Err(error)
+                if is_transient_windows_process_query_error(&error) && attempt + 1 < attempts =>
+            {
+                wait();
+                continue;
+            }
+            Err(error) => return Err(error),
+        }
+        match inspect(process_id) {
+            Ok(snapshot) if snapshot.started_at_micros == expected_started_at_micros => {
+                return Ok(RecordedProcessObservation::Matching(snapshot));
+            }
+            Ok(_) => return Ok(RecordedProcessObservation::Reused),
+            Err(PlatformError::NotFound(_)) => return Ok(RecordedProcessObservation::Missing),
+            Err(error) if process_id != 0 && is_missing_windows_process_error(&error) => {
+                return Ok(RecordedProcessObservation::Missing);
+            }
+            Err(error)
+                if is_transient_windows_process_query_error(&error) && attempt + 1 < attempts =>
+            {
+                wait();
+            }
+            Err(error) => return Err(error),
+        }
+    }
+    unreachable!("positive recorded process attempts always return")
+}
+
+#[cfg(target_os = "windows")]
+pub(crate) fn current_process_snapshot(
+    process_id: u32,
+) -> Result<Option<ProcessSnapshot>, Box<dyn Error>> {
+    observe_process_snapshot_with(
+        process_id,
+        None,
+        WINDOWS_SNAPSHOT_ATTEMPTS,
+        process_snapshot,
+        || thread::sleep(WINDOWS_SNAPSHOT_RETRY_INTERVAL),
+    )
+    .map_err(Into::into)
+}
+
+#[cfg(not(target_os = "windows"))]
+pub(crate) fn current_process_snapshot(
+    process_id: u32,
+) -> Result<Option<ProcessSnapshot>, Box<dyn Error>> {
+    match process_snapshot(process_id) {
+        Ok(snapshot) => Ok(Some(snapshot)),
+        Err(PlatformError::NotFound(_)) => Ok(None),
+        Err(_) if !process_exists(process_id) => Ok(None),
+        Err(error) => Err(error.into()),
+    }
+}
+
+#[cfg(target_os = "windows")]
+pub(crate) fn recorded_process_identity(
+    process_id: u32,
+    started_at_micros: u64,
+) -> Result<RecordedProcessObservation, Box<dyn Error>> {
+    observe_recorded_process_with(
+        process_id,
+        started_at_micros,
+        WINDOWS_SNAPSHOT_ATTEMPTS,
+        process_started_at_micros,
+        process_snapshot,
+        || thread::sleep(WINDOWS_SNAPSHOT_RETRY_INTERVAL),
+    )
+    .map_err(Into::into)
+}
+
+#[cfg(not(target_os = "windows"))]
+pub(crate) fn recorded_process_identity(
+    process_id: u32,
+    started_at_micros: u64,
+) -> Result<RecordedProcessObservation, Box<dyn Error>> {
+    Ok(match current_process_snapshot(process_id)? {
+        Some(snapshot) if snapshot.started_at_micros == started_at_micros => {
+            RecordedProcessObservation::Matching(snapshot)
+        }
+        Some(_) => RecordedProcessObservation::Reused,
+        None => RecordedProcessObservation::Missing,
+    })
+}
+
+pub(crate) fn recorded_process_snapshot(
+    process_id: u32,
+    started_at_micros: u64,
+) -> Result<Option<ProcessSnapshot>, Box<dyn Error>> {
+    Ok(
+        match recorded_process_identity(process_id, started_at_micros)? {
+            RecordedProcessObservation::Matching(snapshot) => Some(snapshot),
+            RecordedProcessObservation::Missing | RecordedProcessObservation::Reused => None,
+        },
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::VecDeque;
+    use std::io;
+    use std::path::PathBuf;
+
+    use super::*;
+
+    fn snapshot(started_at_micros: u64) -> ProcessSnapshot {
+        ProcessSnapshot {
+            id: 42,
+            parent_id: 7,
+            process_group_id: 42,
+            executable: PathBuf::from("codexhost-shim.exe"),
+            started_at_micros,
+        }
+    }
+
+    fn access_denied() -> PlatformError {
+        process_inspection_error(ERROR_ACCESS_DENIED)
+    }
+
+    fn general_failure() -> PlatformError {
+        process_inspection_error(ERROR_GEN_FAILURE)
+    }
+
+    fn invalid_parameter() -> PlatformError {
+        process_inspection_error(ERROR_INVALID_PARAMETER)
+    }
+
+    fn process_inspection_error(code: i32) -> PlatformError {
+        PlatformError::ProcessInspection {
+            process_id: 42,
+            operation: "fixture process query",
+            source: io::Error::from_raw_os_error(code),
+        }
+    }
+
+    #[test]
+    fn retries_permission_denied_until_the_recorded_process_identity_is_observable() {
+        let mut observations = VecDeque::from([
+            Err(access_denied()),
+            Err(access_denied()),
+            Ok(snapshot(101)),
+        ]);
+        let mut waits = 0;
+
+        let observed = observe_process_snapshot_with(
+            42,
+            Some(101),
+            3,
+            |_| observations.pop_front().expect("snapshot observation"),
+            || waits += 1,
+        )
+        .expect("transient access denial should recover");
+
+        assert_eq!(observed, Some(snapshot(101)));
+        assert_eq!(waits, 2);
+        assert!(observations.is_empty());
+    }
+
+    #[test]
+    fn retries_general_failure_from_an_exiting_windows_process() {
+        let mut observations = VecDeque::from([Err(general_failure()), Ok(snapshot(101))]);
+        let mut waits = 0;
+
+        let observed = observe_process_snapshot_with(
+            42,
+            Some(101),
+            3,
+            |_| observations.pop_front().expect("snapshot observation"),
+            || waits += 1,
+        )
+        .expect("an exiting process query should recover");
+
+        assert_eq!(observed, Some(snapshot(101)));
+        assert_eq!(waits, 1);
+        assert!(observations.is_empty());
+    }
+
+    #[test]
+    fn treats_not_found_after_permission_denied_as_an_exited_process() {
+        let mut observations = VecDeque::from([
+            Err(access_denied()),
+            Err(PlatformError::NotFound("process exited".to_owned())),
+        ]);
+        let mut waits = 0;
+
+        let observed = observe_process_snapshot_with(
+            42,
+            Some(101),
+            3,
+            |_| observations.pop_front().expect("snapshot observation"),
+            || waits += 1,
+        )
+        .expect("an explicitly missing process should be absent");
+
+        assert_eq!(observed, None);
+        assert_eq!(waits, 1);
+        assert!(observations.is_empty());
+    }
+
+    #[test]
+    fn treats_invalid_process_parameter_as_an_exited_process() {
+        let mut waits = 0;
+
+        let observed = observe_process_snapshot_with(
+            42,
+            Some(101),
+            3,
+            |_| Err(invalid_parameter()),
+            || waits += 1,
+        )
+        .expect("an invalid recorded PID should be absent");
+
+        assert_eq!(observed, None);
+        assert_eq!(waits, 0);
+    }
+
+    #[test]
+    fn does_not_treat_invalid_parameter_for_pid_zero_as_an_exited_process() {
+        let error = observe_process_snapshot_with(
+            0,
+            None,
+            3,
+            |_| Err(invalid_parameter()),
+            || panic!("PID zero must fail without retrying"),
+        )
+        .expect_err("PID zero is an invalid caller input, not an exited observed process");
+
+        assert_eq!(
+            process_query_raw_os_error(&error),
+            Some(ERROR_INVALID_PARAMETER)
+        );
+    }
+
+    #[test]
+    fn keeps_persistent_permission_denied_as_an_indeterminate_identity() {
+        let mut observations = VecDeque::from([
+            Err(access_denied()),
+            Err(access_denied()),
+            Err(access_denied()),
+            Err(access_denied()),
+            Err(access_denied()),
+        ]);
+        let mut waits = 0;
+
+        let error = observe_process_snapshot_with(
+            42,
+            Some(101),
+            5,
+            |_| observations.pop_front().expect("snapshot observation"),
+            || waits += 1,
+        )
+        .expect_err("persistent access denial must remain fail-safe");
+
+        assert_eq!(
+            process_query_raw_os_error(&error),
+            Some(ERROR_ACCESS_DENIED)
+        );
+        assert!(matches!(error, PlatformError::ProcessInspection { .. }));
+        assert_eq!(waits, 4);
+        assert!(observations.is_empty());
+    }
+
+    #[test]
+    fn rejects_a_reused_pid_after_transient_permission_denied() {
+        let mut observations = VecDeque::from([Err(access_denied()), Ok(snapshot(202))]);
+        let mut waits = 0;
+
+        let observed = observe_process_snapshot_with(
+            42,
+            Some(101),
+            3,
+            |_| observations.pop_front().expect("snapshot observation"),
+            || waits += 1,
+        )
+        .expect("a reused PID should be an observable identity mismatch");
+
+        assert_eq!(observed, None);
+        assert_eq!(waits, 1);
+        assert!(observations.is_empty());
+    }
+
+    #[test]
+    fn rejects_a_reused_pid_before_reading_its_executable() {
+        let mut full_snapshot_reads = 0;
+        let mut waits = 0;
+
+        let observed = observe_recorded_process_with(
+            42,
+            101,
+            5,
+            |_| Ok(202),
+            |_| {
+                full_snapshot_reads += 1;
+                Ok(snapshot(202))
+            },
+            || waits += 1,
+        )
+        .expect("a readable start-time mismatch should prove PID reuse");
+
+        assert_eq!(observed, RecordedProcessObservation::Reused);
+        assert_eq!(full_snapshot_reads, 0);
+        assert_eq!(waits, 0);
+    }
+
+    #[test]
+    fn does_not_retry_a_permission_error_without_windows_access_denied_code() {
+        let mut inspections = 0;
+        let mut waits = 0;
+
+        let error = observe_process_snapshot_with(
+            42,
+            Some(101),
+            5,
+            |_| {
+                inspections += 1;
+                Err(PlatformError::Io(io::Error::new(
+                    io::ErrorKind::PermissionDenied,
+                    "not Windows ERROR_ACCESS_DENIED",
+                )))
+            },
+            || waits += 1,
+        )
+        .expect_err("non-Windows access errors must not be retried");
+
+        assert!(matches!(
+            error,
+            PlatformError::Io(ref source)
+                if source.kind() == io::ErrorKind::PermissionDenied
+                    && source.raw_os_error().is_none()
+        ));
+        assert_eq!(inspections, 1);
+        assert_eq!(waits, 0);
+    }
+}


### PR DESCRIPTION
## Summary

Windows local Host Runtime replacement can enumerate a PID with Toolhelp and then lose the process—or see that PID reused—before executable/start-time identity queries complete. GitHub Windows runners reproduced three raw outcomes in unchanged Shim tests:

- `ERROR_ACCESS_DENIED` (5)
- `ERROR_GEN_FAILURE` (31)
- `ERROR_INVALID_PARAMETER` (87)

The first two previously aborted replacement immediately. The third appeared when `OpenProcess` was called for a PID that had disappeared after observation. This PR adds a narrow, fail-safe identity observation layer for the Shim; it is independent from #96 and #99.

## Behavior

- preserves the original Windows error as `PlatformError::ProcessInspection`, including operation, PID, source error, and raw OS code;
- retries only evidenced transient raw codes 5 and 31;
- uses 5 complete observations with 4 x 20 ms waits, for at most 80 ms of configured retry delay;
- treats raw 87 as absent only for a previously observed nonzero PID;
- reads and compares the recorded creation time before reading executable identity on exact-owner paths;
- represents exact identity as `Matching`, `Missing`, or `Reused` instead of collapsing missing and reused;
- returns persistent/unclassified observation failures and therefore refuses takeover, record removal, and signal delivery;
- keeps the existing final Windows termination control: PID/start time is checked again on the same `PROCESS_TERMINATE` handle immediately before `TerminateProcess`;
- leaves macOS/Linux observation and signal semantics unchanged;
- does not change unrelated TypeScript test timeouts.

Microsoft error-code reference: https://learn.microsoft.com/windows/win32/debug/system-error-codes--0-499-

## TDD and validation

Red/green slices covered:

1. access denied -> matching identity;
2. general failure -> matching identity;
3. invalid parameter -> explicit absence for a nonzero observed PID;
4. PID zero + invalid parameter -> indeterminate error;
5. persistent access denied -> error after the bounded retry;
6. start-time mismatch -> `Reused` without reading executable;
7. non-raw PermissionDenied -> no retry.

Executed validation:

- `npm run check`
  - format, lint, boundary checks, and typecheck passed;
  - TypeScript: 173 files passed, 1 skipped; 1491 tests passed, 15 skipped;
  - Clippy with `-D warnings` passed;
  - full Rust workspace tests passed.
- final Shim suite: 17 unit + 25 proxy integration tests passed;
- full `crates/shim/tests/proxy.rs` repeated 50 times: 50/50 runs, 1250/1250 cross-process tests passed;
- independent standards review: approve, no blockers;
- independent spec review: approve, no blockers;
- security review: both candidate safety gaps fixed; no new candidates.

## Security invariant

An identity that remains unobservable is never treated as absent and never authorizes takeover or signal delivery. Only a complete matching PID/start-time identity can reach termination, which independently rechecks creation time immediately before signaling.

## Relationship to #99

This addresses the pre-existing Windows process-identity flake documented on #99. After this PR merges, #99 can update from `main` and rerun Windows CI without mixing this lifecycle repair into the Aqua broker feature.