### PR TITLE
fix(updater): prefer authenticated GitHub CLI for release checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,12 @@ xattr -dr com.apple.quarantine /Applications/codexhost.app
 
 在 `设置 → 外观` 中可以开启 **换行显示思考文本**，让思考块中的长行自动换行。该选项默认关闭，选择保存在本机并立即生效，普通 Shell 输出不受影响。
 
+### 更新检查与 GitHub 限流
+
+codexhost 优先通过已登录的 [GitHub CLI](https://cli.github.com/)（`gh auth login --hostname github.com`）检查最新 Release，使用账户的 API 额度，减少共享代理出口的匿名限流影响。凭证由 `gh` 管理，codexhost 不读取或保存 Token。
+
+未安装、未登录或调用失败时会回退到公开 API；单次 `gh` 调用最多等待 5 秒。支持 PATH、macOS Homebrew 和常见 Windows/Linux 安装位置；也可通过 Host 环境变量 `CODEXHOST_GH_COMMAND` 指定可执行文件路径（不带参数）。安装包下载和校验流程保持不变；认证请求仍受 GitHub 账户及次级限流约束。
+
 ### 交互展示
 
 <table>

--- a/docs/README.en.md
+++ b/docs/README.en.md
@@ -99,7 +99,13 @@ Fully quit Codex Desktop, open a new terminal, and start codexhost.
 
 In `Settings → Appearance`, enable **Wrap thinking text** to wrap long lines in the persisted thinking transcript. It is off by default, saved locally, and takes effect immediately. Ordinary shell output is unchanged.
 
-### Interaction examples
+### Update checks and GitHub rate limits
+
+codexhost prefers an authenticated [GitHub CLI](https://cli.github.com/) (`gh auth login --hostname github.com`) for latest Release checks, using the account's API quota to reduce anonymous rate limits on shared proxy exits. Credentials remain managed by `gh`; codexhost does not read or store tokens.
+
+If `gh` is missing, unauthenticated, or fails, discovery falls back to the public API. Each CLI invocation is limited to 5 seconds. Discovery searches PATH, macOS Homebrew, and common Windows/Linux installation locations. Set `CODEXHOST_GH_COMMAND` in the Host environment to specify an executable path without arguments. Artifact downloads and verification are unchanged; authenticated requests remain subject to GitHub account and secondary rate limits.
+
+### Interaction Examples
 
 <table>
   <tr>

--- a/packages/host-runtime/src/update-coordinator.ts
+++ b/packages/host-runtime/src/update-coordinator.ts
@@ -11,6 +11,7 @@ import {
   createBackgroundUpdateManager,
   discoverLatestUpdateStatus,
   fetchLatestGitHubRelease,
+  fetchLatestGitHubReleaseWithGitHubCli,
   isUpdateOperationActive,
   recoverUpdateOperationLock,
   resolveInstalledUpdateContext,
@@ -72,8 +73,16 @@ export function createHostUpdateCoordinator(
   };
   const fetchLatest: (signal?: AbortSignal) => Promise<CodexhostLatestRelease> =
     options.fetchLatest ??
-    ((signal?: AbortSignal) =>
-      fetchLatestGitHubRelease({ signal: signal ?? AbortSignal.timeout(15_000) }));
+    (async (signal?: AbortSignal) => {
+      const timeoutSignal = AbortSignal.timeout(15_000);
+      const requestSignal = signal ? AbortSignal.any([signal, timeoutSignal]) : timeoutSignal;
+      const authenticated = await fetchLatestGitHubReleaseWithGitHubCli({
+        ...(options.environment ? { environment: options.environment } : {}),
+        platform,
+        signal: requestSignal,
+      });
+      return authenticated ?? fetchLatestGitHubRelease({ signal: requestSignal });
+    });
   let candidate: CodexhostLatestRelease | null = null;
 
   async function latestStatus(context: InstalledUpdateContext): Promise<UpdateStatus | null> {

--- a/packages/host-runtime/test/update-coordinator.test.ts
+++ b/packages/host-runtime/test/update-coordinator.test.ts
@@ -5,6 +5,7 @@ import os from "node:os";
 import path from "node:path";
 
 import { afterEach, describe, expect, it, vi } from "vitest";
+import type * as UpdateManager from "@codexhost/update-manager";
 
 import {
   createBackgroundUpdateManager,
@@ -13,7 +14,18 @@ import {
 
 import { createHostUpdateCoordinator } from "../src/update-coordinator.js";
 
+const discovery = vi.hoisted(() => ({ cli: vi.fn(), http: vi.fn() }));
+vi.mock("@codexhost/update-manager", async (importOriginal) => ({
+  ...(await importOriginal<typeof UpdateManager>()),
+  fetchLatestGitHubReleaseWithGitHubCli: discovery.cli,
+  fetchLatestGitHubRelease: discovery.http,
+}));
+
 const roots: string[] = [];
+afterEach(() => {
+  vi.clearAllMocks();
+  vi.useRealTimers();
+});
 afterEach(async () => Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true }))));
 
 async function file(filePath: string, contents = "fixture"): Promise<void> {
@@ -112,6 +124,51 @@ function release(version = "1.2.3"): CodexhostLatestRelease {
 }
 
 describe("Host update coordinator", () => {
+  it.each([true, false])(
+    "prefers gh and only falls back when needed (CLI available: %s)",
+    async (available) => {
+      const fixture = await npmFixture();
+      discovery.cli.mockResolvedValue(available ? release() : null);
+      discovery.http.mockResolvedValue(release());
+      const coordinator = createHostUpdateCoordinator({
+        ...fixture,
+        platform: "darwin",
+        architecture: "arm64",
+      });
+      await expect(coordinator.check()).resolves.toMatchObject({
+        latestVersion: "1.2.3",
+        error: null,
+      });
+      expect(discovery.cli).toHaveBeenCalledWith(
+        expect.objectContaining({ environment: fixture.environment, platform: "darwin" }),
+      );
+      expect(discovery.http).toHaveBeenCalledTimes(available ? 0 : 1);
+      if (!available)
+        expect(discovery.http.mock.calls[0]?.[0].signal).toBe(
+          discovery.cli.mock.calls[0]?.[0].signal,
+        );
+    },
+  );
+
+  it("does not fall back after caller cancellation", async () => {
+    const fixture = await npmFixture();
+    const controller = new AbortController();
+    discovery.cli.mockImplementation(async ({ signal }: { signal: AbortSignal }) => {
+      controller.abort();
+      signal.throwIfAborted();
+    });
+    const coordinator = createHostUpdateCoordinator({
+      ...fixture,
+      platform: "darwin",
+      architecture: "arm64",
+    });
+    await expect(coordinator.check(controller.signal)).resolves.toMatchObject({
+      latestVersion: null,
+      error: expect.any(String),
+    });
+    expect(discovery.http).not.toHaveBeenCalled();
+  });
+
   it("hands a macOS update to Launcher without starting the Helper", async () => {
     const fixture = await npmFixture();
     const spawnUpdater = vi.fn(() => ({ pid: 777 }) as unknown as ChildProcess);

--- a/packages/update-manager/src/github-cli-release.ts
+++ b/packages/update-manager/src/github-cli-release.ts
@@ -1,0 +1,122 @@
+import { execFile } from "node:child_process";
+import path from "node:path";
+
+import { parseLatestGitHubRelease, type CodexhostLatestRelease } from "./github-release.js";
+
+const GITHUB_LATEST_RELEASE_ENDPOINT = "repos/BytePioneer-AI/codex-host/releases/latest";
+const MAX_RELEASE_RESPONSE_BYTES = 1024 * 1024;
+const GITHUB_CLI_TIMEOUT_MS = 5_000;
+
+interface GitHubCliRunOptions {
+  environment: NodeJS.ProcessEnv;
+  signal?: AbortSignal;
+}
+
+export type GitHubCliRunner = (
+  executable: string,
+  arguments_: readonly string[],
+  options: GitHubCliRunOptions,
+) => Promise<string>;
+
+export interface GitHubCliReleaseFetchOptions {
+  environment?: NodeJS.ProcessEnv;
+  platform?: NodeJS.Platform;
+  signal?: AbortSignal;
+  executableCandidates?: readonly string[];
+  run?: GitHubCliRunner;
+}
+
+function defaultExecutableCandidates(
+  environment: NodeJS.ProcessEnv,
+  platform: NodeJS.Platform,
+): string[] {
+  if (environment.CODEXHOST_GH_COMMAND) return [environment.CODEXHOST_GH_COMMAND];
+  const candidates = ["gh"];
+  if (platform === "darwin") {
+    candidates.push("/opt/homebrew/bin/gh", "/usr/local/bin/gh");
+  } else if (platform === "win32") {
+    const programFiles = environment.ProgramFiles ?? environment.PROGRAMFILES;
+    const localAppData = environment.LOCALAPPDATA;
+    if (programFiles) candidates.push(path.win32.join(programFiles, "GitHub CLI", "gh.exe"));
+    if (localAppData) {
+      candidates.push(path.win32.join(localAppData, "Programs", "GitHub CLI", "gh.exe"));
+    }
+  } else {
+    candidates.push("/usr/local/bin/gh", "/usr/bin/gh", "/snap/bin/gh");
+  }
+  return [...new Set(candidates.filter((candidate): candidate is string => Boolean(candidate)))];
+}
+
+function runGitHubCli(
+  executable: string,
+  arguments_: readonly string[],
+  options: GitHubCliRunOptions,
+): Promise<string> {
+  return new Promise((resolve, reject) => {
+    execFile(
+      executable,
+      [...arguments_],
+      {
+        encoding: "utf8",
+        env: options.environment,
+        maxBuffer: MAX_RELEASE_RESPONSE_BYTES,
+        timeout: GITHUB_CLI_TIMEOUT_MS,
+        windowsHide: true,
+        ...(options.signal ? { signal: options.signal } : {}),
+      },
+      (error, stdout) => {
+        if (error) reject(error);
+        else resolve(stdout);
+      },
+    );
+  });
+}
+
+/**
+ * Reads the public Release through GitHub CLI so its credential remains owned by
+ * `gh` and the system keychain. Returns null when `gh` is unavailable or not
+ * authenticated (or fails), allowing callers to retain the anonymous HTTP fallback.
+ * CLI stderr is never surfaced because debug output can contain credentials.
+ */
+export async function fetchLatestGitHubReleaseWithGitHubCli(
+  options: GitHubCliReleaseFetchOptions = {},
+): Promise<CodexhostLatestRelease | null> {
+  const environment = options.environment ?? process.env;
+  const platform = options.platform ?? process.platform;
+  const candidates =
+    options.executableCandidates ?? defaultExecutableCandidates(environment, platform);
+  const run = options.run ?? runGitHubCli;
+  const arguments_ = [
+    "api",
+    "--hostname",
+    "github.com",
+    "--method",
+    "GET",
+    "--header",
+    "Accept: application/vnd.github+json",
+    "--header",
+    "X-GitHub-Api-Version: 2022-11-28",
+    GITHUB_LATEST_RELEASE_ENDPOINT,
+  ] as const;
+
+  for (const executable of candidates) {
+    options.signal?.throwIfAborted();
+    try {
+      return parseLatestGitHubRelease(
+        JSON.parse(
+          await run(executable, arguments_, {
+            environment,
+            ...(options.signal ? { signal: options.signal } : {}),
+          }),
+        ),
+      );
+    } catch (error) {
+      options.signal?.throwIfAborted();
+      // Only try another install path when this executable could not be started.
+      // Retrying authentication/network/parse failures would repeat the same request.
+      const code = (error as NodeJS.ErrnoException | null)?.code;
+      if (code !== "ENOENT" && code !== "EACCES") return null;
+    }
+  }
+  return null;
+}

--- a/packages/update-manager/src/index.ts
+++ b/packages/update-manager/src/index.ts
@@ -26,6 +26,11 @@ export {
   type SelectedReleaseArtifact,
 } from "./github-release.js";
 export {
+  fetchLatestGitHubReleaseWithGitHubCli,
+  type GitHubCliReleaseFetchOptions,
+  type GitHubCliRunner,
+} from "./github-cli-release.js";
+export {
   acquireUpdateOperationLock,
   cleanupTerminalUpdateState,
   discoverLatestUpdateStatus,

--- a/packages/update-manager/test/github-cli-process.test.ts
+++ b/packages/update-manager/test/github-cli-process.test.ts
@@ -1,0 +1,43 @@
+import { execFile } from "node:child_process";
+import type * as ChildProcessModule from "node:child_process";
+import { describe, expect, it, vi } from "vitest";
+
+import { fetchLatestGitHubReleaseWithGitHubCli } from "@codexhost/update-manager";
+
+vi.mock("node:child_process", async (importOriginal) => ({
+  ...(await importOriginal<typeof ChildProcessModule>()),
+  execFile: vi.fn(),
+}));
+
+describe("GitHub CLI process", () => {
+  it("bounds subprocess time/output and silently falls back on failure", async () => {
+    const command = vi.mocked(execFile);
+    const controller = new AbortController();
+    const pending = fetchLatestGitHubReleaseWithGitHubCli({
+      executableCandidates: ["/custom/gh"],
+      environment: { PATH: "/bin" },
+      signal: controller.signal,
+    });
+    expect(command).toHaveBeenCalledWith(
+      "/custom/gh",
+      expect.any(Array),
+      {
+        encoding: "utf8",
+        env: { PATH: "/bin" },
+        maxBuffer: 1024 * 1024,
+        timeout: 5_000,
+        windowsHide: true,
+        signal: controller.signal,
+      },
+      expect.any(Function),
+    );
+    const callback = command.mock.calls[0]?.[3] as unknown as (
+      error: Error,
+      stdout: string,
+      stderr: string,
+    ) => void;
+    callback(new Error("timed out"), "", "private debug data");
+    await expect(pending).resolves.toBeNull();
+    expect(command).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/update-manager/test/github-release.test.ts
+++ b/packages/update-manager/test/github-release.test.ts
@@ -5,8 +5,10 @@ import {
   compareSemanticVersions,
   expectedInstallerAssetName,
   fetchLatestGitHubRelease,
+  fetchLatestGitHubReleaseWithGitHubCli,
   parseLatestGitHubRelease,
   selectInstallerReleaseArtifact,
+  type GitHubCliRunner,
 } from "@codexhost/update-manager";
 
 function release(overrides: Record<string, unknown> = {}) {
@@ -110,5 +112,137 @@ describe("GitHub Release update discovery", () => {
       CODEXHOST_LATEST_RELEASE_URL,
       expect.objectContaining({ redirect: "error" }),
     );
+  });
+
+  it("uses the authenticated GitHub CLI without exposing its token", async () => {
+    const run = vi.fn(async () => JSON.stringify(release()));
+    await expect(
+      fetchLatestGitHubReleaseWithGitHubCli({
+        environment: { PATH: "/usr/bin:/bin" },
+        executableCandidates: ["/opt/homebrew/bin/gh"],
+        run,
+      }),
+    ).resolves.toMatchObject({ version: "1.2.3" });
+    expect(run).toHaveBeenCalledWith(
+      "/opt/homebrew/bin/gh",
+      [
+        "api",
+        "--hostname",
+        "github.com",
+        "--method",
+        "GET",
+        "--header",
+        "Accept: application/vnd.github+json",
+        "--header",
+        "X-GitHub-Api-Version: 2022-11-28",
+        "repos/BytePioneer-AI/codex-host/releases/latest",
+      ],
+      { environment: { PATH: "/usr/bin:/bin" } },
+    );
+  });
+
+  it("falls back cleanly when GitHub CLI is unavailable", async () => {
+    const run = vi.fn(async () => {
+      throw Object.assign(new Error("not installed"), { code: "ENOENT" });
+    });
+    await expect(
+      fetchLatestGitHubReleaseWithGitHubCli({
+        executableCandidates: ["gh", "/opt/homebrew/bin/gh"],
+        run,
+      }),
+    ).resolves.toBeNull();
+    expect(run).toHaveBeenCalledTimes(2);
+  });
+
+  it("finds Homebrew gh with the minimal macOS GUI PATH", async () => {
+    const run = vi.fn(async (executable: string) => {
+      if (executable === "gh") throw Object.assign(new Error("missing"), { code: "ENOENT" });
+      return JSON.stringify(release());
+    });
+    await expect(
+      fetchLatestGitHubReleaseWithGitHubCli({
+        environment: { PATH: "/usr/bin:/bin" },
+        platform: "darwin",
+        run,
+      }),
+    ).resolves.toMatchObject({ version: "1.2.3" });
+    expect(run.mock.calls.map(([executable]) => executable)).toEqual([
+      "gh",
+      "/opt/homebrew/bin/gh",
+    ]);
+  });
+
+  it.each(["win32", "linux"] as const)("discovers native gh on %s", async (platform) => {
+    const expected =
+      platform === "win32" ? "C:\\Program Files\\GitHub CLI\\gh.exe" : "/usr/local/bin/gh";
+    const run = vi.fn(async (executable: string) => {
+      if (executable !== expected) throw Object.assign(new Error("missing"), { code: "ENOENT" });
+      return JSON.stringify(release());
+    });
+    await expect(
+      fetchLatestGitHubReleaseWithGitHubCli({
+        environment: { ProgramFiles: "C:\\Program Files" },
+        platform,
+        run,
+      }),
+    ).resolves.toMatchObject({ version: "1.2.3" });
+    expect(run.mock.calls.at(-1)?.[0]).toBe(expected);
+  });
+
+  it("does not substitute another installation for an explicit gh command", async () => {
+    const run = vi.fn<GitHubCliRunner>(async () => {
+      throw Object.assign(new Error("missing"), { code: "ENOENT" });
+    });
+    await expect(
+      fetchLatestGitHubReleaseWithGitHubCli({
+        environment: { CODEXHOST_GH_COMMAND: "/custom/gh" },
+        run,
+      }),
+    ).resolves.toBeNull();
+    expect(run).toHaveBeenCalledOnce();
+    expect(run.mock.calls[0]?.[0]).toBe("/custom/gh");
+  });
+
+  it("does not repeat CLI failures or expose their diagnostics", async () => {
+    const run = vi.fn(async () => {
+      throw new Error("private CLI diagnostic");
+    });
+    await expect(
+      fetchLatestGitHubReleaseWithGitHubCli({
+        executableCandidates: ["gh", "/opt/homebrew/bin/gh"],
+        run,
+      }),
+    ).resolves.toBeNull();
+    expect(run).toHaveBeenCalledOnce();
+  });
+
+  it.each([
+    "not JSON",
+    JSON.stringify(release({ prerelease: true })),
+    JSON.stringify(release({ html_url: "https://example.com/release" })),
+  ])("rejects invalid CLI release output", async (output) => {
+    const run = vi.fn(async () => output);
+    await expect(fetchLatestGitHubReleaseWithGitHubCli({ run })).resolves.toBeNull();
+    expect(run).toHaveBeenCalledOnce();
+  });
+
+  it("does not start gh after cancellation", async () => {
+    const run = vi.fn();
+    await expect(
+      fetchLatestGitHubReleaseWithGitHubCli({ signal: AbortSignal.abort(), run }),
+    ).rejects.toMatchObject({ name: "AbortError" });
+    expect(run).not.toHaveBeenCalled();
+  });
+
+  it("propagates cancellation without exposing subprocess stderr", async () => {
+    const controller = new AbortController();
+    const run = vi.fn(async () => {
+      controller.abort();
+      throw new Error("sensitive subprocess stderr");
+    });
+    await expect(
+      fetchLatestGitHubReleaseWithGitHubCli({ signal: controller.signal, run }),
+    ).rejects.toMatchObject({ name: "AbortError" });
+    expect(run).toHaveBeenCalledOnce();
   });
 });


### PR DESCRIPTION
## 问题与行为

共享代理出口耗尽 GitHub 匿名 API 配额时，codexhost 0.5.0 的更新检查会报 `GitHub latest Release request failed with HTTP 403`，即使用户已经通过 GitHub CLI 登录。实测同一网络下匿名请求额度为 60、剩余 0，而已认证 `gh api` 返回 HTTP 200，账户额度为 5000。

本 PR 让更新检查优先通过 `gh api --hostname github.com` 读取固定仓库的 latest Release，由 GitHub CLI 使用现有凭证。codexhost 不提取或保存 Token；没有 gh、没有登录、调用失败或返回无效 Release 时，回退现有公开 API。安装包下载、SHA-256 校验及安装流程不变。

## 实现

- 复用现有 Release 解析与资产校验；保留固定 endpoint、GET、Accept 与 API version。
- 支持 PATH、macOS Homebrew、常见 Windows/Linux 安装位置，以及显式 `CODEXHOST_GH_COMMAND` 可执行文件路径。显式路径不会被另一安装替代。
- 使用 `execFile`，不经过 shell；单个 CLI 子进程最多等待 5 秒、输出上限 1 MiB。只有 ENOENT/EACCES 才继续尝试安装路径；认证、网络和解析失败直接回退，避免重复请求。
- 整个检查保持 15 秒上限并组合调用方取消信号；取消后不继续请求。不将 CLI stderr 显示在 UI 或日志中。
- 补充中英文使用说明。认证配额和 GitHub 次级限流仍适用，不承诺无限请求。

## 验证

基于当前 `main`（`d2fc939`），macOS ARM64、Node.js 24.13.1：

- `npm run typecheck`：通过。
- `npm run lint`：通过（ESLint 与模块边界检查）。
- 修改文件的 Prettier 检查、`git diff --check`：通过。
- `npx vitest run --config tests/vitest.config.js packages/update-manager/test packages/host-runtime/test/update-coordinator.test.ts`：42 passed，1 skipped（原有 Windows-only 测试）。覆盖认证优先、匿名回退、各平台路径发现、显式路径、无效输出、取消及子进程执行约束。
- 生产 Host Bundle 构建与 `node --check`：通过。
- 实网验收：模拟 GUI 应用的精简 PATH，能通过 Homebrew gh 读取 v0.5.0 与 4 个 Release 资产；不存在的 gh 正常返回回退结果。
- 真实子进程验收：模拟卡住的 gh 在约 5003 ms 后终止并回退；调用方取消可及时终止子进程。
- 本机打包运行时已同步并通过 codesign 校验；为保留活动任务，未重启桌面应用，因此不将本次验收描述为已完成重启后的 UI 端到端验证。

本次未改 Rust，未运行全量 Rust/跨平台测试；跨平台执行仍需上游 CI 验证。
