### PR TITLE
feat: surface OmniRoute credits for OMP and Claude

### DIFF
--- a/packages/adapters/claude-code/src/claude-code-adapter.ts
+++ b/packages/adapters/claude-code/src/claude-code-adapter.ts
@@ -96,6 +96,7 @@ import { ClaudeSubagentLifecycle } from "./subagent-lifecycle.js";
 import { ClaudeTaskTracker } from "./task-tracker.js";
 import { ClaudeToolLifecycle } from "./tool-lifecycle.js";
 import { estimateClaudeRequestCostUsd } from "./usage-estimate.js";
+import { fetchClaudeCredits, type FetchClaudeCreditsInput } from "./claude-credits.js";
 import type {
   ClaudeAdapterDependencies,
   ClaudeApprovalRequest,
@@ -495,6 +496,7 @@ class ClaudeHarnessSession implements HarnessSession {
   readonly #nativeRef: NativeSessionRef;
   readonly #onClosed: () => void;
   readonly #onPlanLimitObserved: (planLimit: ClaudePlanLimitEvent) => ClaudePlanLimitEvent | null;
+  readonly #onTurnSettled: (() => void) | undefined;
   #openMode: "create" | "resume";
   readonly #randomUUID: () => string;
   #requestedModel: HarnessModelRef | undefined;
@@ -547,6 +549,7 @@ class ClaudeHarnessSession implements HarnessSession {
       toolOutputLimit: number;
       cancelTimeoutMs: number;
       continuationQuiescenceMs: number;
+      onTurnSettled?: () => void;
     },
   ) {
     this.#cwd = cwd;
@@ -560,6 +563,7 @@ class ClaudeHarnessSession implements HarnessSession {
     this.#closeTimeoutMs = closeTimeoutMs;
     this.#onClosed = onClosed;
     this.#onPlanLimitObserved = onPlanLimitObserved;
+    this.#onTurnSettled = options.onTurnSettled;
     this.#openMode = options.openMode;
     this.#requestedModel = options.requestedModel;
     this.#requestedPermissionModeId = options.requestedPermissionModeId;
@@ -2130,6 +2134,7 @@ class ClaudeHarnessSession implements HarnessSession {
     this.#occupancy.clear();
     this.#transport?.setIdleLive(false);
     active.resolveCompletion();
+    this.#onTurnSettled?.();
   }
 
   #handleTurnTransportFailure(active: ActiveTurn): void {
@@ -2246,6 +2251,10 @@ export class ClaudeCodeAdapter implements HarnessAdapter {
   readonly #cancelTimeoutMs: number;
   readonly #closeTimeoutMs: number;
   readonly #dependencies: ClaudeAdapterDependencies;
+  readonly #environment: NodeJS.ProcessEnv | undefined;
+  readonly #fetchCredits: (
+    input: FetchClaudeCreditsInput,
+  ) => Promise<AccountCreditsSnapshot | null>;
   readonly #toolOutputLimit: number;
   readonly #continuationQuiescenceMs: number;
   readonly #inspectionCache = new Map<string, HarnessInspection>();
@@ -2254,9 +2263,12 @@ export class ClaudeCodeAdapter implements HarnessAdapter {
   readonly #sessions = new Set<ClaudeHarnessSession>();
   #closePromise: Promise<void> | null = null;
   #latestPlanLimit: ClaudePlanLimitEvent | null = null;
+  #omniRouteCredits: AccountCreditsSnapshot | null = null;
+  #creditsRefresh: Promise<AccountCreditsSnapshot | null> | null = null;
 
   constructor(options: ClaudeCodeAdapterOptions = {}, dependencies?: ClaudeAdapterDependencies) {
     this.#closeTimeoutMs = options.closeTimeoutMs ?? DEFAULT_CLOSE_TIMEOUT_MS;
+    this.#environment = options.environment;
     this.#cancelTimeoutMs = options.cancelTimeoutMs ?? DEFAULT_CANCEL_TIMEOUT_MS;
     if (!Number.isSafeInteger(this.#cancelTimeoutMs) || this.#cancelTimeoutMs <= 0) {
       throw new RangeError("Claude Code cancel timeout must be a positive safe integer");
@@ -2315,6 +2327,46 @@ export class ClaudeCodeAdapter implements HarnessAdapter {
       readSubagentMessages: ({ cwd, sessionId, nativeSubagentId }) =>
         getSubagentMessages(sessionId, nativeSubagentId, { dir: cwd }),
     };
+    this.#fetchCredits =
+      dependencies?.fetchCredits ??
+      ((input) =>
+        fetchClaudeCredits(
+          input.environment
+            ? { environment: input.environment }
+            : this.#environment
+              ? { environment: this.#environment }
+              : {},
+        ));
+  }
+
+  credits(): AccountCreditsSnapshot | null {
+    return projectClaudePlanLimitToCredits(this.#latestPlanLimit) ?? this.#omniRouteCredits;
+  }
+
+  refreshCredits(): Promise<AccountCreditsSnapshot | null> {
+    if (this.#closePromise) return Promise.resolve(this.credits());
+    if (this.#latestPlanLimit) return Promise.resolve(this.credits());
+    if (this.#creditsRefresh) return this.#creditsRefresh;
+    this.#creditsRefresh = this.#loadCredits().finally(() => {
+      this.#creditsRefresh = null;
+    });
+    return this.#creditsRefresh;
+  }
+
+  #scheduleCreditsRefresh(): void {
+    void this.refreshCredits();
+  }
+
+  async #loadCredits(): Promise<AccountCreditsSnapshot | null> {
+    try {
+      const snapshot = await this.#fetchCredits(
+        this.#environment ? { environment: this.#environment } : {},
+      );
+      if (snapshot) this.#omniRouteCredits = snapshot;
+    } catch {
+      // Credits are optional account telemetry; preserve last snapshot.
+    }
+    return this.credits();
   }
 
   async inspect(input: InspectHarnessInput = {}): Promise<HarnessInspection> {
@@ -2324,6 +2376,7 @@ export class ClaudeCodeAdapter implements HarnessAdapter {
         error: invalidState("Claude Code Adapter is closing"),
       };
     }
+    this.#scheduleCreditsRefresh();
     const cwd = path.resolve(input.cwd ?? process.cwd());
     if (!input.refresh) {
       const cached = this.#inspectionCache.get(cwd);
@@ -2600,9 +2653,11 @@ export class ClaudeCodeAdapter implements HarnessAdapter {
         toolOutputLimit: this.#toolOutputLimit,
         cancelTimeoutMs: this.#cancelTimeoutMs,
         continuationQuiescenceMs: this.#continuationQuiescenceMs,
+        onTurnSettled: () => this.#scheduleCreditsRefresh(),
       },
     );
     this.#sessions.add(session);
+    this.#scheduleCreditsRefresh();
     return { ok: true, value: session };
   }
 
@@ -2621,10 +2676,6 @@ export class ClaudeCodeAdapter implements HarnessAdapter {
       }
     }
     return this.#latestPlanLimit;
-  }
-
-  credits(): AccountCreditsSnapshot | null {
-    return projectClaudePlanLimitToCredits(this.#latestPlanLimit);
   }
 
   close(): Promise<void> {

--- a/packages/adapters/claude-code/src/claude-credits.ts
+++ b/packages/adapters/claude-code/src/claude-credits.ts
@@ -1,0 +1,577 @@
+import os from "node:os";
+import path from "node:path";
+
+import {
+  type AccountCreditsAccountUsage,
+  type AccountCreditsSnapshot,
+} from "@codexhost/shared-contracts";
+
+export interface OmniRouteConnection {
+  id: string;
+  provider: string;
+  isActive: boolean;
+  email?: string | null;
+}
+
+export interface OmniRouteCacheEntry {
+  quotas?: Record<string, unknown> | null;
+  plan?: string | null;
+  message?: string | null;
+  fetchedAt?: string | null;
+}
+
+export interface OmniRouteStorageData {
+  connections: ReadonlyArray<OmniRouteConnection>;
+  caches: Record<string, OmniRouteCacheEntry>;
+}
+
+export interface FetchClaudeCreditsInput {
+  environment?: NodeJS.ProcessEnv;
+  dbPath?: string;
+  queryDatabase?(
+    dbPath: string,
+  ): Promise<OmniRouteStorageData | null> | OmniRouteStorageData | null;
+}
+
+interface DatabaseSyncLike {
+  prepare(query: string): { all(): unknown[] };
+  close(): void;
+}
+
+type DatabaseSyncConstructor = new (
+  location: string,
+  options?: { readOnly?: boolean; open?: boolean },
+) => DatabaseSyncLike;
+
+let databaseSyncClass: DatabaseSyncConstructor | null | undefined;
+
+async function loadDatabaseSync(): Promise<DatabaseSyncConstructor | null> {
+  if (databaseSyncClass !== undefined) return databaseSyncClass;
+  try {
+    const sqliteModule = (await import("node:sqlite")) as {
+      DatabaseSync?: DatabaseSyncConstructor;
+    };
+    databaseSyncClass = sqliteModule.DatabaseSync ?? null;
+  } catch {
+    databaseSyncClass = null;
+  }
+  return databaseSyncClass;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function finitePercent(value: unknown): number | undefined {
+  if (typeof value !== "number" || !Number.isFinite(value)) return undefined;
+  return Math.min(100, Math.max(0, value));
+}
+
+function nonNegativeNumber(value: unknown): number | undefined {
+  if (typeof value !== "number" || !Number.isFinite(value) || value < 0) return undefined;
+  return value;
+}
+
+function omnirouteHome(environment: NodeJS.ProcessEnv): string {
+  return (
+    environment.OMNIROUTE_DATA_DIR ??
+    path.join(environment.HOME ?? environment.USERPROFILE ?? os.homedir(), ".omniroute")
+  );
+}
+
+export function defaultOmniRouteDbPath(environment: NodeJS.ProcessEnv = process.env): string {
+  return environment.OMNIROUTE_DB_PATH ?? path.join(omnirouteHome(environment), "storage.sqlite");
+}
+
+function parseQuotaUsedPercent(quota: unknown): { usedPercent: number; resetsAt?: string } | null {
+  if (!isRecord(quota)) return null;
+
+  const resetsAt =
+    typeof quota.resetAt === "string" && quota.resetAt.length > 0 ? quota.resetAt : undefined;
+
+  if (quota.remainingPercentage !== undefined) {
+    const rem = finitePercent(quota.remainingPercentage);
+    if (rem !== undefined) {
+      return {
+        usedPercent: Math.min(100, Math.max(0, 100 - rem)),
+        ...(resetsAt ? { resetsAt } : {}),
+      };
+    }
+  }
+
+  if (quota.isPercentageOnly && typeof quota.used === "number") {
+    const used = finitePercent(quota.used);
+    if (used !== undefined) {
+      return {
+        usedPercent: used,
+        ...(resetsAt ? { resetsAt } : {}),
+      };
+    }
+  }
+
+  const used = nonNegativeNumber(quota.used);
+  const total = nonNegativeNumber(quota.total);
+  if (used !== undefined && total !== undefined && total > 0) {
+    return {
+      usedPercent: Math.min(100, Math.max(0, (used / total) * 100)),
+      ...(resetsAt ? { resetsAt } : {}),
+    };
+  }
+
+  if (used !== undefined && total === undefined) {
+    const clamped = finitePercent(used);
+    if (clamped !== undefined) {
+      return {
+        usedPercent: clamped,
+        ...(resetsAt ? { resetsAt } : {}),
+      };
+    }
+  }
+
+  return null;
+}
+
+function connectionAccountName(conn: OmniRouteConnection): string {
+  if (conn.email && conn.email.trim().length > 0) return conn.email.trim();
+  return `Account (${conn.id.slice(0, 8)})`;
+}
+
+export function parseClaudeOmniRouteCredits(
+  data: OmniRouteStorageData,
+): AccountCreditsSnapshot | null {
+  if (!data || !Array.isArray(data.connections) || !isRecord(data.caches)) return null;
+
+  const activeConnections = data.connections.filter((c) => c.isActive);
+  if (activeConnections.length === 0) return null;
+
+  const productUsage: Array<{
+    product: string;
+    usagePercent: number;
+    resetsAt?: string;
+    accounts?: AccountCreditsAccountUsage[];
+  }> = [];
+
+  // 1. Antigravity pool (`agy`)
+  const agyConns = activeConnections.filter((c) => c.provider === "agy");
+  const agyFlashUsed: number[] = [];
+  const agyFlashResets: string[] = [];
+  const agyAccounts: AccountCreditsAccountUsage[] = [];
+
+  for (const conn of agyConns) {
+    const cache = data.caches[conn.id];
+    const quotas = isRecord(cache?.quotas) ? cache.quotas : undefined;
+    if (!quotas) continue;
+
+    const flashQuota =
+      quotas["gemini-3.7-flash-tiered"] ??
+      quotas["gemini-3.7-flash-medium"] ??
+      quotas["gemini-3.7-flash-high"] ??
+      quotas["gemini-3.7-flash-low"] ??
+      quotas["gemini-pro-agent"] ??
+      quotas["gemini-3.1-flash-lite"] ??
+      quotas["gemini-3.1-pro-low"] ??
+      quotas["gemini-3.1-pro-high"];
+
+    const flashParsed = parseQuotaUsedPercent(flashQuota);
+    if (flashParsed) {
+      agyFlashUsed.push(flashParsed.usedPercent);
+      if (flashParsed.resetsAt) agyFlashResets.push(flashParsed.resetsAt);
+      agyAccounts.push({
+        accountName: connectionAccountName(conn),
+        usagePercent: flashParsed.usedPercent,
+        ...(flashParsed.resetsAt ? { resetsAt: flashParsed.resetsAt } : {}),
+      });
+    }
+  }
+
+  const pooledFlashUsed =
+    agyFlashUsed.length > 0
+      ? Math.round((agyFlashUsed.reduce((a, b) => a + b, 0) / agyFlashUsed.length) * 10) / 10
+      : null;
+
+  const sortedFlashResets = [...agyFlashResets].sort();
+  const earliestFlashReset = sortedFlashResets[0];
+
+  if (pooledFlashUsed !== null) {
+    productUsage.push({
+      product: "Gemini Flash (5h)",
+      usagePercent: pooledFlashUsed,
+      ...(earliestFlashReset ? { resetsAt: earliestFlashReset } : {}),
+      ...(agyAccounts.length > 0 ? { accounts: agyAccounts } : {}),
+    });
+  }
+
+  const agyClaudeUsed: number[] = [];
+  const agyClaudeResets: string[] = [];
+  const agyClaudeAccounts: AccountCreditsAccountUsage[] = [];
+  for (const conn of agyConns) {
+    const cache = data.caches[conn.id];
+    const quotas = isRecord(cache?.quotas) ? cache.quotas : undefined;
+    if (!quotas) continue;
+    const claudeKey =
+      Object.keys(quotas).find((key) => key.startsWith("claude-sonnet")) ??
+      Object.keys(quotas).find((key) => key.startsWith("claude-"));
+    if (!claudeKey) continue;
+    const claudeParsed = parseQuotaUsedPercent(quotas[claudeKey]);
+    if (!claudeParsed) continue;
+    agyClaudeUsed.push(claudeParsed.usedPercent);
+    if (claudeParsed.resetsAt) agyClaudeResets.push(claudeParsed.resetsAt);
+    agyClaudeAccounts.push({
+      accountName: connectionAccountName(conn),
+      usagePercent: claudeParsed.usedPercent,
+      ...(claudeParsed.resetsAt ? { resetsAt: claudeParsed.resetsAt } : {}),
+    });
+  }
+  const pooledClaudeUsed =
+    agyClaudeUsed.length > 0
+      ? Math.round((agyClaudeUsed.reduce((a, b) => a + b, 0) / agyClaudeUsed.length) * 10) / 10
+      : null;
+  const earliestClaudeReset = [...agyClaudeResets].sort()[0];
+  if (pooledClaudeUsed !== null) {
+    productUsage.push({
+      product: "Claude (5h)",
+      usagePercent: pooledClaudeUsed,
+      ...(earliestClaudeReset ? { resetsAt: earliestClaudeReset } : {}),
+      ...(agyClaudeAccounts.length > 0 ? { accounts: agyClaudeAccounts } : {}),
+    });
+  }
+
+  // 2. Grok (`grok-cli` / `grok`)
+  let grokPrimaryUsed: number | null = null;
+  let grokPrimaryReset: string | undefined;
+  const grokBuildAccounts: AccountCreditsAccountUsage[] = [];
+  const grokWeeklyAccounts: AccountCreditsAccountUsage[] = [];
+  const grokConns = activeConnections.filter(
+    (c) => c.provider === "grok-cli" || c.provider === "grok",
+  );
+
+  for (const conn of grokConns) {
+    const cache = data.caches[conn.id];
+    const quotas = isRecord(cache?.quotas) ? cache.quotas : undefined;
+    if (!quotas) continue;
+
+    const weekly = parseQuotaUsedPercent(quotas.weekly);
+    const build = parseQuotaUsedPercent(quotas.product_grok_build);
+
+    if (weekly) {
+      grokWeeklyAccounts.push({
+        accountName: connectionAccountName(conn),
+        usagePercent: weekly.usedPercent,
+        ...(weekly.resetsAt ? { resetsAt: weekly.resetsAt } : {}),
+      });
+    }
+
+    if (build) {
+      const reset = build.resetsAt ?? weekly?.resetsAt;
+      grokBuildAccounts.push({
+        accountName: connectionAccountName(conn),
+        usagePercent: build.usedPercent,
+        ...(reset ? { resetsAt: reset } : {}),
+      });
+    }
+  }
+
+  if (grokWeeklyAccounts.length > 0) {
+    grokPrimaryUsed =
+      Math.round(
+        (grokWeeklyAccounts.reduce((a, b) => a + b.usagePercent, 0) / grokWeeklyAccounts.length) *
+          10,
+      ) / 10;
+    grokPrimaryReset = [...grokWeeklyAccounts]
+      .flatMap((account) => (account.resetsAt ? [account.resetsAt] : []))
+      .sort()[0];
+  }
+
+  if (grokBuildAccounts.length > 0) {
+    const buildReset = grokBuildAccounts.find((a) => a.resetsAt)?.resetsAt;
+    const avgBuild =
+      Math.round(
+        (grokBuildAccounts.reduce((a, b) => a + b.usagePercent, 0) / grokBuildAccounts.length) * 10,
+      ) / 10;
+    productUsage.push({
+      product: "Grok Build",
+      usagePercent: avgBuild,
+      ...(buildReset ? { resetsAt: buildReset } : {}),
+      accounts: grokBuildAccounts,
+    });
+  } else if (grokWeeklyAccounts.length > 0) {
+    const weeklyReset = grokWeeklyAccounts.find((a) => a.resetsAt)?.resetsAt;
+    const avgWeekly =
+      Math.round(
+        (grokWeeklyAccounts.reduce((a, b) => a + b.usagePercent, 0) / grokWeeklyAccounts.length) *
+          10,
+      ) / 10;
+    productUsage.push({
+      product: "Grok (Weekly)",
+      usagePercent: avgWeekly,
+      ...(weeklyReset ? { resetsAt: weeklyReset } : {}),
+      accounts: grokWeeklyAccounts,
+    });
+  }
+
+  // 3. Codex (`codex`)
+  let codexSessionUsed: number | null = null;
+  let codexSessionReset: string | undefined;
+  const codexSessionAccounts: AccountCreditsAccountUsage[] = [];
+  const codexWeeklyAccounts: AccountCreditsAccountUsage[] = [];
+  const codexConns = activeConnections.filter((c) => c.provider === "codex");
+
+  for (const conn of codexConns) {
+    const cache = data.caches[conn.id];
+    const quotas = isRecord(cache?.quotas) ? cache.quotas : undefined;
+    if (!quotas) continue;
+
+    const session = parseQuotaUsedPercent(quotas.session ?? quotas["session (5h)"]);
+    const weekly = parseQuotaUsedPercent(quotas.weekly ?? quotas["weekly (7d)"]);
+
+    if (session) {
+      codexSessionAccounts.push({
+        accountName: connectionAccountName(conn),
+        usagePercent: session.usedPercent,
+        ...(session.resetsAt ? { resetsAt: session.resetsAt } : {}),
+      });
+    }
+    if (weekly) {
+      codexWeeklyAccounts.push({
+        accountName: connectionAccountName(conn),
+        usagePercent: weekly.usedPercent,
+        ...(weekly.resetsAt ? { resetsAt: weekly.resetsAt } : {}),
+      });
+    }
+  }
+
+  if (codexSessionAccounts.length > 0) {
+    const avgSession =
+      Math.round(
+        (codexSessionAccounts.reduce((a, b) => a + b.usagePercent, 0) /
+          codexSessionAccounts.length) *
+          10,
+      ) / 10;
+    codexSessionUsed = avgSession;
+    codexSessionReset = [...codexSessionAccounts]
+      .flatMap((account) => (account.resetsAt ? [account.resetsAt] : []))
+      .sort()[0];
+    productUsage.push({
+      product: "Codex (5h)",
+      usagePercent: avgSession,
+      ...(codexSessionReset ? { resetsAt: codexSessionReset } : {}),
+      accounts: codexSessionAccounts,
+    });
+  }
+  if (codexWeeklyAccounts.length > 0) {
+    const avgWeekly =
+      Math.round(
+        (codexWeeklyAccounts.reduce((a, b) => a + b.usagePercent, 0) / codexWeeklyAccounts.length) *
+          10,
+      ) / 10;
+    const firstReset = codexWeeklyAccounts.find((a) => a.resetsAt)?.resetsAt;
+    productUsage.push({
+      product: "Codex (7d)",
+      usagePercent: avgWeekly,
+      ...(firstReset ? { resetsAt: firstReset } : {}),
+      accounts: codexWeeklyAccounts,
+    });
+  }
+
+  // 4. Claude direct connection
+  let claudeDirectUsed: number | null = null;
+  let claudeDirectReset: string | undefined;
+  const claudeSessionAccounts: AccountCreditsAccountUsage[] = [];
+  const claudeWeeklyAccounts: AccountCreditsAccountUsage[] = [];
+  const claudeConns = activeConnections.filter(
+    (c) => c.provider === "claude" || c.provider === "default_claude_max_5x",
+  );
+
+  for (const conn of claudeConns) {
+    const cache = data.caches[conn.id];
+    const quotas = isRecord(cache?.quotas) ? cache.quotas : undefined;
+    if (!quotas) continue;
+
+    const session = parseQuotaUsedPercent(quotas["session (5h)"] ?? quotas.session);
+    const weekly = parseQuotaUsedPercent(quotas["weekly (7d)"] ?? quotas.weekly);
+
+    if (session) {
+      claudeDirectUsed = session.usedPercent;
+      claudeDirectReset = session.resetsAt;
+      claudeSessionAccounts.push({
+        accountName: connectionAccountName(conn),
+        usagePercent: session.usedPercent,
+        ...(session.resetsAt ? { resetsAt: session.resetsAt } : {}),
+      });
+    }
+    if (weekly) {
+      if (claudeDirectUsed === null) {
+        claudeDirectUsed = weekly.usedPercent;
+        claudeDirectReset = weekly.resetsAt;
+      }
+      claudeWeeklyAccounts.push({
+        accountName: connectionAccountName(conn),
+        usagePercent: weekly.usedPercent,
+        ...(weekly.resetsAt ? { resetsAt: weekly.resetsAt } : {}),
+      });
+    }
+  }
+
+  if (claudeSessionAccounts.length > 0) {
+    const avgSession =
+      Math.round(
+        (claudeSessionAccounts.reduce((a, b) => a + b.usagePercent, 0) /
+          claudeSessionAccounts.length) *
+          10,
+      ) / 10;
+    productUsage.push({
+      product: "Claude (5h)",
+      usagePercent: avgSession,
+      ...(claudeDirectReset ? { resetsAt: claudeDirectReset } : {}),
+      accounts: claudeSessionAccounts,
+    });
+  }
+  if (claudeWeeklyAccounts.length > 0) {
+    const avgWeekly =
+      Math.round(
+        (claudeWeeklyAccounts.reduce((a, b) => a + b.usagePercent, 0) /
+          claudeWeeklyAccounts.length) *
+          10,
+      ) / 10;
+    const firstReset = claudeWeeklyAccounts.find((a) => a.resetsAt)?.resetsAt;
+    productUsage.push({
+      product: "Claude (7d)",
+      usagePercent: avgWeekly,
+      ...(firstReset ? { resetsAt: firstReset } : {}),
+      accounts: claudeWeeklyAccounts,
+    });
+  }
+
+  // 5. Any other active providers with cached quotas
+  const handledProviders = new Set([
+    "agy",
+    "grok-cli",
+    "grok",
+    "codex",
+    "claude",
+    "default_claude_max_5x",
+  ]);
+  const otherConns = activeConnections.filter((c) => !handledProviders.has(c.provider));
+  for (const conn of otherConns) {
+    const cache = data.caches[conn.id];
+    const quotas = isRecord(cache?.quotas) ? cache.quotas : undefined;
+    if (!quotas) continue;
+
+    for (const [quotaKey, quotaVal] of Object.entries(quotas)) {
+      const parsed = parseQuotaUsedPercent(quotaVal);
+      if (parsed) {
+        const prodName = `${conn.provider} (${quotaKey})`;
+        productUsage.push({
+          product: prodName,
+          usagePercent: parsed.usedPercent,
+          ...(parsed.resetsAt ? { resetsAt: parsed.resetsAt } : {}),
+          accounts: [
+            {
+              accountName: connectionAccountName(conn),
+              usagePercent: parsed.usedPercent,
+              ...(parsed.resetsAt ? { resetsAt: parsed.resetsAt } : {}),
+            },
+          ],
+        });
+      }
+    }
+  }
+
+  // Determine primary period and usage
+  let usedPercent: number;
+  let periodType: AccountCreditsSnapshot["periodType"];
+  let resetsAt: string | undefined;
+
+  if (pooledFlashUsed !== null) {
+    usedPercent = pooledFlashUsed;
+    periodType = "five_hour";
+    resetsAt = earliestFlashReset;
+  } else if (claudeDirectUsed !== null) {
+    usedPercent = claudeDirectUsed;
+    periodType = claudeDirectReset ? "five_hour" : "seven_day";
+    resetsAt = claudeDirectReset;
+  } else if (grokPrimaryUsed !== null) {
+    usedPercent = grokPrimaryUsed;
+    periodType = "weekly";
+    resetsAt = grokPrimaryReset;
+  } else if (codexSessionUsed !== null) {
+    usedPercent = codexSessionUsed;
+    periodType = "five_hour";
+    resetsAt = codexSessionReset;
+  } else if (productUsage.length > 0) {
+    const first = productUsage[0];
+    if (!first) return null;
+    usedPercent = first.usagePercent;
+    periodType = "unknown";
+    resetsAt = first.resetsAt;
+  } else {
+    return null;
+  }
+
+  return {
+    usedPercent: Math.min(100, Math.max(0, usedPercent)),
+    periodType,
+    ...(resetsAt ? { resetsAt } : {}),
+    ...(productUsage.length > 0 ? { productUsage } : {}),
+  };
+}
+
+async function defaultQueryDatabase(dbPath: string): Promise<OmniRouteStorageData | null> {
+  const DatabaseClass = await loadDatabaseSync();
+  if (!DatabaseClass) return null;
+
+  try {
+    const db = new DatabaseClass(dbPath, { readOnly: true, open: true });
+    try {
+      const conns = db
+        .prepare(
+          "SELECT id, provider, is_active, email FROM provider_connections WHERE is_active = 1",
+        )
+        .all() as Array<{ id: string; provider: string; is_active: number; email: string | null }>;
+
+      const rows = db
+        .prepare("SELECT key, value FROM key_value WHERE namespace = 'providerLimitsCache'")
+        .all() as Array<{ key: string; value: string }>;
+
+      const caches: Record<string, OmniRouteCacheEntry> = {};
+      for (const row of rows) {
+        try {
+          caches[row.key] = JSON.parse(row.value) as OmniRouteCacheEntry;
+        } catch {
+          // Ignore malformed JSON entries
+        }
+      }
+
+      return {
+        connections: conns.map((c) => ({
+          id: c.id,
+          provider: c.provider,
+          isActive: Boolean(c.is_active),
+          email: c.email,
+        })),
+        caches,
+      };
+    } finally {
+      db.close();
+    }
+  } catch {
+    return null;
+  }
+}
+
+export async function fetchClaudeCredits(
+  input: FetchClaudeCreditsInput = {},
+): Promise<AccountCreditsSnapshot | null> {
+  try {
+    const environment = input.environment ?? process.env;
+    const dbPath = input.dbPath ?? defaultOmniRouteDbPath(environment);
+    const queryDatabase = input.queryDatabase ?? defaultQueryDatabase;
+
+    const data = await queryDatabase(dbPath);
+    if (!data) return null;
+
+    return parseClaudeOmniRouteCredits(data);
+  } catch {
+    return null;
+  }
+}

--- a/packages/adapters/claude-code/src/index.ts
+++ b/packages/adapters/claude-code/src/index.ts
@@ -3,6 +3,17 @@ import { WORKSPACE_CONTRACT_VERSION } from "@codexhost/shared-contracts";
 
 export { ClaudeCodeAdapter } from "./claude-code-adapter.js";
 export type { ClaudeCodeAdapterOptions } from "./claude-code-adapter.js";
+export {
+  fetchClaudeCredits,
+  parseClaudeOmniRouteCredits,
+  defaultOmniRouteDbPath,
+} from "./claude-credits.js";
+export type {
+  FetchClaudeCreditsInput,
+  OmniRouteCacheEntry,
+  OmniRouteConnection,
+  OmniRouteStorageData,
+} from "./claude-credits.js";
 
 export const packageMetadata = {
   name: "@codexhost/adapter-claude-code",

--- a/packages/adapters/claude-code/src/transport.ts
+++ b/packages/adapters/claude-code/src/transport.ts
@@ -1,4 +1,10 @@
-import type { HarnessThinkingOptionId, JsonValue } from "@codexhost/shared-contracts";
+import type {
+  AccountCreditsSnapshot,
+  HarnessThinkingOptionId,
+  JsonValue,
+} from "@codexhost/shared-contracts";
+
+import type { FetchClaudeCreditsInput } from "./claude-credits.js";
 
 import type { ClaudeNativeFileChange } from "./file-change.js";
 import type { ClaudeModelInspectionSnapshot } from "./model-catalog.js";
@@ -240,4 +246,5 @@ export interface ClaudeAdapterDependencies {
     nativeSubagentId: string;
   }): Promise<unknown[]>;
   randomUUID(): string;
+  fetchCredits?(input: FetchClaudeCreditsInput): Promise<AccountCreditsSnapshot | null>;
 }

--- a/packages/adapters/claude-code/test/claude-code-adapter.test.ts
+++ b/packages/adapters/claude-code/test/claude-code-adapter.test.ts
@@ -202,7 +202,10 @@ class FakeClaudeTransport implements ClaudeTurnTransport {
   }
 }
 
-function fixture(options: ClaudeCodeAdapterOptions = {}) {
+function fixture(
+  options: ClaudeCodeAdapterOptions = {},
+  dependencyOverrides: Partial<ClaudeAdapterDependencies> = {},
+) {
   const history: unknown[] = [];
   const transports: FakeClaudeTransport[] = [];
   const inspectors: Array<{
@@ -214,6 +217,7 @@ function fixture(options: ClaudeCodeAdapterOptions = {}) {
   const dependencies: ClaudeAdapterDependencies = {
     randomUUID: () => `claude-id-${++uuid}`,
     inspectInstallation,
+    fetchCredits: async () => null,
     createInspector: vi.fn(() => {
       const inspector = {
         close: vi.fn(async () => undefined),
@@ -259,7 +263,7 @@ function fixture(options: ClaudeCodeAdapterOptions = {}) {
   };
   const adapter = new ClaudeCodeAdapter(
     { closeTimeoutMs: 50, continuationQuiescenceMs: 50, cancelTimeoutMs: 5_000, ...options },
-    dependencies,
+    { ...dependencies, ...dependencyOverrides },
   );
   return { adapter, dependencies, history, inspectors, inspectInstallation, transports };
 }
@@ -3890,6 +3894,25 @@ describe("Claude Code HarnessAdapter", () => {
     await nextEvent(iteratorB);
     await sessionA.close();
     await sessionB.close();
+  });
+
+  it("falls back to OmniRoute credits when custom gateway is used without Anthropic planLimit", async () => {
+    const omnirouteSnapshot = {
+      usedPercent: 8.5,
+      periodType: "five_hour" as const,
+      resetsAt: "2026-08-31T16:54:00.000Z",
+      productUsage: [
+        {
+          product: "Gemini Flash (5h)",
+          usagePercent: 8.5,
+          resetsAt: "2026-08-31T16:54:00.000Z",
+        },
+      ],
+    };
+    const { adapter } = fixture({}, { fetchCredits: async () => omnirouteSnapshot });
+    expect(adapter.credits()).toBeNull();
+    await adapter.refreshCredits();
+    expect(adapter.credits()).toEqual(omnirouteSnapshot);
   });
 
   it("reuses one Transport and Native Session for sequential Turns", async () => {

--- a/packages/adapters/claude-code/test/claude-credits.test.ts
+++ b/packages/adapters/claude-code/test/claude-credits.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, it } from "vitest";
+
+import { parseClaudeOmniRouteCredits, type OmniRouteStorageData } from "../src/claude-credits.js";
+
+describe("Claude Code OmniRoute credits parsing", () => {
+  it("parses pooled Antigravity (agy) Gemini Flash and Claude model quotas", () => {
+    const data: OmniRouteStorageData = {
+      connections: [
+        { id: "conn-1", provider: "agy", isActive: true, email: "user1@example.com" },
+        { id: "conn-2", provider: "agy", isActive: true, email: "user2@example.com" },
+      ],
+      caches: {
+        "conn-1": {
+          quotas: {
+            "gemini-3.7-flash-tiered": {
+              used: 200,
+              total: 1000,
+              remainingPercentage: 80,
+              resetAt: "2026-08-31T16:00:00.000Z",
+            },
+            "claude-sonnet-4-6": {
+              used: 100,
+              total: 1000,
+              remainingPercentage: 90,
+              resetAt: "2026-08-31T17:00:00.000Z",
+            },
+          },
+        },
+        "conn-2": {
+          quotas: {
+            "gemini-3.7-flash-tiered": {
+              used: 0,
+              total: 1000,
+              remainingPercentage: 100,
+              resetAt: "2026-08-31T16:30:00.000Z",
+            },
+            "claude-sonnet-4-6": {
+              used: 0,
+              total: 1000,
+              remainingPercentage: 100,
+              resetAt: "2026-08-31T17:30:00.000Z",
+            },
+          },
+        },
+      },
+    };
+
+    const credits = parseClaudeOmniRouteCredits(data);
+    expect(credits).toEqual({
+      usedPercent: 10,
+      periodType: "five_hour",
+      resetsAt: "2026-08-31T16:00:00.000Z",
+      productUsage: [
+        {
+          product: "Gemini Flash (5h)",
+          usagePercent: 10,
+          resetsAt: "2026-08-31T16:00:00.000Z",
+          accounts: [
+            {
+              accountName: "user1@example.com",
+              usagePercent: 20,
+              resetsAt: "2026-08-31T16:00:00.000Z",
+            },
+            {
+              accountName: "user2@example.com",
+              usagePercent: 0,
+              resetsAt: "2026-08-31T16:30:00.000Z",
+            },
+          ],
+        },
+        {
+          product: "Claude (5h)",
+          usagePercent: 5,
+          resetsAt: "2026-08-31T17:00:00.000Z",
+          accounts: [
+            {
+              accountName: "user1@example.com",
+              usagePercent: 10,
+              resetsAt: "2026-08-31T17:00:00.000Z",
+            },
+            {
+              accountName: "user2@example.com",
+              usagePercent: 0,
+              resetsAt: "2026-08-31T17:30:00.000Z",
+            },
+          ],
+        },
+      ],
+    });
+  });
+
+  it("parses Grok and Codex quotas when configured as gateway upstream", () => {
+    const data: OmniRouteStorageData = {
+      connections: [
+        { id: "conn-grok", provider: "grok-cli", isActive: true },
+        { id: "conn-codex", provider: "codex", isActive: true },
+      ],
+      caches: {
+        "conn-grok": {
+          quotas: {
+            weekly: { used: 40, total: 100, resetAt: "2026-09-04T05:00:00.000Z" },
+            product_grok_build: { used: 35, total: 100, resetAt: "2026-09-04T05:00:00.000Z" },
+          },
+        },
+        "conn-codex": {
+          quotas: {
+            session: { used: 10, total: 100, resetAt: "2026-08-31T16:00:00.000Z" },
+          },
+        },
+      },
+    };
+
+    const credits = parseClaudeOmniRouteCredits(data);
+    expect(credits).toEqual({
+      usedPercent: 40,
+      periodType: "weekly",
+      resetsAt: "2026-09-04T05:00:00.000Z",
+      productUsage: [
+        {
+          product: "Grok Build",
+          usagePercent: 35,
+          resetsAt: "2026-09-04T05:00:00.000Z",
+          accounts: [
+            {
+              accountName: "Account (conn-gro)",
+              usagePercent: 35,
+              resetsAt: "2026-09-04T05:00:00.000Z",
+            },
+          ],
+        },
+        {
+          product: "Codex (5h)",
+          usagePercent: 10,
+          resetsAt: "2026-08-31T16:00:00.000Z",
+          accounts: [
+            {
+              accountName: "Account (conn-cod)",
+              usagePercent: 10,
+              resetsAt: "2026-08-31T16:00:00.000Z",
+            },
+          ],
+        },
+      ],
+    });
+  });
+
+  it("returns null when no active connections exist", () => {
+    expect(parseClaudeOmniRouteCredits({ connections: [], caches: {} })).toBeNull();
+  });
+});

--- a/packages/adapters/omp/src/index.ts
+++ b/packages/adapters/omp/src/index.ts
@@ -2,7 +2,14 @@ import { packageMetadata as harnessAdapter } from "@codexhost/harness-adapter";
 import { WORKSPACE_CONTRACT_VERSION } from "@codexhost/shared-contracts";
 
 export { OmpAdapter } from "./omp-adapter.js";
-export type { OmpAdapterOptions } from "./omp-adapter.js";
+export type { OmpAdapterOptions, OmpAdapterDependencies } from "./omp-adapter.js";
+export { fetchOmpCredits, parseOmniRouteCredits, defaultOmniRouteDbPath } from "./omp-credits.js";
+export type {
+  FetchOmpCreditsInput,
+  OmniRouteCacheEntry,
+  OmniRouteConnection,
+  OmniRouteStorageData,
+} from "./omp-credits.js";
 export {
   OMP_DEFAULT_PERMISSION_MODE_ID,
   OMP_PERMISSION_MODE_CATALOG,

--- a/packages/adapters/omp/src/omp-adapter.ts
+++ b/packages/adapters/omp/src/omp-adapter.ts
@@ -66,8 +66,10 @@ import {
   type NativeCheckpointRef,
   type NativeSessionRef,
   type NativeTurnRef,
+  type AccountCreditsSnapshot,
 } from "@codexhost/shared-contracts";
 
+import { fetchOmpCredits, type FetchOmpCreditsInput } from "./omp-credits.js";
 import { mapOmpSnapshot, resolveOmpForkBoundary, type OmpSessionHistory } from "./omp-history.js";
 import { rollbackOmpLastTurn } from "./omp-last-turn-rollback.js";
 import {
@@ -138,6 +140,7 @@ export interface OmpTurnTransport {
 
 export interface OmpAdapterDependencies {
   createTransport(options: OmpRpcSessionOptions): OmpTurnTransport;
+  fetchCredits?(input: FetchOmpCreditsInput): Promise<AccountCreditsSnapshot | null>;
 }
 
 interface ActiveTool {
@@ -556,6 +559,7 @@ class OmpHarnessSession implements HarnessSession {
   readonly #createTransport: OmpAdapterDependencies["createTransport"];
   readonly #cwd: string;
   readonly #onClosed: () => void;
+  readonly #onTurnSettled: (() => void) | undefined;
   readonly #requestedModel: HarnessModelRef | undefined;
   readonly #requestedThinkingOptionId: HarnessThinkingOptionId | undefined;
   readonly #toolOutputLimit: number;
@@ -591,11 +595,13 @@ class OmpHarnessSession implements HarnessSession {
       startedTransport?: OmpTurnTransport;
       startedThinkingLevels?: HarnessThinkingOptionId[] | null;
       initialUsage?: HostUsage | null;
+      onTurnSettled?: () => void;
     },
   ) {
     this.#cwd = cwd;
     this.#createTransport = createTransport;
     this.#onClosed = onClosed;
+    this.#onTurnSettled = options.onTurnSettled;
     this.#closeTimeoutMs = options.closeTimeoutMs;
     this.#requestedModel = options.model;
     this.#requestedThinkingOptionId = options.thinkingOptionId;
@@ -1843,6 +1849,7 @@ class OmpHarnessSession implements HarnessSession {
       ...(nativeTurnRef ? { nativeTurnRef } : {}),
     });
     active.resolveCompletion();
+    this.#onTurnSettled?.();
     queueMicrotask(() => {
       if (this.#phase === "open") void this.#refreshUsage(active.command.turnId);
     });
@@ -1944,12 +1951,16 @@ export class OmpAdapter implements HarnessAdapter {
   };
   readonly #closeTimeoutMs: number;
   readonly #createTransport: OmpAdapterDependencies["createTransport"];
+  readonly #environment: NodeJS.ProcessEnv | undefined;
+  readonly #fetchCredits: (input: FetchOmpCreditsInput) => Promise<AccountCreditsSnapshot | null>;
   readonly #inspectionCache = new Map<string, Extract<HarnessInspection, { status: "ready" }>>();
   readonly #inspectionInFlight = new Map<string, Promise<HarnessInspection>>();
   readonly #inspections = new Set<OmpTurnTransport>();
   readonly #sessions = new Set<OmpHarnessSession>();
   readonly #toolOutputLimit: number;
   #closePromise: Promise<void> | null = null;
+  #credits: AccountCreditsSnapshot | null = null;
+  #creditsRefresh: Promise<AccountCreditsSnapshot | null> | null = null;
   #thinkingSelectionSupported: boolean | null = null;
 
   constructor(
@@ -1960,7 +1971,47 @@ export class OmpAdapter implements HarnessAdapter {
   ) {
     this.#createTransport = dependencies.createTransport;
     this.#closeTimeoutMs = options.closeTimeoutMs ?? 2_000;
+    this.#environment = options.environment;
     this.#toolOutputLimit = options.toolOutputLimit ?? DEFAULT_TOOL_OUTPUT_LIMIT;
+    this.#fetchCredits =
+      dependencies.fetchCredits ??
+      ((input) =>
+        fetchOmpCredits(
+          input.environment
+            ? { environment: input.environment }
+            : this.#environment
+              ? { environment: this.#environment }
+              : {},
+        ));
+  }
+
+  credits(): AccountCreditsSnapshot | null {
+    return this.#credits;
+  }
+
+  refreshCredits(): Promise<AccountCreditsSnapshot | null> {
+    if (this.#closePromise) return Promise.resolve(this.#credits);
+    if (this.#creditsRefresh) return this.#creditsRefresh;
+    this.#creditsRefresh = this.#loadCredits().finally(() => {
+      this.#creditsRefresh = null;
+    });
+    return this.#creditsRefresh;
+  }
+
+  #scheduleCreditsRefresh(): void {
+    void this.refreshCredits();
+  }
+
+  async #loadCredits(): Promise<AccountCreditsSnapshot | null> {
+    try {
+      const snapshot = await this.#fetchCredits(
+        this.#environment ? { environment: this.#environment } : {},
+      );
+      if (snapshot) this.#credits = snapshot;
+    } catch {
+      // Credits are optional account telemetry; preserve last snapshot.
+    }
+    return this.#credits;
   }
 
   async inspect(input: InspectHarnessInput = {}): Promise<HarnessInspection> {
@@ -1974,6 +2025,7 @@ export class OmpAdapter implements HarnessAdapter {
         },
       };
     }
+    this.#scheduleCreditsRefresh();
     const cwd = input.cwd ?? process.cwd();
     const inFlight = this.#inspectionInFlight.get(cwd);
     if (inFlight) return inFlight;
@@ -2271,9 +2323,11 @@ export class OmpAdapter implements HarnessAdapter {
           ? { startedThinkingLevels: options.startedThinkingLevels }
           : {}),
         ...(options.initialUsage !== undefined ? { initialUsage: options.initialUsage } : {}),
+        onTurnSettled: () => this.#scheduleCreditsRefresh(),
       },
     );
     this.#sessions.add(session);
+    this.#scheduleCreditsRefresh();
     return session;
   }
 

--- a/packages/adapters/omp/src/omp-credits.ts
+++ b/packages/adapters/omp/src/omp-credits.ts
@@ -1,0 +1,575 @@
+import os from "node:os";
+import path from "node:path";
+
+import {
+  type AccountCreditsAccountUsage,
+  type AccountCreditsSnapshot,
+} from "@codexhost/shared-contracts";
+
+export interface OmniRouteConnection {
+  id: string;
+  provider: string;
+  isActive: boolean;
+  email?: string | null;
+}
+
+export interface OmniRouteCacheEntry {
+  quotas?: Record<string, unknown> | null;
+  plan?: string | null;
+  message?: string | null;
+  fetchedAt?: string | null;
+}
+
+export interface OmniRouteStorageData {
+  connections: ReadonlyArray<OmniRouteConnection>;
+  caches: Record<string, OmniRouteCacheEntry>;
+}
+
+export interface FetchOmpCreditsInput {
+  environment?: NodeJS.ProcessEnv;
+  dbPath?: string;
+  queryDatabase?(
+    dbPath: string,
+  ): Promise<OmniRouteStorageData | null> | OmniRouteStorageData | null;
+}
+
+interface DatabaseSyncLike {
+  prepare(query: string): { all(): unknown[] };
+  close(): void;
+}
+
+type DatabaseSyncConstructor = new (
+  location: string,
+  options?: { readOnly?: boolean; open?: boolean },
+) => DatabaseSyncLike;
+
+let databaseSyncClass: DatabaseSyncConstructor | null | undefined;
+
+async function loadDatabaseSync(): Promise<DatabaseSyncConstructor | null> {
+  if (databaseSyncClass !== undefined) return databaseSyncClass;
+  try {
+    const sqliteModule = (await import("node:sqlite")) as {
+      DatabaseSync?: DatabaseSyncConstructor;
+    };
+    databaseSyncClass = sqliteModule.DatabaseSync ?? null;
+  } catch {
+    databaseSyncClass = null;
+  }
+  return databaseSyncClass;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function finitePercent(value: unknown): number | undefined {
+  if (typeof value !== "number" || !Number.isFinite(value)) return undefined;
+  return Math.min(100, Math.max(0, value));
+}
+
+function nonNegativeNumber(value: unknown): number | undefined {
+  if (typeof value !== "number" || !Number.isFinite(value) || value < 0) return undefined;
+  return value;
+}
+
+function omnirouteHome(environment: NodeJS.ProcessEnv): string {
+  return (
+    environment.OMNIROUTE_DATA_DIR ??
+    path.join(environment.HOME ?? environment.USERPROFILE ?? os.homedir(), ".omniroute")
+  );
+}
+
+export function defaultOmniRouteDbPath(environment: NodeJS.ProcessEnv = process.env): string {
+  return environment.OMNIROUTE_DB_PATH ?? path.join(omnirouteHome(environment), "storage.sqlite");
+}
+
+function parseQuotaUsedPercent(quota: unknown): { usedPercent: number; resetsAt?: string } | null {
+  if (!isRecord(quota)) return null;
+
+  const resetsAt =
+    typeof quota.resetAt === "string" && quota.resetAt.length > 0 ? quota.resetAt : undefined;
+
+  if (quota.remainingPercentage !== undefined) {
+    const rem = finitePercent(quota.remainingPercentage);
+    if (rem !== undefined) {
+      return {
+        usedPercent: Math.min(100, Math.max(0, 100 - rem)),
+        ...(resetsAt ? { resetsAt } : {}),
+      };
+    }
+  }
+
+  if (quota.isPercentageOnly && typeof quota.used === "number") {
+    const used = finitePercent(quota.used);
+    if (used !== undefined) {
+      return {
+        usedPercent: used,
+        ...(resetsAt ? { resetsAt } : {}),
+      };
+    }
+  }
+
+  const used = nonNegativeNumber(quota.used);
+  const total = nonNegativeNumber(quota.total);
+  if (used !== undefined && total !== undefined && total > 0) {
+    return {
+      usedPercent: Math.min(100, Math.max(0, (used / total) * 100)),
+      ...(resetsAt ? { resetsAt } : {}),
+    };
+  }
+
+  if (used !== undefined && total === undefined) {
+    const clamped = finitePercent(used);
+    if (clamped !== undefined) {
+      return {
+        usedPercent: clamped,
+        ...(resetsAt ? { resetsAt } : {}),
+      };
+    }
+  }
+
+  return null;
+}
+
+function connectionAccountName(conn: OmniRouteConnection): string {
+  if (conn.email && conn.email.trim().length > 0) return conn.email.trim();
+  return `Account (${conn.id.slice(0, 8)})`;
+}
+
+export function parseOmniRouteCredits(data: OmniRouteStorageData): AccountCreditsSnapshot | null {
+  if (!data || !Array.isArray(data.connections) || !isRecord(data.caches)) return null;
+
+  const activeConnections = data.connections.filter((c) => c.isActive);
+  if (activeConnections.length === 0) return null;
+
+  const productUsage: Array<{
+    product: string;
+    usagePercent: number;
+    resetsAt?: string;
+    accounts?: AccountCreditsAccountUsage[];
+  }> = [];
+
+  // 1. Antigravity pool (`agy`)
+  const agyConns = activeConnections.filter((c) => c.provider === "agy");
+  const agyFlashUsed: number[] = [];
+  const agyFlashResets: string[] = [];
+  const agyAccounts: AccountCreditsAccountUsage[] = [];
+
+  for (const conn of agyConns) {
+    const cache = data.caches[conn.id];
+    const quotas = isRecord(cache?.quotas) ? cache.quotas : undefined;
+    if (!quotas) continue;
+
+    const flashQuota =
+      quotas["gemini-3.7-flash-tiered"] ??
+      quotas["gemini-3.7-flash-medium"] ??
+      quotas["gemini-3.7-flash-high"] ??
+      quotas["gemini-3.7-flash-low"] ??
+      quotas["gemini-pro-agent"] ??
+      quotas["gemini-3.1-flash-lite"] ??
+      quotas["gemini-3.1-pro-low"] ??
+      quotas["gemini-3.1-pro-high"];
+
+    const flashParsed = parseQuotaUsedPercent(flashQuota);
+    if (flashParsed) {
+      agyFlashUsed.push(flashParsed.usedPercent);
+      if (flashParsed.resetsAt) agyFlashResets.push(flashParsed.resetsAt);
+      agyAccounts.push({
+        accountName: connectionAccountName(conn),
+        usagePercent: flashParsed.usedPercent,
+        ...(flashParsed.resetsAt ? { resetsAt: flashParsed.resetsAt } : {}),
+      });
+    }
+  }
+
+  const pooledFlashUsed =
+    agyFlashUsed.length > 0
+      ? Math.round((agyFlashUsed.reduce((a, b) => a + b, 0) / agyFlashUsed.length) * 10) / 10
+      : null;
+
+  const sortedFlashResets = [...agyFlashResets].sort();
+  const earliestFlashReset = sortedFlashResets[0];
+
+  if (pooledFlashUsed !== null) {
+    productUsage.push({
+      product: "Gemini Flash (5h)",
+      usagePercent: pooledFlashUsed,
+      ...(earliestFlashReset ? { resetsAt: earliestFlashReset } : {}),
+      ...(agyAccounts.length > 0 ? { accounts: agyAccounts } : {}),
+    });
+  }
+
+  const agyClaudeUsed: number[] = [];
+  const agyClaudeResets: string[] = [];
+  const agyClaudeAccounts: AccountCreditsAccountUsage[] = [];
+  for (const conn of agyConns) {
+    const cache = data.caches[conn.id];
+    const quotas = isRecord(cache?.quotas) ? cache.quotas : undefined;
+    if (!quotas) continue;
+    const claudeKey =
+      Object.keys(quotas).find((key) => key.startsWith("claude-sonnet")) ??
+      Object.keys(quotas).find((key) => key.startsWith("claude-"));
+    if (!claudeKey) continue;
+    const claudeParsed = parseQuotaUsedPercent(quotas[claudeKey]);
+    if (!claudeParsed) continue;
+    agyClaudeUsed.push(claudeParsed.usedPercent);
+    if (claudeParsed.resetsAt) agyClaudeResets.push(claudeParsed.resetsAt);
+    agyClaudeAccounts.push({
+      accountName: connectionAccountName(conn),
+      usagePercent: claudeParsed.usedPercent,
+      ...(claudeParsed.resetsAt ? { resetsAt: claudeParsed.resetsAt } : {}),
+    });
+  }
+  const pooledClaudeUsed =
+    agyClaudeUsed.length > 0
+      ? Math.round((agyClaudeUsed.reduce((a, b) => a + b, 0) / agyClaudeUsed.length) * 10) / 10
+      : null;
+  const earliestClaudeReset = [...agyClaudeResets].sort()[0];
+  if (pooledClaudeUsed !== null) {
+    productUsage.push({
+      product: "Claude (5h)",
+      usagePercent: pooledClaudeUsed,
+      ...(earliestClaudeReset ? { resetsAt: earliestClaudeReset } : {}),
+      ...(agyClaudeAccounts.length > 0 ? { accounts: agyClaudeAccounts } : {}),
+    });
+  }
+
+  // 2. Grok (`grok-cli` / `grok`)
+  let grokPrimaryUsed: number | null = null;
+  let grokPrimaryReset: string | undefined;
+  const grokBuildAccounts: AccountCreditsAccountUsage[] = [];
+  const grokWeeklyAccounts: AccountCreditsAccountUsage[] = [];
+  const grokConns = activeConnections.filter(
+    (c) => c.provider === "grok-cli" || c.provider === "grok",
+  );
+
+  for (const conn of grokConns) {
+    const cache = data.caches[conn.id];
+    const quotas = isRecord(cache?.quotas) ? cache.quotas : undefined;
+    if (!quotas) continue;
+
+    const weekly = parseQuotaUsedPercent(quotas.weekly);
+    const build = parseQuotaUsedPercent(quotas.product_grok_build);
+
+    if (weekly) {
+      grokWeeklyAccounts.push({
+        accountName: connectionAccountName(conn),
+        usagePercent: weekly.usedPercent,
+        ...(weekly.resetsAt ? { resetsAt: weekly.resetsAt } : {}),
+      });
+    }
+
+    if (build) {
+      const reset = build.resetsAt ?? weekly?.resetsAt;
+      grokBuildAccounts.push({
+        accountName: connectionAccountName(conn),
+        usagePercent: build.usedPercent,
+        ...(reset ? { resetsAt: reset } : {}),
+      });
+    }
+  }
+
+  if (grokWeeklyAccounts.length > 0) {
+    grokPrimaryUsed =
+      Math.round(
+        (grokWeeklyAccounts.reduce((a, b) => a + b.usagePercent, 0) / grokWeeklyAccounts.length) *
+          10,
+      ) / 10;
+    grokPrimaryReset = [...grokWeeklyAccounts]
+      .flatMap((account) => (account.resetsAt ? [account.resetsAt] : []))
+      .sort()[0];
+  }
+
+  if (grokBuildAccounts.length > 0) {
+    const buildReset = grokBuildAccounts.find((a) => a.resetsAt)?.resetsAt;
+    const avgBuild =
+      Math.round(
+        (grokBuildAccounts.reduce((a, b) => a + b.usagePercent, 0) / grokBuildAccounts.length) * 10,
+      ) / 10;
+    productUsage.push({
+      product: "Grok Build",
+      usagePercent: avgBuild,
+      ...(buildReset ? { resetsAt: buildReset } : {}),
+      accounts: grokBuildAccounts,
+    });
+  } else if (grokWeeklyAccounts.length > 0) {
+    const weeklyReset = grokWeeklyAccounts.find((a) => a.resetsAt)?.resetsAt;
+    const avgWeekly =
+      Math.round(
+        (grokWeeklyAccounts.reduce((a, b) => a + b.usagePercent, 0) / grokWeeklyAccounts.length) *
+          10,
+      ) / 10;
+    productUsage.push({
+      product: "Grok (Weekly)",
+      usagePercent: avgWeekly,
+      ...(weeklyReset ? { resetsAt: weeklyReset } : {}),
+      accounts: grokWeeklyAccounts,
+    });
+  }
+
+  // 3. Codex (`codex`)
+  let codexSessionUsed: number | null = null;
+  let codexSessionReset: string | undefined;
+  const codexSessionAccounts: AccountCreditsAccountUsage[] = [];
+  const codexWeeklyAccounts: AccountCreditsAccountUsage[] = [];
+  const codexConns = activeConnections.filter((c) => c.provider === "codex");
+
+  for (const conn of codexConns) {
+    const cache = data.caches[conn.id];
+    const quotas = isRecord(cache?.quotas) ? cache.quotas : undefined;
+    if (!quotas) continue;
+
+    const session = parseQuotaUsedPercent(quotas.session ?? quotas["session (5h)"]);
+    const weekly = parseQuotaUsedPercent(quotas.weekly ?? quotas["weekly (7d)"]);
+
+    if (session) {
+      codexSessionAccounts.push({
+        accountName: connectionAccountName(conn),
+        usagePercent: session.usedPercent,
+        ...(session.resetsAt ? { resetsAt: session.resetsAt } : {}),
+      });
+    }
+    if (weekly) {
+      codexWeeklyAccounts.push({
+        accountName: connectionAccountName(conn),
+        usagePercent: weekly.usedPercent,
+        ...(weekly.resetsAt ? { resetsAt: weekly.resetsAt } : {}),
+      });
+    }
+  }
+
+  if (codexSessionAccounts.length > 0) {
+    const avgSession =
+      Math.round(
+        (codexSessionAccounts.reduce((a, b) => a + b.usagePercent, 0) /
+          codexSessionAccounts.length) *
+          10,
+      ) / 10;
+    codexSessionUsed = avgSession;
+    codexSessionReset = [...codexSessionAccounts]
+      .flatMap((account) => (account.resetsAt ? [account.resetsAt] : []))
+      .sort()[0];
+    productUsage.push({
+      product: "Codex (5h)",
+      usagePercent: avgSession,
+      ...(codexSessionReset ? { resetsAt: codexSessionReset } : {}),
+      accounts: codexSessionAccounts,
+    });
+  }
+  if (codexWeeklyAccounts.length > 0) {
+    const avgWeekly =
+      Math.round(
+        (codexWeeklyAccounts.reduce((a, b) => a + b.usagePercent, 0) / codexWeeklyAccounts.length) *
+          10,
+      ) / 10;
+    const firstReset = codexWeeklyAccounts.find((a) => a.resetsAt)?.resetsAt;
+    productUsage.push({
+      product: "Codex (7d)",
+      usagePercent: avgWeekly,
+      ...(firstReset ? { resetsAt: firstReset } : {}),
+      accounts: codexWeeklyAccounts,
+    });
+  }
+
+  // 4. Claude direct connection
+  let claudeDirectUsed: number | null = null;
+  let claudeDirectReset: string | undefined;
+  const claudeSessionAccounts: AccountCreditsAccountUsage[] = [];
+  const claudeWeeklyAccounts: AccountCreditsAccountUsage[] = [];
+  const claudeConns = activeConnections.filter(
+    (c) => c.provider === "claude" || c.provider === "default_claude_max_5x",
+  );
+
+  for (const conn of claudeConns) {
+    const cache = data.caches[conn.id];
+    const quotas = isRecord(cache?.quotas) ? cache.quotas : undefined;
+    if (!quotas) continue;
+
+    const session = parseQuotaUsedPercent(quotas["session (5h)"] ?? quotas.session);
+    const weekly = parseQuotaUsedPercent(quotas["weekly (7d)"] ?? quotas.weekly);
+
+    if (session) {
+      claudeDirectUsed = session.usedPercent;
+      claudeDirectReset = session.resetsAt;
+      claudeSessionAccounts.push({
+        accountName: connectionAccountName(conn),
+        usagePercent: session.usedPercent,
+        ...(session.resetsAt ? { resetsAt: session.resetsAt } : {}),
+      });
+    }
+    if (weekly) {
+      if (claudeDirectUsed === null) {
+        claudeDirectUsed = weekly.usedPercent;
+        claudeDirectReset = weekly.resetsAt;
+      }
+      claudeWeeklyAccounts.push({
+        accountName: connectionAccountName(conn),
+        usagePercent: weekly.usedPercent,
+        ...(weekly.resetsAt ? { resetsAt: weekly.resetsAt } : {}),
+      });
+    }
+  }
+
+  if (claudeSessionAccounts.length > 0) {
+    const avgSession =
+      Math.round(
+        (claudeSessionAccounts.reduce((a, b) => a + b.usagePercent, 0) /
+          claudeSessionAccounts.length) *
+          10,
+      ) / 10;
+    productUsage.push({
+      product: "Claude (5h)",
+      usagePercent: avgSession,
+      ...(claudeDirectReset ? { resetsAt: claudeDirectReset } : {}),
+      accounts: claudeSessionAccounts,
+    });
+  }
+  if (claudeWeeklyAccounts.length > 0) {
+    const avgWeekly =
+      Math.round(
+        (claudeWeeklyAccounts.reduce((a, b) => a + b.usagePercent, 0) /
+          claudeWeeklyAccounts.length) *
+          10,
+      ) / 10;
+    const firstReset = claudeWeeklyAccounts.find((a) => a.resetsAt)?.resetsAt;
+    productUsage.push({
+      product: "Claude (7d)",
+      usagePercent: avgWeekly,
+      ...(firstReset ? { resetsAt: firstReset } : {}),
+      accounts: claudeWeeklyAccounts,
+    });
+  }
+
+  // 5. Any other active providers with cached quotas
+  const handledProviders = new Set([
+    "agy",
+    "grok-cli",
+    "grok",
+    "codex",
+    "claude",
+    "default_claude_max_5x",
+  ]);
+  const otherConns = activeConnections.filter((c) => !handledProviders.has(c.provider));
+  for (const conn of otherConns) {
+    const cache = data.caches[conn.id];
+    const quotas = isRecord(cache?.quotas) ? cache.quotas : undefined;
+    if (!quotas) continue;
+
+    for (const [quotaKey, quotaVal] of Object.entries(quotas)) {
+      const parsed = parseQuotaUsedPercent(quotaVal);
+      if (parsed) {
+        const prodName = `${conn.provider} (${quotaKey})`;
+        productUsage.push({
+          product: prodName,
+          usagePercent: parsed.usedPercent,
+          ...(parsed.resetsAt ? { resetsAt: parsed.resetsAt } : {}),
+          accounts: [
+            {
+              accountName: connectionAccountName(conn),
+              usagePercent: parsed.usedPercent,
+              ...(parsed.resetsAt ? { resetsAt: parsed.resetsAt } : {}),
+            },
+          ],
+        });
+      }
+    }
+  }
+
+  // Determine primary period and usage
+  let usedPercent: number;
+  let periodType: AccountCreditsSnapshot["periodType"];
+  let resetsAt: string | undefined;
+
+  if (pooledFlashUsed !== null) {
+    usedPercent = pooledFlashUsed;
+    periodType = "five_hour";
+    resetsAt = earliestFlashReset;
+  } else if (grokPrimaryUsed !== null) {
+    usedPercent = grokPrimaryUsed;
+    periodType = "weekly";
+    resetsAt = grokPrimaryReset;
+  } else if (codexSessionUsed !== null) {
+    usedPercent = codexSessionUsed;
+    periodType = "five_hour";
+    resetsAt = codexSessionReset;
+  } else if (claudeDirectUsed !== null) {
+    usedPercent = claudeDirectUsed;
+    periodType = claudeDirectReset ? "five_hour" : "seven_day";
+    resetsAt = claudeDirectReset;
+  } else if (productUsage.length > 0) {
+    const first = productUsage[0];
+    if (!first) return null;
+    usedPercent = first.usagePercent;
+    periodType = "unknown";
+    resetsAt = first.resetsAt;
+  } else {
+    return null;
+  }
+
+  return {
+    usedPercent: Math.min(100, Math.max(0, usedPercent)),
+    periodType,
+    ...(resetsAt ? { resetsAt } : {}),
+    ...(productUsage.length > 0 ? { productUsage } : {}),
+  };
+}
+
+async function defaultQueryDatabase(dbPath: string): Promise<OmniRouteStorageData | null> {
+  const DatabaseClass = await loadDatabaseSync();
+  if (!DatabaseClass) return null;
+
+  try {
+    const db = new DatabaseClass(dbPath, { readOnly: true, open: true });
+    try {
+      const conns = db
+        .prepare(
+          "SELECT id, provider, is_active, email FROM provider_connections WHERE is_active = 1",
+        )
+        .all() as Array<{ id: string; provider: string; is_active: number; email: string | null }>;
+
+      const rows = db
+        .prepare("SELECT key, value FROM key_value WHERE namespace = 'providerLimitsCache'")
+        .all() as Array<{ key: string; value: string }>;
+
+      const caches: Record<string, OmniRouteCacheEntry> = {};
+      for (const row of rows) {
+        try {
+          caches[row.key] = JSON.parse(row.value) as OmniRouteCacheEntry;
+        } catch {
+          // Ignore malformed JSON entries
+        }
+      }
+
+      return {
+        connections: conns.map((c) => ({
+          id: c.id,
+          provider: c.provider,
+          isActive: Boolean(c.is_active),
+          email: c.email,
+        })),
+        caches,
+      };
+    } finally {
+      db.close();
+    }
+  } catch {
+    return null;
+  }
+}
+
+export async function fetchOmpCredits(
+  input: FetchOmpCreditsInput = {},
+): Promise<AccountCreditsSnapshot | null> {
+  try {
+    const environment = input.environment ?? process.env;
+    const dbPath = input.dbPath ?? defaultOmniRouteDbPath(environment);
+    const queryDatabase = input.queryDatabase ?? defaultQueryDatabase;
+
+    const data = await queryDatabase(dbPath);
+    if (!data) return null;
+
+    return parseOmniRouteCredits(data);
+  } catch {
+    return null;
+  }
+}

--- a/packages/adapters/omp/test/omp-adapter.test.ts
+++ b/packages/adapters/omp/test/omp-adapter.test.ts
@@ -245,7 +245,7 @@ describe("OMP Adapter Session environment", () => {
   it("uses OMP's native yolo default without changing ordinary create semantics", async () => {
     const transport = new FakeOmpTransport();
     const createTransport = vi.fn(() => transport);
-    const adapter = new OmpAdapter({}, { createTransport });
+    const adapter = new OmpAdapter({}, { fetchCredits: async () => null, createTransport });
     const opened = await adapter.open({
       kind: "create",
       cwd: "/synthetic",
@@ -266,7 +266,7 @@ describe("OMP Adapter Session environment", () => {
   it("defers a cold OMP Permission Mode selection until startup", async () => {
     const transport = new RestartableOmpTransport();
     const createTransport = vi.fn(() => transport);
-    const adapter = new OmpAdapter({}, { createTransport });
+    const adapter = new OmpAdapter({}, { fetchCredits: async () => null, createTransport });
     const opened = await adapter.open({
       kind: "create",
       cwd: "/synthetic",
@@ -306,7 +306,7 @@ describe("OMP Adapter Session environment", () => {
       .mockImplementationOnce(() => inspection)
       .mockImplementationOnce(() => initial)
       .mockImplementationOnce(() => replacement);
-    const adapter = new OmpAdapter({}, { createTransport });
+    const adapter = new OmpAdapter({}, { fetchCredits: async () => null, createTransport });
 
     await expect(adapter.inspect({ cwd: "/synthetic" })).resolves.toMatchObject({
       status: "ready",
@@ -364,7 +364,7 @@ describe("OMP Adapter Session environment", () => {
       .mockImplementationOnce(() => initial)
       .mockImplementationOnce(() => failedReplacement)
       .mockImplementationOnce(() => recovery);
-    const adapter = new OmpAdapter({}, { createTransport });
+    const adapter = new OmpAdapter({}, { fetchCredits: async () => null, createTransport });
     const opened = await adapter.open({
       kind: "create",
       cwd: "/synthetic",
@@ -394,7 +394,7 @@ describe("OMP Adapter Session environment", () => {
   it("passes per-Session delegation environment to the native transport", async () => {
     const transport = new FakeOmpTransport();
     const createTransport = vi.fn(() => transport);
-    const adapter = new OmpAdapter({}, { createTransport });
+    const adapter = new OmpAdapter({}, { fetchCredits: async () => null, createTransport });
     const opened = await adapter.open({
       kind: "create",
       cwd: "/synthetic",
@@ -433,7 +433,10 @@ describe("OMP Adapter inspection", () => {
       Object.assign(new Error("spawn omp ENOENT"), { code: "ENOENT" }),
     );
     const close = vi.spyOn(transport, "close");
-    const adapter = new OmpAdapter({}, { createTransport: () => transport });
+    const adapter = new OmpAdapter(
+      {},
+      { fetchCredits: async () => null, createTransport: () => transport },
+    );
 
     await expect(adapter.inspect({ cwd: "/synthetic" })).resolves.toMatchObject({
       status: "notInstalled",
@@ -481,7 +484,7 @@ describe("OMP Adapter Fork", () => {
     const verifySessionCwd = vi.fn(async () => undefined);
     transport.verifySessionCwd = verifySessionCwd;
     const createTransport = vi.fn(() => transport);
-    const adapter = new OmpAdapter({}, { createTransport });
+    const adapter = new OmpAdapter({}, { fetchCredits: async () => null, createTransport });
     const sourceRef = nativeSessionRefSchema.parse({
       harnessId: "omp",
       nativeSessionId: "source-session",
@@ -553,6 +556,7 @@ describe("OMP Adapter Subagents", () => {
   it("projects native Subagent lifecycle into a Host delegation Item", async () => {
     const transport = new FakeOmpTransport();
     const dependencies: OmpAdapterDependencies = {
+      fetchCredits: async () => null,
       createTransport: (options: OmpRpcSessionOptions) => {
         transport.onSubagentEvent = options.onSubagentEvent ?? null;
         return transport;
@@ -626,6 +630,7 @@ describe("OMP Adapter Subagents", () => {
   it("exposes only OMP compact as a Harness command", async () => {
     const transport = new FakeOmpTransport();
     const dependencies: OmpAdapterDependencies = {
+      fetchCredits: async () => null,
       createTransport: () => transport,
     };
     const adapter = new OmpAdapter({}, dependencies);
@@ -655,6 +660,7 @@ describe("OMP Adapter Subagents", () => {
   it("reads a stable OMP Subagent transcript as a Child Host Thread", async () => {
     const transport = new FakeOmpTransport();
     const dependencies: OmpAdapterDependencies = {
+      fetchCredits: async () => null,
       createTransport: () => transport,
     };
     const adapter = new OmpAdapter({}, dependencies);
@@ -686,6 +692,7 @@ describe("OMP Adapter Subagents", () => {
   it("materializes a background Subagent that starts after the parent Turn is idle", async () => {
     const transport = new FakeOmpTransport();
     const dependencies: OmpAdapterDependencies = {
+      fetchCredits: async () => null,
       createTransport: (options: OmpRpcSessionOptions) => {
         transport.onSubagentEvent = options.onSubagentEvent ?? null;
         return transport;
@@ -768,6 +775,7 @@ describe("OMP Adapter Subagents", () => {
   it("keeps an autonomous Turn open until all background Subagents settle", async () => {
     const transport = new FakeOmpTransport();
     const dependencies: OmpAdapterDependencies = {
+      fetchCredits: async () => null,
       createTransport: (options: OmpRpcSessionOptions) => {
         transport.onSubagentEvent = options.onSubagentEvent ?? null;
         return transport;
@@ -847,7 +855,10 @@ describe("OMP Adapter Subagents", () => {
   it("projects a native Edit File Change from numbered details.diff without faulting the Session", async () => {
     const transport = new FakeOmpTransport();
     transport.autoCompleteTurn = false;
-    const adapter = new OmpAdapter({}, { createTransport: () => transport });
+    const adapter = new OmpAdapter(
+      {},
+      { fetchCredits: async () => null, createTransport: () => transport },
+    );
     const opened = await adapter.open({ kind: "create", cwd: "/synthetic" });
     expect(opened.ok).toBe(true);
     if (!opened.ok) return;
@@ -930,6 +941,70 @@ describe("OMP Adapter Subagents", () => {
       outcome: { status: "succeeded" },
     });
     await opened.value.close();
+    await adapter.close();
+  });
+
+  it("caches OMP OmniRoute account credits on the Adapter without changing Session Usage", async () => {
+    const snapshot = {
+      usedPercent: 15,
+      resetsAt: "2026-08-31T16:00:00.000Z",
+      periodType: "five_hour" as const,
+      productUsage: [
+        {
+          product: "Gemini Flash (5h)",
+          usagePercent: 15,
+          resetsAt: "2026-08-31T16:00:00.000Z",
+        },
+      ],
+    };
+    const transport = new FakeOmpTransport();
+    const adapter = new OmpAdapter(
+      {},
+      {
+        createTransport: () => transport,
+        fetchCredits: async () => snapshot,
+      },
+    );
+    expect(adapter.credits()).toBeNull();
+    await expect(adapter.inspect({ cwd: "/synthetic" })).resolves.toMatchObject({
+      status: "ready",
+    });
+    await expect(adapter.refreshCredits()).resolves.toEqual(snapshot);
+    expect(adapter.credits()).toEqual(snapshot);
+    await adapter.close();
+  });
+
+  it("refreshes OMP OmniRoute account credits after a Turn settles", async () => {
+    let fetches = 0;
+    const transport = new FakeOmpTransport();
+    const adapter = new OmpAdapter(
+      {},
+      {
+        createTransport: () => transport,
+        fetchCredits: async () => {
+          fetches += 1;
+          return {
+            usedPercent: Math.min(fetches * 10, 100),
+            periodType: "five_hour" as const,
+          };
+        },
+      },
+    );
+    const opened = await adapter.open({ kind: "create", cwd: "/synthetic" });
+    if (!opened.ok) throw new Error(opened.error.message);
+    await adapter.refreshCredits();
+    const fetchesAfterOpen = fetches;
+    expect(fetchesAfterOpen).toBeGreaterThan(0);
+
+    const session = opened.value;
+    const turnId = "turn-omp-credits" as HostTurnId;
+    await expect(
+      session.execute({ type: "turn.start", turnId, input: [{ type: "text", text: "hello" }] }),
+    ).resolves.toEqual({ ok: true, value: { turnId } });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(fetches).toBeGreaterThan(fetchesAfterOpen);
+    expect(adapter.credits()?.usedPercent).toBe(Math.min(fetches * 10, 100));
+    await session.close();
     await adapter.close();
   });
 });

--- a/packages/adapters/omp/test/omp-credits.test.ts
+++ b/packages/adapters/omp/test/omp-credits.test.ts
@@ -1,0 +1,202 @@
+import { describe, expect, it } from "vitest";
+
+import { parseOmniRouteCredits, type OmniRouteStorageData } from "../src/omp-credits.js";
+
+describe("OMP OmniRoute credits parsing", () => {
+  it("parses pooled Antigravity (agy) quotas into AccountCreditsSnapshot", () => {
+    const data: OmniRouteStorageData = {
+      connections: [
+        { id: "conn-1", provider: "agy", isActive: true, email: "user1@example.com" },
+        { id: "conn-2", provider: "agy", isActive: true, email: "user2@example.com" },
+      ],
+      caches: {
+        "conn-1": {
+          quotas: {
+            "gemini-3.7-flash-tiered": {
+              used: 200,
+              total: 1000,
+              remainingPercentage: 80,
+              resetAt: "2026-08-31T16:00:00.000Z",
+            },
+            "claude-sonnet-4-6": {
+              used: 100,
+              total: 1000,
+              remainingPercentage: 90,
+              resetAt: "2026-08-31T17:00:00.000Z",
+            },
+          },
+        },
+        "conn-2": {
+          quotas: {
+            "gemini-3.7-flash-tiered": {
+              used: 0,
+              total: 1000,
+              remainingPercentage: 100,
+              resetAt: "2026-08-31T16:30:00.000Z",
+            },
+            "claude-sonnet-4-6": {
+              used: 0,
+              total: 1000,
+              remainingPercentage: 100,
+              resetAt: "2026-08-31T17:30:00.000Z",
+            },
+          },
+        },
+      },
+    };
+
+    const credits = parseOmniRouteCredits(data);
+    expect(credits).toEqual({
+      usedPercent: 10,
+      periodType: "five_hour",
+      resetsAt: "2026-08-31T16:00:00.000Z",
+      productUsage: [
+        {
+          product: "Gemini Flash (5h)",
+          usagePercent: 10,
+          resetsAt: "2026-08-31T16:00:00.000Z",
+          accounts: [
+            {
+              accountName: "user1@example.com",
+              usagePercent: 20,
+              resetsAt: "2026-08-31T16:00:00.000Z",
+            },
+            {
+              accountName: "user2@example.com",
+              usagePercent: 0,
+              resetsAt: "2026-08-31T16:30:00.000Z",
+            },
+          ],
+        },
+        {
+          product: "Claude (5h)",
+          usagePercent: 5,
+          resetsAt: "2026-08-31T17:00:00.000Z",
+          accounts: [
+            {
+              accountName: "user1@example.com",
+              usagePercent: 10,
+              resetsAt: "2026-08-31T17:00:00.000Z",
+            },
+            {
+              accountName: "user2@example.com",
+              usagePercent: 0,
+              resetsAt: "2026-08-31T17:30:00.000Z",
+            },
+          ],
+        },
+      ],
+    });
+  });
+
+  it("parses Grok Build quotas", () => {
+    const data: OmniRouteStorageData = {
+      connections: [
+        { id: "conn-grok", provider: "grok-cli", isActive: true, email: "grok@example.com" },
+      ],
+      caches: {
+        "conn-grok": {
+          quotas: {
+            weekly: {
+              used: 44,
+              total: 100,
+              resetAt: "2026-09-04T05:00:00.000Z",
+            },
+            product_grok_build: {
+              used: 43,
+              total: 100,
+              resetAt: "2026-09-04T05:00:00.000Z",
+            },
+            product_grokchat: {
+              used: 1,
+              total: 100,
+              resetAt: "2026-09-04T05:00:00.000Z",
+            },
+          },
+        },
+      },
+    };
+
+    const credits = parseOmniRouteCredits(data);
+    expect(credits).toEqual({
+      usedPercent: 44,
+      periodType: "weekly",
+      resetsAt: "2026-09-04T05:00:00.000Z",
+      productUsage: [
+        {
+          product: "Grok Build",
+          usagePercent: 43,
+          resetsAt: "2026-09-04T05:00:00.000Z",
+          accounts: [
+            {
+              accountName: "grok@example.com",
+              usagePercent: 43,
+              resetsAt: "2026-09-04T05:00:00.000Z",
+            },
+          ],
+        },
+      ],
+    });
+  });
+
+  it("parses Codex 5h and 7d quotas", () => {
+    const data: OmniRouteStorageData = {
+      connections: [
+        { id: "conn-codex", provider: "codex", isActive: true, email: "codex@example.com" },
+      ],
+      caches: {
+        "conn-codex": {
+          quotas: {
+            session: {
+              used: 25,
+              total: 100,
+              resetAt: "2026-08-31T16:00:00.000Z",
+            },
+            weekly: {
+              used: 15,
+              total: 100,
+              resetAt: "2026-09-07T11:00:00.000Z",
+            },
+          },
+        },
+      },
+    };
+
+    const credits = parseOmniRouteCredits(data);
+    expect(credits).toEqual({
+      usedPercent: 25,
+      periodType: "five_hour",
+      resetsAt: "2026-08-31T16:00:00.000Z",
+      productUsage: [
+        {
+          product: "Codex (5h)",
+          usagePercent: 25,
+          resetsAt: "2026-08-31T16:00:00.000Z",
+          accounts: [
+            {
+              accountName: "codex@example.com",
+              usagePercent: 25,
+              resetsAt: "2026-08-31T16:00:00.000Z",
+            },
+          ],
+        },
+        {
+          product: "Codex (7d)",
+          usagePercent: 15,
+          resetsAt: "2026-09-07T11:00:00.000Z",
+          accounts: [
+            {
+              accountName: "codex@example.com",
+              usagePercent: 15,
+              resetsAt: "2026-09-07T11:00:00.000Z",
+            },
+          ],
+        },
+      ],
+    });
+  });
+
+  it("returns null when no active connections or quotas exist", () => {
+    expect(parseOmniRouteCredits({ connections: [], caches: {} })).toBeNull();
+  });
+});

--- a/packages/renderer-extension/src/index.ts
+++ b/packages/renderer-extension/src/index.ts
@@ -65,7 +65,12 @@ export type { RendererHarnessMessages } from "./renderer-harness-localization.js
 export { mountRendererHarnessCommandControl } from "./renderer-harness-command-control.js";
 export type { RendererHarnessCommandControl } from "./renderer-harness-command-control.js";
 export {
+  creditsFamilyFromSelection,
+  creditsHeaderEntries,
   creditsPeriodLabel,
+  creditsPopoverRows,
+  creditsProviderShortLabel,
+  creditsSelectionHint,
   formatRendererCreditsReset,
   rendererCreditsTone,
 } from "./renderer-credits-control.js";
@@ -231,6 +236,9 @@ export type { RendererSettingsShell } from "./settings/shell.js";
 export {
   SETTINGS_HEADER_SURFACE_SELECTOR,
   SETTINGS_TRIGGER_ATTRIBUTE,
+  findRendererHeaderStartSlot,
+  findRendererHeaderTitleCluster,
+  findRendererHeaderTitleOverflow,
   inspectRendererSettingsContract,
   installRendererSettingsHeaderTrigger,
   mountRendererSettingsTrigger,

--- a/packages/renderer-extension/src/renderer-binding-probe.ts
+++ b/packages/renderer-extension/src/renderer-binding-probe.ts
@@ -165,7 +165,7 @@ export function rendererUsageRefreshDelay(attempt: number): number {
  * to pick up account limits after Usage has already arrived.
  */
 function externalAgentHasAccountCredits(agent: RendererAgent): boolean {
-  return agent === "codex" || agent === "grok" || agent === "claude-code";
+  return agent === "codex" || agent === "grok" || agent === "claude-code" || agent === "omp";
 }
 
 export function shouldRetryExternalThreadUsage(

--- a/packages/renderer-extension/src/renderer-composer-dom.ts
+++ b/packages/renderer-extension/src/renderer-composer-dom.ts
@@ -32,6 +32,7 @@ import {
   type RendererPermissionModePickerControl,
 } from "./renderer-permission-mode-picker.js";
 import {
+  creditsSelectionHint,
   mountRendererCreditsControl,
   renderRendererCreditsControl,
   type RendererCreditsControl,
@@ -42,6 +43,11 @@ import {
   type RendererUsageControl,
 } from "./renderer-usage-control.js";
 import type { RendererSettingsLocale } from "./settings/localization.js";
+import {
+  findRendererHeaderStartSlot,
+  findRendererHeaderTitleCluster,
+  findRendererHeaderTitleOverflow,
+} from "./settings/trigger.js";
 import type { RendererAdapterStatus } from "./versioned-renderer-adapter.js";
 import {
   mountRendererHarnessCommandControl,
@@ -472,13 +478,22 @@ function usagePlacementAnchor(control: ComposerAgentControl): HTMLElement | null
 }
 
 /**
- * Credits stays attached to the renderer-owned permission-mode slot. It is
- * independent from the native context indicator because Credits describes
- * account limits, not the current thread's context window.
+ * Credits mounts immediately after the thread-title overflow (`…`) button.
+ * It is independent from composer Usage because Credits describes account
+ * limits, not the current thread's context window.
  */
-export function creditsPlacementAnchor(control: ComposerAgentControl): HTMLElement | null {
-  const root = control.permissionModePicker?.root;
-  return root?.parentElement ? root : null;
+export function creditsPlacementAnchor(
+  _control?: ComposerAgentControl,
+  ownerDocument?: Document,
+): HTMLElement | null {
+  const doc =
+    ownerDocument ?? (typeof globalThis.document === "undefined" ? null : globalThis.document);
+  if (!doc) return null;
+  return (
+    findRendererHeaderTitleOverflow(doc) ??
+    findRendererHeaderTitleCluster(doc) ??
+    findRendererHeaderStartSlot(doc)
+  );
 }
 
 function refreshTrailingClusterPlacement(control: ComposerAgentControl): void {
@@ -581,9 +596,6 @@ export function reconcileComposerNativeControls(
 ): void {
   refreshNativeContextUsageControl(control);
   refreshNativeModelControl(control);
-  // Resolve the permission-mode picker's position before Credits anchors to
-  // it below, so Credits never reads a stale (e.g. mount-time fallback)
-  // location for it within this same pass.
   refreshNativePermissionModeControl(control);
   refreshTrailingClusterPlacement(control);
   refreshUsagePlacement(control);
@@ -734,7 +746,16 @@ export function renderComposerAgentControl(
   );
   if (control.usage) renderRendererUsageControl(control.usage, usage, locale);
   control.harnessCommands.setLocale(locale);
-  renderRendererCreditsControl(control.credits, accountCredits);
+  renderRendererCreditsControl(
+    control.credits,
+    accountCredits,
+    creditsSelectionHint({
+      modelLabel: selectedCatalogModel?.label,
+      modelId: selectedModel?.id,
+      resolvedModelLabel: modelView.resolvedModelLabel,
+      agent: state.agent,
+    }),
+  );
 }
 
 export function disposeComposerAgentControl(control: ComposerAgentControl): void {

--- a/packages/renderer-extension/src/renderer-credits-control.ts
+++ b/packages/renderer-extension/src/renderer-credits-control.ts
@@ -1,4 +1,8 @@
-import type { AccountCreditsSnapshot } from "@codexhost/shared-contracts";
+import type {
+  AccountCreditsAccountUsage,
+  AccountCreditsProductUsage,
+  AccountCreditsSnapshot,
+} from "@codexhost/shared-contracts";
 
 import {
   applyRendererPopoverChrome,
@@ -10,13 +14,29 @@ import {
   TRIGGER_CHIP_CLASS,
 } from "./renderer-trigger-chip-style.js";
 
+const CREDITS_STYLE_ATTRIBUTE = "data-codexhost-credits-style";
+const HEADER_FAMILY_LABELS = new Set(["Gemini", "Grok", "Codex", "Claude"]);
+
+export interface RendererCreditsHeaderEntry {
+  label: string;
+  usedPercent: number;
+  resetsAt?: string;
+  accounts?: AccountCreditsAccountUsage[];
+  products: AccountCreditsProductUsage[];
+}
+
 export interface RendererCreditsControl {
   root: HTMLDivElement;
   trigger: HTMLButtonElement;
+  extras: HTMLDivElement;
+  extrasInner: HTMLDivElement;
   popover: HTMLDivElement;
   anchor: HTMLElement | null;
+  expanded: boolean;
+  entries: RendererCreditsHeaderEntry[];
   dispose(): void;
-  place(anchor: HTMLElement | null): boolean;
+  /** Place the control immediately after `reference` in the app header. */
+  place(reference: HTMLElement | null): boolean;
 }
 
 export type RendererCreditsTone = "ok" | "warn" | "hot";
@@ -25,6 +45,136 @@ export function rendererCreditsTone(usedPercent: number): RendererCreditsTone {
   if (usedPercent >= 90) return "hot";
   if (usedPercent >= 70) return "warn";
   return "ok";
+}
+
+/**
+ * Compact provider label for the header chip. Prefer a short family name over
+ * the full product window string so multiple providers can sit side-by-side.
+ */
+export function creditsProviderShortLabel(product: string): string {
+  const normalized = product.trim();
+  if (/^gemini/iu.test(normalized)) return "Gemini";
+  if (/^grok/iu.test(normalized)) return "Grok";
+  if (/^codex/iu.test(normalized)) return "Codex";
+  if (/^claude/iu.test(normalized)) return "Claude";
+  if (normalized === "GrokBuild") return "Grok";
+  if (normalized === "GrokChat") return "Chat";
+  if (normalized === "GrokImagine") return "Imagine";
+  if (normalized === "GrokVoice") return "Voice";
+  const token = normalized.split(/[\s(/]/u)[0]?.trim();
+  return token && token.length > 0 ? token : "Limit";
+}
+
+/**
+ * Map the Composer Model selection onto a quota family. OmniRoute labels look
+ * like `grok-cli / grok-4` or `agy / gemini-3.7-flash-tiered`; native Grok and
+ * Codex Agents contribute their agent id as a fallback hint.
+ */
+export function creditsFamilyFromSelection(selection: string | null | undefined): string | null {
+  if (!selection || selection.trim().length === 0) return null;
+  const text = selection.toLowerCase();
+  if (/(?:^|[^a-z])grok(?:-cli)?(?:[^a-z]|$)/u.test(text) || text.includes("product_grok")) {
+    return "Grok";
+  }
+  if (/(?:^|[^a-z])gemini(?:[^a-z]|$)/u.test(text)) return "Gemini";
+  if (/(?:^|[^a-z])claude(?:[^a-z]|$)/u.test(text)) return "Claude";
+  if (/(?:^|[^a-z])codex(?:[^a-z]|$)/u.test(text)) return "Codex";
+  if (/(?:^|[^a-z])agy(?:[^a-z]|$)/u.test(text)) return "Gemini";
+  return null;
+}
+
+export function creditsSelectionHint(input: {
+  modelLabel?: string | undefined;
+  modelId?: string | undefined;
+  resolvedModelLabel?: string | undefined;
+  agent?: string | undefined;
+}): string {
+  const parts = [input.modelLabel, input.modelId, input.resolvedModelLabel];
+  if (input.agent === "grok" || input.agent === "codex") parts.push(input.agent);
+  return parts
+    .filter((part): part is string => typeof part === "string" && part.trim().length > 0)
+    .join(" ");
+}
+
+function periodHeaderEntry(credits: AccountCreditsSnapshot): RendererCreditsHeaderEntry {
+  const product = creditsPeriodLabel(credits.periodType);
+  return {
+    label: product.replace(/ limit$/iu, ""),
+    usedPercent: credits.usedPercent,
+    ...(credits.resetsAt ? { resetsAt: credits.resetsAt } : {}),
+    products: [
+      {
+        product,
+        usagePercent: credits.usedPercent,
+        ...(credits.resetsAt ? { resetsAt: credits.resetsAt } : {}),
+      },
+    ],
+  };
+}
+
+function entryRepresentsPrimary(
+  entry: RendererCreditsHeaderEntry,
+  credits: AccountCreditsSnapshot,
+): boolean {
+  if (entry.usedPercent === credits.usedPercent && entry.resetsAt === credits.resetsAt) {
+    return true;
+  }
+  return entry.products.some(
+    (product) =>
+      product.usagePercent === credits.usedPercent && product.resetsAt === credits.resetsAt,
+  );
+}
+
+function buildCreditsHeaderEntries(credits: AccountCreditsSnapshot): RendererCreditsHeaderEntry[] {
+  if (!credits.productUsage || credits.productUsage.length === 0) {
+    return [periodHeaderEntry(credits)];
+  }
+
+  const byLabel = new Map<string, RendererCreditsHeaderEntry>();
+  for (const product of credits.productUsage) {
+    const label = creditsProviderShortLabel(product.product);
+    const previous = byLabel.get(label);
+    const products = [...(previous?.products ?? []), product];
+    const hotter = !previous || product.usagePercent > previous.usedPercent;
+    byLabel.set(label, {
+      label,
+      usedPercent: hotter ? product.usagePercent : previous.usedPercent,
+      ...(hotter
+        ? product.resetsAt
+          ? { resetsAt: product.resetsAt }
+          : {}
+        : previous.resetsAt
+          ? { resetsAt: previous.resetsAt }
+          : {}),
+      ...(hotter
+        ? product.accounts
+          ? { accounts: product.accounts }
+          : {}
+        : previous.accounts
+          ? { accounts: previous.accounts }
+          : {}),
+      products,
+    });
+  }
+  const grouped = [...byLabel.values()];
+  const known = grouped.filter((entry) => HEADER_FAMILY_LABELS.has(entry.label));
+  const entries = known.length > 0 ? known : grouped;
+  if (entries.some((entry) => entryRepresentsPrimary(entry, credits))) return entries;
+  return [periodHeaderEntry(credits), ...entries];
+}
+
+export function creditsHeaderEntries(
+  credits: AccountCreditsSnapshot,
+  selection?: string | null,
+): RendererCreditsHeaderEntry[] {
+  const entries = buildCreditsHeaderEntries(credits);
+  const family = creditsFamilyFromSelection(selection);
+  if (!family) return entries;
+  const index = entries.findIndex((entry) => entry.label === family);
+  if (index <= 0) return entries;
+  const selected = entries[index];
+  if (!selected) return entries;
+  return [selected, ...entries.filter((_, entryIndex) => entryIndex !== index)];
 }
 
 /**
@@ -74,6 +224,75 @@ function toneColor(tone: RendererCreditsTone): string {
   return "#3d9a64";
 }
 
+function ensureRendererCreditsStyle(ownerDocument: Document): void {
+  if (ownerDocument.querySelector(`style[${CREDITS_STYLE_ATTRIBUTE}]`)) return;
+  const style = ownerDocument.createElement("style");
+  style.setAttribute(CREDITS_STYLE_ATTRIBUTE, "true");
+  style.textContent = `
+    [data-codexhost-credits-control] {
+      cursor: pointer;
+    }
+    [data-codexhost-credits-chip] {
+      cursor: pointer;
+      -webkit-app-region: no-drag;
+    }
+    [data-codexhost-credits-chip]:hover:not(:disabled) {
+      background: rgba(127, 127, 127, 0.18);
+    }
+    [data-codexhost-credits-expand] {
+      display: inline-flex;
+      flex: 0 0 auto;
+      align-items: center;
+      justify-content: center;
+      width: 10px;
+      font-size: 13px;
+      line-height: 1;
+      opacity: 0.38;
+      transform: translateX(0);
+      transition: opacity 140ms ease, transform 140ms ease;
+    }
+    [data-codexhost-credits-control]:hover [data-codexhost-credits-expand],
+    [data-codexhost-credits-chip]:hover [data-codexhost-credits-expand],
+    [data-codexhost-credits-chip]:focus-visible [data-codexhost-credits-expand] {
+      opacity: 1;
+      transform: translateX(2px);
+    }
+    [data-codexhost-credits-control][data-expanded="true"] [data-codexhost-credits-expand] {
+      transform: rotate(180deg);
+      opacity: 0.85;
+    }
+    [data-codexhost-credits-extras] {
+      position: fixed;
+      display: flex;
+      align-items: center;
+      max-width: 0;
+      overflow: hidden;
+      pointer-events: none;
+      opacity: 0;
+      transition: max-width 220ms ease, opacity 160ms ease;
+    }
+    [data-codexhost-credits-extras][data-expanded="true"] {
+      max-width: min(480px, 70vw);
+      opacity: 1;
+      pointer-events: auto;
+    }
+    [data-codexhost-credits-extras-inner] {
+      display: flex;
+      min-width: 0;
+      align-items: center;
+      gap: 4px;
+      padding-left: 4px;
+    }
+    @media (prefers-reduced-motion: reduce) {
+      [data-codexhost-credits-extras],
+      [data-codexhost-credits-expand] {
+        transition: none;
+      }
+    }
+  `;
+  (ownerDocument.head ?? ownerDocument.documentElement).append(style);
+}
+
 function renderCreditsBar(usagePercent: number, color: string): HTMLDivElement {
   const track = document.createElement("div");
   track.dataset.codexhostCreditsBar = "";
@@ -91,49 +310,57 @@ function renderCreditsBar(usagePercent: number, color: string): HTMLDivElement {
   return track;
 }
 
-function renderCreditsHeader(credits: AccountCreditsSnapshot): HTMLDivElement {
-  const wrapper = document.createElement("div");
-  wrapper.style.marginBottom = "11px";
-
-  const top = document.createElement("div");
-  top.style.display = "flex";
-  top.style.alignItems = "flex-start";
-  top.style.justifyContent = "space-between";
-  top.style.gap = "12px";
-  top.style.marginBottom = "5px";
-
-  // Same left-label / right-percent column order as each tile below, so the
-  // reset line always lands under its own label instead of zig-zagging sides.
-  const left = document.createElement("div");
-  const label = document.createElement("div");
-  label.textContent = creditsPeriodLabel(credits.periodType);
-  label.style.fontSize = "12.5px";
-  label.style.fontWeight = "600";
-  left.append(label);
-  if (credits.resetsAt) {
-    const reset = document.createElement("div");
-    reset.textContent = `resets ${formatRendererCreditsReset(credits.resetsAt)}`;
-    reset.style.fontSize = "11px";
-    reset.style.color = "color-mix(in srgb, currentColor 62%, transparent)";
-    left.append(reset);
-  }
-
-  const color = toneColor(rendererCreditsTone(credits.usedPercent));
-  const percent = document.createElement("span");
-  percent.textContent = formatRendererCreditsPercent(credits.usedPercent);
-  percent.style.fontSize = "26px";
-  percent.style.fontWeight = "700";
-  percent.style.fontVariantNumeric = "tabular-nums";
-  percent.style.color = color;
-
-  top.append(left, percent);
-
-  wrapper.append(top, renderCreditsBar(credits.usedPercent, color));
-  return wrapper;
+function mutedCaption(text: string, fontSize: string): HTMLDivElement {
+  const caption = document.createElement("div");
+  caption.textContent = text;
+  caption.style.fontSize = fontSize;
+  caption.style.color = "color-mix(in srgb, currentColor 62%, transparent)";
+  return caption;
 }
 
-function renderCreditsTile(label: string, usagePercent: number, resetsAt?: string): HTMLDivElement {
-  const color = toneColor(rendererCreditsTone(usagePercent));
+export interface RendererCreditsPopoverRow {
+  label: string;
+  usagePercent: number;
+  resetsAt?: string;
+  detail?: string;
+}
+
+/**
+ * One popover row per account when OmniRoute reports them, otherwise one row
+ * per product window. The family-level summary is omitted so the same percent
+ * is never shown twice.
+ */
+export function creditsPopoverRows(entry: RendererCreditsHeaderEntry): RendererCreditsPopoverRow[] {
+  const multipleWindows = entry.products.length > 1;
+  const rows: RendererCreditsPopoverRow[] = [];
+  for (const product of entry.products) {
+    const windowLabel = productLabel(product.product);
+    if (product.accounts && product.accounts.length > 0) {
+      for (const account of product.accounts) {
+        rows.push({
+          label: account.accountName,
+          usagePercent: account.usagePercent,
+          ...(account.resetsAt
+            ? { resetsAt: account.resetsAt }
+            : product.resetsAt
+              ? { resetsAt: product.resetsAt }
+              : {}),
+          ...(multipleWindows ? { detail: windowLabel } : {}),
+        });
+      }
+      continue;
+    }
+    rows.push({
+      label: windowLabel,
+      usagePercent: product.usagePercent,
+      ...(product.resetsAt ? { resetsAt: product.resetsAt } : {}),
+    });
+  }
+  return rows;
+}
+
+function renderCreditsTile(row: RendererCreditsPopoverRow): HTMLDivElement {
+  const color = toneColor(rendererCreditsTone(row.usagePercent));
 
   const tile = document.createElement("div");
   tile.style.marginBottom = "11px";
@@ -146,37 +373,39 @@ function renderCreditsTile(label: string, usagePercent: number, resetsAt?: strin
   top.style.marginBottom = "5px";
 
   const left = document.createElement("div");
-  const name = document.createElement("span");
-  name.textContent = label;
+  left.style.minWidth = "0";
+  const name = document.createElement("div");
+  name.textContent = row.label;
   name.style.fontSize = "12px";
+  name.style.fontWeight = "600";
+  name.style.overflow = "hidden";
+  name.style.textOverflow = "ellipsis";
+  name.style.whiteSpace = "nowrap";
+  name.style.maxWidth = "190px";
   left.append(name);
-  if (resetsAt) {
-    const reset = document.createElement("div");
-    reset.textContent = `resets ${formatRendererCreditsReset(resetsAt)}`;
-    reset.style.fontSize = "10.5px";
-    reset.style.color = "color-mix(in srgb, currentColor 62%, transparent)";
-    left.append(reset);
+  if (row.detail) left.append(mutedCaption(row.detail, "10.5px"));
+  if (row.resetsAt) {
+    left.append(mutedCaption(`resets ${formatRendererCreditsReset(row.resetsAt)}`, "10.5px"));
   }
 
   const percent = document.createElement("span");
-  percent.textContent = formatRendererCreditsPercent(usagePercent);
-  percent.style.fontSize = "12px";
+  percent.textContent = formatRendererCreditsPercent(row.usagePercent);
+  percent.style.fontSize = "16px";
+  percent.style.fontWeight = "700";
   percent.style.fontVariantNumeric = "tabular-nums";
   percent.style.color = color;
   top.append(left, percent);
 
-  tile.append(top, renderCreditsBar(usagePercent, color));
+  tile.append(top, renderCreditsBar(row.usagePercent, color));
   return tile;
 }
 
-function renderDetails(popover: HTMLDivElement, credits: AccountCreditsSnapshot): void {
-  const glowColor = toneColor(rendererCreditsTone(credits.usedPercent));
+function renderDetails(popover: HTMLDivElement, entry: RendererCreditsHeaderEntry): void {
+  const rows = creditsPopoverRows(entry);
+  const glowColor = toneColor(rendererCreditsTone(rows[0]?.usagePercent ?? entry.usedPercent));
   popover.style.backgroundImage = `radial-gradient(160px 100px at 18% -10%, color-mix(in srgb, ${glowColor} 20%, transparent), transparent 70%)`;
   popover.replaceChildren();
-  popover.append(renderCreditsHeader(credits));
-  const tiles = (credits.productUsage ?? []).map((product) =>
-    renderCreditsTile(productLabel(product.product), product.usagePercent, product.resetsAt),
-  );
+  const tiles = rows.map((row) => renderCreditsTile(row));
   const lastTile = tiles.at(-1);
   if (lastTile) lastTile.style.marginBottom = "0";
   popover.append(...tiles);
@@ -190,66 +419,91 @@ function popoverIsOpen(popover: HTMLDivElement): boolean {
   }
 }
 
-function positionPopover(control: Pick<RendererCreditsControl, "trigger" | "popover">): void {
-  const triggerRect = control.trigger.getBoundingClientRect();
-  const width = Math.min(280, Math.max(220, window.innerWidth - 24));
+function positionPopover(control: Pick<RendererCreditsControl, "root" | "popover">): void {
+  const triggerRect = control.root.getBoundingClientRect();
+  const width = Math.min(320, Math.max(240, window.innerWidth - 24));
   const left = Math.max(12, Math.min(triggerRect.left, window.innerWidth - width - 12));
   control.popover.style.width = `${width}px`;
   control.popover.style.left = `${left}px`;
   control.popover.style.right = "auto";
+
+  const spaceAbove = triggerRect.top;
+  const spaceBelow = window.innerHeight - triggerRect.bottom;
+  if (spaceBelow >= spaceAbove) {
+    control.popover.style.top = `${Math.min(window.innerHeight - 12, triggerRect.bottom + 8)}px`;
+    control.popover.style.bottom = "auto";
+    return;
+  }
   control.popover.style.top = "auto";
   control.popover.style.bottom = `${Math.max(12, window.innerHeight - triggerRect.top + 8)}px`;
 }
 
-function closePopover(control: Pick<RendererCreditsControl, "trigger" | "popover">): void {
+function positionCreditsExtras(control: RendererCreditsControl): void {
+  const canExpand = control.expanded && control.entries.length > 1;
+  control.extras.dataset.expanded = String(canExpand);
+  control.extras.style.position = "fixed";
+  control.extras.style.zIndex = "2147483646";
+  if (!canExpand) return;
+  control.extras.hidden = false;
+  const rect = control.trigger.getBoundingClientRect();
+  control.extras.style.left = `${Math.round(rect.right + 4)}px`;
+  control.extras.style.top = `${Math.round(rect.top)}px`;
+  control.extras.style.height = `${Math.round(rect.height)}px`;
+}
+
+function setCreditsExpanded(control: RendererCreditsControl, expanded: boolean): void {
+  control.expanded = expanded;
+  control.root.dataset.expanded = String(expanded);
+  const value = String(expanded);
+  control.trigger.setAttribute("aria-expanded", value);
+  for (const button of [
+    ...control.root.querySelectorAll<HTMLButtonElement>("[data-codexhost-credits-chip]"),
+    ...control.extras.querySelectorAll<HTMLButtonElement>("[data-codexhost-credits-chip]"),
+  ]) {
+    button.setAttribute("aria-expanded", value);
+  }
+  positionCreditsExtras(control);
+}
+
+function closePopover(control: Pick<RendererCreditsControl, "root" | "trigger" | "popover">): void {
   if (popoverIsOpen(control.popover) && typeof control.popover.hidePopover === "function") {
     control.popover.hidePopover();
   }
   control.popover.hidden = true;
-  control.trigger.setAttribute("aria-expanded", "false");
 }
 
-function openPopover(control: Pick<RendererCreditsControl, "trigger" | "popover">): void {
+function openPopover(control: Pick<RendererCreditsControl, "root" | "trigger" | "popover">): void {
   positionPopover(control);
   control.popover.hidden = false;
   if (typeof control.popover.showPopover === "function" && !popoverIsOpen(control.popover)) {
     control.popover.showPopover();
   }
-  control.trigger.setAttribute("aria-expanded", "true");
 }
 
-function togglePopover(control: Pick<RendererCreditsControl, "trigger" | "popover">): void {
-  if (control.trigger.getAttribute("aria-expanded") === "true") closePopover(control);
-  else openPopover(control);
+function entryForChip(
+  control: RendererCreditsControl,
+  chip: HTMLElement,
+): RendererCreditsHeaderEntry | undefined {
+  const family = chip.dataset.codexhostCreditsFamily;
+  return control.entries.find((entry) => entry.label === family) ?? control.entries[0];
 }
 
-export function mountRendererCreditsControl(composerId: string): RendererCreditsControl {
-  ensureRendererTriggerChipStyle(document);
+function showEntryPopover(control: RendererCreditsControl, chip: HTMLElement): void {
+  const entry = entryForChip(control, chip);
+  if (!entry) return;
+  renderDetails(control.popover, entry);
+  openPopover(control);
+}
 
-  const root = document.createElement("div");
-  root.dataset.codexhostCreditsControl = composerId;
-  root.className = "relative min-w-0";
-  root.style.display = "none";
-  root.style.alignItems = "center";
-  root.style.alignSelf = "center";
-  root.style.height = "28px";
-  root.style.flex = "0 0 auto";
-  root.style.verticalAlign = "middle";
-
-  const trigger = document.createElement("button");
+function styleCreditsChip(trigger: HTMLButtonElement): void {
   trigger.className = TRIGGER_CHIP_CLASS;
   trigger.type = "button";
   trigger.setAttribute("aria-haspopup", "dialog");
   trigger.setAttribute("aria-expanded", "false");
-  trigger.setAttribute("aria-label", "Account limit");
-  trigger.title = "Account limit";
+  trigger.dataset.codexhostCreditsChip = "";
   trigger.style.gap = "5px";
   trigger.style.width = "fit-content";
-  trigger.style.maxWidth = "min(72px, 18vw)";
-  // Match the 28px height shared by the Model/Permission-mode/Agent triggers
-  // it sits next to — a shorter box here previously threw off the row's
-  // vertical alignment (visible as Credits sitting a few px lower than its
-  // neighbors), whether the host lays this row out as flex or inline content.
+  trigger.style.maxWidth = "min(132px, 28vw)";
   trigger.style.height = "28px";
   trigger.style.padding = "0 8px";
   trigger.style.verticalAlign = "middle";
@@ -257,6 +511,17 @@ export function mountRendererCreditsControl(composerId: string): RendererCredits
   trigger.style.lineHeight = "16px";
   trigger.style.fontVariantNumeric = "tabular-nums";
   trigger.style.letterSpacing = "0";
+  trigger.style.flex = "0 0 auto";
+  trigger.style.cursor = "pointer";
+  trigger.style.setProperty("-webkit-app-region", "no-drag");
+}
+
+function createCreditsChip(popoverId: string): HTMLButtonElement {
+  const trigger = document.createElement("button");
+  styleCreditsChip(trigger);
+  trigger.setAttribute("aria-controls", popoverId);
+  trigger.setAttribute("aria-label", "Account limit");
+  trigger.title = "Account limit";
 
   const ringSlot = document.createElement("span");
   ringSlot.dataset.codexhostCreditsRing = "";
@@ -270,7 +535,68 @@ export function mountRendererCreditsControl(composerId: string): RendererCredits
   label.style.overflow = "hidden";
   label.style.textOverflow = "ellipsis";
   label.style.whiteSpace = "nowrap";
-  trigger.append(ringSlot, label);
+  const expand = document.createElement("span");
+  expand.dataset.codexhostCreditsExpand = "";
+  expand.setAttribute("aria-hidden", "true");
+  expand.textContent = "›";
+  expand.hidden = true;
+  trigger.append(ringSlot, label, expand);
+  return trigger;
+}
+
+function renderCreditsChipContent(
+  trigger: HTMLButtonElement,
+  entry: RendererCreditsHeaderEntry,
+  expandable = false,
+): void {
+  const percent = formatRendererCreditsPercent(entry.usedPercent);
+  const title = expandable
+    ? `${entry.label} ${percent}. Click to show other quotas.`
+    : `${entry.label} ${percent}`;
+  const tone = rendererCreditsTone(entry.usedPercent);
+  const ringSlot = trigger.querySelector<HTMLElement>("[data-codexhost-credits-ring]");
+  const label = trigger.querySelector<HTMLElement>("[data-codexhost-credits-label]");
+  const expand = trigger.querySelector<HTMLElement>("[data-codexhost-credits-expand]");
+  if (ringSlot) {
+    ringSlot.replaceChildren(
+      createRendererUsageRing(entry.usedPercent, {
+        size: 14,
+        strokeWidth: 2.4,
+        color: toneColor(tone),
+      }),
+    );
+  }
+  if (label) label.textContent = `${entry.label} ${percent}`;
+  if (expand) expand.hidden = !expandable;
+  trigger.dataset.codexhostCreditsFamily = entry.label;
+  trigger.setAttribute("aria-label", title);
+  trigger.title = title;
+}
+
+export function mountRendererCreditsControl(composerId: string): RendererCreditsControl {
+  ensureRendererTriggerChipStyle(document);
+  ensureRendererCreditsStyle(document);
+
+  const root = document.createElement("div");
+  root.dataset.codexhostCreditsControl = composerId;
+  root.dataset.expanded = "false";
+  root.className = "relative min-w-0";
+  root.style.display = "none";
+  root.style.alignItems = "center";
+  root.style.alignSelf = "center";
+  root.style.height = "28px";
+  root.style.flex = "0 0 auto";
+  root.style.gap = "0";
+  root.style.marginLeft = "8px";
+  root.style.verticalAlign = "middle";
+  root.style.setProperty("-webkit-app-region", "no-drag");
+
+  const extras = document.createElement("div");
+  extras.dataset.codexhostCreditsExtras = "";
+  extras.hidden = true;
+  const extrasInner = document.createElement("div");
+  extrasInner.dataset.codexhostCreditsExtrasInner = "";
+  extras.append(extrasInner);
 
   const popover = document.createElement("div");
   popover.id = `${composerId}-credits-popover`;
@@ -280,48 +606,54 @@ export function mountRendererCreditsControl(composerId: string): RendererCredits
   popover.hidden = typeof popover.showPopover !== "function";
   popover.style.position = "fixed";
   popover.style.inset = "auto";
-  popover.style.width = "240px";
-  popover.style.maxWidth = "min(280px, calc(100vw - 24px))";
+  popover.style.width = "260px";
+  popover.style.maxWidth = "min(320px, calc(100vw - 24px))";
+  popover.style.maxHeight = "min(360px, calc(100vh - 24px))";
+  popover.style.overflowY = "auto";
   popover.style.padding = "10px 12px";
   applyRendererPopoverChrome(popover);
   popover.style.font = "13px/1.35 system-ui, sans-serif";
   popover.style.letterSpacing = "0";
   popover.style.zIndex = "2147483647";
-  trigger.setAttribute("aria-controls", popover.id);
 
+  const trigger = createCreditsChip(popover.id);
   let placementReference: Element | null = null;
+  const repositionExtras = (): void => positionCreditsExtras(control);
   const control: RendererCreditsControl = {
     root,
     trigger,
+    extras,
+    extrasInner,
     popover,
     anchor: null,
+    expanded: false,
+    entries: [],
     dispose() {
       closePopover(control);
       if (closeTimer !== null) window.clearTimeout(closeTimer);
+      document.removeEventListener("pointerdown", onDocumentPointerDown, true);
+      window.removeEventListener("resize", repositionExtras);
       root.remove();
+      extras.remove();
       popover.remove();
       placementReference = null;
     },
-    place(anchor) {
-      // Credits sits immediately *before* its anchor (the permission-mode
-      // picker) rather than being derived by walking up from the Usage
-      // control's current DOM position. Anchoring directly to a
-      // renderer-owned, already-tracked element keeps this stable across
-      // reconciliation passes instead of re-deriving a different ancestor
-      // once the host page's own DOM settles a few seconds after mount.
-      if (!anchor?.parentElement) return false;
-      const parent = anchor.parentElement;
+    place(reference) {
+      // Insert immediately after the thread-title overflow (`…`) button.
+      if (!reference?.parentElement) return false;
+      const parent = reference.parentElement;
+      const before = reference.nextSibling;
       if (
-        control.anchor === anchor &&
-        placementReference === anchor &&
+        control.anchor === reference &&
+        placementReference === reference &&
         root.parentElement === parent &&
-        root.nextElementSibling === anchor
+        root.previousSibling === reference
       ) {
         return true;
       }
-      control.anchor = anchor;
-      placementReference = anchor;
-      if (root !== anchor) parent.insertBefore(root, anchor);
+      control.anchor = reference;
+      placementReference = reference;
+      parent.insertBefore(root, before);
       return true;
     },
   };
@@ -336,58 +668,134 @@ export function mountRendererCreditsControl(composerId: string): RendererCredits
     cancelClose();
     closeTimer = window.setTimeout(() => {
       closeTimer = null;
-      if (!trigger.matches(":hover") && !popover.matches(":hover")) closePopover(control);
+      if (!root.matches(":hover") && !popover.matches(":hover") && !extras.matches(":hover")) {
+        closePopover(control);
+      }
     }, 140);
   };
+  const onDocumentPointerDown = (event: Event): void => {
+    const target = event.target;
+    if (!(target instanceof Node)) return;
+    if (root.contains(target) || popover.contains(target) || extras.contains(target)) return;
+    setCreditsExpanded(control, false);
+    closePopover(control);
+  };
 
-  trigger.addEventListener("click", () => togglePopover(control));
-  trigger.addEventListener("pointerenter", () => {
+  let lastToggleAt = 0;
+  const toggleExpand = (event: Event): void => {
+    const chip = (event.target as Element | null)?.closest?.("[data-codexhost-credits-chip]");
+    if (!(chip instanceof HTMLButtonElement)) return;
+    if (!root.contains(chip) && !extras.contains(chip)) return;
+    if ("button" in event && typeof event.button === "number" && event.button !== 0) return;
+    event.preventDefault();
+    event.stopPropagation();
+    const now = Date.now();
+    if (now - lastToggleAt < 350) return;
+    lastToggleAt = now;
+    const canExpand = control.entries.length > 1;
+    if (!canExpand) {
+      if (popoverIsOpen(control.popover)) closePopover(control);
+      else showEntryPopover(control, chip);
+      return;
+    }
+    if (chip === control.trigger || !control.expanded) {
+      setCreditsExpanded(control, !control.expanded);
+    }
+  };
+  root.addEventListener("pointerdown", toggleExpand, true);
+  root.addEventListener("click", toggleExpand, true);
+  window.addEventListener("resize", repositionExtras);
+  extras.addEventListener("pointerover", (event) => {
+    const chip = (event.target as Element | null)?.closest?.("[data-codexhost-credits-chip]");
+    if (!(chip instanceof HTMLButtonElement) || !extras.contains(chip)) return;
     cancelClose();
-    openPopover(control);
+    showEntryPopover(control, chip);
   });
-  trigger.addEventListener("pointerleave", scheduleClose);
-  trigger.addEventListener("focus", () => {
+  extras.addEventListener("pointerleave", scheduleClose);
+  extras.addEventListener("pointerdown", toggleExpand, true);
+  root.addEventListener("pointerover", (event) => {
+    const chip = (event.target as Element | null)?.closest?.("[data-codexhost-credits-chip]");
+    if (!(chip instanceof HTMLButtonElement) || !root.contains(chip)) return;
+    const related = event.relatedTarget;
+    if (related instanceof Node && chip.contains(related)) return;
     cancelClose();
-    openPopover(control);
+    showEntryPopover(control, chip);
   });
-  trigger.addEventListener("blur", scheduleClose);
+  root.addEventListener("pointerleave", scheduleClose);
+  root.addEventListener(
+    "focusin",
+    (event) => {
+      const chip = (event.target as Element | null)?.closest?.("[data-codexhost-credits-chip]");
+      if (!(chip instanceof HTMLButtonElement) || !root.contains(chip)) return;
+      cancelClose();
+      showEntryPopover(control, chip);
+    },
+    true,
+  );
+  root.addEventListener("focusout", scheduleClose, true);
   popover.addEventListener("pointerenter", cancelClose);
   popover.addEventListener("pointerleave", scheduleClose);
-  popover.addEventListener("toggle", () => {
-    trigger.setAttribute("aria-expanded", String(popoverIsOpen(popover)));
-  });
+  document.addEventListener("pointerdown", onDocumentPointerDown, true);
   root.append(trigger);
-  document.body.append(popover);
+  document.body.append(extras, popover);
   return control;
 }
 
 export function renderRendererCreditsControl(
   control: RendererCreditsControl,
   accountCredits: AccountCreditsSnapshot | null,
+  selection?: string | null,
 ): boolean {
   if (accountCredits === null) {
     control.root.style.display = "none";
+    control.entries = [];
+    setCreditsExpanded(control, false);
     closePopover(control);
     return false;
   }
-  const percent = formatRendererCreditsPercent(accountCredits.usedPercent);
-  const title = `${creditsPeriodLabel(accountCredits.periodType)} ${percent}`;
-  const tone = rendererCreditsTone(accountCredits.usedPercent);
-  const ringSlot = control.trigger.querySelector<HTMLElement>("[data-codexhost-credits-ring]");
-  const label = control.trigger.querySelector<HTMLElement>("[data-codexhost-credits-label]");
-  if (ringSlot) {
-    ringSlot.replaceChildren(
-      createRendererUsageRing(accountCredits.usedPercent, {
-        size: 14,
-        strokeWidth: 2.4,
-        color: toneColor(tone),
-      }),
-    );
+
+  const previousFamily = control.entries[0]?.label;
+  const entries = creditsHeaderEntries(accountCredits, selection);
+  control.entries = entries;
+  if (entries[0]?.label !== previousFamily) setCreditsExpanded(control, false);
+
+  const popoverId = control.popover.id;
+  const extraEntries = entries.slice(1);
+  renderCreditsChipContent(
+    control.trigger,
+    entries[0] ?? { label: "Limit", usedPercent: 0, products: [] },
+    extraEntries.length > 0,
+  );
+  let extraChips = [
+    ...control.extrasInner.querySelectorAll<HTMLButtonElement>("[data-codexhost-credits-chip]"),
+  ];
+  while (extraChips.length < extraEntries.length) {
+    const chip = createCreditsChip(popoverId);
+    control.extrasInner.append(chip);
+    extraChips = [
+      ...control.extrasInner.querySelectorAll<HTMLButtonElement>("[data-codexhost-credits-chip]"),
+    ];
   }
-  if (label) label.textContent = percent;
+  while (extraChips.length > extraEntries.length) {
+    extraChips.pop()?.remove();
+    extraChips = [
+      ...control.extrasInner.querySelectorAll<HTMLButtonElement>("[data-codexhost-credits-chip]"),
+    ];
+  }
+  for (const [index, entry] of extraEntries.entries()) {
+    const chip = extraChips[index];
+    if (!chip) continue;
+    renderCreditsChipContent(chip, entry);
+  }
+
+  control.extras.hidden = extraEntries.length === 0;
   control.root.style.display = "inline-flex";
-  control.trigger.setAttribute("aria-label", title);
-  control.trigger.title = title;
-  renderDetails(control.popover, accountCredits);
+  if (popoverIsOpen(control.popover)) {
+    const hovered = control.root.querySelector<HTMLElement>(
+      "[data-codexhost-credits-chip]:hover, [data-codexhost-credits-chip]:focus",
+    );
+    const entry = hovered ? entryForChip(control, hovered) : entries[0];
+    if (entry) renderDetails(control.popover, entry);
+  }
   return true;
 }

--- a/packages/renderer-extension/src/settings/trigger.ts
+++ b/packages/renderer-extension/src/settings/trigger.ts
@@ -113,6 +113,13 @@ export function inspectRendererSettingsContract(
   };
 }
 
+function visibleHeaderShellSlots(header: HTMLElement): HTMLElement[] {
+  return [...header.querySelectorAll<HTMLElement>(SETTINGS_HEADER_SLOT_SELECTOR)].filter((slot) => {
+    const bounds = measuredBounds(slot);
+    return bounds.width > 0 && bounds.height > 0;
+  });
+}
+
 function findRendererSettingsHeaderInsertionPoint(
   ownerDocument: Document,
 ): RendererSettingsHeaderInsertionPoint | null {
@@ -122,13 +129,95 @@ function findRendererSettingsHeaderInsertionPoint(
   const headerBounds = measuredBounds(header);
   if (headerBounds.width <= 0 || headerBounds.height <= 0) return null;
 
-  const endSlot = [...header.querySelectorAll<HTMLElement>(SETTINGS_HEADER_SLOT_SELECTOR)]
-    .filter((slot) => {
-      const bounds = measuredBounds(slot);
-      return bounds.width > 0 && bounds.height > 0;
-    })
-    .toSorted((left, right) => measuredBounds(right).left - measuredBounds(left).left)[0];
+  const endSlot = visibleHeaderShellSlots(header).toSorted(
+    (left, right) => measuredBounds(right).left - measuredBounds(left).left,
+  )[0];
   return endSlot ? { parent: header, before: endSlot } : null;
+}
+
+function applicationHeader(ownerDocument?: Document): HTMLElement | null {
+  const doc =
+    ownerDocument ?? (typeof globalThis.document === "undefined" ? null : globalThis.document);
+  if (!doc || typeof doc.querySelector !== "function") return null;
+
+  const header = doc.querySelector<HTMLElement>(SETTINGS_APPLICATION_HEADER_SELECTOR);
+  if (!header) return null;
+
+  const headerBounds = measuredBounds(header);
+  if (headerBounds.width <= 0 || headerBounds.height <= 0) return null;
+  return header;
+}
+
+/**
+ * Leftmost visible header shell slot. This is *not* the thread-title cluster:
+ * Codex keeps the folder / title / overflow menu in a sibling between the
+ * start and end shell slots.
+ */
+export function findRendererHeaderStartSlot(ownerDocument?: Document): HTMLElement | null {
+  const header = applicationHeader(ownerDocument);
+  if (!header) return null;
+
+  return (
+    visibleHeaderShellSlots(header).toSorted(
+      (left, right) => measuredBounds(left).left - measuredBounds(right).left,
+    )[0] ?? null
+  );
+}
+
+function headerEndSlot(header: HTMLElement): HTMLElement | null {
+  const slots = visibleHeaderShellSlots(header).toSorted(
+    (left, right) => measuredBounds(left).left - measuredBounds(right).left,
+  );
+  return slots.length > 1 ? (slots[slots.length - 1] ?? null) : null;
+}
+
+function isOwnedHeaderControl(element: HTMLElement): boolean {
+  return Boolean(
+    element.closest?.(
+      "[data-codexhost-credits-control], [data-codexhost-settings-trigger], [data-codexhost-credits-extras]",
+    ),
+  );
+}
+
+/**
+ * The thread-title overflow (`…`) button — the rightmost native control in the
+ * left title band. Credits inserts immediately after this node so it stays
+ * next to the folder / title, not in the Share / settings group.
+ */
+export function findRendererHeaderTitleOverflow(ownerDocument?: Document): HTMLElement | null {
+  const header = applicationHeader(ownerDocument);
+  if (!header || typeof header.querySelectorAll !== "function") return null;
+
+  const headerBounds = measuredBounds(header);
+  const leftBandRight = headerBounds.left + Math.max(280, headerBounds.width * 0.42);
+  const endSlot = headerEndSlot(header);
+  const buttons = [...header.querySelectorAll<HTMLElement>("button, [role='button']")];
+  const leftButtons = buttons.filter((button) => {
+    if (endSlot && typeof endSlot.contains === "function" && endSlot.contains(button)) return false;
+    if (isOwnedHeaderControl(button)) return false;
+    const bounds = measuredBounds(button);
+    if (bounds.width <= 0 || bounds.height <= 0) return false;
+    return bounds.left >= headerBounds.left - 1 && bounds.right <= leftBandRight;
+  });
+  leftButtons.sort((left, right) => measuredBounds(right).left - measuredBounds(left).left);
+  return leftButtons[0] ?? null;
+}
+
+/**
+ * Header child that owns the folder, thread title, and overflow (`…`) control.
+ * Used only as a fallback when the overflow button itself cannot be resolved.
+ */
+export function findRendererHeaderTitleCluster(ownerDocument?: Document): HTMLElement | null {
+  const header = applicationHeader(ownerDocument);
+  if (!header) return null;
+
+  const overflow = findRendererHeaderTitleOverflow(ownerDocument);
+  if (overflow?.parentElement) return overflow.parentElement;
+
+  const slots = visibleHeaderShellSlots(header).toSorted(
+    (left, right) => measuredBounds(left).left - measuredBounds(right).left,
+  );
+  return slots[0] ?? null;
 }
 
 export function mountRendererSettingsTrigger(

--- a/packages/renderer-extension/test/renderer-binding-probe.test.ts
+++ b/packages/renderer-extension/test/renderer-binding-probe.test.ts
@@ -290,6 +290,14 @@ describe("Renderer Composer DOM behavior", () => {
         { usedPercent: 62, periodType: "five_hour" },
       ),
     ).toBe(false);
+    expect(shouldRetryExternalThreadUsage("omp", { totalCostUsd: 0.168 })).toBe(true);
+    expect(
+      shouldRetryExternalThreadUsage(
+        "omp",
+        { totalCostUsd: 0.168 },
+        { usedPercent: 64, periodType: "weekly" },
+      ),
+    ).toBe(false);
     expect(rendererUsageRefreshDelay(0)).toBe(250);
     expect(rendererUsageRefreshDelay(1)).toBe(500);
     expect(rendererUsageRefreshDelay(99)).toBe(8000);
@@ -494,26 +502,123 @@ describe("Renderer Composer DOM behavior", () => {
     expect(placeCredits).not.toHaveBeenCalled();
   });
 
-  it("anchors credits to the permission-mode picker's own root", () => {
-    const permissionModeRoot = { parentElement: {} } as HTMLElement;
-    const control = {
-      permissionModePicker: { root: permissionModeRoot },
-    } as unknown as ComposerAgentControl;
+  it("anchors credits after the left-side thread-title overflow button", () => {
+    const button = (
+      left: number,
+      width: number,
+      extra: Record<string, unknown> = {},
+    ): HTMLElement =>
+      ({
+        getBoundingClientRect: () => ({
+          left,
+          right: left + width,
+          top: 36,
+          bottom: 64,
+          width,
+          height: 28,
+        }),
+        closest: () => null,
+        ...extra,
+      }) as unknown as HTMLElement;
+    const folder = button(16, 28);
+    const title = button(48, 220);
+    const overflow = button(272, 28);
+    const share = button(860, 72);
+    const startSlot = {
+      getBoundingClientRect: () => ({
+        left: 0,
+        right: 40,
+        top: 36,
+        bottom: 72,
+        width: 40,
+        height: 36,
+      }),
+    } as unknown as HTMLElement;
+    const endSlot = {
+      getBoundingClientRect: () => ({
+        left: 900,
+        right: 1020,
+        top: 36,
+        bottom: 72,
+        width: 120,
+        height: 36,
+      }),
+      contains: (node: Node) => node === share,
+    } as unknown as HTMLElement;
+    const header = {
+      getBoundingClientRect: () => ({
+        left: 0,
+        right: 1100,
+        top: 36,
+        bottom: 82,
+        width: 1100,
+        height: 46,
+      }),
+      children: [startSlot, endSlot],
+      querySelector: () => null,
+      querySelectorAll: (selector: string) => {
+        if (selector === ':scope > [data-test-id="header-shell-slot"]') return [startSlot, endSlot];
+        if (selector === "button, [role='button']") return [folder, title, overflow, share];
+        return [];
+      },
+    };
+    const ownerDocument = {
+      querySelector: (selector: string) =>
+        selector === 'header[data-pip-obstacle="app-shell-header"]' ? header : null,
+    } as unknown as Document;
 
-    expect(creditsPlacementAnchor(control)).toBe(permissionModeRoot);
+    expect(creditsPlacementAnchor({} as ComposerAgentControl, ownerDocument)).toBe(overflow);
   });
 
-  it("does not anchor credits until the permission-mode picker has been inserted into the DOM", () => {
-    const permissionModeRoot = { parentElement: null } as unknown as HTMLElement;
-    const control = {
-      permissionModePicker: { root: permissionModeRoot },
-    } as unknown as ComposerAgentControl;
-
-    expect(creditsPlacementAnchor(control)).toBeNull();
+  it("does not anchor credits until the application header start slot is visible", () => {
+    const ownerDocument = {
+      querySelector: () => null,
+    } as unknown as Document;
+    expect(creditsPlacementAnchor({} as ComposerAgentControl, ownerDocument)).toBeNull();
   });
 
-  it("places credits immediately before the permission-mode picker, independent of Usage", () => {
-    const permissionModeRoot = { parentElement: {} } as HTMLElement;
+  it("places credits against the header start slot, independent of Usage", () => {
+    const overflow = {
+      getBoundingClientRect: () => ({
+        left: 200,
+        right: 228,
+        top: 36,
+        bottom: 64,
+        width: 28,
+        height: 28,
+      }),
+      closest: () => null,
+    } as unknown as HTMLElement;
+    const startSlot = {
+      getBoundingClientRect: () => ({
+        left: 0,
+        right: 120,
+        top: 36,
+        bottom: 72,
+        width: 120,
+        height: 36,
+      }),
+    } as unknown as HTMLElement;
+    const header = {
+      getBoundingClientRect: () => ({
+        left: 0,
+        right: 1100,
+        top: 36,
+        bottom: 82,
+        width: 1100,
+        height: 46,
+      }),
+      querySelectorAll: (selector: string) => {
+        if (selector === ':scope > [data-test-id="header-shell-slot"]') return [startSlot];
+        if (selector === "button, [role='button']") return [overflow];
+        return [];
+      },
+    };
+    vi.stubGlobal("document", {
+      querySelector: (selector: string) =>
+        selector === 'header[data-pip-obstacle="app-shell-header"]' ? header : null,
+    });
+
     const placeUsage = vi.fn();
     const placeCredits = vi.fn();
     const control = {
@@ -522,7 +627,7 @@ describe("Renderer Composer DOM behavior", () => {
       nativeModelControl: null,
       nativePermissionModeControl: null,
       nativeContextUsageControl: null,
-      permissionModePicker: { root: permissionModeRoot },
+      permissionModePicker: { root: { parentElement: {} } },
       credits: {
         anchor: null,
         place: placeCredits,
@@ -535,9 +640,12 @@ describe("Renderer Composer DOM behavior", () => {
       },
     } as unknown as ComposerAgentControl;
 
-    reconcileComposerNativeControls(control, true, false);
-
-    expect(placeCredits).toHaveBeenCalledWith(permissionModeRoot);
+    try {
+      reconcileComposerNativeControls(control, true, false);
+      expect(placeCredits).toHaveBeenCalledWith(overflow);
+    } finally {
+      vi.unstubAllGlobals();
+    }
   });
 
   it("does not treat codexhost Usage controls as native anchors", () => {

--- a/packages/renderer-extension/test/renderer-credits-control.test.ts
+++ b/packages/renderer-extension/test/renderer-credits-control.test.ts
@@ -1,7 +1,12 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  creditsFamilyFromSelection,
+  creditsHeaderEntries,
   creditsPeriodLabel,
+  creditsPopoverRows,
+  creditsProviderShortLabel,
+  creditsSelectionHint,
   formatRendererCreditsReset,
   rendererCreditsTone,
 } from "../src/renderer-credits-control.js";
@@ -24,6 +29,133 @@ describe("Renderer credits control", () => {
     expect(creditsPeriodLabel("seven_day")).toBe("7-day limit");
     expect(creditsPeriodLabel("unknown")).toBe("Account limit");
     expect(formatRendererCreditsReset("not-a-date")).toBe("not-a-date");
+  });
+
+  it("shortens provider product labels for the header chips", () => {
+    expect(creditsProviderShortLabel("Gemini Flash (5h)")).toBe("Gemini");
+    expect(creditsProviderShortLabel("Grok Build")).toBe("Grok");
+    expect(creditsProviderShortLabel("Codex (5h)")).toBe("Codex");
+    expect(creditsProviderShortLabel("Claude (7d)")).toBe("Claude");
+  });
+
+  it("builds one header chip per provider family, keeping the hotter window", () => {
+    expect(
+      creditsHeaderEntries({
+        usedPercent: 35,
+        periodType: "weekly",
+        productUsage: [
+          { product: "Grok Build", usagePercent: 35 },
+          { product: "Codex (5h)", usagePercent: 10 },
+          { product: "Codex (7d)", usagePercent: 55 },
+        ],
+      }),
+    ).toEqual([
+      {
+        label: "Grok",
+        usedPercent: 35,
+        products: [{ product: "Grok Build", usagePercent: 35 }],
+      },
+      {
+        label: "Codex",
+        usedPercent: 55,
+        products: [
+          { product: "Codex (5h)", usagePercent: 10 },
+          { product: "Codex (7d)", usagePercent: 55 },
+        ],
+      },
+    ]);
+  });
+
+  it("keeps the native 5-hour primary window when productUsage only has the 7-day bucket", () => {
+    expect(
+      creditsHeaderEntries({
+        usedPercent: 62,
+        periodType: "five_hour",
+        resetsAt: "2026-08-31T16:00:00.000Z",
+        productUsage: [
+          {
+            product: "7-day window",
+            usagePercent: 18,
+            resetsAt: "2026-09-07T11:00:00.000Z",
+          },
+        ],
+      }).map((entry) => ({ label: entry.label, usedPercent: entry.usedPercent })),
+    ).toEqual([
+      { label: "5-hour", usedPercent: 62 },
+      { label: "7-day", usedPercent: 18 },
+    ]);
+  });
+
+  it("maps the selected Model onto a quota family", () => {
+    expect(creditsFamilyFromSelection("grok-cli / grok-4")).toBe("Grok");
+    expect(creditsFamilyFromSelection("agy / gemini-3.7-flash-tiered")).toBe("Gemini");
+    expect(creditsFamilyFromSelection("codex / gpt-5.4")).toBe("Codex");
+    expect(creditsFamilyFromSelection("agy / claude-sonnet-4-6")).toBe("Claude");
+    expect(creditsFamilyFromSelection("omp-model-v1.abc")).toBeNull();
+    expect(
+      creditsSelectionHint({
+        modelLabel: "grok-cli / grok-4",
+        agent: "omp",
+      }),
+    ).toContain("grok-cli");
+  });
+
+  it("lists per-account rows instead of a duplicated family summary", () => {
+    expect(
+      creditsPopoverRows({
+        label: "Gemini",
+        usedPercent: 50,
+        resetsAt: "2026-09-02T22:43:00.000Z",
+        products: [
+          {
+            product: "Gemini Flash (5h)",
+            usagePercent: 50,
+            resetsAt: "2026-09-02T22:43:00.000Z",
+            accounts: [
+              {
+                accountName: "user1@example.com",
+                usagePercent: 80,
+                resetsAt: "2026-09-02T22:43:00.000Z",
+              },
+              {
+                accountName: "user2@example.com",
+                usagePercent: 20,
+                resetsAt: "2026-09-02T21:10:00.000Z",
+              },
+            ],
+          },
+        ],
+      }),
+    ).toEqual([
+      {
+        label: "user1@example.com",
+        usagePercent: 80,
+        resetsAt: "2026-09-02T22:43:00.000Z",
+      },
+      {
+        label: "user2@example.com",
+        usagePercent: 20,
+        resetsAt: "2026-09-02T21:10:00.000Z",
+      },
+    ]);
+  });
+
+  it("puts the selected family first and keeps other model families for expand", () => {
+    expect(
+      creditsHeaderEntries(
+        {
+          usedPercent: 32.6,
+          periodType: "weekly",
+          productUsage: [
+            { product: "Gemini Flash (5h)", usagePercent: 32.6 },
+            { product: "Grok Build", usagePercent: 64 },
+            { product: "Codex (5h)", usagePercent: 14 },
+            { product: "Firecrawl (monthly)", usagePercent: 0 },
+          ],
+        },
+        "grok-cli / grok-4",
+      ).map((entry) => entry.label),
+    ).toEqual(["Grok", "Gemini", "Codex"]);
   });
 
   it("formats a same-day reset as a precise time and every other reset as a dated time", () => {

--- a/packages/shared-contracts/src/index.ts
+++ b/packages/shared-contracts/src/index.ts
@@ -87,6 +87,7 @@ export type {
   ThreadCommandsInspectParams,
 } from "./harness-commands.js";
 export {
+  accountCreditsAccountUsageSchema,
   accountCreditsProductUsageSchema,
   accountCreditsSnapshotSchema,
   threadUsageInspectionParamsSchema,
@@ -94,6 +95,8 @@ export {
   threadUsageSnapshotSchema,
 } from "./thread-usage.js";
 export type {
+  AccountCreditsAccountUsage,
+  AccountCreditsProductUsage,
   AccountCreditsSnapshot,
   ThreadUsageInspection,
   ThreadUsageInspectionParams,

--- a/packages/shared-contracts/src/thread-usage.ts
+++ b/packages/shared-contracts/src/thread-usage.ts
@@ -73,13 +73,26 @@ export type ThreadUsageSnapshot = z.infer<typeof threadUsageSnapshotSchema>;
 
 const usagePercentSchema = z.number().finite().min(0).max(100);
 
+export const accountCreditsAccountUsageSchema = z
+  .object({
+    accountName: z.string().min(1),
+    usagePercent: usagePercentSchema,
+    resetsAt: z.string().min(1).optional(),
+  })
+  .strict();
+
+export type AccountCreditsAccountUsage = z.infer<typeof accountCreditsAccountUsageSchema>;
+
 export const accountCreditsProductUsageSchema = z
   .object({
     product: z.string().min(1),
     usagePercent: usagePercentSchema,
     resetsAt: z.string().min(1).optional(),
+    accounts: z.array(accountCreditsAccountUsageSchema).optional(),
   })
   .strict();
+
+export type AccountCreditsProductUsage = z.infer<typeof accountCreditsProductUsageSchema>;
 
 export const accountCreditsSnapshotSchema = z
   .object({

--- a/packages/shared-contracts/test/thread-usage.test.ts
+++ b/packages/shared-contracts/test/thread-usage.test.ts
@@ -29,6 +29,20 @@ describe("Thread Usage contracts", () => {
           usedPercent: 33,
           resetsAt: "2026-08-20T03:32:07.498525+00:00",
           periodType: "weekly",
+          productUsage: [
+            {
+              product: "Grok Build",
+              usagePercent: 33,
+              resetsAt: "2026-08-20T03:32:07.498525+00:00",
+              accounts: [
+                {
+                  accountName: "user@example.com",
+                  usagePercent: 33,
+                  resetsAt: "2026-08-20T03:32:07.498525+00:00",
+                },
+              ],
+            },
+          ],
         },
       }),
     ).toMatchObject({


### PR DESCRIPTION
## Purpose

Surface local OmniRoute account quotas in Codex Desktop for OMP and for Claude Code when Anthropic plan-limit events are absent. The credits pill maps the Composer Model onto a provider family and expands to per-account rows.

## Changes

- Extend `AccountCreditsSnapshot` product usage with optional per-account rows.
- Read `~/.omniroute/storage.sqlite` from the OMP and Claude Code adapters (read-only). Claude still prefers native Anthropic plan windows.
- Retry OMP thread-usage until account credits arrive, matching Grok/Claude.
- Place credits after the thread-title overflow in the app header, independent of composer Usage.
- Keep native Codex/Claude 5-hour primary windows when `productUsage` only carries the 7-day bucket.

## Validation

- `npm run lint`
- `npm run typecheck`
- Focused vitest: OmniRoute parsers, OMP/Claude adapter credits, renderer credits control, binding probe
- Full `npm run test:typescript` except local Windows env failures (`cargo` missing from npm PATH, symlink EPERM, host-bundle 5s timeout). Those tests are unchanged by this PR.
- `cargo fmt --all --check` with cargo on PATH

No Rust sources changed.