### PR TITLE
fix: preserve Browser Use through shim re-entry

### DIFF
--- a/crates/platform/src/installation.rs
+++ b/crates/platform/src/installation.rs
@@ -27,6 +27,8 @@ use super::DesktopInstallation;
 use super::PlatformError;
 #[cfg(target_os = "windows")]
 use super::WindowsAppxActivationIdentity;
+#[cfg(target_os = "windows")]
+use super::canonical_existing_file;
 
 #[cfg(any(target_os = "windows", target_os = "macos", target_os = "linux"))]
 pub(super) fn sha256_file(path: &Path) -> Result<String, PlatformError> {
@@ -216,8 +218,31 @@ fn discover_installed_windows_package() -> Result<WindowsPackageDetails, Platfor
 }
 
 #[cfg(target_os = "windows")]
+fn desktop_cli_candidate(
+    canonical_cache_root: &Path,
+    candidate: PathBuf,
+) -> Result<Option<(SystemTime, PathBuf)>, PlatformError> {
+    if !candidate.is_file() {
+        return Ok(None);
+    }
+    let modified = candidate
+        .metadata()
+        .and_then(|metadata| metadata.modified())
+        .unwrap_or(SystemTime::UNIX_EPOCH);
+    let canonical = candidate.canonicalize().map_err(PlatformError::Io)?;
+    Ok(canonical
+        .starts_with(canonical_cache_root)
+        .then_some((modified, canonical)))
+}
+
+#[cfg(target_os = "windows")]
 fn find_desktop_cli_cache(local_app_data: &Path) -> Result<Option<PathBuf>, PlatformError> {
     let cache_root = local_app_data.join("OpenAI/Codex/bin");
+    let canonical_cache_root = match cache_root.canonicalize() {
+        Ok(root) => root,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(error) => return Err(PlatformError::Io(error)),
+    };
     let mut candidates = vec![cache_root.join("codex.exe")];
 
     if let Ok(entries) = cache_root.read_dir() {
@@ -230,19 +255,12 @@ fn find_desktop_cli_cache(local_app_data: &Path) -> Result<Option<PathBuf>, Plat
 
     candidates
         .into_iter()
-        .filter(|candidate| candidate.is_file())
-        .map(|candidate| {
-            let modified = candidate
-                .metadata()
-                .and_then(|metadata| metadata.modified())
-                .unwrap_or(SystemTime::UNIX_EPOCH);
-            let canonical = candidate.canonicalize().map_err(PlatformError::Io)?;
-            Ok((modified, canonical))
-        })
+        .map(|candidate| desktop_cli_candidate(&canonical_cache_root, candidate))
         .collect::<Result<Vec<_>, PlatformError>>()
         .map(|candidates| {
             candidates
                 .into_iter()
+                .flatten()
                 .max_by_key(|(modified, _)| *modified)
                 .map(|(_, candidate)| candidate)
         })
@@ -317,6 +335,91 @@ fn windows_local_app_data() -> Result<PathBuf, PlatformError> {
                 "LOCALAPPDATA is unavailable; cannot locate the Desktop CLI cache".into(),
             )
         })
+}
+
+/// Locate the executable CLI maintained by Codex Desktop without enumerating
+/// the installed AppX package.
+///
+/// Desktop helpers can preserve `CODEX_CLI_PATH` while dropping private
+/// launcher state. This focused lookup lets the Shim recover the same
+/// Desktop-managed CLI that normal installation discovery selects, without
+/// paying the PackageManager cost on every helper invocation.
+#[cfg(target_os = "windows")]
+pub fn discover_desktop_managed_codex_cli() -> Result<PathBuf, PlatformError> {
+    if let Some(root) = custom_install_root(env::var_os) {
+        let installation = discover_codex_desktop_from_root(&root)?;
+        let executable = canonical_existing_file(&installation.executable_codex_cli)?;
+        if !executable.starts_with(&installation.install_root) {
+            return Err(PlatformError::Invalid(format!(
+                "portable Codex CLI '{}' resolves outside installation root '{}'",
+                installation.executable_codex_cli.display(),
+                installation.install_root.display()
+            )));
+        }
+        return Ok(executable);
+    }
+    find_desktop_cli_cache(&windows_local_app_data()?)?.ok_or_else(|| {
+        PlatformError::NotFound(
+            "no runnable Codex CLI was found in the Desktop-managed cache; launch the official Desktop once to create it".into(),
+        )
+    })
+}
+
+#[cfg(all(test, target_os = "windows"))]
+mod desktop_managed_cli_tests {
+    use std::fs;
+
+    use super::{desktop_cli_candidate, find_desktop_cli_cache};
+
+    #[test]
+    fn focused_cli_discovery_uses_only_the_desktop_managed_cache() {
+        let root = crate::temporary_directory("desktop-managed-cli");
+        let cache = root.join("OpenAI/Codex/bin/cache-build");
+        fs::create_dir_all(&cache).expect("create Desktop-managed CLI cache");
+        let expected = cache.join("codex.exe");
+        fs::write(&expected, b"codex").expect("write cached Codex CLI");
+
+        let discovered = find_desktop_cli_cache(&root)
+            .expect("search Desktop-managed CLI cache")
+            .expect("discover cached Codex CLI");
+        assert_eq!(discovered, expected.canonicalize().expect("canonical CLI"));
+
+        fs::remove_dir_all(root).expect("remove Desktop-managed CLI fixture");
+    }
+
+    #[test]
+    fn focused_cli_discovery_does_not_consult_path() {
+        let root = crate::temporary_directory("desktop-managed-cli-missing");
+        let unrelated = root.join("path-entry");
+        fs::create_dir_all(&unrelated).expect("create unrelated PATH directory");
+        fs::write(unrelated.join("codex.exe"), b"codex").expect("write unrelated CLI");
+        let original_path = std::env::var_os("PATH");
+
+        // The lookup takes an explicit Desktop cache root and never reads PATH.
+        let discovered = find_desktop_cli_cache(&root).expect("search empty Desktop cache");
+        assert!(discovered.is_none());
+        assert_eq!(std::env::var_os("PATH"), original_path);
+
+        fs::remove_dir_all(root).expect("remove unrelated PATH fixture");
+    }
+
+    #[test]
+    fn focused_cli_discovery_rejects_candidates_outside_the_cache_root() {
+        let root = crate::temporary_directory("desktop-managed-cli-containment");
+        let cache = root.join("OpenAI/Codex/bin");
+        fs::create_dir_all(&cache).expect("create Desktop-managed CLI cache");
+        let outside = root.join("outside-codex.exe");
+        fs::write(&outside, b"codex").expect("write outside CLI");
+
+        let candidate = desktop_cli_candidate(
+            &cache.canonicalize().expect("canonical cache root"),
+            outside,
+        )
+        .expect("inspect outside CLI");
+        assert!(candidate.is_none());
+
+        fs::remove_dir_all(root).expect("remove containment fixture");
+    }
 }
 
 #[cfg(target_os = "windows")]

--- a/crates/platform/src/lib.rs
+++ b/crates/platform/src/lib.rs
@@ -40,7 +40,7 @@ pub use desktop_launch::{DesktopSession, launch_desktop_session};
 #[cfg(not(target_os = "linux"))]
 pub use installation::discover_codex_desktop;
 #[cfg(target_os = "windows")]
-pub use installation::discover_codex_desktop_from_root;
+pub use installation::{discover_codex_desktop_from_root, discover_desktop_managed_codex_cli};
 #[cfg(target_os = "linux")]
 pub use linux_installation::discover_codex_desktop;
 pub use macos_native_harness_broker::{

--- a/crates/shim/src/lib.rs
+++ b/crates/shim/src/lib.rs
@@ -9,6 +9,8 @@ use std::process::{Command, ExitStatus, Stdio};
 use std::thread;
 use std::time::{Duration, Instant};
 
+#[cfg(target_os = "windows")]
+use codexhost_platform::discover_desktop_managed_codex_cli;
 use codexhost_platform::{
     CODEX_CLI_PATH_ENV, STOCK_CODEX_PATH_ENV, canonical_existing_file,
     configure_background_command, node_entrypoint_path, proxy_environment, spawn_supervised,
@@ -656,16 +658,54 @@ fn child_command(
     Ok(command)
 }
 
+/// Resolve the official CLI for both the launcher-managed process tree and
+/// Windows Desktop helpers that persist only the standard `CODEX_CLI_PATH`
+/// override.
+///
+/// The launcher-provided path remains authoritative. Installation discovery is
+/// deliberately restricted to a re-entry where `CODEX_CLI_PATH` identifies
+/// this exact Shim, so an unrelated or direct invocation still fails closed.
+fn resolve_stock_codex_path(current_executable: &Path) -> ShimResult<PathBuf> {
+    let stock_codex_path = match env::var_os(STOCK_CODEX_PATH_ENV) {
+        Some(configured) => PathBuf::from(configured),
+        None => {
+            #[cfg(not(target_os = "windows"))]
+            return Err(format!("{STOCK_CODEX_PATH_ENV} is required").into());
+
+            #[cfg(target_os = "windows")]
+            {
+                let cli_override = env::var_os(CODEX_CLI_PATH_ENV)
+                    .map(PathBuf::from)
+                    .ok_or_else(|| format!("{STOCK_CODEX_PATH_ENV} is required"))?;
+                let cli_override = canonical_existing_file(&cli_override)?;
+                let current_executable = canonical_existing_file(current_executable)?;
+                if cli_override != current_executable {
+                    return Err(format!(
+                        "{STOCK_CODEX_PATH_ENV} is required when {CODEX_CLI_PATH_ENV} does not identify the running Shim"
+                    )
+                    .into());
+                }
+                discover_desktop_managed_codex_cli().map_err(|error| {
+                    format!(
+                        "{STOCK_CODEX_PATH_ENV} is unavailable and the Desktop-managed official Codex CLI could not be discovered: {error}"
+                    )
+                })?
+            }
+        }
+    };
+    Ok(validate_proxy_target(
+        current_executable,
+        &stock_codex_path,
+    )?)
+}
+
 /// Runs the byte-transparent proxy and emits optional lifecycle observations.
 pub fn run_proxy_with_observer(
     arguments: &[OsString],
     observer: &impl ProxyObserver,
 ) -> ShimResult<i32> {
     let current_executable = env::current_exe()?;
-    let stock_codex_path = env::var_os(STOCK_CODEX_PATH_ENV)
-        .map(PathBuf::from)
-        .ok_or_else(|| format!("{STOCK_CODEX_PATH_ENV} is required"))?;
-    let stock_codex_path = validate_proxy_target(&current_executable, &stock_codex_path)?;
+    let stock_codex_path = resolve_stock_codex_path(&current_executable)?;
     observer.invocation(arguments, &stock_codex_path);
 
     let started = Instant::now();

--- a/crates/shim/tests/proxy.rs
+++ b/crates/shim/tests/proxy.rs
@@ -13,6 +13,8 @@ use std::time::Duration;
 #[cfg(any(target_os = "windows", target_os = "macos", target_os = "linux"))]
 use std::time::Instant;
 
+#[cfg(target_os = "windows")]
+use codexhost_platform::CUSTOM_INSTALL_ROOT_ENV;
 #[cfg(any(target_os = "macos", target_os = "linux"))]
 use codexhost_platform::parent_process_id;
 use codexhost_platform::{CODEX_CLI_PATH_ENV, STOCK_CODEX_PATH_ENV};
@@ -279,6 +281,108 @@ fn rejects_missing_official_cli_without_falling_back_to_path() {
     assert!(!output.status.success());
     assert!(output.stdout.is_empty());
     assert!(String::from_utf8_lossy(&output.stderr).contains("does not exist"));
+}
+
+#[cfg(target_os = "windows")]
+#[test]
+fn rejects_missing_stock_cli_when_cli_override_does_not_name_the_running_shim() {
+    let output = Command::new(shim_path())
+        .env_remove(STOCK_CODEX_PATH_ENV)
+        .env(CODEX_CLI_PATH_ENV, fake_codex_path())
+        .stdin(Stdio::null())
+        .output()
+        .expect("run shim with unrelated CLI override");
+    assert!(!output.status.success());
+    assert!(output.stdout.is_empty());
+    assert!(String::from_utf8_lossy(&output.stderr).contains("does not identify the running Shim"));
+}
+
+#[test]
+fn rejects_missing_stock_cli_without_a_cli_override() {
+    let output = Command::new(shim_path())
+        .env_remove(STOCK_CODEX_PATH_ENV)
+        .env_remove(CODEX_CLI_PATH_ENV)
+        .stdin(Stdio::null())
+        .output()
+        .expect("run shim without managed environment");
+    assert!(!output.status.success());
+    assert!(output.stdout.is_empty());
+    assert!(
+        String::from_utf8_lossy(&output.stderr)
+            .contains(&format!("{STOCK_CODEX_PATH_ENV} is required"))
+    );
+}
+
+#[cfg(target_os = "windows")]
+#[test]
+fn discovers_official_cli_when_browser_helper_preserves_only_codex_cli_path() {
+    let installation_root = temporary_directory().join("portable-codex");
+    let app_root = installation_root.join("app");
+    let resources = app_root.join("resources");
+    fs::create_dir_all(&resources).expect("create portable Codex resources");
+    fs::write(app_root.join("ChatGPT.exe"), b"desktop").expect("write fake Desktop executable");
+    fs::write(resources.join("app.asar"), b"asar").expect("write fake app.asar");
+    fs::copy(fake_codex_path(), resources.join("codex.exe"))
+        .expect("install fake official Codex CLI");
+
+    let output = Command::new(shim_path())
+        .args(["config", "read"])
+        .env_remove(STOCK_CODEX_PATH_ENV)
+        .env(CODEX_CLI_PATH_ENV, shim_path())
+        .env(CUSTOM_INSTALL_ROOT_ENV, &installation_root)
+        .env_remove(HOST_NODE_PATH_ENV)
+        .env_remove(HOST_RUNTIME_PATH_ENV)
+        .env_remove(REMOTE_SSH_MANAGED_ENV)
+        .env("FAKE_CODEX_PRINT_INVOCATION", "1")
+        .stdin(Stdio::null())
+        .output()
+        .expect("run Browser Use style shim invocation");
+
+    assert!(
+        output.status.success(),
+        "Browser Use style shim invocation exited {}; stderr={}",
+        output.status,
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(output.stdout.is_empty());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("args=config|read"), "{stderr}");
+    assert!(stderr.contains("codex_cli_path_present=false"), "{stderr}");
+
+    fs::remove_dir_all(
+        installation_root
+            .parent()
+            .expect("portable installation parent"),
+    )
+    .expect("remove portable Codex installation");
+}
+
+#[cfg(target_os = "windows")]
+#[test]
+fn browser_helper_fallback_does_not_guess_an_official_cli_from_path() {
+    let missing_installation = temporary_directory().join("missing-portable-codex");
+    let output = Command::new(shim_path())
+        .env_remove(STOCK_CODEX_PATH_ENV)
+        .env(CODEX_CLI_PATH_ENV, shim_path())
+        .env(CUSTOM_INSTALL_ROOT_ENV, &missing_installation)
+        .env("PATH", fake_codex_path().parent().expect("fake CLI parent"))
+        .stdin(Stdio::null())
+        .output()
+        .expect("run Browser Use style shim invocation without an installation");
+
+    assert!(!output.status.success());
+    assert!(output.stdout.is_empty());
+    assert!(
+        String::from_utf8_lossy(&output.stderr)
+            .contains("Desktop-managed official Codex CLI could not be discovered")
+    );
+
+    fs::remove_dir_all(
+        missing_installation
+            .parent()
+            .expect("missing installation parent"),
+    )
+    .expect("remove missing portable installation fixture");
 }
 
 #[cfg(any(target_os = "macos", target_os = "linux"))]

--- a/openspec/specs/windows-codex-transparent-proxy-probe/spec.md
+++ b/openspec/specs/windows-codex-transparent-proxy-probe/spec.md
@@ -45,13 +45,20 @@ Probe SHALL 记录判断 `CODEX_CLI_PATH` 接入所需的 argv、cwd、环境键
 
 ### Requirement: 明确定位官方 Codex CLI 并阻止递归
 
-Launcher MUST 在设置 Shim 路径前解析当前 Desktop 对应的官方 Codex CLI 绝对路径，Shim MUST 使用该明确路径启动官方 CLI。Shim MUST NOT 依赖当前 `PATH` 猜测目标，并 MUST 在创建子进程前清除或重写 `CODEX_CLI_PATH`。
+Launcher MUST 在设置 Shim 路径前解析当前 Desktop 对应的官方 Codex CLI 绝对路径，Shim MUST 使用该明确路径启动官方 CLI。若 Desktop 的子工具仅保留了指向当前 Shim 的 `CODEX_CLI_PATH` 而未传播 codexhost 私有的官方 CLI 路径，Shim MAY通过 Desktop 管理的官方 CLI 缓存或显式 portable 安装恢复对应目标。Shim MUST NOT 依赖当前 `PATH` 猜测目标，并 MUST 在创建子进程前清除或重写 `CODEX_CLI_PATH`。
 
 #### Scenario: 转发已观察到的调用
 
 - **WHEN** Shim 收到 app-server 或非 app-server 调用且官方 CLI 路径有效
 - **THEN** Shim MUST 使用原 argv 启动该官方 CLI
 - **AND** 子进程环境 MUST NOT 再把 `CODEX_CLI_PATH` 指向当前 Shim
+
+#### Scenario: Desktop 子工具仅保留标准 CLI 覆盖
+
+- **WHEN** Desktop 启动的 Browser Use 等子工具通过 `CODEX_CLI_PATH` 再次调用当前 Shim，但没有传播 `CODEXHOST_STOCK_CODEX_PATH`
+- **THEN** Shim MUST通过 Desktop 管理的官方 CLI 缓存或显式 portable 安装解析目标并透明转发原始调用
+- **AND** Shim MUST仅在 `CODEX_CLI_PATH` 规范化后确实指向自身时采用该恢复路径
+- **AND** 官方 CLI 子进程 MUST不继承 `CODEX_CLI_PATH`
 
 #### Scenario: 官方 CLI 解析到 Shim 自身
 
@@ -135,4 +142,3 @@ Shim SHALL 传播官方 CLI 的正常退出和失败状态，并在取消、父�
 - **WHEN** 真实 Desktop Gate 结果为 FAIL 或 BLOCKED
 - **THEN** 结果 MUST 记录失败阶段、证据、影响和下一决策
 - **AND** 后续正式实现 MUST NOT 把 Windows 透明代理标记为已验证能力
-


### PR DESCRIPTION
## Summary  - let the Windows Shim recover Codex Desktop's managed official CLI when a Desktop helper preserves only `CODEX_CLI_PATH` - keep the launcher-provided `CODEXHOST_STOCK_CODEX_PATH` authoritative and fail closed unless the fallback invocation identifies the exact running Shim - keep fallback discovery off `PATH`, constrain canonical targets to the Windows Desktop CLI cache or explicit portable installation root, and continue removing `CODEX_CLI_PATH` from official child processes - cover Browser Use-style re-entry, unrelated/missing overrides, no-`PATH` fallback, cache containment, and update the Windows transparent-proxy spec  ## Problem  Recent Codex Desktop Browser Use setup persists the inherited `CODEX_CLI_PATH` into the browser helper's MCP environment but does not persist the private `CODEXHOST_STOCK_CODEX_PATH`. When Desktop was launched by codexhost, the helper therefore invoked `codexhost-shim` without the stock CLI target. The Shim exited with:  ```text codexhost shim: CODEXHOST_STOCK_CODEX_PATH is required ```  Both the in-app browser and Chrome extension then failed closed before navigation with `The admin-enforced policy could not be verified`, because Browser Use could not complete `config/read` / `configRequirements/read`.  ## Validation  - red regression before fix: Browser Use-style Shim invocation exited 1 with missing `CODEXHOST_STOCK_CODEX_PATH` - fixed real Windows CLI fallback: `codex-cli 0.153.0-alpha.5`, exit 0; focused lookup averaged ~70 ms over three runs - fixed real app-server protocol: `initialize`, `config/read`, and `configRequirements/read` all succeeded with only `CODEX_CLI_PATH` present; ~198 ms total - `npm run check`   - format / lint / boundary checks passed   - TypeScript: 186 files passed, 3 skipped; 1644 tests passed, 18 skipped   - Rust clippy and full workspace tests passed - `npm run build` - `npx --yes @fission-ai/openspec@1.10.0 validate windows-codex-transparent-proxy-probe --type spec --strict`  `openspec validate --all --strict` passed 52/54 items. The two failures are pre-existing incomplete Claude usage change deltas (`optimize-claude-usage-refresh` and `project-claude-code-session-usage`) and do not touch this PR.  ## Live Windows candidate validation

Packaged and installed `0.4.5-pr147.74f9747.1` from head `74f9747b599791eab7fdb7249f2821fa38e1913e`, then restarted the managed Desktop chain with that candidate.

- process tree: Launcher and active Shim both resolve inside the PR #147 candidate
- generated Browser Use config: `CODEX_CLI_PATH` resolves to the PR #147 Shim
- codexhost control path: `harness inspect pi` returned `status: ready` with the live model catalog
- policy/config path: 16 successful `config/read` and 15 successful `configRequirements/read` responses; zero non-null errors, zero `enterprise_policy_unavailable`, and zero Shim errors
- in-app browser: `https://www.google.com/` reached DOM-ready and reconnect reported title `Google`
- Chrome extension: `https://example.com/` reported title `Example Domain`; an additional minimal navigation to `https://www.wikipedia.org/` completed and reported title `Wikipedia`

The first composite browser probes exceeded their outer timeout while performing post-navigation page reads, but reconnecting showed the requested pages had loaded. A navigation-only Chrome probe completed normally in about 21 seconds. The original admin-policy verification failure no longer reproduces.

Related but not closed: #130 tracks a distinct macOS IAB native-pipe discovery failure.