### PR TITLE
fix(deepseek): compat dsh web flags and describe

### DIFF
--- a/packages/adapters/deepseek-harness/src/host-client.ts
+++ b/packages/adapters/deepseek-harness/src/host-client.ts
@@ -1,10 +1,20 @@
-import { spawn, type ChildProcess } from "node:child_process";
+import { spawn, spawnSync, type ChildProcess } from "node:child_process";
 import { randomUUID } from "node:crypto";
 import { accessSync, constants, statSync } from "node:fs";
+import { homedir } from "node:os";
 import path from "node:path";
 
 import { sanitizeDiagnosticTail } from "@codexhost/harness-adapter";
-import type { HostFrame, MuxFrame, RpcError, RpcRequest } from "@deepseek-ai/dsh-host-apiproxy/api";
+import type {
+  HostFrame,
+  MuxFrame,
+  RequestPayload,
+  ResponseValue,
+  RpcError,
+  RpcMethodMap,
+  RpcRequest,
+  RpcResponse,
+} from "@deepseek-ai/dsh-host-apiproxy/api";
 import { hostFrameSchema, muxFrameSchema } from "@deepseek-ai/dsh-host-apiproxy/api/events.schema";
 import {
   serverRequestSchema,
@@ -120,6 +130,58 @@ function parseCommandExecution(value: unknown): DeepSeekCommandExecution | undef
   return value as DeepSeekCommandExecution;
 }
 
+/** `host.describe.version` stays `0.0.1` across this field addition; branch on payload shape. */
+function isMissingHomeDescribeError(error: unknown): boolean {
+  if (typeof error !== "object" || error === null || !("issues" in error)) return false;
+  const issues = error.issues;
+  return (
+    Array.isArray(issues) &&
+    issues.some((issue) => {
+      const pathValue = record(issue)?.path;
+      return Array.isArray(pathValue) && pathValue.length === 1 && pathValue[0] === "home";
+    })
+  );
+}
+
+function parseHostDescribeValue(value: unknown): {
+  version: string;
+  cwd: string;
+  provider: string;
+  model: string;
+  attachedSessions: number;
+  home: string;
+  canOpenPath: boolean;
+} {
+  const description = record(value);
+  if (
+    !description ||
+    typeof description.version !== "string" ||
+    typeof description.provider !== "string" ||
+    typeof description.model !== "string"
+  ) {
+    throw new DeepSeekHarnessTransportError(
+      "protocolError",
+      "DeepSeek Harness Host returned an invalid host.describe value",
+    );
+  }
+  return {
+    version: description.version,
+    cwd: typeof description.cwd === "string" ? description.cwd : "",
+    provider: description.provider,
+    model: description.model,
+    attachedSessions:
+      typeof description.attachedSessions === "number" &&
+      Number.isSafeInteger(description.attachedSessions) &&
+      description.attachedSessions >= 0
+        ? description.attachedSessions
+        : 0,
+    home: typeof description.home === "string" && description.home.length > 0
+      ? description.home
+      : homedir(),
+    canOpenPath: description.canOpenPath === true,
+  };
+}
+
 export class NodeDeepSeekHostClient extends AbstractApiClient {
   readonly commands: DeepSeekCommandClient;
   readonly #endpoint: URL;
@@ -136,6 +198,57 @@ export class NodeDeepSeekHostClient extends AbstractApiClient {
 
   protected doFetch(input: URL, init?: RequestInit): Promise<Response> {
     return globalThis.fetch(input, init);
+  }
+
+  protected override async callUnary<K extends keyof RpcMethodMap>(
+    method: K,
+    payload: RequestPayload<K>,
+    signal?: AbortSignal,
+    timeoutPolicy?: Parameters<AbstractApiClient["callUnary"]>[3],
+  ): Promise<RpcResponse<ResponseValue<K>>> {
+    try {
+      return await super.callUnary(method, payload, signal, timeoutPolicy);
+    } catch (error) {
+      if (method !== "host.describe" || !isMissingHomeDescribeError(error)) throw error;
+      const rpcId = this.mintRpcId();
+      const message = {
+        type: "client-request" as const,
+        rpcId,
+        method: "host.describe",
+        payload: {},
+      };
+      this.onEnvelope(message);
+      const response = await this.doFetch(new URL("/api/host.describe", this.#endpoint), {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(message),
+        signal: signal ?? AbortSignal.timeout(this.timeoutMs),
+      });
+      if (!response.ok) {
+        throw new DeepSeekHarnessTransportError(
+          "unavailable",
+          `DeepSeek Harness 'host.describe' transport failed with HTTP ${response.status}`,
+        );
+      }
+      const full = serverResponseSchema.parse(await response.json());
+      this.onEnvelope(full);
+      if (full.rpcId !== rpcId) {
+        throw new DeepSeekHarnessTransportError(
+          "protocolError",
+          "DeepSeek Harness 'host.describe' returned an unexpected RPC identity",
+        );
+      }
+      if (!full.result.ok) {
+        // K is host.describe here; the wire error envelope is method-independent.
+        const failed: RpcResponse<ResponseValue<K>> = full as RpcResponse<ResponseValue<K>>;
+        return failed;
+      }
+      const described: RpcResponse<ResponseValue<K>> = {
+        rpcId: full.rpcId,
+        result: { ok: true, value: parseHostDescribeValue(full.result.value) as ResponseValue<K> },
+      };
+      return described;
+    }
   }
 
   protected override openMux(
@@ -339,6 +452,7 @@ export interface DeepSeekHostConnectionDependencies {
     },
   ): ChildProcess;
   sleep(milliseconds: number): Promise<void>;
+  readWebHelp?(invocation: DeepSeekCommandInvocation, environment: NodeJS.ProcessEnv): string;
 }
 
 export interface DeepSeekHostSubscriber {
@@ -436,6 +550,43 @@ export function resolveDeepSeekCommand(
         kind: "npx",
       }
     : null;
+}
+
+export function dshWebHelpSupportsNoOpen(helpText: string): boolean {
+  return /(?:^|\s)--no-open(?:\s|$)/u.test(helpText);
+}
+
+export function deepSeekWebArguments(
+  endpoint: URL,
+  flags: { noOpen?: boolean } = {},
+): string[] {
+  return [
+    "web",
+    ...(flags.noOpen ? ["--no-open"] : []),
+    "--host",
+    endpoint.hostname,
+    "--port",
+    endpoint.port || "80",
+  ];
+}
+
+export function readDshWebHelp(
+  invocation: DeepSeekCommandInvocation,
+  environment: NodeJS.ProcessEnv,
+): string {
+  const processInvocation = deepSeekProcessInvocation(
+    invocation.command,
+    [...invocation.arguments, "web", "--help"],
+    environment,
+  );
+  const result = spawnSync(processInvocation.command, processInvocation.arguments, {
+    env: environment,
+    encoding: "utf8",
+    timeout: 5_000,
+    windowsHide: true,
+    windowsVerbatimArguments: processInvocation.windowsVerbatimArguments,
+  });
+  return `${result.stdout ?? ""}\n${result.stderr ?? ""}`;
 }
 
 export function deepSeekProcessInvocation(
@@ -577,14 +728,13 @@ export class DeepSeekHostConnection {
         );
       }
       const endpoint = new URL(this.#endpoint);
+      const help = (this.#dependencies.readWebHelp ?? readDshWebHelp)(
+        invocation,
+        this.#environment,
+      );
       const args = [
         ...invocation.arguments,
-        "web",
-        "--no-open",
-        "--host",
-        endpoint.hostname,
-        "--port",
-        endpoint.port || "80",
+        ...deepSeekWebArguments(endpoint, { noOpen: dshWebHelpSupportsNoOpen(help) }),
       ];
       const processInvocation = deepSeekProcessInvocation(
         invocation.command,

--- a/packages/adapters/deepseek-harness/src/host-client.ts
+++ b/packages/adapters/deepseek-harness/src/host-client.ts
@@ -218,11 +218,18 @@ export class NodeDeepSeekHostClient extends AbstractApiClient {
         payload: {},
       };
       this.onEnvelope(message);
+      const timeout = AbortSignal.timeout(this.timeoutMs);
+      const requestSignal =
+        timeoutPolicy === "caller-signal-only"
+          ? signal
+          : signal
+            ? AbortSignal.any([signal, timeout])
+            : timeout;
       const response = await this.doFetch(new URL("/api/host.describe", this.#endpoint), {
         method: "POST",
         headers: { "content-type": "application/json" },
         body: JSON.stringify(message),
-        signal: signal ?? AbortSignal.timeout(this.timeoutMs),
+        ...(requestSignal ? { signal: requestSignal } : {}),
       });
       if (!response.ok) {
         throw new DeepSeekHarnessTransportError(
@@ -230,7 +237,15 @@ export class NodeDeepSeekHostClient extends AbstractApiClient {
           `DeepSeek Harness 'host.describe' transport failed with HTTP ${response.status}`,
         );
       }
-      const full = serverResponseSchema.parse(await response.json());
+      let full: ReturnType<typeof serverResponseSchema.parse>;
+      try {
+        full = serverResponseSchema.parse(await response.json());
+      } catch (parseError) {
+        throw commandProtocolError(
+          "host.describe",
+          `an invalid response: ${parseError instanceof Error ? parseError.message : String(parseError)}`,
+        );
+      }
       this.onEnvelope(full);
       if (full.rpcId !== rpcId) {
         throw new DeepSeekHarnessTransportError(

--- a/packages/adapters/deepseek-harness/test/host-client.test.ts
+++ b/packages/adapters/deepseek-harness/test/host-client.test.ts
@@ -13,6 +13,8 @@ import {
   NodeDeepSeekCommandClient,
   NodeDeepSeekHostClient,
   deepSeekProcessInvocation,
+  deepSeekWebArguments,
+  dshWebHelpSupportsNoOpen,
   resolveDeepSeekCommand,
   type DeepSeekHostConnectionDependencies,
 } from "../src/host-client.js";
@@ -83,6 +85,49 @@ describe("DeepSeek local Host connection", () => {
         type: "client-request",
         method: "commands/list",
         payload: { args: { agentId: "session-1" } },
+      });
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+
+  it("accepts host.describe from DSH 0.1.0 that omits home", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn((input: URL, init?: RequestInit) => {
+        const body = JSON.parse(String(init?.body)) as Record<string, unknown>;
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({
+              type: "server-response",
+              rpcId: body.rpcId,
+              result: {
+                ok: true,
+                value: {
+                  version: "0.0.1",
+                  cwd: "/workspace",
+                  provider: "deepseek-official",
+                  model: "deepseek-v4-flash",
+                  attachedSessions: 0,
+                  canOpenPath: true,
+                },
+              },
+            }),
+          ),
+        );
+      }),
+    );
+    try {
+      const client = new NodeDeepSeekHostClient("http://127.0.0.1:43123");
+      const described = await client.host.describe({});
+      expect(described.result).toMatchObject({
+        ok: true,
+        value: {
+          version: "0.0.1",
+          provider: "deepseek-official",
+          model: "deepseek-v4-flash",
+          home: expect.any(String),
+        },
       });
     } finally {
       vi.unstubAllGlobals();
@@ -292,6 +337,7 @@ describe("DeepSeek local Host connection", () => {
         ),
       spawn,
       sleep: () => Promise.resolve(),
+      readWebHelp: () => "",
     };
     const connection = new DeepSeekHostConnection(
       { command: executable, endpoint: "http://127.0.0.1:43123" },
@@ -301,7 +347,7 @@ describe("DeepSeek local Host connection", () => {
     await connection.connect();
     const expectedInvocation = deepSeekProcessInvocation(
       executable,
-      ["web", "--no-open", "--host", "127.0.0.1", "--port", "43123"],
+      deepSeekWebArguments(new URL("http://127.0.0.1:43123")),
       process.env,
     );
     expect(spawn).toHaveBeenCalledWith(expectedInvocation.command, expectedInvocation.arguments, {
@@ -311,6 +357,56 @@ describe("DeepSeek local Host connection", () => {
     });
     await connection.close();
     expect(child.kill).toHaveBeenCalledWith("SIGTERM");
+  });
+
+  it("passes --no-open only when this dsh web CLI still advertises it", async () => {
+    const executableDirectory = mkdtempSync(path.join(os.tmpdir(), "codexhost-dsh-no-open-"));
+    const executable = path.join(executableDirectory, "dsh");
+    writeFileSync(executable, "#!/bin/sh\nexit 0\n");
+    chmodSync(executable, 0o755);
+    let ready = false;
+    const child = childProcess();
+    const spawn = vi.fn(() => {
+      ready = true;
+      return child;
+    });
+    const dependencies: DeepSeekHostConnectionDependencies = {
+      createClient: () =>
+        fakeClient(() =>
+          ready
+            ? Promise.resolve(
+                success({
+                  version: "0.0.1",
+                  cwd: "/workspace",
+                  provider: "deepseek-official",
+                  model: "deepseek-v4-flash",
+                  attachedSessions: 0,
+                  canOpenPath: false,
+                }),
+              )
+            : Promise.reject(new TypeError("fetch failed")),
+        ),
+      spawn,
+      sleep: () => Promise.resolve(),
+      readWebHelp: () => "Options:\n  --no-open\n  --host <host>\n  --port <port>\n",
+    };
+    const connection = new DeepSeekHostConnection(
+      { command: executable, endpoint: "http://127.0.0.1:43123" },
+      dependencies,
+    );
+
+    await connection.connect();
+    const expectedInvocation = deepSeekProcessInvocation(
+      executable,
+      deepSeekWebArguments(new URL("http://127.0.0.1:43123"), { noOpen: true }),
+      process.env,
+    );
+    expect(spawn).toHaveBeenCalledWith(expectedInvocation.command, expectedInvocation.arguments, {
+      env: process.env,
+      stdio: "pipe",
+      windowsVerbatimArguments: expectedInvocation.windowsVerbatimArguments,
+    });
+    await connection.close();
   });
 
   it("classifies an npx DSH package startup exit as not installed", async () => {
@@ -332,6 +428,7 @@ describe("DeepSeek local Host connection", () => {
       createClient: () => fakeClient(() => Promise.reject(new TypeError("fetch failed"))),
       spawn,
       sleep: () => Promise.resolve(),
+      readWebHelp: () => "",
     };
     const connection = new DeepSeekHostConnection(
       { endpoint: "http://127.0.0.1:43123", environment },
@@ -345,12 +442,7 @@ describe("DeepSeek local Host connection", () => {
         "--offline",
         "--no-install",
         "@deepseek-ai/dsh",
-        "web",
-        "--no-open",
-        "--host",
-        "127.0.0.1",
-        "--port",
-        "43123",
+        ...deepSeekWebArguments(new URL("http://127.0.0.1:43123")),
       ],
       environment,
     );
@@ -430,5 +522,11 @@ describe("DeepSeek local Host connection", () => {
     expect(resolved).toMatchObject({ arguments: [] });
     expect(resolved?.command.toLowerCase()).toBe(executable.toLowerCase());
     expect(resolveDeepSeekCommand(undefined, { PATH: "" })).toBeNull();
+  });
+
+  it("detects --no-open from dsh web help without matching nearby flags", () => {
+    expect(dshWebHelpSupportsNoOpen("Options:\n  --no-open\n  --host <host>\n")).toBe(true);
+    expect(dshWebHelpSupportsNoOpen("Options:\n  --host <host>\n  --port <port>\n")).toBe(false);
+    expect(dshWebHelpSupportsNoOpen("--no-open-browser")).toBe(false);
   });
 });

--- a/packages/adapters/deepseek-harness/test/host-client.test.ts
+++ b/packages/adapters/deepseek-harness/test/host-client.test.ts
@@ -134,6 +134,87 @@ describe("DeepSeek local Host connection", () => {
     }
   });
 
+  it("keeps the client timeout when host.describe fallback receives a caller signal", async () => {
+    const signals: AbortSignal[] = [];
+    const caller = new AbortController();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn((_input: URL, init?: RequestInit) => {
+        if (init?.signal) signals.push(init.signal);
+        const body = JSON.parse(String(init?.body)) as Record<string, unknown>;
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({
+              type: "server-response",
+              rpcId: body.rpcId,
+              result: {
+                ok: true,
+                value: {
+                  version: "0.0.1",
+                  cwd: "/workspace",
+                  provider: "deepseek-official",
+                  model: "deepseek-v4-flash",
+                  attachedSessions: 0,
+                  canOpenPath: true,
+                },
+              },
+            }),
+          ),
+        );
+      }),
+    );
+    try {
+      const client = new NodeDeepSeekHostClient("http://127.0.0.1:43123");
+      await client.host.describe({}, caller.signal);
+      expect(signals.at(-1)).toBeDefined();
+      expect(signals.at(-1)).not.toBe(caller.signal);
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+
+  it("wraps invalid host.describe fallback envelopes as transport errors", async () => {
+    let calls = 0;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn((_input: URL, init?: RequestInit) => {
+        calls += 1;
+        const body = JSON.parse(String(init?.body)) as Record<string, unknown>;
+        if (calls === 1) {
+          return Promise.resolve(
+            new Response(
+              JSON.stringify({
+                type: "server-response",
+                rpcId: body.rpcId,
+                result: {
+                  ok: true,
+                  value: {
+                    version: "0.0.1",
+                    cwd: "/workspace",
+                    provider: "deepseek-official",
+                    model: "deepseek-v4-flash",
+                    attachedSessions: 0,
+                    canOpenPath: true,
+                  },
+                },
+              }),
+            ),
+          );
+        }
+        return Promise.resolve(new Response("not-json"));
+      }),
+    );
+    try {
+      const client = new NodeDeepSeekHostClient("http://127.0.0.1:43123");
+      await expect(client.host.describe({})).rejects.toMatchObject({
+        name: "DeepSeekHarnessTransportError",
+        code: "protocolError",
+      });
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+
   it("retries commands/execute with the newer empty images field only when requested", async () => {
     const payloads: Array<Record<string, unknown>> = [];
     vi.stubGlobal(


### PR DESCRIPTION
## Summary

DeepSeek Harness inspection fails on current local `dsh` 0.1.0-rc.6 while other harnesses stay ready.

- Probe `dsh web --help` and pass `--no-open` only when that CLI still advertises it. Newer dsh treats `--no-open` as an unknown option and exits during Host startup.
- Accept `host.describe` payloads that omit `home`. The adapter SDK (`@deepseek-ai/dsh-host-apiproxy` 0.1.1-rc.2) requires `home`, but 0.1.0-rc.6 does not send it. The Host `version` field remains `0.0.1` on both sides, so this branches on response shape rather than protocol version.

## Test plan

- `npx vitest run packages/adapters/deepseek-harness/test/host-client.test.ts packages/adapters/deepseek-harness/test/deepseek-harness-adapter.test.ts --config tests/vitest.config.js` (54 tests)
- Live inspect against local `dsh` 0.1.0-rc.6: Adapter spawned Web Host and `inspect()` returned `ready` with 14 models.