### PR TITLE
fix: 修复源码 checkout 下 delegation CLI 无法使用

### DIFF
--- a/crates/launcher/src/installation_layout.rs
+++ b/crates/launcher/src/installation_layout.rs
@@ -2,6 +2,9 @@ use std::env;
 use std::ffi::OsStr;
 use std::path::{Path, PathBuf};
 
+const HOST_NODE_PATH_ENV: &str = "CODEXHOST_HOST_NODE_PATH";
+const HOST_RUNTIME_PATH_ENV: &str = "CODEXHOST_HOST_RUNTIME_PATH";
+
 #[derive(Debug, PartialEq, Eq)]
 pub struct InstalledResources {
     pub shim: PathBuf,
@@ -25,6 +28,21 @@ impl InstalledResources {
                 executable.display()
             ));
         }
+
+        let node_override = env::var_os(HOST_NODE_PATH_ENV);
+        let host_runtime_override = env::var_os(HOST_RUNTIME_PATH_ENV);
+        if let Some(resources) = Self::from_source_checkout(
+            executable,
+            node_override.as_deref(),
+            host_runtime_override.as_deref(),
+        ) {
+            return Ok(resources);
+        }
+
+        Self::from_installed_layout(executable)
+    }
+
+    fn from_installed_layout(executable: &Path) -> Result<Self, String> {
         let executable_directory = executable.parent().ok_or_else(|| {
             format!(
                 "codexhost executable has no installation directory: {}",
@@ -58,12 +76,51 @@ impl InstalledResources {
             renderer_extension: resource_root.join("app/renderer-extension.js"),
         })
     }
+
+    fn from_source_checkout(
+        executable: &Path,
+        node_override: Option<&OsStr>,
+        host_runtime_override: Option<&OsStr>,
+    ) -> Option<Self> {
+        let (repository_root, build_directory) = source_checkout_layout(executable)?;
+        let executable_suffix = env::consts::EXE_SUFFIX;
+        let node = node_override
+            .map(PathBuf::from)
+            .unwrap_or_else(|| PathBuf::from(format!("node{executable_suffix}")));
+        let host_runtime = host_runtime_override
+            .map(PathBuf::from)
+            .unwrap_or_else(|| repository_root.join("packages/host-runtime/dist/main.js"));
+
+        Some(Self {
+            shim: build_directory.join(format!("codexhost-shim{executable_suffix}")),
+            node,
+            host_runtime,
+            desktop_controller: repository_root
+                .join("packages/desktop-control/dist/release-main.js"),
+            renderer_extension: repository_root
+                .join("packages/renderer-extension/dist/production.js"),
+        })
+    }
+}
+
+fn source_checkout_layout(executable: &Path) -> Option<(PathBuf, PathBuf)> {
+    let build_directory = executable.parent()?;
+    let profile = build_directory.file_name()?;
+    if profile != OsStr::new("debug") && profile != OsStr::new("release") {
+        return None;
+    }
+    let target_directory = build_directory.parent()?;
+    if target_directory.file_name() != Some(OsStr::new("target")) {
+        return None;
+    }
+    let repository_root = target_directory.parent()?;
+    Some((repository_root.to_path_buf(), build_directory.to_path_buf()))
 }
 
 #[cfg(test)]
 mod tests {
     use std::env;
-    use std::path::Path;
+    use std::path::{Path, PathBuf};
 
     use super::InstalledResources;
 
@@ -103,6 +160,48 @@ mod tests {
                 .host_runtime,
             contents.join("Resources/app/host-runtime.mjs")
         );
+    }
+
+    #[test]
+    fn resolves_resources_from_a_source_checkout() {
+        let root = env::temp_dir().join("codexhost source checkout");
+        let executable = root
+            .join("target/debug")
+            .join(format!("codexhost{}", env::consts::EXE_SUFFIX));
+
+        assert_eq!(
+            InstalledResources::from_source_checkout(&executable, None, None)
+                .expect("source checkout"),
+            InstalledResources {
+                shim: root
+                    .join("target/debug")
+                    .join(format!("codexhost-shim{}", env::consts::EXE_SUFFIX)),
+                node: PathBuf::from(format!("node{}", env::consts::EXE_SUFFIX)),
+                host_runtime: root.join("packages/host-runtime/dist/main.js"),
+                desktop_controller: root.join("packages/desktop-control/dist/release-main.js"),
+                renderer_extension: root.join("packages/renderer-extension/dist/production.js"),
+            }
+        );
+    }
+
+    #[test]
+    fn source_checkout_prefers_runtime_overrides() {
+        let root = env::temp_dir().join("codexhost source overrides");
+        let executable = root
+            .join("target/release")
+            .join(format!("codexhost{}", env::consts::EXE_SUFFIX));
+        let node = root.join("custom/node");
+        let host_runtime = root.join("custom/host-runtime.mjs");
+
+        let resources = InstalledResources::from_source_checkout(
+            &executable,
+            Some(node.as_os_str()),
+            Some(host_runtime.as_os_str()),
+        )
+        .expect("source checkout");
+
+        assert_eq!(resources.node, node);
+        assert_eq!(resources.host_runtime, host_runtime);
     }
 
     #[test]


### PR DESCRIPTION
## 目的

修复 #83：源码构建出的 launcher 位于 `target/debug` 或 `target/release` 时，`codexhost delegate`、`harness inspect`、`thread ...` 仍按正式安装布局查找 `target/runtime/node*` 和 `target/app/host-runtime.mjs`，导致源码 checkout 下 delegation CLI 全部不可用。

## 修改内容

让 `InstalledResources` 在保留现有正式安装布局行为不变的前提下，识别标准 Cargo 源码构建布局。

源码 checkout 下：

- `codexhost-shim` 从 launcher 同级的 `target/debug|release` 解析；
- Host Runtime 使用 `packages/host-runtime/dist/main.js`；
- Desktop Controller 和 Renderer 使用现有开发产物路径；
- 如果设置了 `CODEXHOST_HOST_NODE_PATH` / `CODEXHOST_HOST_RUNTIME_PATH`，继续以显式覆盖为准；
- 未设置 Node 覆盖时使用平台 Node 命令（`node` / `node.exe`），由现有 `Command::new(...)` 按正常 PATH 规则解析。

源码布局解析阶段不提前校验资源文件。原因是 `launch` 已经会校验最终解析后的显式资源；如果这里提前校验 fallback，会在 `--node` / `--host-runtime` 覆盖生效前错误拒绝合法的 `npm start` 调用。

## 回归测试

补充并覆盖：

- 原有 release `bin/` 安装布局保持不变；
- 原有 macOS bundle 布局保持不变；
- Cargo `target/debug` 源码资源映射；
- 开发环境 Node / Host Runtime 显式覆盖；
- 原有相对 executable 路径拒绝逻辑。

## 验证状态

当前 PR 保持 Draft。GitHub 将这个 fork 的首次工作流标记为 `action_required`，因此 CI job 尚未真正执行。分支基于当前 `main`，已整理为单个 commit，改动仅涉及 `crates/launcher/src/installation_layout.rs`。