### PR TITLE
fix: 修复重启后 Harness 身份图标无法自动恢复

### DIFF
--- a/packages/renderer-extension/src/renderer-sidebar-agent-icons.ts
+++ b/packages/renderer-extension/src/renderer-sidebar-agent-icons.ts
@@ -275,6 +275,7 @@ export function installRendererSidebarAgentIcons(options: {
     if (timer !== undefined) clearTimeout(timer);
     ownershipRetryTimers.delete(key);
     ownershipRetryAttempts.delete(key);
+    failed.delete(key);
     provisionalCodex.delete(key);
   };
 
@@ -282,7 +283,7 @@ export function installRendererSidebarAgentIcons(options: {
     const key = ownershipKey(hostId, threadId);
     if (
       disposed ||
-      !provisionalCodex.has(key) ||
+      (!failed.has(key) && !provisionalCodex.has(key)) ||
       pending.has(key) ||
       ownershipRetryTimers.has(key)
     ) {
@@ -390,7 +391,14 @@ export function installRendererSidebarAgentIcons(options: {
     }
     for (const [hostId, unresolved] of unresolvedByHost) {
       const client = options.getClient(hostId);
-      if (!client) continue;
+      if (!client) {
+        for (const threadId of unresolved) {
+          const key = ownershipKey(hostId, threadId);
+          failed.add(key);
+          scheduleOwnershipRetry(hostId, threadId);
+        }
+        continue;
+      }
       const threadIds = [...unresolved];
       for (let index = 0; index < threadIds.length; index += THREAD_OWNERSHIP_LIST_MAX_LENGTH) {
         requestOwnership(
@@ -408,13 +416,11 @@ export function installRendererSidebarAgentIcons(options: {
   return {
     refresh() {
       failed.clear();
-      for (const key of provisionalCodex) {
-        const timer = ownershipRetryTimers.get(key);
-        if (timer !== undefined) clearTimeout(timer);
-        ownershipRetryTimers.delete(key);
-        ownershipRetryAttempts.delete(key);
-        ownershipByThread.delete(key);
-      }
+      for (const timer of ownershipRetryTimers.values()) clearTimeout(timer);
+      ownershipRetryTimers.clear();
+      ownershipRetryAttempts.clear();
+      for (const key of provisionalCodex) ownershipByThread.delete(key);
+      provisionalCodex.clear();
       scheduleScan();
     },
     dispose() {

--- a/packages/renderer-extension/test/renderer-sidebar-agent-icons.test.ts
+++ b/packages/renderer-extension/test/renderer-sidebar-agent-icons.test.ts
@@ -382,34 +382,74 @@ describe("Renderer sidebar Agent ownership", () => {
     control.dispose();
   });
 
-  it("fails undecorated, retries only on refresh, and ignores pending results after disposal", async () => {
-    const row = new FakeRow("pi-thread");
-    const dom = new FakeDom([row]);
-    const client = clientWith(vi.fn().mockRejectedValue(new Error("unavailable")));
-    const control = installRendererSidebarAgentIcons({ getClient: () => client, dom });
-    await settle();
-    dom.change();
-    await settle();
-    expect(client.listThreadOwnership).toHaveBeenCalledTimes(1);
-    expect(row.agent).toBeNull();
+  it("retries failed ownership requests without requiring an explicit refresh", async () => {
+    vi.useFakeTimers();
+    try {
+      const row = new FakeRow("pi-thread");
+      const dom = new FakeDom([row]);
+      const listThreadOwnership = vi
+        .fn<(input: ThreadOwnershipListParams) => Promise<ThreadOwnershipListResult>>()
+        .mockRejectedValueOnce(new Error("unavailable"))
+        .mockResolvedValue({
+          threads: [
+            {
+              threadId: "pi-thread" as HostThreadId,
+              owner: "external",
+              harnessId: PI_HARNESS_ID,
+            },
+          ],
+        });
+      const client = clientWith(listThreadOwnership);
+      const control = installRendererSidebarAgentIcons({ getClient: () => client, dom });
 
-    control.refresh();
-    await settle();
-    expect(client.listThreadOwnership).toHaveBeenCalledTimes(2);
-    control.dispose();
-    expect(dom.cleared).toBe(true);
-    expect(dom.listeners.size).toBe(0);
+      await vi.runAllTimersAsync();
+
+      expect(listThreadOwnership).toHaveBeenCalledTimes(2);
+      expect(row.agent).toBe("pi");
+      control.dispose();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
-  it("contains a synchronous early-client failure and retries after refresh", async () => {
-    const row = new FakeRow("pi-thread");
-    const dom = new FakeDom([row]);
-    const listThreadOwnership = vi
-      .fn<(input: ThreadOwnershipListParams) => Promise<ThreadOwnershipListResult>>()
-      .mockImplementationOnce(() => {
-        throw new Error("request manager unavailable");
-      })
-      .mockResolvedValue({
+  it("contains a synchronous early-client failure and retries automatically", async () => {
+    vi.useFakeTimers();
+    try {
+      const row = new FakeRow("pi-thread");
+      const dom = new FakeDom([row]);
+      const listThreadOwnership = vi
+        .fn<(input: ThreadOwnershipListParams) => Promise<ThreadOwnershipListResult>>()
+        .mockImplementationOnce(() => {
+          throw new Error("request manager unavailable");
+        })
+        .mockResolvedValue({
+          threads: [
+            {
+              threadId: "pi-thread" as HostThreadId,
+              owner: "external",
+              harnessId: PI_HARNESS_ID,
+            },
+          ],
+        });
+      const client = clientWith(listThreadOwnership);
+      const control = installRendererSidebarAgentIcons({ getClient: () => client, dom });
+
+      await vi.runAllTimersAsync();
+
+      expect(listThreadOwnership).toHaveBeenCalledTimes(2);
+      expect(row.agent).toBe("pi");
+      control.dispose();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("retries when the ownership client is unavailable during the first scan", async () => {
+    vi.useFakeTimers();
+    try {
+      const row = new FakeRow("pi-thread");
+      const dom = new FakeDom([row]);
+      const client = clientWith(async () => ({
         threads: [
           {
             threadId: "pi-thread" as HostThreadId,
@@ -417,18 +457,39 @@ describe("Renderer sidebar Agent ownership", () => {
             harnessId: PI_HARNESS_ID,
           },
         ],
-      });
-    const client = clientWith(listThreadOwnership);
-    const control = installRendererSidebarAgentIcons({ getClient: () => client, dom });
+      }));
+      const getClient = vi.fn<() => RendererModelClient | null>().mockReturnValueOnce(null);
+      getClient.mockReturnValue(client);
+      const control = installRendererSidebarAgentIcons({ getClient, dom });
 
-    await settle();
-    expect(row.agent).toBeNull();
-    control.refresh();
-    await settle();
+      await vi.runAllTimersAsync();
 
-    expect(listThreadOwnership).toHaveBeenCalledTimes(2);
-    expect(row.agent).toBe("pi");
-    control.dispose();
+      expect(getClient).toHaveBeenCalledTimes(2);
+      expect(client.listThreadOwnership).toHaveBeenCalledTimes(1);
+      expect(row.agent).toBe("pi");
+      control.dispose();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("keeps failed ownership retries bounded while the service stays unavailable", async () => {
+    vi.useFakeTimers();
+    try {
+      const row = new FakeRow("pi-thread");
+      const dom = new FakeDom([row]);
+      const client = clientWith(vi.fn().mockRejectedValue(new Error("unavailable")));
+      const control = installRendererSidebarAgentIcons({ getClient: () => client, dom });
+
+      await vi.runAllTimersAsync();
+
+      expect(client.listThreadOwnership).toHaveBeenCalledTimes(6);
+      expect(vi.getTimerCount()).toBe(0);
+      expect(row.agent).toBeNull();
+      control.dispose();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("maps only known external Harness ownership to Renderer Agents", () => {


### PR DESCRIPTION
## 目的

修复 #101 中侧栏 Harness 身份图标在冷启动后消失、且之后无法自动恢复的问题。

现有 `renderer-sidebar-agent-icons.ts` 对“ownership 查询成功但暂时返回 Codex ownership”已经有 100 / 300 / 800 / 1500 / 3000 ms 的有界退避重试，但有两个冷启动路径没有进入这套恢复机制：

1. 首次扫描时 `getClient(hostId)` 还没有返回可用 client；
2. `listThreadOwnership(...)` 在 runtime / request manager 尚未就绪时抛错。

第二种情况下 thread 会进入 `failed` 集合，而 `scan()` 会跳过 `failed` key；现有 `scheduleOwnershipRetry()` 又只允许 `provisionalCodex` 进入重试，因此状态会一直冻结，除非之后刚好发生显式 `refresh()`。这与 #101 报告的“重启后图标全部消失并且多次重启仍不恢复”存在直接对应关系。

## 修改内容

保持现有 ownership 缓存和重试结构不变，只扩展已有 bounded backoff 的适用范围：

- ownership 请求失败后，`failed` key 也允许进入现有退避重试；
- 首次扫描拿不到 ownership client 时，将当前未解析 thread 标记为可重试，并使用同一套退避重新扫描；
- 一旦成功解析到外部 Harness 或本地 ownership，统一清理失败状态、重试计数和 timer；
- `refresh()` 现在会同时清理失败重试和 provisional-Codex 重试 timer，避免手动刷新后遗留旧 timer；
- 重试仍严格受现有 `OWNERSHIP_RETRY_DELAYS_MS` 限制，不引入常驻轮询。

没有修改 Thread ID 的 React Fiber 提取逻辑，也没有修改 mapping-store、ownership 协议或 Desktop DOM contract，避免在缺少实机诊断证据时扩大修复范围。

## 回归测试

在现有 `renderer-sidebar-agent-icons.test.ts` 中补充/调整测试，覆盖：

- ownership Promise 异步失败后，无需手动 `refresh()` 即可恢复；
- request manager 同步早期失败后自动恢复；
- 首次扫描 ownership client 不存在，后续 client 就绪后自动恢复；
- ownership 服务持续不可用时，初始请求 + 5 次退避后停止，确保不会形成无限轮询；
- 原有 provisional Codex ownership 重试行为继续保留。

## 变更范围

仅涉及：

- `packages/renderer-extension/src/renderer-sidebar-agent-icons.ts`
- `packages/renderer-extension/test/renderer-sidebar-agent-icons.test.ts`

分支基于当前 `main`，已整理为单个 commit。

## 验证状态

当前保持 Draft。这个 fork 的上游 Actions 仍需要维护者批准后才能真正执行，因此暂不声明完整 CI 已通过；PR 启动后会根据 CI / review 结果继续修正。

Fixes #101