### PR TITLE
fix(host-runtime): disable permessage-deflate in app-server probe

### DIFF
--- a/packages/host-runtime/src/app-server-websocket-options.ts
+++ b/packages/host-runtime/src/app-server-websocket-options.ts
@@ -1,0 +1,15 @@
+/**
+ * Handshake options shared by every WebSocket client that talks to a codex
+ * app-server listener.
+ *
+ * The stock codex app-server uses tokio-tungstenite, which supports no
+ * WebSocket extension and aborts the upgrade without writing an HTTP response
+ * when a client offers one. `ws` enables permessage-deflate by default, so any
+ * client that omits this flag hangs until its own timeout instead of
+ * completing the handshake. Keep the same handshake for every private
+ * listener.
+ */
+export const APP_SERVER_WEBSOCKET_CLIENT_OPTIONS = {
+  maxPayload: 128 * 1024 * 1024,
+  perMessageDeflate: false,
+} as const;

--- a/packages/host-runtime/src/remote-host-lifecycle.ts
+++ b/packages/host-runtime/src/remote-host-lifecycle.ts
@@ -6,6 +6,7 @@ import { Duplex } from "node:stream";
 
 import WebSocket from "ws";
 
+import { APP_SERVER_WEBSOCKET_CLIENT_OPTIONS } from "./app-server-websocket-options.js";
 import {
   inspectRemoteHostInstallation,
   type RemoteHostInstallationStatus,
@@ -113,7 +114,10 @@ async function probeWebSocket(input: {
   timeoutMs: number;
   timeoutMessage: string;
 }): Promise<RemoteHostRuntimeStatus> {
-  const socket = new WebSocket("ws://localhost/", { createConnection: input.createConnection });
+  const socket = new WebSocket("ws://localhost/", {
+    ...APP_SERVER_WEBSOCKET_CLIENT_OPTIONS,
+    createConnection: input.createConnection,
+  });
   try {
     return await new Promise<RemoteHostRuntimeStatus>((resolve) => {
       let settled = false;

--- a/packages/host-runtime/src/remote-official-connection.ts
+++ b/packages/host-runtime/src/remote-official-connection.ts
@@ -3,6 +3,7 @@ import { PassThrough, Writable } from "node:stream";
 
 import WebSocket, { type RawData } from "ws";
 
+import { APP_SERVER_WEBSOCKET_CLIENT_OPTIONS } from "./app-server-websocket-options.js";
 import type {
   OfficialAppServerConnection,
   OfficialAppServerExit,
@@ -36,12 +37,6 @@ export async function createRemoteOfficialAppServerConnection(
   let pending = Buffer.alloc(0);
   let outputPaused = false;
 
-  const webSocketOptions = {
-    maxPayload: 128 * 1024 * 1024,
-    // The native Codex daemon client uses tokio-tungstenite without offering
-    // permessage-deflate. Keep the same handshake for every private listener.
-    perMessageDeflate: false,
-  } as const;
   let socket: WebSocket;
   if (endpoint.startsWith("ws://")) {
     const url = new URL(endpoint);
@@ -52,10 +47,10 @@ export async function createRemoteOfficialAppServerConnection(
     ) {
       throw new Error("Shared official app-server URL must use a loopback WebSocket endpoint");
     }
-    socket = new WebSocket(endpoint, webSocketOptions);
+    socket = new WebSocket(endpoint, APP_SERVER_WEBSOCKET_CLIENT_OPTIONS);
   } else {
     socket = new WebSocket("ws://localhost/", {
-      ...webSocketOptions,
+      ...APP_SERVER_WEBSOCKET_CLIENT_OPTIONS,
       createConnection: () => net.createConnection(endpoint),
     });
   }

--- a/packages/host-runtime/test/remote-host-lifecycle.test.ts
+++ b/packages/host-runtime/test/remote-host-lifecycle.test.ts
@@ -1,6 +1,10 @@
+import { createServer, type Server } from "node:http";
+import { mkdtemp, mkdir, rm } from "node:fs/promises";
 import path from "node:path";
+import type { Duplex } from "node:stream";
 
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { WebSocketServer } from "ws";
 
 import type {
   RemoteHostInstallationStatus,
@@ -188,4 +192,64 @@ describe("remote Host lifecycle", () => {
     ).rejects.toThrow("not owned by codexhost");
     expect(terminate).not.toHaveBeenCalled();
   });
+
+  it.skipIf(process.platform === "win32")(
+    "probes a listener that rejects clients offering WebSocket extensions",
+    async () => {
+      // The stock codex app-server uses tokio-tungstenite, which supports no
+      // extension and aborts the upgrade without writing an HTTP response when a
+      // client offers one. `ws` enables permessage-deflate by default, so a probe
+      // that keeps that default hangs until its timeout and reports "unknown"
+      // instead of classifying the listener.
+      //
+      // Unix socket paths are capped near 104 bytes and the probe appends a
+      // fixed suffix to CODEX_HOME, so bind under a short base directory.
+      const codexHome = await mkdtemp("/tmp/cxh-");
+      await mkdir(path.join(codexHome, "app-server-control"), { recursive: true });
+      const listenerPath = path.join(codexHome, "app-server-control", "app-server-control.sock");
+
+      const server: Server = createServer();
+      const webSockets = new WebSocketServer({ noServer: true });
+      server.on("upgrade", (request, socket: Duplex, head) => {
+        if (request.headers["sec-websocket-extensions"]) {
+          socket.destroy();
+          return;
+        }
+        webSockets.handleUpgrade(request, socket, head, (client) => {
+          client.on("message", () =>
+            client.send(
+              JSON.stringify({
+                id: 1,
+                error: {
+                  code: -32600,
+                  message: "Invalid request: unknown variant `codexhost/update/status`",
+                },
+              }),
+            ),
+          );
+        });
+      });
+      await new Promise<void>((resolve) => server.listen(listenerPath, resolve));
+
+      restore = setRemoteHostLifecycleDependenciesForTest({
+        inspectInstallation: vi.fn().mockResolvedValue(readyInstallation),
+      });
+
+      try {
+        await expect(
+          inspectRemoteHost({ environment: { CODEX_HOME: codexHome } }),
+        ).resolves.toMatchObject({
+          runtime: {
+            state: "conflict",
+            protocol: "stock-codex",
+            socketPath: listenerPath,
+          },
+        });
+      } finally {
+        webSockets.close();
+        await new Promise<void>((resolve) => server.close(() => resolve()));
+        await rm(codexHome, { recursive: true, force: true });
+      }
+    },
+  );
 });


### PR DESCRIPTION
## Purpose

`codexhost remote start` always fails on a host where a stock codex app-server is
already listening:

```
$ codexhost remote start
codexhost remote: Remote Host protocol probe timed out
```

`codexhost remote status` reports the same and exits 1, even though the
installation is `"state": "ready", "issues": []` and the app-server is listening
and responding normally.

## Root cause

`probeWebSocket()` in `remote-host-lifecycle.ts` constructed its `ws` client with
the library default:

```js
const socket = new WebSocket("ws://localhost/", { createConnection: input.createConnection });
```

`ws` enables permessage-deflate by default, so the handshake offers
`Sec-WebSocket-Extensions: permessage-deflate; client_max_window_bits`. The stock
codex app-server uses tokio-tungstenite, which supports no extension and **aborts
the upgrade without writing an HTTP response at all**, rather than replying 101
with the extension omitted. The client waits out its own 5s timeout, so both the
direct probe and the `codex app-server proxy` fallback return `state: "unknown"`,
and `startRemoteHost()` aborts before it can terminate the stock listener and take
over.

`createRemoteOfficialAppServerConnection()` already documented this exact
constraint and passed `perMessageDeflate: false` — `probeWebSocket()` just missed
the flag.

## Change

- Add `APP_SERVER_WEBSOCKET_CLIENT_OPTIONS` (`maxPayload` + `perMessageDeflate: false`)
  as the single handshake used by every client that talks to an app-server listener.
- Use it in `probeWebSocket()` (the fix) and in `createRemoteOfficialAppServerConnection()`
  (replacing its local literal), so a third call site can't reintroduce this.
- Add a regression test that binds a listener which, like tokio-tungstenite, destroys
  any upgrade offering an extension, and asserts the probe still classifies it as
  `stock-codex`.

## Validation

Reproduced against a live stock codex app-server listener (`codex-cli` 0.152.0,
`@codexhost/cli` 0.4.0, Node v24.14.0, Linux x86_64). Raw handshakes against the
socket, varying only the extensions header:

| Handshake | Server response |
|---|---|
| no `Sec-WebSocket-Extensions` | `HTTP/1.1 101 Switching Protocols` |
| `permessage-deflate; client_max_window_bits` | connection closed, **zero bytes returned** |
| any bogus extension | connection closed, zero bytes returned |

Same A/B through a real `ws` client against that listener:

```
deflate=true : ERR socket hang up
deflate=false: MSG {"error":{"code":-32600,"message":"Invalid request: unknown variant `codexhost/update/status` ...
```

The `deflate=false` response is exactly the shape
`classifyRemoteHostProbeResponse()` expects for the `stock-codex` conflict branch,
so once the handshake succeeds the classifier works as designed. Patching the
shipped runtime in place turned the reported `"state": "unknown"` into:

```json
"runtime": { "state": "conflict", "protocol": "stock-codex" }
```

which is the state `startRemoteHost()` needs in order to replace the stock listener.

Checks run on this branch:

- `npm run lint` — pass
- `npm run typecheck` — pass
- `npm run build:typescript` — pass
- `npm run format:check` (on changed files) — pass
- `packages/host-runtime` tests — 28 files, 277 passed / 2 skipped
- The new test fails without the fix (probe returns `unknown`) and passes with it.

Full `npm run test:typescript` has 6 failures in
`tools/dev-desktop/run.test.mjs` and `packages/adapters/claude-code/test/command.test.ts`;
I confirmed these are **pre-existing on a clean `main`** and unrelated to this change.
`npm run test:rust` was not run.

The new test is skipped on Windows, which has no unix-socket listener path here.
