### PR TITLE
fix: preserve remote turns across transport disconnects

### DIFF
--- a/crates/shim/src/lib.rs
+++ b/crates/shim/src/lib.rs
@@ -499,6 +499,35 @@ fn launch_detached_remote_listener(arguments: &[OsString]) -> ShimResult<i32> {
     let current_executable = env::current_exe()?;
     let socket_path = default_remote_socket_path()?;
     let previous_socket = socket_identity(&socket_path);
+    if previous_socket.is_some() {
+        let stock_codex_path = env::var_os(STOCK_CODEX_PATH_ENV)
+            .map(PathBuf::from)
+            .ok_or_else(|| format!("{STOCK_CODEX_PATH_ENV} is required"))?;
+        let launcher_managed = env::var_os(LAUNCHER_PID_ENV).is_some();
+        let (node_path, host_runtime_path) = select_host_paths(
+            env::var_os(HOST_NODE_PATH_ENV),
+            env::var_os(HOST_RUNTIME_PATH_ENV),
+            launcher_managed,
+            env::var_os(NPM_NODE_PATH_ENV),
+            env::var_os(NPM_PACKAGE_ROOT_ENV),
+        );
+        let node_path = node_path.as_deref().map(Path::new);
+        let host_runtime_path = host_runtime_path.as_deref().map(Path::new);
+        if remote_lifecycle::existing_listener_is_reusable(
+            &socket_path,
+            &stock_codex_path,
+            node_path,
+            host_runtime_path,
+        )? {
+            UnixStream::connect(&socket_path).map_err(|error| {
+                format!(
+                    "managed remote listener at {} is owned by the installed runtime but is not accepting connections: {error}",
+                    socket_path.display()
+                )
+            })?;
+            return Ok(0);
+        }
+    }
     let mut command = Command::new(&current_executable);
     command
         .args(arguments)

--- a/crates/shim/src/remote_lifecycle.rs
+++ b/crates/shim/src/remote_lifecycle.rs
@@ -186,8 +186,9 @@ fn has_default_listener(arguments: &[String]) -> bool {
     app_server && (exact_arguments || shell_command) && !proxy
 }
 
-fn is_managed_desktop_ssh_service(arguments: &[String]) -> bool {
-    arguments == ["codex app-server desktop-ssh-websocket-v0.sock"]
+fn is_managed_remote_listener_service(arguments: &[String]) -> bool {
+    arguments == ["codexhost remote app-server listener"]
+        || arguments == ["codex app-server desktop-ssh-websocket-v0.sock"]
 }
 
 fn command_mentions_path(arguments: &[String], expected: &Path) -> bool {
@@ -228,9 +229,9 @@ fn matching_root(
             ListenerRole::Managed => {
                 executable.as_ref() == Some(&expected_node)
                     && (command_mentions_path(&arguments, expected_command)
-                        || is_managed_desktop_ssh_service(&arguments))
+                        || is_managed_remote_listener_service(&arguments))
                     && (has_default_listener(&arguments)
-                        || is_managed_desktop_ssh_service(&arguments))
+                        || is_managed_remote_listener_service(&arguments))
             }
         };
         if listener_matches {
@@ -384,7 +385,7 @@ pub fn run_terminate(arguments: &[String]) -> LifecycleResult<i32> {
 
 #[cfg(test)]
 mod tests {
-    use super::{command_mentions_path, has_default_listener, is_managed_desktop_ssh_service};
+    use super::{command_mentions_path, has_default_listener, is_managed_remote_listener_service};
     use std::path::Path;
 
     fn arguments(values: &[&str]) -> Vec<String> {
@@ -413,10 +414,13 @@ mod tests {
             "--listen",
             "unix:///tmp/custom.sock",
         ])));
-        assert!(is_managed_desktop_ssh_service(&arguments(&[
+        assert!(is_managed_remote_listener_service(&arguments(&[
+            "codexhost remote app-server listener",
+        ])));
+        assert!(is_managed_remote_listener_service(&arguments(&[
             "codex app-server desktop-ssh-websocket-v0.sock",
         ])));
-        assert!(!is_managed_desktop_ssh_service(&arguments(&[
+        assert!(!is_managed_remote_listener_service(&arguments(&[
             "codex app-server desktop-ssh-websocket-v1.sock",
         ])));
     }

--- a/crates/shim/src/remote_lifecycle.rs
+++ b/crates/shim/src/remote_lifecycle.rs
@@ -241,6 +241,75 @@ fn matching_root(
     Ok(None)
 }
 
+fn matching_roots(
+    owners: &[u32],
+    all: &[ProcessSnapshot],
+    options: &TerminateOptions,
+) -> LifecycleResult<Vec<ProcessSnapshot>> {
+    let snapshots = all
+        .iter()
+        .cloned()
+        .map(|snapshot| (snapshot.id, snapshot))
+        .collect::<HashMap<_, _>>();
+    let mut roots = Vec::new();
+    for owner_id in owners {
+        let Some(owner) = snapshots.get(owner_id) else {
+            continue;
+        };
+        if let Some(root) = matching_root(owner, &snapshots, options)?
+            && !roots
+                .iter()
+                .any(|candidate: &ProcessSnapshot| candidate.id == root.id)
+        {
+            roots.push(root);
+        }
+    }
+    Ok(roots)
+}
+
+pub fn existing_listener_is_reusable(
+    socket_path: &Path,
+    stock_codex_path: &Path,
+    node_path: Option<&Path>,
+    host_runtime_path: Option<&Path>,
+) -> LifecycleResult<bool> {
+    let (role, node_path, host_runtime_path) = match (node_path, host_runtime_path) {
+        (Some(node_path), Some(host_runtime_path)) => (
+            ListenerRole::Managed,
+            node_path.to_owned(),
+            host_runtime_path.to_owned(),
+        ),
+        (None, None) => (
+            ListenerRole::Stock,
+            stock_codex_path.to_owned(),
+            stock_codex_path.to_owned(),
+        ),
+        _ => {
+            return Err(
+                "CODEXHOST_HOST_NODE_PATH and CODEXHOST_HOST_RUNTIME_PATH must be configured together"
+                    .into(),
+            );
+        }
+    };
+    let options = TerminateOptions {
+        role,
+        socket_path: socket_path.to_owned(),
+        stock_codex_path: stock_codex_path.to_owned(),
+        node_path,
+        host_runtime_path,
+    };
+    let owners = socket_owner_process_ids(socket_path)?;
+    if owners.is_empty() {
+        return Ok(false);
+    }
+    let all = process_snapshots()?;
+    let roots = matching_roots(&owners, &all, &options)?;
+    if roots.len() == 1 {
+        return Ok(true);
+    }
+    Err("remote Host socket owner does not match the requested installed listener".into())
+}
+
 fn descendants(root: &ProcessSnapshot, snapshots: &[ProcessSnapshot]) -> Vec<ProcessSnapshot> {
     let mut selected = vec![root.clone()];
     let mut selected_ids = HashSet::from([root.id]);
@@ -301,24 +370,7 @@ pub fn run_terminate(arguments: &[String]) -> LifecycleResult<i32> {
         .into());
     }
     let all = process_snapshots()?;
-    let snapshots = all
-        .iter()
-        .cloned()
-        .map(|snapshot| (snapshot.id, snapshot))
-        .collect::<HashMap<_, _>>();
-    let mut roots = Vec::new();
-    for owner_id in owners {
-        let Some(owner) = snapshots.get(&owner_id) else {
-            continue;
-        };
-        if let Some(root) = matching_root(owner, &snapshots, &options)?
-            && !roots
-                .iter()
-                .any(|candidate: &ProcessSnapshot| candidate.id == root.id)
-        {
-            roots.push(root);
-        }
-    }
+    let mut roots = matching_roots(&owners, &all, &options)?;
     if roots.len() != 1 {
         return Err(
             "remote Host socket owner does not match the requested installed listener".into(),

--- a/crates/shim/tests/proxy.rs
+++ b/crates/shim/tests/proxy.rs
@@ -21,6 +21,8 @@ use codexhost_platform::{process_exists, process_snapshot};
 use codexhost_shim::{HOST_NODE_PATH_ENV, HOST_RUNTIME_PATH_ENV, REMOTE_SSH_MANAGED_ENV};
 #[cfg(any(target_os = "windows", target_os = "macos", target_os = "linux"))]
 use fs2::FileExt;
+#[cfg(any(target_os = "macos", target_os = "linux"))]
+use std::os::unix::fs::MetadataExt;
 
 fn shim_path() -> PathBuf {
     PathBuf::from(env!("CARGO_BIN_EXE_codexhost-shim"))
@@ -283,7 +285,7 @@ fn rejects_missing_official_cli_without_falling_back_to_path() {
 
 #[cfg(any(target_os = "macos", target_os = "linux"))]
 #[test]
-fn managed_remote_listener_detaches_after_the_socket_is_ready() {
+fn managed_remote_listener_detaches_and_reuses_a_matching_socket_owner() {
     static NEXT_REMOTE_DIRECTORY_ID: AtomicU64 = AtomicU64::new(0);
 
     let directory = PathBuf::from("/tmp").join(format!(
@@ -327,9 +329,9 @@ fn managed_remote_listener_detaches_after_the_socket_is_ready() {
     while !ready.exists() && Instant::now() < ready_deadline {
         thread::sleep(Duration::from_millis(20));
     }
-    let ready = fs::read_to_string(&ready).expect("read detached listener identity");
+    let ready_contents = fs::read_to_string(&ready).expect("read detached listener identity");
     let value = |label: &str| {
-        ready
+        ready_contents
             .lines()
             .find_map(|line| line.strip_prefix(label))
             .expect("listener identity field")
@@ -373,29 +375,168 @@ fn managed_remote_listener_detaches_after_the_socket_is_ready() {
     assert!(process_exists(root_id), "detached listener root exited");
     assert!(process_exists(shim_id), "detached listener Shim exited");
 
-    let termination = Command::new("/bin/kill")
-        .args(["-TERM", &shim_id.to_string()])
-        .status()
-        .expect("stop detached listener Shim");
-    assert!(termination.success());
-    let deadline = Instant::now() + Duration::from_secs(5);
-    while (process_exists(root_id) || process_exists(shim_id)) && Instant::now() < deadline {
-        thread::sleep(Duration::from_millis(20));
-    }
-    if process_exists(root_id) || process_exists(shim_id) {
+    let original_socket = fs::metadata(&socket).expect("read original listener socket identity");
+    let repeated_started = Instant::now();
+    let repeated = Command::new(shim_path())
+        .args([
+            "-c",
+            "features.code_mode_host=true",
+            "app-server",
+            "--listen",
+            "unix://",
+        ])
+        .env_remove(HOST_NODE_PATH_ENV)
+        .env_remove(HOST_RUNTIME_PATH_ENV)
+        .env_remove("CODEXHOST_REMOTE_LISTENER_CHILD")
+        .env(STOCK_CODEX_PATH_ENV, fake_codex_path())
+        .env(CODEX_CLI_PATH_ENV, shim_path())
+        .env(REMOTE_SSH_MANAGED_ENV, "1")
+        .env("CODEX_HOME", &codex_home)
+        .env("FAKE_CODEX_UNIX_LISTENER_PATH", &socket)
+        .env("FAKE_CODEX_READY_PATH", &ready)
+        .stdin(Stdio::null())
+        .output()
+        .expect("repeat managed remote listener bootstrap");
+    let repeated_elapsed = repeated_started.elapsed();
+    let repeated_ready = fs::read_to_string(&ready).expect("read repeated listener identity");
+    let repeated_value = |label: &str| {
+        repeated_ready
+            .lines()
+            .find_map(|line| line.strip_prefix(label))
+            .expect("repeated listener identity field")
+            .parse::<u32>()
+            .expect("repeated listener identity PID")
+    };
+    let repeated_root_id = repeated_value("root=");
+    let repeated_shim_id = repeated_value("shim=");
+    let repeated_socket = fs::metadata(&socket).expect("read repeated listener socket identity");
+
+    let alternate_stock = directory.join("alternate-fake-codex");
+    fs::copy(fake_codex_path(), &alternate_stock).expect("copy alternate stock Codex fixture");
+    let mismatched = Command::new(shim_path())
+        .args([
+            "-c",
+            "features.code_mode_host=true",
+            "app-server",
+            "--listen",
+            "unix://",
+        ])
+        .env_remove(HOST_NODE_PATH_ENV)
+        .env_remove(HOST_RUNTIME_PATH_ENV)
+        .env_remove("CODEXHOST_REMOTE_LISTENER_CHILD")
+        .env(STOCK_CODEX_PATH_ENV, &alternate_stock)
+        .env(CODEX_CLI_PATH_ENV, shim_path())
+        .env(REMOTE_SSH_MANAGED_ENV, "1")
+        .env("CODEX_HOME", &codex_home)
+        .env("FAKE_CODEX_UNIX_LISTENER_PATH", &socket)
+        .env("FAKE_CODEX_READY_PATH", &ready)
+        .stdin(Stdio::null())
+        .output()
+        .expect("run mismatched managed remote listener bootstrap");
+    let mismatched_ready = fs::read_to_string(&ready).expect("read mismatched listener identity");
+    let mismatched_value = |label: &str| {
+        mismatched_ready
+            .lines()
+            .find_map(|line| line.strip_prefix(label))
+            .expect("mismatched listener identity field")
+            .parse::<u32>()
+            .expect("mismatched listener identity PID")
+    };
+    let mismatched_root_id = mismatched_value("root=");
+    let mismatched_shim_id = mismatched_value("shim=");
+    let mismatched_socket =
+        fs::metadata(&socket).expect("read mismatched listener socket identity");
+    let original_processes_survived = process_exists(root_id) && process_exists(shim_id);
+
+    let process_ids = [
+        root_id,
+        shim_id,
+        repeated_root_id,
+        repeated_shim_id,
+        mismatched_root_id,
+        mismatched_shim_id,
+    ]
+    .into_iter()
+    .collect::<std::collections::HashSet<_>>();
+    for process_id in [shim_id, repeated_shim_id, mismatched_shim_id]
+        .into_iter()
+        .collect::<std::collections::HashSet<_>>()
+    {
         let _ = Command::new("/bin/kill")
-            .args(["-KILL", &shim_id.to_string(), &root_id.to_string()])
+            .args(["-TERM", &process_id.to_string()])
             .status();
     }
-    assert!(
-        !process_exists(root_id),
-        "detached listener root survived shutdown"
-    );
-    assert!(
-        !process_exists(shim_id),
-        "detached listener Shim survived shutdown"
-    );
+    let deadline = Instant::now() + Duration::from_secs(5);
+    while process_ids.iter().copied().any(process_exists) && Instant::now() < deadline {
+        thread::sleep(Duration::from_millis(20));
+    }
+    for process_id in process_ids
+        .iter()
+        .copied()
+        .filter(|process_id| process_exists(*process_id))
+    {
+        let _ = Command::new("/bin/kill")
+            .args(["-KILL", &process_id.to_string()])
+            .status();
+    }
     fs::remove_dir_all(directory).expect("remove remote listener fixture");
+
+    assert!(
+        repeated.status.success(),
+        "repeated bootstrap failed: {}; stderr={}",
+        repeated.status,
+        String::from_utf8_lossy(&repeated.stderr)
+    );
+    assert!(
+        repeated_elapsed < Duration::from_secs(2),
+        "repeated bootstrap did not reuse the listener promptly"
+    );
+    assert!(
+        original_processes_survived,
+        "repeated bootstrap terminated the original listener"
+    );
+    assert_eq!(
+        repeated_root_id, root_id,
+        "repeated bootstrap replaced the listener root"
+    );
+    assert_eq!(
+        repeated_shim_id, shim_id,
+        "repeated bootstrap replaced the listener Shim"
+    );
+    assert_eq!(
+        (repeated_socket.dev(), repeated_socket.ino()),
+        (original_socket.dev(), original_socket.ino()),
+        "repeated bootstrap replaced the listener socket"
+    );
+    assert!(
+        !mismatched.status.success(),
+        "bootstrap unexpectedly reused a listener from another installed runtime"
+    );
+    assert!(
+        String::from_utf8_lossy(&mismatched.stderr)
+            .contains("remote Host socket owner does not match"),
+        "unexpected mismatched bootstrap error: {}",
+        String::from_utf8_lossy(&mismatched.stderr)
+    );
+    assert_eq!(
+        mismatched_root_id, root_id,
+        "mismatched bootstrap replaced the listener root"
+    );
+    assert_eq!(
+        mismatched_shim_id, shim_id,
+        "mismatched bootstrap replaced the listener Shim"
+    );
+    assert_eq!(
+        (mismatched_socket.dev(), mismatched_socket.ino()),
+        (original_socket.dev(), original_socket.ino()),
+        "mismatched bootstrap replaced the listener socket"
+    );
+    for process_id in process_ids {
+        assert!(
+            !process_exists(process_id),
+            "detached listener process {process_id} survived shutdown"
+        );
+    }
 }
 
 #[cfg(any(target_os = "macos", target_os = "linux"))]

--- a/openspec/specs/remote-ssh-harness-host/spec.md
+++ b/openspec/specs/remote-ssh-harness-host/spec.md
@@ -8,7 +8,7 @@ Define secure, isolated, and reversible execution of registered Harnesses throug
 
 ### Requirement: Remote Host SHALL use Codex's native SSH control transport
 
-On macOS and Linux, codexhost SHALL recognize a Codex `app-server --listen unix://` invocation, own the resolved Unix control socket, accept Codex WebSocket connections, and create one Host session per connection. One long-lived stock Codex app-server listener SHALL serve all of those Host sessions through a private sibling Unix socket, with one independent WebSocket connection per Host session. The native Shim SHALL forward `app-server proxy` and other app-server management commands to stock Codex without entering Host Runtime.
+On macOS and Linux, codexhost SHALL recognize a Codex `app-server --listen unix://` invocation, own the resolved Unix control socket, accept Codex WebSocket connections, and create one Host session per connection. One long-lived stock Codex app-server listener SHALL serve all of those Host sessions through a private sibling Unix socket, with one independent WebSocket connection per Host session. An unexpected Desktop transport disconnect SHALL end that Host session's Desktop input without treating the disconnect as a user cancellation. If an official or external Harness Turn is active, or an official `turn/start` has been forwarded and is awaiting its response, the Host session SHALL retain its owned runtime resources until the work reaches a real terminal event. Explicit listener shutdown SHALL still hard-close every owned Host session. The native Shim SHALL forward `app-server proxy` and other app-server management commands to stock Codex without entering Host Runtime.
 
 #### Scenario: Desktop connects through the stock proxy
 
@@ -33,6 +33,29 @@ On macOS and Linux, codexhost SHALL recognize a Codex `app-server --listen unix:
 - **AND** the stock app-server attaches the second connection to its loaded Thread and native subscription state
 - **AND** codexhost does not start a competing stdio app-server or surface an `active writer` error caused by a second process
 - **AND** closing either Desktop connection does not stop the shared stock listener or the remaining connection
+
+#### Scenario: Desktop transport drops during an active Turn
+
+- **GIVEN** a remote Host session has an active native Codex or external Harness Turn
+- **WHEN** its Desktop WebSocket closes without an explicit `turn/interrupt`
+- **THEN** codexhost ends only that session's Desktop input and does not send or synthesize Turn cancellation
+- **AND** the owned official connection and Harness Session remain alive until the Turn emits its real terminal event
+- **AND** the terminal state is persisted before the disconnected Host session releases its resources
+
+#### Scenario: Desktop transport drops while official Turn start is in flight
+
+- **GIVEN** a remote Host session has forwarded an official `turn/start` request
+- **WHEN** its Desktop WebSocket closes before the response or `turn/started` event arrives
+- **THEN** codexhost retains the official connection while the start request is pending
+- **AND** a successful response keeps the session alive until `turn/completed`
+- **AND** a failed response releases the disconnected session without leaking it
+
+#### Scenario: Remote listener stops with detached work
+
+- **GIVEN** a Desktop WebSocket has disconnected while its Host session is draining active work
+- **WHEN** the remote listener is explicitly stopped
+- **THEN** codexhost hard-closes the detached Host session and all of its owned resources
+- **AND** listener shutdown does not wait indefinitely for the Turn to finish
 
 ### Requirement: Remote Harness execution SHALL remain local to the SSH host
 

--- a/openspec/specs/remote-ssh-harness-host/spec.md
+++ b/openspec/specs/remote-ssh-harness-host/spec.md
@@ -54,7 +54,9 @@ On macOS and Linux, codexhost SHALL recognize a Codex `app-server --listen unix:
 
 - **GIVEN** the installed managed Remote Host already owns a healthy control socket
 - **WHEN** Desktop invokes the same default `app-server --listen unix://` bootstrap again
-- **THEN** the Shim verifies the socket owner against the installed Node and Host Runtime paths
+- **AND** Desktop first applies its stock-listener cleanup selector
+- **THEN** the managed listener does not advertise the stock `desktop-ssh-websocket-v0.sock` process marker and survives that cleanup
+- **AND** the Shim verifies the socket owner against the installed Node and Host Runtime paths
 - **AND** it returns success without starting a competing listener or replacing the socket identity
 - **AND** a socket owned by a different installed command is rejected instead of reused or overwritten
 

--- a/openspec/specs/remote-ssh-harness-host/spec.md
+++ b/openspec/specs/remote-ssh-harness-host/spec.md
@@ -50,6 +50,14 @@ On macOS and Linux, codexhost SHALL recognize a Codex `app-server --listen unix:
 - **AND** a successful response keeps the session alive until `turn/completed`
 - **AND** a failed response releases the disconnected session without leaking it
 
+#### Scenario: Desktop repeats a matching remote listener bootstrap
+
+- **GIVEN** the installed managed Remote Host already owns a healthy control socket
+- **WHEN** Desktop invokes the same default `app-server --listen unix://` bootstrap again
+- **THEN** the Shim verifies the socket owner against the installed Node and Host Runtime paths
+- **AND** it returns success without starting a competing listener or replacing the socket identity
+- **AND** a socket owned by a different installed command is rejected instead of reused or overwritten
+
 #### Scenario: Remote listener stops with detached work
 
 - **GIVEN** a Desktop WebSocket has disconnected while its Host session is draining active work

--- a/packages/host-runtime/src/app-server-host.ts
+++ b/packages/host-runtime/src/app-server-host.ts
@@ -443,6 +443,8 @@ export class AppServerHost {
   #delegationCoordinator: HarnessDelegationCoordinator;
   #unregisterDelegationApi: (() => void) | undefined;
   #activeOfficialTurns = new Map<string, string>();
+  #pendingOfficialTurnStarts = new Map<unknown, string>();
+  #activeWorkDrainWaiters = new Set<() => void>();
   #pendingOfficialDelegationThreads = new Set<string>();
   #pendingOfficialTerminalStatuses = new Map<string, DelegationStartResult["status"]>();
   #officialUsageByThread = new Map<string, HostUsage>();
@@ -455,6 +457,7 @@ export class AppServerHost {
   #subagentThreadStatuses = new Map<string, "active" | "idle">();
   #runningSubagentsByParent = new Map<string, Set<string>>();
   #closeRequested = false;
+  #drainActiveWorkOnInputEnd = false;
   #desktopInputEnded = false;
 
   constructor(options: AppServerHostOptions) {
@@ -524,8 +527,17 @@ export class AppServerHost {
   close(): void {
     if (this.#closeRequested) return;
     this.#closeRequested = true;
+    this.#signalActiveWorkChanged();
     this.#options.desktopInput.destroy();
     this.#terminateOfficial();
+  }
+
+  disconnect(): void {
+    if (this.#closeRequested || this.#desktopInputEnded || this.#drainActiveWorkOnInputEnd) return;
+    this.#drainActiveWorkOnInputEnd = true;
+    const desktopInput = this.#options.desktopInput as Readable & { end?: () => void };
+    if (typeof desktopInput.end === "function") desktopInput.end();
+    else desktopInput.destroy();
   }
 
   async run(): Promise<number> {
@@ -625,6 +637,7 @@ export class AppServerHost {
       }
       this.#officialRequestBroker.failAll(new Error("codexhost Host Runtime closed"));
       this.#externalRuntime.clear();
+      this.#pendingOfficialTurnStarts.clear();
       this.#routeObservationTracker.clear();
       this.#unregisterDelegationApi?.();
       this.#unregisterDelegationApi = undefined;
@@ -638,6 +651,49 @@ export class AppServerHost {
     const official = this.#official;
     if (!official) return;
     official.close();
+  }
+
+  #hasActiveWork(): boolean {
+    return (
+      this.#pendingOfficialTurnStarts.size > 0 ||
+      this.#activeOfficialTurns.size > 0 ||
+      this.#runningSubagentsByParent.size > 0 ||
+      this.#externalRuntime
+        .values()
+        .some((thread) => thread.running || thread.activeTurnId !== null)
+    );
+  }
+
+  async #waitForActiveWorkToDrain(): Promise<void> {
+    while (!this.#closeRequested && this.#hasActiveWork()) {
+      await new Promise<void>((resolve) => this.#activeWorkDrainWaiters.add(resolve));
+    }
+  }
+
+  #signalActiveWorkChanged(): void {
+    if (!this.#closeRequested && this.#hasActiveWork()) return;
+    const waiters = [...this.#activeWorkDrainWaiters];
+    this.#activeWorkDrainWaiters.clear();
+    for (const resolve of waiters) resolve();
+  }
+
+  #observeOfficialTurnStartResponse(value: JsonValue): void {
+    if (!isRecord(value) || !("id" in value)) return;
+    const threadId = this.#pendingOfficialTurnStarts.get(value.id);
+    if (!threadId) return;
+    this.#pendingOfficialTurnStarts.delete(value.id);
+    const result = isRecord(value.result) ? value.result : null;
+    const turn = result && isRecord(result.turn) ? result.turn : null;
+    if (turn && typeof turn.id === "string") {
+      this.#activeOfficialTurns.set(threadId, turn.id);
+    }
+    this.#signalActiveWorkChanged();
+  }
+
+  #forgetPendingOfficialTurnStarts(threadId: string): void {
+    for (const [requestId, pendingThreadId] of this.#pendingOfficialTurnStarts) {
+      if (pendingThreadId === threadId) this.#pendingOfficialTurnStarts.delete(requestId);
+    }
   }
 
   async #forwardDesktop(): Promise<void> {
@@ -900,6 +956,9 @@ export class AppServerHost {
           await this.#startExternalTurn(request, resolution.thread);
           continue;
         }
+        if (typeof threadId === "string") {
+          this.#pendingOfficialTurnStarts.set(request.id, threadId);
+        }
       }
       if (request.method === "turn/interrupt") {
         const params = requestObject(request);
@@ -1014,10 +1073,19 @@ export class AppServerHost {
           continue;
         }
       }
-      await writeFrame(official.stdin, frame);
+      try {
+        await writeFrame(official.stdin, frame);
+      } catch (error) {
+        if (request.method === "turn/start") {
+          this.#pendingOfficialTurnStarts.delete(request.id);
+          this.#signalActiveWorkChanged();
+        }
+        throw error;
+      }
     }
     this.#desktopInputEnded = true;
-    official.stdin.end();
+    if (this.#drainActiveWorkOnInputEnd) await this.#waitForActiveWorkToDrain();
+    if (!this.#closeRequested) official.stdin.end();
   }
 
   async #forwardOfficial(): Promise<void> {
@@ -1030,6 +1098,7 @@ export class AppServerHost {
         const frame = current.value;
         const following = frames.next();
         const parsed = parseJsonFrame(frame);
+        this.#observeOfficialTurnStartResponse(parsed);
         if (isRecord(parsed) && parsed.method === "account/updated")
           this.#resetOfficialUsageState();
         if (this.#officialRequestBroker.handle(parsed)) {
@@ -1073,11 +1142,15 @@ export class AppServerHost {
     const params = value.params;
     if (value.method === "turn/started" && typeof params.threadId === "string") {
       const turn = isRecord(params.turn) ? params.turn : null;
-      if (turn && typeof turn.id === "string")
+      if (turn && typeof turn.id === "string") {
+        this.#forgetPendingOfficialTurnStarts(params.threadId);
         this.#activeOfficialTurns.set(params.threadId, turn.id);
+      }
     }
     if (value.method === "turn/completed" && typeof params.threadId === "string") {
+      this.#forgetPendingOfficialTurnStarts(params.threadId);
       this.#activeOfficialTurns.delete(params.threadId);
+      this.#signalActiveWorkChanged();
       const delegation = await this.#repository.getDelegationByChild(
         hostThreadIdSchema.parse(params.threadId),
       );
@@ -1368,6 +1441,7 @@ export class AppServerHost {
       };
     } catch (error) {
       this.#activeOfficialTurns.delete(threadId);
+      this.#signalActiveWorkChanged();
       await this.#officialRequestBroker
         .request("thread/delete", { threadId })
         .catch(() => undefined);
@@ -2045,6 +2119,7 @@ export class AppServerHost {
       thread.responseGates.delete(turnId);
       thread.ephemeralTurnIds.delete(turnId);
       gate.resolve();
+      this.#signalActiveWorkChanged();
       throw error;
     }
     if (!result.ok) {
@@ -2054,6 +2129,7 @@ export class AppServerHost {
       thread.responseGates.delete(turnId);
       thread.ephemeralTurnIds.delete(turnId);
       gate.resolve();
+      this.#signalActiveWorkChanged();
       await this.#writer.json(rpcError(request, -32073, result.error.message));
       return;
     }
@@ -2882,6 +2958,7 @@ export class AppServerHost {
       thread.activeTurnId = null;
       thread.projectedTurns.delete(turnId);
       thread.responseGates.delete(turnId);
+      this.#signalActiveWorkChanged();
       throw new Error(result.error.message);
     }
   }
@@ -2975,6 +3052,7 @@ export class AppServerHost {
       thread.projectedTurns.delete(turnId);
       thread.responseGates.delete(turnId);
       gate.resolve();
+      this.#signalActiveWorkChanged();
       await this.#writer.json(rpcError(request, -32073, result.error.message));
       return;
     }
@@ -3231,6 +3309,7 @@ export class AppServerHost {
       thread.activeTurnId = null;
       thread.projectedTurns.delete(event.turnId);
       thread.responseGates.delete(event.turnId);
+      this.#signalActiveWorkChanged();
       const delegation = await this.#repository.getDelegationByChild(thread.record.hostThreadId);
       if (delegation) {
         const status =
@@ -3397,6 +3476,7 @@ export class AppServerHost {
     if (!running) return;
     running.delete(childThreadId);
     if (running.size === 0) this.#runningSubagentsByParent.delete(parentThreadId);
+    this.#signalActiveWorkChanged();
   }
 
   #hasRunningSubagents(parentThreadId: string): boolean {

--- a/packages/host-runtime/src/remote-app-server.ts
+++ b/packages/host-runtime/src/remote-app-server.ts
@@ -36,7 +36,9 @@ const APP_SERVER_FLAG_OPTIONS = new Set([
 
 export interface RemoteAppServerSession {
   run(): Promise<number>;
-  /** Requests cancellation synchronously; run settles after owned resources are released. */
+  /** Ends remote Desktop input without cancelling active work. */
+  disconnect(): void;
+  /** Requests hard cancellation synchronously; run settles after owned resources are released. */
   close(): void;
 }
 
@@ -371,6 +373,7 @@ export function createRemoteAppServerWebSocketListener(input: {
     input.diagnosticOutput.write(`codexhost remote WebSocket server: ${error.message}\n`);
   });
   const sessions = new Set<Promise<unknown>>();
+  const sessionClosers = new Set<() => void>();
   let listening = false;
   let ownedSocketIdentity: UnixFileIdentity | null = null;
   let closing: Promise<void> | null = null;
@@ -386,8 +389,25 @@ export function createRemoteAppServerWebSocketListener(input: {
     });
     sendOutputFrames(socket, desktopOutput);
     let inputTail = Promise.resolve();
+    let sessionDisconnecting = false;
     let sessionClosing = false;
     let sessionFinished = false;
+    const disconnectSession = (): void => {
+      if (sessionDisconnecting || sessionClosing || sessionFinished) return;
+      sessionDisconnecting = true;
+      const disconnect = (): void => {
+        if (sessionClosing || sessionFinished) return;
+        try {
+          session.disconnect();
+        } catch (error) {
+          input.diagnosticOutput.write(
+            `codexhost remote app-server disconnect: ${error instanceof Error ? error.message : String(error)}\n`,
+          );
+          closeSession();
+        }
+      };
+      void inputTail.then(disconnect, disconnect);
+    };
     const closeSession = (): void => {
       desktopInput.destroy();
       if (sessionClosing || sessionFinished) return;
@@ -416,8 +436,11 @@ export function createRemoteAppServerWebSocketListener(input: {
       );
       void inputTail.catch(() => socket.close(1011, "Host Runtime input failed"));
     });
-    socket.once("close", closeSession);
-    socket.once("error", closeSession);
+    // A transport disconnect is not a user cancellation. End the Desktop input
+    // after accepted frames drain so AppServerHost can keep an active Turn alive
+    // until its real terminal event. Listener shutdown still uses closeSession.
+    socket.once("close", disconnectSession);
+    socket.once("error", disconnectSession);
     const running = session
       .run()
       .then((code) => {
@@ -433,10 +456,13 @@ export function createRemoteAppServerWebSocketListener(input: {
       })
       .finally(() => {
         sessionFinished = true;
+        desktopInput.destroy();
         desktopOutput.end();
         sessions.delete(running);
+        sessionClosers.delete(closeSession);
       });
     sessions.add(running);
+    sessionClosers.add(closeSession);
   });
 
   return {
@@ -476,6 +502,8 @@ export function createRemoteAppServerWebSocketListener(input: {
     close() {
       if (closing) return closing;
       closing = (async () => {
+        const closingSessions = [...sessions];
+        for (const closeSession of sessionClosers) closeSession();
         for (const socket of webSockets.clients) socket.terminate();
         await new Promise<void>((resolve) => webSockets.close(() => resolve()));
         const closeServer = async (): Promise<void> => {
@@ -501,7 +529,7 @@ export function createRemoteAppServerWebSocketListener(input: {
         } else {
           await closeServer();
         }
-        await Promise.allSettled(sessions);
+        await Promise.allSettled(closingSessions);
         closed.resolve(undefined);
       })();
       return closing;

--- a/packages/host-runtime/src/run-host-runtime.ts
+++ b/packages/host-runtime/src/run-host-runtime.ts
@@ -44,6 +44,7 @@ import { createHostUpdateCoordinator, type HostUpdateCoordinator } from "./updat
 
 const STOCK_CODEX_PATH_ENV = "CODEXHOST_STOCK_CODEX_PATH";
 const DEFAULT_AGENT_ENV = "CODEXHOST_DEFAULT_AGENT";
+export const MANAGED_REMOTE_APP_SERVER_PROCESS_TITLE = "codexhost remote app-server listener";
 
 export function createRemoteOfficialAppServerPlan(
   arguments_: readonly string[],
@@ -329,7 +330,7 @@ export async function runHostRuntime(input: {
           officialState.unexpectedExit = result;
           void listener.close();
         });
-        process.title = "codex app-server desktop-ssh-websocket-v0.sock";
+        process.title = MANAGED_REMOTE_APP_SERVER_PROCESS_TITLE;
         process.once("SIGINT", stop);
         process.once("SIGTERM", stop);
         await listener.closed;

--- a/packages/host-runtime/test/app-server-host.test.ts
+++ b/packages/host-runtime/test/app-server-host.test.ts
@@ -724,6 +724,198 @@ describe("AppServerHost HarnessAdapter projection", () => {
     }
   });
 
+  it("lets an active official Turn reach its terminal event after Desktop disconnects", async () => {
+    const fixture = createFixture();
+    const threadId = "019cbe86-76cf-7721-b5e4-978934e18757";
+    const turnId = "019cbe86-8eef-79d0-8658-cf2c64aa38cf";
+
+    try {
+      writeRequest(fixture.desktopInput, {
+        id: 1,
+        method: "turn/start",
+        params: { threadId, input: [{ type: "text", text: "keep running" }] },
+      });
+      await readJsonLine(fixture.official.stdin);
+      fixture.official.stdout.write(
+        `${JSON.stringify({ method: "turn/started", params: { threadId, turn: { id: turnId } } })}\n`,
+      );
+      await fixture.collector.waitFor((message) => turnEvent(message, "turn/started", turnId));
+
+      fixture.host.disconnect();
+      const beforeTerminal = await Promise.race([
+        fixture.running.then(() => "settled" as const),
+        new Promise<"pending">((resolve) => setTimeout(() => resolve("pending"), 25)),
+      ]);
+
+      expect(beforeTerminal).toBe("pending");
+      expect(fixture.official.kill).not.toHaveBeenCalled();
+
+      fixture.official.stdout.write(
+        `${JSON.stringify({
+          method: "turn/completed",
+          params: { threadId, turn: { id: turnId, status: "completed" } },
+        })}\n`,
+      );
+      await expect(
+        fixture.collector.waitFor((message) => turnEvent(message, "turn/completed", turnId)),
+      ).resolves.toBeTruthy();
+      await expect(fixture.running).resolves.toBe(0);
+      expect(fixture.official.kill).not.toHaveBeenCalled();
+    } finally {
+      fixture.host.close();
+      fixture.desktopInput.end();
+      await fixture.running;
+      rmSync(fixture.mappingStoreDirectory, { recursive: true, force: true });
+    }
+  });
+
+  it("keeps a forwarded official turn/start alive across the pre-response disconnect race", async () => {
+    const fixture = createFixture();
+    const threadId = "019cbe87-ae18-7543-97f1-c60deeb61b17";
+    const turnId = "019cbe87-b77a-78a2-a16a-c6ad1fc2a026";
+
+    try {
+      writeRequest(fixture.desktopInput, {
+        id: 1,
+        method: "turn/start",
+        params: { threadId, input: [{ type: "text", text: "start then disconnect" }] },
+      });
+      await readJsonLine(fixture.official.stdin);
+      fixture.host.disconnect();
+
+      const beforeResponse = await Promise.race([
+        fixture.running.then(() => "settled" as const),
+        new Promise<"pending">((resolve) => setTimeout(() => resolve("pending"), 25)),
+      ]);
+      expect(beforeResponse).toBe("pending");
+
+      fixture.official.stdout.write(
+        `${JSON.stringify({ id: 1, result: { turn: { id: turnId } } })}\n`,
+      );
+      await expect(
+        fixture.collector.waitFor((message) => requestId(message, 1)),
+      ).resolves.toBeTruthy();
+      expect(fixture.official.stdin.writableEnded).toBe(false);
+
+      fixture.official.stdout.write(
+        `${JSON.stringify({
+          method: "turn/completed",
+          params: { threadId, turn: { id: turnId, status: "completed" } },
+        })}\n`,
+      );
+      await expect(fixture.running).resolves.toBe(0);
+      expect(fixture.official.kill).not.toHaveBeenCalled();
+    } finally {
+      fixture.host.close();
+      fixture.desktopInput.end();
+      await fixture.running;
+      rmSync(fixture.mappingStoreDirectory, { recursive: true, force: true });
+    }
+  });
+
+  it("releases a disconnected Host session when pending official turn/start fails", async () => {
+    const fixture = createFixture();
+    const threadId = "019cbe88-9a77-78ae-919f-79cfe1468e11";
+
+    try {
+      writeRequest(fixture.desktopInput, {
+        id: 1,
+        method: "turn/start",
+        params: { threadId, input: [{ type: "text", text: "rejected start" }] },
+      });
+      await readJsonLine(fixture.official.stdin);
+      fixture.host.disconnect();
+      fixture.official.stdout.write(
+        `${JSON.stringify({ id: 1, error: { code: -32000, message: "synthetic rejection" } })}\n`,
+      );
+
+      await expect(
+        fixture.collector.waitFor((message) => requestId(message, 1)),
+      ).resolves.toBeTruthy();
+      await expect(fixture.running).resolves.toBe(0);
+      expect(fixture.official.kill).not.toHaveBeenCalled();
+    } finally {
+      fixture.host.close();
+      fixture.desktopInput.end();
+      await fixture.running;
+      rmSync(fixture.mappingStoreDirectory, { recursive: true, force: true });
+    }
+  });
+
+  it("releases a disconnected Host when official completion precedes the start response", async () => {
+    const fixture = createFixture();
+    const threadId = "019cbe89-91f5-71c8-b24d-0410e73a2ef4";
+    const turnId = "019cbe89-9e78-7e49-ac62-3958b8db3881";
+
+    try {
+      writeRequest(fixture.desktopInput, {
+        id: 1,
+        method: "turn/start",
+        params: { threadId, input: [{ type: "text", text: "finish immediately" }] },
+      });
+      await readJsonLine(fixture.official.stdin);
+      fixture.host.disconnect();
+      fixture.official.stdout.write(
+        `${JSON.stringify({
+          method: "turn/completed",
+          params: { threadId, turn: { id: turnId, status: "completed" } },
+        })}\n`,
+      );
+      fixture.official.stdout.write(
+        `${JSON.stringify({ id: 1, result: { turn: { id: turnId } } })}\n`,
+      );
+
+      await expect(fixture.running).resolves.toBe(0);
+      expect(fixture.official.kill).not.toHaveBeenCalled();
+    } finally {
+      fixture.host.close();
+      fixture.desktopInput.end();
+      await fixture.running;
+      rmSync(fixture.mappingStoreDirectory, { recursive: true, force: true });
+    }
+  });
+
+  it("lets an active external Harness Turn finish after Desktop disconnects", async () => {
+    const fixture = createFixture();
+    let session: FakeHarnessSession | undefined;
+
+    try {
+      const threadId = await startPiThread(fixture);
+      const turnId = await startPiTurn(fixture, threadId);
+      session = fixture.adapter.sessions[0];
+      if (!session) throw new Error("Fake Pi Session was not opened");
+      const close = vi.spyOn(session, "close");
+      await fixture.collector.waitFor((message) => turnEvent(message, "turn/started", turnId));
+
+      fixture.host.disconnect();
+      const beforeTerminal = await Promise.race([
+        fixture.running.then(() => "settled" as const),
+        new Promise<"pending">((resolve) => setTimeout(() => resolve("pending"), 25)),
+      ]);
+
+      expect(beforeTerminal).toBe("pending");
+      expect(close).not.toHaveBeenCalled();
+
+      session.appendText("completed after transport disconnect");
+      session.succeedTurn();
+      await expect(
+        fixture.collector.waitFor((message) => turnEvent(message, "turn/completed", turnId)),
+      ).resolves.toBeTruthy();
+      await expect(fixture.running).resolves.toBe(0);
+      expect(close).toHaveBeenCalled();
+    } finally {
+      try {
+        session?.succeedTurn();
+      } catch {
+        // A failing implementation may already have interrupted the synthetic Turn.
+      }
+      fixture.host.close();
+      fixture.desktopInput.end();
+      await fixture.running;
+      rmSync(fixture.mappingStoreDirectory, { recursive: true, force: true });
+    }
+  });
+
   it("fails when official app-server output closes before Desktop input", async () => {
     const fixture = createFixture();
 

--- a/packages/host-runtime/test/remote-app-server.test.ts
+++ b/packages/host-runtime/test/remote-app-server.test.ts
@@ -248,6 +248,7 @@ describe("remote SSH app-server transport", () => {
           output.end();
           return 0;
         },
+        disconnect: () => (input as PassThrough).end(),
         close: () => undefined,
       }),
     });
@@ -274,20 +275,28 @@ describe("remote SSH app-server transport", () => {
     await expect(lstat(socketPath)).rejects.toMatchObject({ code: "ENOENT" });
   });
 
-  it("closes the Host session when its WebSocket disconnects", async () => {
+  it("ends Desktop input on disconnect and reserves hard close for listener shutdown", async () => {
     const socketPath = testSocketPath();
     let finishSession = (): void => undefined;
+    const disconnectSession = vi.fn();
     const closeSession = vi.fn(() => finishSession());
+    const inputEnded = Promise.withResolvers<undefined>();
     const listener = createRemoteAppServerWebSocketListener({
       socketPath,
       diagnosticOutput: new PassThrough(),
-      createSession: () => ({
-        run: () =>
-          new Promise<number>((resolve) => {
-            finishSession = () => resolve(0);
-          }),
-        close: closeSession,
-      }),
+      createSession: ({ input }) => {
+        input.once("end", () => inputEnded.resolve(undefined));
+        input.resume();
+        disconnectSession.mockImplementation(() => (input as PassThrough).end());
+        return {
+          run: () =>
+            new Promise<number>((resolve) => {
+              finishSession = () => resolve(0);
+            }),
+          disconnect: disconnectSession,
+          close: closeSession,
+        };
+      },
     });
 
     try {
@@ -299,8 +308,12 @@ describe("remote SSH app-server transport", () => {
       client.close();
       await once(client, "close");
 
-      await vi.waitFor(() => expect(closeSession).toHaveBeenCalledOnce());
+      await new Promise<void>((resolve) => setImmediate(resolve));
+      expect(disconnectSession).toHaveBeenCalledOnce();
+      expect(closeSession).not.toHaveBeenCalled();
+      await expect(inputEnded.promise).resolves.toBeUndefined();
       await expect(listener.close()).resolves.toBeUndefined();
+      expect(closeSession).toHaveBeenCalledOnce();
     } finally {
       finishSession();
       await listener.close();
@@ -333,6 +346,7 @@ describe("remote SSH app-server transport", () => {
             new Promise<number>((resolve) => {
               finishSession = () => resolve(0);
             }),
+          disconnect: () => desktopInput.end(),
           close: () => finishSession(),
         };
       },
@@ -552,6 +566,7 @@ describe("remote SSH app-server transport", () => {
             new Promise<number>((resolve) => {
               finishFirstSession = () => resolve(0);
             }),
+          disconnect: () => undefined,
           close: () => undefined,
         }),
       });
@@ -563,6 +578,7 @@ describe("remote SSH app-server transport", () => {
             output.end();
             return 0;
           },
+          disconnect: () => undefined,
           close: () => undefined,
         }),
       });
@@ -614,7 +630,11 @@ describe("remote SSH app-server transport", () => {
       const listener = createRemoteAppServerWebSocketListener({
         socketPath,
         diagnosticOutput: new PassThrough(),
-        createSession: () => ({ run: async () => 0, close: () => undefined }),
+        createSession: () => ({
+          run: async () => 0,
+          disconnect: () => undefined,
+          close: () => undefined,
+        }),
       });
 
       try {
@@ -636,7 +656,11 @@ describe("remote SSH app-server transport", () => {
       const listener = createRemoteAppServerWebSocketListener({
         socketPath,
         diagnosticOutput: new PassThrough(),
-        createSession: () => ({ run: async () => 0, close: () => undefined }),
+        createSession: () => ({
+          run: async () => 0,
+          disconnect: () => undefined,
+          close: () => undefined,
+        }),
       });
 
       try {
@@ -661,7 +685,11 @@ describe("remote SSH app-server transport", () => {
       const listener = createRemoteAppServerWebSocketListener({
         socketPath,
         diagnosticOutput: new PassThrough(),
-        createSession: () => ({ run: async () => 0, close: () => undefined }),
+        createSession: () => ({
+          run: async () => 0,
+          disconnect: () => undefined,
+          close: () => undefined,
+        }),
       });
 
       await expect(listener.listen()).rejects.toThrow("requires a private directory");

--- a/packages/host-runtime/test/remote-control-app-server.test.ts
+++ b/packages/host-runtime/test/remote-control-app-server.test.ts
@@ -216,6 +216,9 @@ describe("Remote Control app-server bridge", () => {
             output.end();
             return 0;
           },
+          disconnect() {
+            (input as PassThrough).end();
+          },
           close() {
             input.destroy();
           },

--- a/packages/host-runtime/test/remote-official-connection.test.ts
+++ b/packages/host-runtime/test/remote-official-connection.test.ts
@@ -125,6 +125,7 @@ describe("remote official app-server connection", () => {
           await new Promise<void>((resolve) => input.once("close", resolve));
           return 0;
         },
+        disconnect: () => input.destroy(),
         close: () => input.destroy(),
       }),
     });

--- a/packages/host-runtime/test/run-host-runtime.test.ts
+++ b/packages/host-runtime/test/run-host-runtime.test.ts
@@ -6,9 +6,18 @@ import {
   createRemoteControlOfficialAppServerPlan,
   createRemoteOfficialAppServerPlan,
   hasLauncherManagedUpdateRuntime,
+  MANAGED_REMOTE_APP_SERVER_PROCESS_TITLE,
 } from "../src/run-host-runtime.js";
 
 describe("Host Runtime composition", () => {
+  it("keeps the managed listener outside the official Desktop bootstrap kill selector", () => {
+    const officialDesktopBootstrapKillSelector = /codex.*desktop-ssh-websocket-v0\.sock/;
+
+    expect(MANAGED_REMOTE_APP_SERVER_PROCESS_TITLE).not.toMatch(
+      officialDesktopBootstrapKillSelector,
+    );
+  });
+
   it("shares one official listener across every remote Host session", () => {
     expect(
       createRemoteOfficialAppServerPlan(


### PR DESCRIPTION
## Summary

- separate an unexpected remote Desktop WebSocket disconnect from an explicit Host shutdown
- keep native Codex and external Harness turns alive until their real terminal event, including the `turn/start` response race
- retain hard cleanup when the listener itself stops, so idle and shutdown paths do not leak sessions

## Root cause

The remote WebSocket listener called `AppServerHost.close()` for every socket `close` or `error`. `close()` terminates the Host's inner official app-server connection and closes external Harness sessions. A transient outer transport close (observed as WebSocket code 1006 / SSH proxy BrokenPipe) therefore became a real turn cancellation even though Desktop never sent `turn/interrupt`.

## Behavior

A socket disconnect now requests a graceful Host disconnect after accepted input frames drain. The Host closes immediately when idle, but if it owns an active native/external turn or a forwarded official `turn/start`, it keeps the runtime alive until success, failure, or interruption is observed. Explicit listener shutdown still invokes hard `close()` on every session.

One Host session is still created per Desktop connection. Detached output is drained rather than replayed to an unrelated client; persisted native history remains the recovery source. The existing Aqua broker single-writer lease continues to prevent duplicate Claude writers during reconnect.

## Validation

- added regression coverage for listener disconnect vs shutdown
- added native Codex active-turn disconnect coverage
- added external Harness active-turn disconnect coverage
- covered pending `turn/start`, rejected starts, and completion-before-response ordering
- `npm run check`
  - 1649 TypeScript tests passed; 18 platform-specific tests skipped
  - Rust fmt, Clippy (`-D warnings`), workspace tests, and doc tests passed

No installed Desktop, managed remote runtime, credentials, or live session state was modified while preparing this PR.