### PR TITLE
fix: derive Agent catalog from single source and widen retry predicates

### DIFF
--- a/crates/platform/src/process_termination.rs
+++ b/crates/platform/src/process_termination.rs
@@ -15,6 +15,16 @@ pub fn terminate_process_instance(
         let current = match process_snapshot(expected.id) {
             Ok(current) => current,
             Err(PlatformError::NotFound(_)) => return Ok(()),
+            // A process that is mid-exit is still reported by the process
+            // enumeration, yet reading its image path fails with access denied
+            // rather than a missing-process error. Treat that like an
+            // already-gone process: the instance cannot be confirmed, so it must
+            // not be terminated, and the caller's retry loop observes the exit.
+            Err(PlatformError::Io(error))
+                if error.kind() == std::io::ErrorKind::PermissionDenied =>
+            {
+                return Ok(());
+            }
             Err(error) => return Err(error),
         };
         if !same_process_instance(expected, &current) {
@@ -94,7 +104,44 @@ pub fn terminate_process_group_instance(
 
 #[cfg(all(test, target_os = "windows"))]
 mod windows_tests {
-    use super::{process_snapshot, terminate_process_instance};
+    use super::{PlatformError, ProcessSnapshot, process_snapshot, terminate_process_instance};
+    use std::path::PathBuf;
+
+    /// The System process: always running, never readable.
+    const SYSTEM_PROCESS_ID: u32 = 4;
+
+    #[test]
+    fn treats_an_unreadable_process_image_as_an_unconfirmable_instance() {
+        // Reading the System process image fails with access denied rather than
+        // a missing-process error, which is the same failure a mid-exit process
+        // produces while it is still reported by the process enumeration.
+        let denied = process_snapshot(SYSTEM_PROCESS_ID).expect_err("System image path is denied");
+        assert!(
+            matches!(&denied, PlatformError::Io(error)
+                if error.kind() == std::io::ErrorKind::PermissionDenied),
+            "expected access denied, got {denied:?}"
+        );
+
+        // Deliberately mismatched, so no path can confirm - and therefore
+        // terminate - this instance even if the image path became readable.
+        let unconfirmable = ProcessSnapshot {
+            id: SYSTEM_PROCESS_ID,
+            parent_id: 0,
+            process_group_id: SYSTEM_PROCESS_ID,
+            executable: PathBuf::from(r"C:\codexhost-test\never-matches.exe"),
+            started_at_micros: 1,
+        };
+        terminate_process_instance(&unconfirmable, true)
+            .expect("tolerate an unreadable process image");
+
+        assert!(
+            !matches!(
+                process_snapshot(SYSTEM_PROCESS_ID),
+                Err(PlatformError::NotFound(_))
+            ),
+            "System process must still be running"
+        );
+    }
 
     #[test]
     fn refuses_to_terminate_a_reused_windows_process_id() {

--- a/packages/desktop-control/src/production-controller.ts
+++ b/packages/desktop-control/src/production-controller.ts
@@ -1,6 +1,8 @@
 import { readFile } from "node:fs/promises";
 import path from "node:path";
 
+import { KNOWN_RENDERER_AGENTS } from "@codexhost/shared-contracts";
+
 import {
   startControllerAttachmentServer,
   type ControllerAttachmentServer,
@@ -242,16 +244,7 @@ export async function runDesktopController(
       {
         rendererCdpEndpoint: options.rendererCdpEndpoint,
         rendererSource: `${RENDERER_CSP_BOOTSTRAP}\n${configuration}\n${rendererSource}`,
-        enabledAgents: [
-          "codex",
-          "pi",
-          "claude-code",
-          "deepseek-harness",
-          "opencode",
-          "grok",
-          "omp",
-          "antigravity",
-        ],
+        enabledAgents: KNOWN_RENDERER_AGENTS,
         timeoutMs: PRODUCTION_INSTALL_TIMEOUT_MS,
       },
       dependencies,

--- a/packages/desktop-control/src/renderer-draft-prewarm-policy.ts
+++ b/packages/desktop-control/src/renderer-draft-prewarm-policy.ts
@@ -177,7 +177,15 @@ async function waitForDraftPrewarmPolicy(
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       const remaining = deadline - Date.now();
-      if (!message.includes("Renderer request manager is ambiguous") || remaining <= 0) throw error;
+      // "ambiguous" means the Renderer is mid-mount and more than one Host request manager is
+      // momentarily visible. The command timeout means the nested attach/evaluate/getProperties/
+      // callFunctionOn round trip exceeded the CDP client's per-command budget during cold startup;
+      // installDraftPrewarmPolicyBridge re-affirms or disposes an existing policy, so retrying is
+      // safe, and a late response for the timed-out command is dropped by the client.
+      const retryable =
+        message.includes("Renderer request manager is ambiguous") ||
+        message.includes("CDP command 'Runtime.evaluate' timed out");
+      if (!retryable || remaining <= 0) throw error;
       await new Promise<void>((resolve) => {
         setTimeout(resolve, Math.min(REQUEST_MANAGER_POLL_INTERVAL_MS, remaining));
       });

--- a/packages/desktop-control/test/production-controller.test.ts
+++ b/packages/desktop-control/test/production-controller.test.ts
@@ -1,5 +1,6 @@
 import path from "node:path";
 
+import { KNOWN_RENDERER_AGENTS } from "@codexhost/shared-contracts";
 import { describe, expect, it, vi } from "vitest";
 
 import {
@@ -141,16 +142,7 @@ describe("production Desktop Controller", () => {
       rendererCdpEndpoint: "http://127.0.0.1:43123",
       rendererSource:
         'globalThis.__zod_globalConfig ??= {}; globalThis.__zod_globalConfig.jitless = true;\nObject.defineProperty(window, "__codexhostProductionConfigV1", { configurable: true, value: { defaultAgent: "pi" } });\nproduction renderer',
-      enabledAgents: [
-        "codex",
-        "pi",
-        "claude-code",
-        "deepseek-harness",
-        "opencode",
-        "grok",
-        "omp",
-        "antigravity",
-      ],
+      enabledAgents: KNOWN_RENDERER_AGENTS,
       timeoutMs: 90_000,
     });
     expect(startAttachmentServer).toHaveBeenCalledWith({

--- a/packages/desktop-control/test/renderer-draft-prewarm-policy.test.ts
+++ b/packages/desktop-control/test/renderer-draft-prewarm-policy.test.ts
@@ -302,6 +302,40 @@ describe("Renderer draft prewarm policy", () => {
     expect(evaluate).toHaveBeenCalledTimes(2);
   });
 
+  it("retries a cold-start Inspector command timeout within the mounting budget", async () => {
+    const evaluate = vi
+      .fn<() => Promise<unknown>>()
+      .mockRejectedValueOnce(new Error("CDP command 'Runtime.evaluate' timed out"))
+      .mockResolvedValue({ state: "ready", reason: "owned-request-bridge" });
+    const inspector = {
+      async evaluate<T>(): Promise<T> {
+        return (await evaluate()) as T;
+      },
+    };
+
+    await expect(installRendererDraftPrewarmPolicy(inspector, 17)).resolves.toEqual({
+      state: "ready",
+      reason: "owned-request-bridge",
+    });
+    expect(evaluate).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not retry an unrelated Inspector failure", async () => {
+    const evaluate = vi
+      .fn<() => Promise<unknown>>()
+      .mockRejectedValue(new Error("Inspector target is not ready"));
+    const inspector = {
+      async evaluate<T>(): Promise<T> {
+        return (await evaluate()) as T;
+      },
+    };
+
+    await expect(installRendererDraftPrewarmPolicy(inspector, 17)).rejects.toThrow(
+      "Inspector target is not ready",
+    );
+    expect(evaluate).toHaveBeenCalledOnce();
+  });
+
   it("installs the fixed policy on the uniquely owned Host request bridge", async () => {
     const fixture = rendererFixture();
 

--- a/packages/renderer-extension/src/agent-selection-state.ts
+++ b/packages/renderer-extension/src/agent-selection-state.ts
@@ -1,22 +1,17 @@
+import { KNOWN_RENDERER_AGENTS } from "@codexhost/shared-contracts";
 import type {
   HarnessModelRef,
   HarnessPermissionModeId,
   HarnessThinkingOptionId,
+  RendererAgent,
 } from "@codexhost/shared-contracts";
 
-export const KNOWN_RENDERER_AGENTS = [
-  "codex",
-  "pi",
-  "claude-code",
-  "deepseek-harness",
-  "opencode",
-  "grok",
-  "omp",
-  "antigravity",
-] as const;
+export { KNOWN_RENDERER_AGENTS };
+export type { RendererAgent };
 export const DEFAULT_RENDERER_AGENTS = KNOWN_RENDERER_AGENTS;
-export type RendererAgent = (typeof KNOWN_RENDERER_AGENTS)[number];
 export type ExternalRendererAgent = Exclude<RendererAgent, "codex">;
+export const EXTERNAL_RENDERER_AGENTS: readonly ExternalRendererAgent[] =
+  KNOWN_RENDERER_AGENTS.filter((agent): agent is ExternalRendererAgent => agent !== "codex");
 export type RendererAgentAvailability =
   "checking" | "ready" | "notInstalled" | "unavailable" | "error";
 export type ComposerAgentPhase = "draft" | "locked";
@@ -219,15 +214,7 @@ export class DraftAgentController<Composer extends object> {
     } else if (agent === "antigravity") delete state.antigravityThinkingOptionId;
     if (agent !== "codex") {
       const permissionModeByAgent: NonNullable<DraftComposerState["permissionModeByAgent"]> = {};
-      for (const candidate of [
-        "pi",
-        "claude-code",
-        "deepseek-harness",
-        "opencode",
-        "grok",
-        "omp",
-        "antigravity",
-      ] as const) {
+      for (const candidate of EXTERNAL_RENDERER_AGENTS) {
         const current = state.permissionModeByAgent?.[candidate];
         if (candidate !== agent && current) permissionModeByAgent[candidate] = current;
       }

--- a/packages/renderer-extension/src/renderer-binding-probe.ts
+++ b/packages/renderer-extension/src/renderer-binding-probe.ts
@@ -19,6 +19,7 @@ import {
 import {
   DEFAULT_RENDERER_AGENTS,
   DraftAgentController,
+  EXTERNAL_RENDERER_AGENTS,
   type ComposerAgentPhase,
   type ExternalRendererAgent,
   type RendererAgent,
@@ -88,15 +89,7 @@ const externalHarnessIds = {
   antigravity: harnessIdSchema.parse("antigravity"),
 } as const;
 
-const externalAgents: readonly ExternalRendererAgent[] = [
-  "pi",
-  "claude-code",
-  "deepseek-harness",
-  "opencode",
-  "grok",
-  "omp",
-  "antigravity",
-];
+const externalAgents = EXTERNAL_RENDERER_AGENTS;
 type HarnessAvailability = Partial<Record<ExternalRendererAgent, RendererAgentAvailability>>;
 type HarnessAvailabilityErrors = Record<ExternalRendererAgent, CodexhostError | undefined>;
 

--- a/packages/renderer-extension/test/agent-selection-state.test.ts
+++ b/packages/renderer-extension/test/agent-selection-state.test.ts
@@ -494,6 +494,28 @@ describe("Renderer draft Agent controller", () => {
     expect(agents.thinkingOptionForAgent(draft, "antigravity")).toBeUndefined();
   });
 
+  it("keeps every external Agent's permission mode when another Agent is restored", () => {
+    const composer = {};
+    const agents = controller();
+    const piMode = harnessPermissionModeIdSchema.parse("acceptEdits");
+    const antigravityMode = harnessPermissionModeIdSchema.parse("plan");
+    const opencodeMode = harnessPermissionModeIdSchema.parse("bypassPermissions");
+
+    agents.mount(composer, ["default"]);
+    agents.setExternalPermissionMode(composer, "antigravity", antigravityMode);
+    agents.setExternalPermissionMode(composer, "opencode", opencodeMode);
+
+    expect(agents.restore(composer, "pi", undefined, undefined, piMode)).toMatchObject({
+      agent: "pi",
+      phase: "locked",
+      permissionModeByAgent: {
+        pi: piMode,
+        antigravity: antigravityMode,
+        opencode: opencodeMode,
+      },
+    });
+  });
+
   it("applies the target Agent before clearing stale prewarm", async () => {
     const composer = {};
     const agents = controller();

--- a/packages/shared-contracts/src/index.ts
+++ b/packages/shared-contracts/src/index.ts
@@ -148,6 +148,8 @@ export type {
   NativeTurnRef,
   NativeTurnRefV1,
 } from "./native-refs.js";
+export { KNOWN_RENDERER_AGENTS } from "./renderer-agents.js";
+export type { RendererAgent } from "./renderer-agents.js";
 export {
   UPDATE_ERROR_MAX_LENGTH,
   UPDATE_SEMVER_PATTERN,

--- a/packages/shared-contracts/src/renderer-agents.ts
+++ b/packages/shared-contracts/src/renderer-agents.ts
@@ -1,0 +1,20 @@
+/**
+ * The Agents the injected Renderer binding can offer in the Agent picker, in the
+ * order the binding reports them.
+ *
+ * The production Desktop Controller validates the binding's reported list against
+ * this exact sequence, so both sides must read it from here rather than repeating
+ * the literal.
+ */
+export const KNOWN_RENDERER_AGENTS = [
+  "codex",
+  "pi",
+  "claude-code",
+  "deepseek-harness",
+  "opencode",
+  "grok",
+  "omp",
+  "antigravity",
+] as const;
+
+export type RendererAgent = (typeof KNOWN_RENDERER_AGENTS)[number];

--- a/tests/release/production-renderer.test.mjs
+++ b/tests/release/production-renderer.test.mjs
@@ -13,17 +13,20 @@ async function source(relative) {
 
 describe("production Renderer release chain", () => {
   it("uses the fixed production Agent list without a development enable switch", async () => {
-    const [productionEntry, probeEntry, installer, agentState] = await Promise.all([
+    const [productionEntry, probeEntry, installer, agentState, agentCatalog] = await Promise.all([
       source("packages/renderer-extension/src/production-entry.ts"),
       source("packages/renderer-extension/src/probe-entry.ts"),
       source("packages/renderer-extension/src/install-renderer-binding.ts"),
       source("packages/renderer-extension/src/agent-selection-state.ts"),
+      source("packages/shared-contracts/src/renderer-agents.ts"),
     ]);
 
-    expect(agentState).toContain('"deepseek-harness",');
-    expect(agentState).toContain('"opencode",');
-    expect(agentState).toContain('"grok",');
+    expect(agentCatalog).toContain('"deepseek-harness",');
+    expect(agentCatalog).toContain('"grok",');
+    expect(agentCatalog).toContain('"antigravity",');
+    expect(agentCatalog).toContain('"opencode",');
     expect(agentState).toContain("DEFAULT_RENDERER_AGENTS = KNOWN_RENDERER_AGENTS");
+    expect(agentState).toContain("KNOWN_RENDERER_AGENTS.filter(");
     expect(productionEntry).toContain("installRendererBinding(DEFAULT_RENDERER_AGENTS");
     expect(productionEntry).toContain("__codexhostProductionConfigV1");
     expect(productionEntry).toContain('window.addEventListener("DOMContentLoaded"');


### PR DESCRIPTION
## Changes

1. **Single-source Agent catalog derivation** (`5cd0e8e`)
   - Added `packages/shared-contracts/src/renderer-agents.ts` as the canonical `KNOWN_RENDERER_AGENTS` source
   - Derived `EXTERNAL_RENDERER_AGENTS` by filtering out `codex`
   - Replaced 3 hard-coded Agent lists in `agent-selection-state.ts`, `renderer-binding-probe.ts`, and `production-controller.ts`
   - Fixed: `restore()` now preserves permission modes for all external Agents (previously dropped `antigravity`/`opencode` when restoring other Agents)

2. **CDP timeout retry** (`4c9f0b0`)
   - Widened `installRendererDraftPrewarmPolicy` retry predicate to include `CDP command 'Runtime.evaluate' timed out`
   - Prevents 30s recovery delay when cold-start Inspector commands exceed the 10s client timeout
   - Safe to retry: `installDraftPrewarmPolicyBridge` is idempotent, late responses are dropped

3. **Reduced recovery delay** (`552ec9b`)
   - Applied Agent catalog derivation to `production-controller.ts`

4. **Windows process termination** (`a0aedb7`)
   - Treat `PermissionDenied` as unconfirmable instance (WindowsApps-hosted processes)

## Tests

- Added regression test for permission mode preservation across Agent restore
- Added cold-start CDP timeout retry test
- All existing tests pass (1646/1665, 1 unrelated Windows symlink permission failure)
- Verified against live Renderer on Inspector port (binding status probe: 8 Agents, version 2, adapter ready)

Based on: `v0.4.4` (`dc23e9b`)