### PR TITLE
fix: restore OpenCode lint baseline

### DIFF
--- a/packages/adapters/opencode/src/opencode-adapter.ts
+++ b/packages/adapters/opencode/src/opencode-adapter.ts
@@ -1722,8 +1722,9 @@ class OpenCodeHarnessSession implements HarnessSession, OpenCodeTransportListene
     const candidates = messages.filter(
       ({ info }) => info.role === "user" && !active.preexistingUserMessageIds.has(info.id),
     );
-    if (candidates.length === 1) {
-      this.#bindUserMessage(active, candidates[0]!.info.id);
+    const [candidate] = candidates;
+    if (candidates.length === 1 && candidate) {
+      this.#bindUserMessage(active, candidate.info.id);
       return;
     }
     const parents = new Set(
@@ -1732,8 +1733,9 @@ class OpenCodeHarnessSession implements HarnessSession, OpenCodeTransportListene
         .map(({ info }) => (info as AssistantMessage).parentID),
     );
     const linked = candidates.filter(({ info }) => parents.has(info.id));
-    if (linked.length === 1) {
-      this.#bindUserMessage(active, linked[0]!.info.id);
+    const [linkedCandidate] = linked;
+    if (linked.length === 1 && linkedCandidate) {
+      this.#bindUserMessage(active, linkedCandidate.info.id);
       return;
     }
     if (candidates.length > 1) {


### PR DESCRIPTION
## Summary

- replace two forbidden non-null assertions in OpenCode user-message resolution with explicit guarded narrowing
- preserve the existing single-candidate, uniquely linked candidate, and ambiguous-candidate protocol behavior
- restore the repository lint baseline as an isolated one-file change

## Validation

- `npm run format:check`
- `npm run lint`
- `npm run typecheck`
- `npm exec -- vitest run packages/adapters/opencode/test` (45 passed, 2 skipped)
- `npm run test:typescript` (1547 passed, 17 skipped)
- `npm run check:rust`

## Review

- Standards review: no documented-standard violations; one low-confidence pre-existing duplication shape retained to avoid an unnecessary abstraction
- Spec review: no findings; no behavior or dependency changes