### PR TITLE
fix: isolate Aqua broker socket errors

### DIFF
--- a/packages/harness-broker/src/server.ts
+++ b/packages/harness-broker/src/server.ts
@@ -267,6 +267,10 @@ export async function startHarnessBrokerServer(input: {
       closed: false,
     };
     connections.add(state);
+    socket.on("error", () => {
+      state.closed = true;
+      socket.destroy();
+    });
 
     const send = async (frame: object): Promise<void> => {
       state.outputSequence += 1;

--- a/packages/harness-broker/test/harness-broker.test.ts
+++ b/packages/harness-broker/test/harness-broker.test.ts
@@ -1,5 +1,5 @@
 import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
-import net from "node:net";
+import net, { type Server, type Socket } from "node:net";
 import os from "node:os";
 import path from "node:path";
 
@@ -104,6 +104,48 @@ describe("macOS Aqua Harness broker", () => {
     await opened.value.close();
     await adapter.close();
     await server.close();
+  });
+
+  it("isolates accepted socket errors without stopping the broker", async () => {
+    const root = await mkdtemp(path.join(os.tmpdir(), "codexhost-harness-broker-"));
+    roots.push(root);
+    const descriptorPath = path.join(root, "broker-v1.json");
+    const socketPath =
+      process.platform === "win32"
+        ? `\\\\.\\pipe\\codexhost-harness-broker-${process.pid}-${randomUUID()}`
+        : path.join(root, "broker.sock");
+    const native = new FakeHarnessAdapter(harnessIdSchema.parse("claude-code"));
+    const createServer = vi.spyOn(net, "createServer");
+    const broker = await startHarnessBrokerServer({ descriptorPath, socketPath, adapter: native });
+    const nativeServer = createServer.mock.results.at(-1)?.value as Server | undefined;
+    if (!nativeServer) throw new Error("fixture did not observe the native broker server");
+    let peer: Socket | undefined;
+    let client: Socket | undefined;
+
+    try {
+      const accepted = new Promise<Socket>((resolve) => nativeServer.once("connection", resolve));
+      client = net.createConnection(socketPath);
+      client.on("error", () => undefined);
+      peer = await accepted;
+      const peerClosed = new Promise<void>((resolve) => peer?.once("close", resolve));
+
+      expect(() =>
+        peer?.emit(
+          "error",
+          Object.assign(new Error("synthetic connection reset"), { code: "ECONNRESET" }),
+        ),
+      ).not.toThrow();
+      await peerClosed;
+
+      const adapter = new BrokeredHarnessAdapter({ descriptorPath });
+      await expect(adapter.inspect({ cwd: root })).resolves.toMatchObject({ status: "ready" });
+      await adapter.close();
+    } finally {
+      client?.destroy();
+      peer?.destroy();
+      await broker.close();
+      createServer.mockRestore();
+    }
   });
 
   it.each([

--- a/packages/harness-broker/test/harness-broker.test.ts
+++ b/packages/harness-broker/test/harness-broker.test.ts
@@ -120,13 +120,20 @@ describe("macOS Aqua Harness broker", () => {
     const nativeServer = createServer.mock.results.at(-1)?.value as Server | undefined;
     if (!nativeServer) throw new Error("fixture did not observe the native broker server");
     let peer: Socket | undefined;
-    let client: Socket | undefined;
+    let firstAdapter: BrokeredHarnessAdapter | undefined;
+    let secondAdapter: BrokeredHarnessAdapter | undefined;
 
     try {
       const accepted = new Promise<Socket>((resolve) => nativeServer.once("connection", resolve));
-      client = net.createConnection(socketPath);
-      client.on("error", () => undefined);
+      firstAdapter = new BrokeredHarnessAdapter({ descriptorPath });
+      const opened = await firstAdapter.open({ kind: "create", cwd: root });
       peer = await accepted;
+      expect(opened.ok).toBe(true);
+      if (!opened.ok) throw new Error(opened.error.message);
+      const nativeSession = native.sessions[0];
+      const nativeRef = opened.value.initialState.nativeRef;
+      if (!nativeSession || !nativeRef) throw new Error("fixture failed to open a native Session");
+      const nativeClose = vi.spyOn(nativeSession, "close");
       const peerClosed = new Promise<void>((resolve) => peer?.once("close", resolve));
 
       expect(() =>
@@ -136,12 +143,18 @@ describe("macOS Aqua Harness broker", () => {
         ),
       ).not.toThrow();
       await peerClosed;
+      await vi.waitFor(() => expect(nativeClose).toHaveBeenCalledOnce());
 
-      const adapter = new BrokeredHarnessAdapter({ descriptorPath });
-      await expect(adapter.inspect({ cwd: root })).resolves.toMatchObject({ status: "ready" });
-      await adapter.close();
+      secondAdapter = new BrokeredHarnessAdapter({ descriptorPath });
+      await expect(secondAdapter.inspect({ cwd: root })).resolves.toMatchObject({
+        status: "ready",
+      });
+      const resumed = await secondAdapter.open({ kind: "resume", cwd: root, nativeRef });
+      expect(resumed.ok).toBe(true);
+      if (resumed.ok) await resumed.value.close();
     } finally {
-      client?.destroy();
+      await firstAdapter?.close();
+      await secondAdapter?.close();
       peer?.destroy();
       await broker.close();
       createServer.mockRestore();


### PR DESCRIPTION
## Summary

- handle errors emitted by an accepted Aqua Harness broker socket at the per-connection boundary
- close the affected connection through the existing cleanup path without terminating the listening broker
- cover an authenticated active Session, native Session cleanup, writer release, and a subsequent authenticated inspect/resume

## Root cause

Accepted broker sockets did not retain an `error` listener after `net.createServer` accepted them. A peer reset such as `ECONNRESET` could therefore become an uncaught EventEmitter error and terminate the Aqua broker owner process. The abrupt exit left the descriptor and socket behind with a dead owner PID, causing managed Remote Host Claude Code inspection to fail at `harnessBroker` with `Claude Aqua broker owner process is unavailable`.

The fix installs the listener synchronously for each accepted socket, marks only that connection closed, and destroys only that socket. The existing `close` handler remains responsible for removing the connection, closing its Sessions, and releasing writer reservations. Descriptor ownership, token/generation authentication, protocol validation, and broker-wide lifecycle behavior are unchanged.

## Validation

- `npm run format:check`
- `npm run lint`
- `npm run typecheck`
- `npm run test:typescript` — 183 test files passed, 3 skipped; 1600 tests passed, 18 skipped
- `npm run check:rust`
- focused Harness broker regression — 11 passed, 1 platform skip
- Standards review — no hard or blocking findings
- Spec review — no actionable findings
- security diff scan of the production change — complete, no reportable findings

## Scope

This PR intentionally does not change launchd `KeepAlive`, automatic recovery of an already-dead owner, or whether `descriptor_ready` validates owner liveness. Those are separate lifecycle/status improvements.
