### PR TITLE
fix(opencode): tolerate non-string command templates

### DIFF
--- a/packages/adapters/opencode/src/sdk-transport.ts
+++ b/packages/adapters/opencode/src/sdk-transport.ts
@@ -125,10 +125,14 @@ export class SdkOpenCodeTransport implements OpenCodeTransport {
 
   async commands() {
     const client = await this.#getClient();
-    return responseData(
+    const commands = responseData(
       await withTimeout(client.command.list(), this.#commandTimeoutMs, "OpenCode Command list"),
       "Command list",
     );
+    return commands.map((command) => ({
+      ...command,
+      template: typeof command.template === "string" ? command.template : "",
+    }));
   }
 
   async createSession(

--- a/packages/adapters/opencode/test/sdk-command-normalization.test.ts
+++ b/packages/adapters/opencode/test/sdk-command-normalization.test.ts
@@ -1,0 +1,36 @@
+import type { OpencodeClient } from "@opencode-ai/sdk/v2/client";
+import { describe, expect, it } from "vitest";
+
+import { SdkOpenCodeTransport } from "../src/sdk-transport.js";
+
+describe("OpenCode SDK command normalization", () => {
+  it("normalizes a non-string command template at the SDK boundary", async () => {
+    const client = {
+      command: {
+        list: async () => ({
+          data: [
+            {
+              name: "review",
+              description: "Review the workspace",
+              template: {},
+              hints: [],
+            },
+          ],
+          error: undefined,
+        }),
+      },
+    } as unknown as OpencodeClient;
+    const connection = {
+      stderrTail: "",
+      client: async () => client,
+      close: async () => undefined,
+    };
+    const transport = new SdkOpenCodeTransport(connection, "/synthetic", {
+      commandTimeoutMs: 100,
+    });
+
+    await expect(transport.commands()).resolves.toEqual([
+      expect.objectContaining({ name: "review", template: "" }),
+    ]);
+  });
+});


### PR DESCRIPTION
Fixes #120.

Normalize OpenCode command metadata at the SDK boundary so a malformed or version-skewed non-string `command.template` cannot reach the adapter command catalog and trigger `.includes is not a function`.

Non-string templates are normalized to an empty string while preserving the rest of the command metadata. Adds a focused regression test for the malformed SDK response.