### PR TITLE
fix: degrade Pi unknown-command RPC errors that omit request id

### DIFF
--- a/packages/adapters/pi/src/pi-rpc-session.ts
+++ b/packages/adapters/pi/src/pi-rpc-session.ts
@@ -1213,7 +1213,26 @@ export class PiRpcSession {
   #handleResponse(value: Record<string, unknown>): void {
     const id = value.id;
     if (typeof id !== "string") {
-      this.#fail(new PiRpcFaultError("protocolError", "Pi RPC response has no id"));
+      // Current Pi builds omit the request id from unknown-command error
+      // frames; route them back to the unique pending command they name so
+      // unsupported commands still degrade gracefully instead of faulting.
+      const unknownCommand =
+        value.success === false &&
+        typeof value.command === "string" &&
+        value.error === `Unknown command: ${value.command}`
+          ? value.command
+          : null;
+      const orphaned = [...this.#pending.entries()].filter(
+        ([, pending]) => pending.command === unknownCommand,
+      );
+      if (unknownCommand === null || orphaned.length !== 1 || !orphaned[0]) {
+        this.#fail(new PiRpcFaultError("protocolError", "Pi RPC response has no id"));
+        return;
+      }
+      const [orphanedId, pending] = orphaned[0];
+      if (pending.timeout) clearTimeout(pending.timeout);
+      this.#pending.delete(orphanedId);
+      pending.reject(new PiRpcUnsupportedCommandError(pending.command));
       return;
     }
     const pending = this.#pending.get(id);

--- a/packages/adapters/pi/test/pi-rpc-session.test.ts
+++ b/packages/adapters/pi/test/pi-rpc-session.test.ts
@@ -39,6 +39,7 @@ type Scenario =
   | "malformed-catalog"
   | "malformed-thinking"
   | "unsupported-thinking"
+  | "unsupported-thinking-no-id"
   | "stats-full"
   | "stats-cache-hit"
   | "stats-context-only"
@@ -304,6 +305,15 @@ class FakePiRpcProcess extends EventEmitter {
       if (this.#scenario === "unsupported-thinking") {
         this.#output({
           id: command.id,
+          type: "response",
+          command: command.type,
+          success: false,
+          error: `Unknown command: ${command.type}`,
+        });
+        return;
+      }
+      if (this.#scenario === "unsupported-thinking-no-id") {
+        this.#output({
           type: "response",
           command: command.type,
           success: false,
@@ -1419,6 +1429,16 @@ describe("Pi RPC Turn aggregation", () => {
     await expect(malformed.getAvailableThinkingLevels()).rejects.toThrow("invalid level");
     expect(onFault).toHaveBeenCalledWith(expect.objectContaining({ kind: "protocolError" }));
     await malformed.close();
+  });
+
+  it("degrades an unknown Thinking command whose error frame has no id", async () => {
+    const onFault = vi.fn();
+    const rpc = session("unsupported-thinking-no-id", onFault);
+    await rpc.start();
+    await expect(rpc.getAvailableThinkingLevels()).resolves.toBeNull();
+    await expect(rpc.getAvailableModels()).resolves.toHaveLength(2);
+    expect(onFault).not.toHaveBeenCalled();
+    await rpc.close();
   });
 
   it("faults a malformed native Model catalog", async () => {


### PR DESCRIPTION
## Why

Pi 0.73.1 (current `@mariozechner/pi-coding-agent`) answers unknown RPC commands with an error frame that **omits `id`**:

```json
{"type":"response","command":"get_available_thinking_levels","success":false,"error":"Unknown command: get_available_thinking_levels"}
```

`get_state` and `get_available_models` still echo the request id. Inspect then calls `get_available_thinking_levels`; the adapter already maps an id-correlated `Unknown command` to `PiRpcUnsupportedCommandError` so Thinking can degrade to unsupported. An id-less frame instead trips `Pi RPC response has no id`, faults the whole session, and the connections panel marks **Pi as error**.

This is a Pi RPC protocol quirk, not a Codex Desktop / Renderer injection bug. It reproduces by talking to `pi --mode rpc` directly, on any OS that runs that Pi version.

## Change

If a response has no `id`, but it is an `Unknown command: <name>` error and exactly one pending request uses that command name, reject that pending request with `PiRpcUnsupportedCommandError`. Any other id-less frame still faults.

## Test

- Unit: `packages/adapters/pi/test/pi-rpc-session.test.ts` — `degrades an unknown Thinking command whose error frame has no id` (41 tests in this file pass).
- Live: Linux + ChatGPT Desktop 26.901 + Pi 0.73.1; after this adapter behavior, `codexhost` binding probe reports `pi: ready`.

## Relation to #113

#113 already contains this adapter hunk, mixed with the 26.810 Renderer request-bridge work. That PR is waiting on whether the Desktop probe issue is Linux-only. This change is independent and can land on `main` without that Desktop discussion.