### PR TITLE
fix(windows): isolate Desktop tool helpers and restore proxy inheritance

### DIFF
--- a/crates/platform/Cargo.toml
+++ b/crates/platform/Cargo.toml
@@ -32,6 +32,7 @@ windows = { version = "0.62.2", features = [
   "Management_Deployment",
   "Storage_Search",
   "Win32_Foundation",
+  "Win32_Networking_WinHttp",
   "Win32_System_Com",
   "Win32_System_Console",
   "Win32_System_Threading",

--- a/crates/platform/src/desktop_launch.rs
+++ b/crates/platform/src/desktop_launch.rs
@@ -42,7 +42,10 @@ const REMOTE_PROFILE_ONLY_ENVIRONMENT: [&str; 3] = [
 
 fn remove_codexhost_environment(command: &mut Command, names: impl IntoIterator<Item = OsString>) {
     for name in names {
-        if name == CODEX_CLI_PATH_ENV || name.to_string_lossy().starts_with("CODEXHOST_") {
+        if name == CODEX_CLI_PATH_ENV
+            || (cfg!(target_os = "windows") && name == "CODEX_NODE_REPL_PATH")
+            || name.to_string_lossy().starts_with("CODEXHOST_")
+        {
             command.env_remove(name);
         }
     }
@@ -65,7 +68,58 @@ fn managed_desktop_environment(
         ),
     ];
     environment.extend_from_slice(additional_environment);
+    #[cfg(target_os = "windows")]
+    if let Some(wrapper) =
+        managed_node_repl_override(&shim_path, std::env::var_os("CODEX_NODE_REPL_PATH"))
+    {
+        environment.push((OsString::from("CODEX_NODE_REPL_PATH"), wrapper));
+    }
     Ok(environment)
+}
+
+#[cfg(target_os = "windows")]
+fn managed_node_repl_override(shim: &Path, existing: Option<OsString>) -> Option<OsString> {
+    const WRAPPER: &str = "codexhost-node-repl.exe";
+    if existing.as_ref().is_some_and(|value| {
+        !Path::new(value)
+            .file_name()
+            .is_some_and(|name| name.to_string_lossy().eq_ignore_ascii_case(WRAPPER))
+    }) {
+        return None; // Preserve an explicit user-selected tool runtime.
+    }
+    canonical_existing_file(&shim.with_file_name(WRAPPER))
+        .ok()
+        .map(|path| path.into_os_string())
+}
+
+#[cfg(all(test, target_os = "windows"))]
+mod node_repl_override_tests {
+    use super::*;
+
+    #[test]
+    fn uses_packaged_wrapper_and_preserves_user_override() {
+        let directory =
+            std::env::temp_dir().join(format!("codexhost-tool-override-{}", std::process::id()));
+        std::fs::create_dir(&directory).expect("isolated launcher fixture");
+        let shim = directory.join("codexhost-shim.exe");
+        let wrapper = directory.join("codexhost-node-repl.exe");
+        assert!(managed_node_repl_override(&shim, None).is_none());
+        std::fs::write(&wrapper, b"fixture").unwrap();
+        let expected = Some(canonical_existing_file(&wrapper).unwrap().into_os_string());
+        assert_eq!(managed_node_repl_override(&shim, None), expected);
+        assert_eq!(
+            managed_node_repl_override(
+                &shim,
+                Some("C:/old/libexec/codexhost-node-repl.exe".into())
+            ),
+            expected
+        );
+        assert!(
+            managed_node_repl_override(&shim, Some("C:/custom/node_repl.exe".into())).is_none()
+        );
+        assert!(managed_node_repl_override(&shim, Some(OsString::new())).is_none());
+        std::fs::remove_dir_all(directory).unwrap();
+    }
 }
 
 fn configure_managed_desktop_environment(

--- a/crates/platform/src/desktop_launch.rs
+++ b/crates/platform/src/desktop_launch.rs
@@ -69,10 +69,10 @@ fn managed_desktop_environment(
     ];
     environment.extend_from_slice(additional_environment);
     #[cfg(target_os = "windows")]
-    if let Some(wrapper) =
+    if let Some(runtime) =
         managed_node_repl_override(&shim_path, std::env::var_os("CODEX_NODE_REPL_PATH"))
     {
-        environment.push((OsString::from("CODEX_NODE_REPL_PATH"), wrapper));
+        environment.push((OsString::from("CODEX_NODE_REPL_PATH"), runtime));
     }
     Ok(environment)
 }
@@ -85,7 +85,9 @@ fn managed_node_repl_override(shim: &Path, existing: Option<OsString>) -> Option
             .file_name()
             .is_some_and(|name| name.to_string_lossy().eq_ignore_ascii_case(WRAPPER))
     }) {
-        return None; // Preserve an explicit user-selected tool runtime.
+        // AppX activation does not inherit the launcher's process environment.
+        // Forward custom values (including empty ones), not just non-overrides.
+        return existing;
     }
     canonical_existing_file(&shim.with_file_name(WRAPPER))
         .ok()
@@ -95,6 +97,74 @@ fn managed_node_repl_override(shim: &Path, existing: Option<OsString>) -> Option
 #[cfg(all(test, target_os = "windows"))]
 mod node_repl_override_tests {
     use super::*;
+
+    #[test]
+    fn appx_environment_preserves_explicit_node_repl_override() {
+        const CHILD: &str = "CODEXHOST_TEST_APPX_NODE_REPL_ENV";
+        if std::env::var_os(CHILD).is_none() {
+            // Isolate process environment from parallel tests; never mutate the
+            // environment of the multi-threaded test runner.
+            for value in ["C:/custom tools/工具/node_repl.exe", ""] {
+                let mut command = Command::new(std::env::current_exe().unwrap());
+                command
+                    .args([
+                        "--exact",
+                        "desktop_launch::node_repl_override_tests::appx_environment_preserves_explicit_node_repl_override",
+                        "--nocapture",
+                    ])
+                    .env(CHILD, "1")
+                    .env("CODEX_NODE_REPL_PATH", value);
+                super::super::configure_background_command(&mut command);
+                let output = command.output().expect("run isolated environment test");
+                assert!(
+                    output.status.success(),
+                    "AppX override {value:?} was not preserved: {}{}",
+                    String::from_utf8_lossy(&output.stdout),
+                    String::from_utf8_lossy(&output.stderr),
+                );
+            }
+            return;
+        }
+
+        let directory =
+            std::env::temp_dir().join(format!("codexhost-appx-node-env-{}", std::process::id()));
+        std::fs::create_dir(&directory).expect("isolated AppX fixture");
+        let shim = directory.join("codexhost-shim.exe");
+        std::fs::write(&shim, b"fixture").unwrap();
+        std::fs::write(directory.join("codexhost-node-repl.exe"), b"fixture").unwrap();
+        let installation = DesktopInstallation {
+            identity: DesktopIdentity::WindowsPackage {
+                package_name: "fixture".into(),
+                package_family_name: "fixture".into(),
+                appx_activation: Some(super::super::WindowsAppxActivationIdentity {
+                    package_full_name: "fixture".into(),
+                    app_user_model_id: "fixture!App".into(),
+                }),
+            },
+            version: "1.0.0".into(),
+            build: "1".into(),
+            asar_integrity: String::new(),
+            install_root: directory.clone(),
+            desktop_launcher: directory.join("Desktop.exe"),
+            desktop_executable: directory.join("Desktop.exe"),
+            packaged_codex_cli: directory.join("codex.exe"),
+            executable_codex_cli: directory.join("codex.exe"),
+        };
+        let environment = managed_desktop_environment(&installation, &shim, &[]).unwrap();
+        let block = super::super::windows_desktop::windows_environment_block(&environment)
+            .expect("serialize the environment passed to AppX");
+        std::fs::remove_dir_all(&directory).unwrap();
+        let decoded = String::from_utf16(&block).unwrap();
+        let actual = decoded
+            .split('\0')
+            .filter(|entry| entry.starts_with("CODEX_NODE_REPL_PATH="))
+            .collect::<Vec<_>>();
+        let expected = format!(
+            "CODEX_NODE_REPL_PATH={}",
+            std::env::var("CODEX_NODE_REPL_PATH").unwrap()
+        );
+        assert_eq!(actual, [expected.as_str()]);
+    }
 
     #[test]
     fn uses_packaged_wrapper_and_preserves_user_override() {
@@ -114,10 +184,14 @@ mod node_repl_override_tests {
             ),
             expected
         );
-        assert!(
-            managed_node_repl_override(&shim, Some("C:/custom/node_repl.exe".into())).is_none()
+        assert_eq!(
+            managed_node_repl_override(&shim, Some("C:/custom/node_repl.exe".into())),
+            Some("C:/custom/node_repl.exe".into())
         );
-        assert!(managed_node_repl_override(&shim, Some(OsString::new())).is_none());
+        assert_eq!(
+            managed_node_repl_override(&shim, Some(OsString::new())),
+            Some(OsString::new())
+        );
         std::fs::remove_dir_all(directory).unwrap();
     }
 }

--- a/crates/platform/src/lib.rs
+++ b/crates/platform/src/lib.rs
@@ -29,6 +29,9 @@ mod windows_desktop;
 mod windows_process;
 #[cfg(target_os = "windows")]
 #[allow(unsafe_code)]
+mod windows_proxy;
+#[cfg(target_os = "windows")]
+#[allow(unsafe_code)]
 mod windows_ui;
 
 pub use background::detach_from_terminal;
@@ -71,6 +74,8 @@ pub use process::{
 };
 pub use process_supervision::{ChildProcessGuard, SupervisedChild, spawn_supervised};
 pub use process_termination::{terminate_process_group_instance, terminate_process_instance};
+#[cfg(target_os = "windows")]
+pub use proxy_environment::desktop_helper_proxy_environment;
 pub use proxy_environment::proxy_environment;
 #[cfg(target_os = "macos")]
 pub use system_proxy::{SystemProxySettings, system_proxy_settings};

--- a/crates/platform/src/proxy_environment.rs
+++ b/crates/platform/src/proxy_environment.rs
@@ -6,11 +6,26 @@ use std::ffi::{OsStr, OsString};
 use crate::{SystemProxySettings, system_proxy_settings};
 
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
-struct ProxySettings {
-    http_proxy: Option<String>,
-    https_proxy: Option<String>,
-    all_proxy: Option<String>,
-    exceptions: Vec<String>,
+pub(crate) struct ProxySettings {
+    pub(crate) http_proxy: Option<String>,
+    pub(crate) https_proxy: Option<String>,
+    pub(crate) all_proxy: Option<String>,
+    pub(crate) exceptions: Vec<String>,
+}
+
+/// Windows Desktop tool servers may retain CODEX_CLI_PATH but discard proxy
+/// variables. Restore only the current user's static system proxy in that
+/// scoped helper path; explicit environment values (including empty) win.
+#[cfg(target_os = "windows")]
+pub fn desktop_helper_proxy_environment() -> Vec<(OsString, OsString)> {
+    let system = match crate::windows_proxy::static_proxy_settings() {
+        Ok(settings) => settings,
+        Err(_) => {
+            eprintln!("codexhost: could not read Windows helper proxy settings");
+            None
+        }
+    };
+    proxy_environment_from(env::vars_os(), system.as_ref())
 }
 
 /// Returns the proxy environment that should be passed to a codexhost child.
@@ -212,6 +227,28 @@ mod tests {
     #[test]
     fn omits_proxy_variables_when_neither_source_has_one() {
         assert!(proxy_environment_from([], None).is_empty());
+    }
+
+    #[test]
+    fn explicit_empty_proxy_urls_disable_system_fallbacks() {
+        let environment = proxy_environment_from(
+            ["HTTP_PROXY", "HTTPS_PROXY", "ALL_PROXY"]
+                .map(|name| (OsString::from(name), OsString::new())),
+            Some(&ProxySettings {
+                http_proxy: Some("http://system:3128".into()),
+                https_proxy: Some("http://system:3128".into()),
+                all_proxy: Some("socks5://system:1080".into()),
+                exceptions: vec![],
+            }),
+        );
+        for name in ["HTTP_PROXY", "HTTPS_PROXY", "ALL_PROXY"] {
+            assert!(environment.contains(&(OsString::from(name), OsString::new())));
+        }
+        assert!(
+            !environment
+                .iter()
+                .any(|(name, _)| name == "NODE_USE_ENV_PROXY")
+        );
     }
 
     #[test]

--- a/crates/platform/src/windows_proxy.rs
+++ b/crates/platform/src/windows_proxy.rs
@@ -1,0 +1,135 @@
+use windows::Win32::Foundation::{GlobalFree, HGLOBAL};
+use windows::Win32::Networking::WinHttp::{
+    WINHTTP_CURRENT_USER_IE_PROXY_CONFIG, WinHttpGetIEProxyConfigForCurrentUser,
+};
+
+use crate::proxy_environment::ProxySettings;
+
+struct OwnedProxyConfig(WINHTTP_CURRENT_USER_IE_PROXY_CONFIG);
+
+impl Drop for OwnedProxyConfig {
+    fn drop(&mut self) {
+        for value in [
+            self.0.lpszProxy,
+            self.0.lpszProxyBypass,
+            self.0.lpszAutoConfigUrl,
+        ] {
+            if !value.is_null() {
+                // WinHTTP allocates each returned string with GlobalAlloc.
+                unsafe {
+                    let _ = GlobalFree(Some(HGLOBAL(value.0.cast())));
+                }
+            }
+        }
+    }
+}
+
+pub(crate) fn static_proxy_settings() -> windows::core::Result<Option<ProxySettings>> {
+    let mut config = OwnedProxyConfig(WINHTTP_CURRENT_USER_IE_PROXY_CONFIG::default());
+    // Read the current user's configuration; this never changes Windows settings.
+    unsafe {
+        WinHttpGetIEProxyConfigForCurrentUser(&mut config.0)?;
+    }
+    if config.0.fAutoDetect.as_bool() || !config.0.lpszAutoConfigUrl.is_null() {
+        // PAC/WPAD requires per-URL evaluation. Do not approximate it as a global proxy.
+        return Ok(None);
+    }
+    if config.0.lpszProxy.is_null() {
+        return Ok(None);
+    }
+    // Pointers are owned by config and remain valid until its Drop.
+    let proxy = unsafe { config.0.lpszProxy.to_string()? };
+    let bypass = if config.0.lpszProxyBypass.is_null() {
+        String::new()
+    } else {
+        unsafe { config.0.lpszProxyBypass.to_string()? }
+    };
+    Ok(Some(parse_static_proxy(&proxy, &bypass)))
+}
+
+fn parse_static_proxy(proxy: &str, bypass: &str) -> ProxySettings {
+    let mut settings = ProxySettings::default();
+    for entry in proxy
+        .split(';')
+        .map(str::trim)
+        .filter(|entry| !entry.is_empty())
+    {
+        let (protocol, address) = entry
+            .split_once('=')
+            .map_or((None, entry), |(protocol, address)| {
+                (Some(protocol.trim().to_ascii_lowercase()), address.trim())
+            });
+        if address.is_empty() || address.chars().any(char::is_whitespace) {
+            continue;
+        }
+        let scheme = if protocol.as_deref() == Some("socks") {
+            "socks5"
+        } else {
+            "http"
+        };
+        let url = if address.contains("://") {
+            address.to_owned()
+        } else {
+            format!("{scheme}://{address}")
+        };
+        match protocol.as_deref() {
+            None => {
+                settings.http_proxy = Some(url.clone());
+                settings.https_proxy = Some(url);
+            }
+            Some("http") => settings.http_proxy = Some(url),
+            Some("https") => settings.https_proxy = Some(url),
+            Some("socks") => settings.all_proxy = Some(url),
+            _ => {}
+        }
+    }
+    settings.exceptions = bypass
+        .split(';')
+        .map(str::trim)
+        .filter(|value| !value.is_empty() && !value.eq_ignore_ascii_case("<local>"))
+        .map(|value| {
+            value
+                .strip_prefix("*.")
+                .map_or_else(|| value.to_owned(), |suffix| format!(".{suffix}"))
+        })
+        .collect();
+    settings
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_protocol_specific_proxies_and_bypasses() {
+        let settings = parse_static_proxy(
+            "http=127.0.0.1:3128;https=[::1]:8443;socks=proxy:1080;ftp=ignored:21",
+            "localhost;*.example.test;<local>;;10.0.0.0/8",
+        );
+        assert_eq!(
+            settings.http_proxy.as_deref(),
+            Some("http://127.0.0.1:3128")
+        );
+        assert_eq!(settings.https_proxy.as_deref(), Some("http://[::1]:8443"));
+        assert_eq!(settings.all_proxy.as_deref(), Some("socks5://proxy:1080"));
+        assert_eq!(
+            settings.exceptions,
+            ["localhost", ".example.test", "10.0.0.0/8"]
+        );
+    }
+
+    #[test]
+    fn supports_single_proxy_without_inventing_disabled_values() {
+        let settings = parse_static_proxy("https://proxy.example:443", "");
+        assert_eq!(settings.http_proxy, settings.https_proxy);
+        assert_eq!(
+            settings.http_proxy.as_deref(),
+            Some("https://proxy.example:443")
+        );
+        assert!(settings.all_proxy.is_none());
+        assert_eq!(
+            parse_static_proxy("http=;https=bad address;ftp=ignored", ""),
+            ProxySettings::default()
+        );
+    }
+}

--- a/crates/shim/Cargo.toml
+++ b/crates/shim/Cargo.toml
@@ -13,6 +13,10 @@ name = "codexhost-shim"
 path = "src/main.rs"
 
 [[bin]]
+name = "codexhost-node-repl"
+path = "src/node_repl_main.rs"
+
+[[bin]]
 name = "fake-codex-cli"
 path = "tests/fixtures/fake-codex-cli.rs"
 required-features = ["test-utils"]

--- a/crates/shim/src/desktop_invocation.rs
+++ b/crates/shim/src/desktop_invocation.rs
@@ -1,0 +1,96 @@
+//! A managed Desktop also passes its environment to native tool helpers. Their
+//! private app-servers must not become another owner of the Host Runtime.
+
+#[cfg(any(target_os = "windows", test))]
+use codexhost_platform::ProcessSnapshot;
+
+pub(crate) fn is_desktop_helper() -> bool {
+    #[cfg(target_os = "windows")]
+    {
+        let Some(launcher_id) = std::env::var(super::LAUNCHER_PID_ENV)
+            .ok()
+            .and_then(|value| value.parse::<u32>().ok())
+            .filter(|id| *id != 0)
+        else {
+            return false;
+        };
+        is_helper_descendant(std::process::id(), launcher_id, |id| {
+            codexhost_platform::process_snapshot(id).ok()
+        })
+    }
+    #[cfg(not(target_os = "windows"))]
+    false
+}
+
+#[cfg(any(target_os = "windows", test))]
+fn is_helper_descendant(
+    shim_id: u32,
+    launcher_id: u32,
+    mut inspect: impl FnMut(u32) -> Option<ProcessSnapshot>,
+) -> bool {
+    let Some(mut child) = inspect(shim_id) else {
+        return false;
+    };
+    // Windows launch is launcher -> Desktop -> shim. Only a positively observed
+    // deeper descendant is a helper; stale/missing launch metadata keeps the
+    // existing explicit Host/remote invocation behavior. Bound ancestry work.
+    for depth in 1..=32 {
+        if child.parent_id == 0 || child.parent_id == child.id {
+            return false;
+        }
+        let Some(parent) = inspect(child.parent_id) else {
+            return false;
+        };
+        if parent.started_at_micros > child.started_at_micros {
+            return false; // Parent PID was reused.
+        }
+        if parent.id == launcher_id {
+            return depth > 2;
+        }
+        child = parent;
+    }
+    false
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn snapshot(id: u32, parent_id: u32) -> ProcessSnapshot {
+        ProcessSnapshot {
+            id,
+            parent_id,
+            process_group_id: 0,
+            executable: std::path::PathBuf::from("fixture"),
+            started_at_micros: u64::from(id),
+        }
+    }
+
+    #[test]
+    fn distinguishes_desktop_from_nested_helpers() {
+        let inspect = |id| (id >= 1).then(|| snapshot(id, id - 1));
+        assert!(!is_helper_descendant(3, 1, inspect));
+        assert!(is_helper_descendant(4, 1, inspect));
+        assert!(is_helper_descendant(5, 1, inspect));
+        assert!(!is_helper_descendant(3, 99, inspect));
+    }
+
+    #[test]
+    fn rejects_missing_reused_and_unbounded_ancestry() {
+        assert!(!is_helper_descendant(4, 1, |_| None));
+        assert!(!is_helper_descendant(4, 1, |id| {
+            let mut value = snapshot(id, id - 1);
+            if id == 2 {
+                value.started_at_micros = 99;
+            }
+            Some(value)
+        }));
+        assert!(!is_helper_descendant(4, 1, |id| Some(snapshot(id, id))));
+        let mut calls = 0;
+        assert!(!is_helper_descendant(100, 1, |id| {
+            calls += 1;
+            Some(snapshot(id, id - 1))
+        }));
+        assert_eq!(calls, 33);
+    }
+}

--- a/crates/shim/src/lib.rs
+++ b/crates/shim/src/lib.rs
@@ -17,6 +17,7 @@ use codexhost_platform::{
     validate_proxy_target,
 };
 
+mod desktop_invocation;
 mod local_runtime_lease;
 mod process_identity;
 #[cfg(any(target_os = "macos", target_os = "linux"))]
@@ -624,6 +625,7 @@ fn child_command(
     arguments: &[OsString],
     current_executable: &Path,
     stock_codex_path: &Path,
+    desktop_helper: bool,
 ) -> ShimResult<Command> {
     let launcher_managed = env::var_os(LAUNCHER_PID_ENV).is_some();
     let inherited_remote_profile = launcher_managed
@@ -641,7 +643,14 @@ fn child_command(
         } else {
             Vec::new()
         };
-    if should_start_host_runtime(arguments) {
+    #[cfg(target_os = "windows")]
+    let remote_proxy_environment = if desktop_helper || env::var_os(STOCK_CODEX_PATH_ENV).is_none()
+    {
+        codexhost_platform::desktop_helper_proxy_environment()
+    } else {
+        remote_proxy_environment
+    };
+    if !desktop_helper && should_start_host_runtime(arguments) {
         match host_paths {
             (Some(node_path), Some(runtime_path)) => {
                 let node_path =
@@ -675,6 +684,16 @@ fn child_command(
     }
 
     let mut command = Command::new(stock_codex_path);
+    if desktop_helper {
+        // Do not pass launcher/runtime credentials or npm routing back into the
+        // stock helper's descendants. The official CLI still performs policy,
+        // authentication, and tool approvals using its normal configuration.
+        for (name, _) in env::vars_os() {
+            if name.to_string_lossy().starts_with("CODEXHOST_") {
+                command.env_remove(name);
+            }
+        }
+    }
     command
         .args(arguments)
         .env_remove(CODEX_CLI_PATH_ENV)
@@ -739,7 +758,9 @@ pub fn run_proxy_with_observer(
 
     let started = Instant::now();
     let shutdown_signals = ShutdownSignals::install()?;
-    let local_host_runtime = should_start_host_runtime(arguments)
+    let desktop_helper = desktop_invocation::is_desktop_helper();
+    let local_host_runtime = !desktop_helper
+        && should_start_host_runtime(arguments)
         && host_runtime_paths_are_configured()
         && !is_managed_remote_listener(arguments)
         && env::var_os(DATA_DIRECTORY_ENV).is_some();
@@ -750,7 +771,12 @@ pub fn run_proxy_with_observer(
     } else {
         None
     };
-    let mut command = child_command(arguments, &current_executable, &stock_codex_path)?;
+    let mut command = child_command(
+        arguments,
+        &current_executable,
+        &stock_codex_path,
+        desktop_helper,
+    )?;
     command
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())

--- a/crates/shim/src/node_repl_main.rs
+++ b/crates/shim/src/node_repl_main.rs
@@ -1,0 +1,60 @@
+#![forbid(unsafe_code)]
+#![cfg_attr(
+    all(target_os = "windows", not(debug_assertions)),
+    windows_subsystem = "windows"
+)]
+
+#[cfg(target_os = "windows")]
+fn run() -> Result<i32, Box<dyn std::error::Error>> {
+    use codexhost_platform::{
+        canonical_existing_file, configure_background_command, desktop_helper_proxy_environment,
+        spawn_supervised, validate_proxy_target,
+    };
+    use std::path::PathBuf;
+    use std::process::{Command, Stdio};
+
+    // Desktop supplies this official primary-runtime path with its tool config.
+    // Never search PATH or execute a shell to locate the underlying runtime.
+    let node = canonical_existing_file(&PathBuf::from(
+        std::env::var_os("NODE_REPL_NODE_PATH")
+            .ok_or("NODE_REPL_NODE_PATH is required for the Desktop tool proxy")?,
+    ))?;
+    if !node
+        .file_name()
+        .is_some_and(|name| name.to_string_lossy().eq_ignore_ascii_case("node.exe"))
+    {
+        return Err(
+            "NODE_REPL_NODE_PATH must identify the official Node runtime executable".into(),
+        );
+    }
+    let runtime = validate_proxy_target(
+        &std::env::current_exe()?,
+        &node.with_file_name("node_repl.exe"),
+    )?;
+    let mut command = Command::new(runtime);
+    command
+        .args(std::env::args_os().skip(1))
+        .envs(desktop_helper_proxy_environment())
+        .stdin(Stdio::inherit())
+        .stdout(Stdio::inherit())
+        .stderr(Stdio::inherit());
+    configure_background_command(&mut command);
+    let mut child = spawn_supervised(&mut command)?;
+    Ok(child.wait()?.code().unwrap_or(1))
+}
+
+#[cfg(not(target_os = "windows"))]
+fn run() -> Result<i32, Box<dyn std::error::Error>> {
+    Err("the Desktop node_repl proxy is only used on Windows".into())
+}
+
+fn main() {
+    let code = match run() {
+        Ok(code) => code,
+        Err(error) => {
+            eprintln!("codexhost tool proxy: {error}");
+            1
+        }
+    };
+    std::process::exit(code);
+}

--- a/crates/shim/tests/fixtures/fake-codex-cli.rs
+++ b/crates/shim/tests/fixtures/fake-codex-cli.rs
@@ -194,6 +194,22 @@ fn run_orphan_shim_launcher() -> bool {
 #[allow(clippy::zombie_processes)]
 fn main() {
     let arguments = env::args().skip(1).collect::<Vec<_>>();
+    if let Some(shim) = env::var_os("FAKE_CODEX_HELPER_SHIM") {
+        let depth = environment_u64("FAKE_CODEX_HELPER_DEPTH", 0);
+        let mut command = Command::new(if depth == 0 {
+            PathBuf::from(shim)
+        } else {
+            env::current_exe().expect("fake helper executable")
+        });
+        command.args(&arguments);
+        if depth == 0 {
+            command.env_remove("FAKE_CODEX_HELPER_SHIM");
+        } else {
+            command.env("FAKE_CODEX_HELPER_DEPTH", (depth - 1).to_string());
+        }
+        let status = command.status().expect("run fake Desktop or helper child");
+        process::exit(status.code().unwrap_or(1));
+    }
     #[cfg(any(target_os = "macos", target_os = "linux"))]
     if env::var_os("FAKE_CODEX_CRASH").is_some() {
         use std::os::unix::process::CommandExt;
@@ -289,6 +305,18 @@ fn main() {
                 eprintln!("{name}={}", value.to_string_lossy());
             }
         }
+    }
+
+    if env::var_os("FAKE_CODEX_ROUTE_RESPONSE").is_some() {
+        io::stdin().read_exact(&mut [0]).expect("routing request");
+        io::stdout()
+            .write_all(b"response")
+            .expect("routing response");
+        io::stdout().flush().expect("flush routing response");
+        io::stdin()
+            .read_to_end(&mut Vec::new())
+            .expect("routing EOF");
+        return;
     }
 
     if env::var_os("FAKE_CODEX_SPAWN_CHILD").is_some() {

--- a/crates/shim/tests/proxy.rs
+++ b/crates/shim/tests/proxy.rs
@@ -34,6 +34,119 @@ fn fake_codex_path() -> PathBuf {
     PathBuf::from(env!("CARGO_BIN_EXE_fake-codex-cli"))
 }
 
+#[cfg(target_os = "windows")]
+#[test]
+fn node_repl_proxy_preserves_stdio_and_explicit_proxy_configuration() {
+    let directory = temporary_directory();
+    let node = directory.join("node.exe");
+    fs::copy(fake_codex_path(), &node).unwrap();
+    fs::copy(fake_codex_path(), directory.join("node_repl.exe")).unwrap();
+    let mut child = Command::new(env!("CARGO_BIN_EXE_codexhost-node-repl"))
+        .args(["--fixture-option", "two words"])
+        .env("NODE_REPL_NODE_PATH", &node)
+        .env("HTTP_PROXY", "http://explicit.invalid:3128")
+        .env("HTTPS_PROXY", "")
+        .env("ALL_PROXY", "")
+        .env("NODE_USE_ENV_PROXY", "0")
+        .env("FAKE_CODEX_PRINT_INVOCATION", "1")
+        .env("FAKE_CODEX_PRINT_PROXY_ENV", "1")
+        .env("FAKE_CODEX_EXIT_CODE", "7")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .unwrap();
+    let input = b"{\"jsonrpc\":\"2.0\"}\r\n\0\xFF";
+    child.stdin.take().unwrap().write_all(input).unwrap();
+    let output = child.wait_with_output().unwrap();
+    assert_eq!(output.status.code(), Some(7));
+    assert_eq!(output.stdout, input);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("args=--fixture-option|two words"),
+        "{stderr}"
+    );
+    assert!(
+        stderr.contains("HTTP_PROXY=http://explicit.invalid:3128"),
+        "{stderr}"
+    );
+    assert!(stderr.contains("NODE_USE_ENV_PROXY=0"), "{stderr}");
+    fs::remove_dir_all(directory).unwrap();
+}
+
+#[cfg(target_os = "windows")]
+#[test]
+fn node_repl_proxy_does_not_search_path_for_missing_runtime() {
+    let output = Command::new(env!("CARGO_BIN_EXE_codexhost-node-repl"))
+        .env_remove("NODE_REPL_NODE_PATH")
+        .stdin(Stdio::null())
+        .output()
+        .unwrap();
+    assert!(!output.status.success());
+    assert!(output.stdout.is_empty());
+    assert!(String::from_utf8_lossy(&output.stderr).contains("NODE_REPL_NODE_PATH is required"));
+}
+
+#[cfg(target_os = "windows")]
+#[test]
+fn desktop_helpers_do_not_reenter_host_runtime() {
+    // Test process = launcher, first fixture = Desktop, additional fixtures = helpers.
+    // Use the same inherited configuration and stdio command at every depth.
+    for depth in [0, 1, 2] {
+        let directory = temporary_directory();
+        let mut child = Command::new(fake_codex_path())
+            .args(["app-server", "--listen", "stdio://"])
+            .env("FAKE_CODEX_HELPER_SHIM", shim_path())
+            .env("FAKE_CODEX_HELPER_DEPTH", depth.to_string())
+            .env("FAKE_CODEX_PRINT_INVOCATION", "1")
+            .env("FAKE_CODEX_ROUTE_RESPONSE", "1")
+            .env("CODEXHOST_LAUNCHER_PID", process::id().to_string())
+            .env("CODEXHOST_DATA_DIR", &directory)
+            .env_remove("CODEXHOST_NPM_NODE_PATH")
+            .env_remove("CODEXHOST_NPM_PACKAGE_ROOT")
+            .env(STOCK_CODEX_PATH_ENV, fake_codex_path())
+            .env(CODEX_CLI_PATH_ENV, shim_path())
+            .env(HOST_NODE_PATH_ENV, fake_codex_path())
+            .env(HOST_RUNTIME_PATH_ENV, fake_codex_path())
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .expect("spawn launcher-owned Desktop fixture");
+        let mut stdin = child.stdin.take().expect("fixture stdin");
+        stdin.write_all(b"x").expect("write fixture request");
+        let mut response = [0; 8];
+        child
+            .stdout
+            .as_mut()
+            .unwrap()
+            .read_exact(&mut response)
+            .expect("read routing response before closing stdin");
+        assert_eq!(&response, b"response");
+        drop(stdin);
+        let output = child.wait_with_output().expect("wait for fixture");
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        assert!(output.status.success(), "depth={depth}: {stderr}");
+        assert!(output.stdout.is_empty());
+        if depth == 0 {
+            assert!(
+                !stderr.contains("args=app-server|"),
+                "main Desktop must use Host Runtime: {stderr}"
+            );
+        } else {
+            assert!(
+                stderr.contains("args=app-server|--listen|stdio://"),
+                "helper must use stock CLI: {stderr}"
+            );
+            assert!(
+                !directory.join("local-host-runtime-owner.lock").exists(),
+                "helper must not acquire a Host Runtime lease"
+            );
+        }
+        fs::remove_dir_all(directory).expect("remove isolated routing fixture");
+    }
+}
+
 fn temporary_directory() -> PathBuf {
     static NEXT_DIRECTORY_ID: AtomicU64 = AtomicU64::new(0);
 
@@ -336,6 +449,9 @@ fn discovers_official_cli_when_browser_helper_preserves_only_codex_cli_path() {
         .env_remove(HOST_RUNTIME_PATH_ENV)
         .env_remove(REMOTE_SSH_MANAGED_ENV)
         .env("FAKE_CODEX_PRINT_INVOCATION", "1")
+        .env("FAKE_CODEX_PRINT_PROXY_ENV", "1")
+        .env("HTTP_PROXY", "http://explicit-proxy.invalid:3128")
+        .env_remove("NODE_USE_ENV_PROXY")
         .stdin(Stdio::null())
         .output()
         .expect("run Browser Use style shim invocation");
@@ -350,6 +466,11 @@ fn discovers_official_cli_when_browser_helper_preserves_only_codex_cli_path() {
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(stderr.contains("args=config|read"), "{stderr}");
     assert!(stderr.contains("codex_cli_path_present=false"), "{stderr}");
+    assert!(
+        stderr.contains("HTTP_PROXY=http://explicit-proxy.invalid:3128"),
+        "{stderr}"
+    );
+    assert!(stderr.contains("NODE_USE_ENV_PROXY=1"), "{stderr}");
 
     fs::remove_dir_all(
         installation_root

--- a/docs/windows-tool-compatibility.md
+++ b/docs/windows-tool-compatibility.md
@@ -29,7 +29,9 @@ separately from actual administrator-policy denials.
 
 The Windows package includes `libexec/codexhost-node-repl.exe`. The launcher uses
 Desktop's supported `CODEX_NODE_REPL_PATH` override when the wrapper is present,
-unless the user has selected a different custom runtime. The wrapper resolves
+unless the user has selected a different custom runtime. Explicit custom values,
+including empty values, are forwarded unchanged in the AppX activation environment;
+they must not rely on inheritance from the launcher process. The wrapper resolves
 the official `node_repl.exe` next to Desktop's `NODE_REPL_NODE_PATH`; it does not
 search PATH or modify the official runtime. Arguments, stdio, and exit status
 are forwarded, with the child supervised by the existing Windows job mechanism.

--- a/docs/windows-tool-compatibility.md
+++ b/docs/windows-tool-compatibility.md
@@ -1,0 +1,73 @@
+# Windows Browser Use and Computer Use compatibility
+
+Two distinct subprocess boundaries matter when Desktop runs through codexhost.
+
+## Native Computer Use auxiliary app-server
+
+Desktop passes its CLI override and launcher environment to its native helpers.
+An auxiliary `app-server` invocation therefore used to enter the Host Runtime
+again. With the primary runtime already running, it exits with `STORE_LOCKED`
+(`Another codexhost process owns Mapping Store`). A helper can surface only
+`codex app-server exited before returning response 1`.
+
+On Windows the managed launch tree is `launcher -> Desktop -> shim`. The shim
+now recognizes positively observed deeper descendants of the same launcher as
+helpers. It sends those calls to the validated official CLI, without acquiring
+a local Host Runtime lease or forwarding internal `CODEXHOST_*` environment.
+The direct Desktop child still enters the Host Runtime. Missing, stale, reused,
+or unresolvable ancestry does not opt a process into helper routing. Remote
+Unix listener behavior is unchanged.
+
+## Browser tool networking
+
+The official MCP stdio launcher filters inherited environment variables. A
+working main app-server does not prove that `node_repl`, `cua_repl`, or their
+auxiliary app-server has the same proxy settings. Browser discovery/navigation
+can work while trusted service HTTP requests or later page-state operations
+fail. `nodeRepl.fetch request failed` and debugger errors must be diagnosed
+separately from actual administrator-policy denials.
+
+The Windows package includes `libexec/codexhost-node-repl.exe`. The launcher uses
+Desktop's supported `CODEX_NODE_REPL_PATH` override when the wrapper is present,
+unless the user has selected a different custom runtime. The wrapper resolves
+the official `node_repl.exe` next to Desktop's `NODE_REPL_NODE_PATH`; it does not
+search PATH or modify the official runtime. Arguments, stdio, and exit status
+are forwarded, with the child supervised by the existing Windows job mechanism.
+
+The wrapper and sparse-environment CLI helper path recover the current user's
+static Windows proxy configuration through WinHTTP. Explicit proxy environment
+values, including empty values and `NODE_USE_ENV_PROXY=0`, take precedence.
+Missing proxy aliases and `NODE_USE_ENV_PROXY=1` are supplied when applicable.
+No local ports are hardcoded, no system settings are written, and no policy,
+authentication, certificate validation, model check, or tool approval is disabled.
+
+PAC/WPAD is not flattened into a global environment proxy. In those environments,
+configure the appropriate explicit MCP proxy environment through normal Codex
+configuration. Windows `<local>` (all dotless hosts) cannot be represented
+exactly by portable `NO_PROXY`; it is omitted, while localhost and loopback
+addresses are retained. Existing bypass entries and domain suffixes are carried
+forward using the existing proxy-environment normalization.
+
+## Verification
+
+Use a fresh candidate and preserve the current installation for rollback.
+
+1. Confirm the direct Desktop shim still owns the primary Host Runtime and can
+   submit a normal turn. Check another Harness and thread resume as appropriate.
+2. Inspect only routing/proxy environment keys in the tool process and its CLI
+   child. Do not dump complete process environments, credentials, or auth files.
+3. Test a trusted service HTTP request through official `node_repl`. Record the
+   status/elapsed time, not the authenticated response body. A shell `curl` or an
+   untrusted JavaScript `fetch` is not an equivalent end-to-end test.
+4. Test in-app browser and Chrome independently: open a public test page, read
+   its visible content, click a link, and verify the new page. Opening a tab or
+   obtaining its title alone does not prove page-state/control functionality.
+5. Test native Computer Use with a returned Calculator window: observe, perform
+   a harmless input, and observe again. Preserve all normal app approvals.
+6. Confirm the main Host Runtime remains the same healthy owner after tool use.
+
+The regression suite covers direct Desktop versus nested helper routing, lease
+non-acquisition, process-identity failures, proxy precedence, runtime discovery,
+stdio/exit forwarding, and Windows-only release payload inclusion. Real browser
+and native UI tests still require a Desktop restart into the candidate; build
+and protocol checks alone are not a claim that all three UI modules passed.

--- a/scripts/release/prepare-npm.mjs
+++ b/scripts/release/prepare-npm.mjs
@@ -193,6 +193,7 @@ export function expectedNpmPackagePaths(target) {
     "README.md",
     `bin/codexhost${target.executableSuffix}`,
     `libexec/codexhost-shim${target.executableSuffix}`,
+    ...(target.hostPlatform === "win32" ? ["libexec/codexhost-node-repl.exe"] : []),
     `libexec/codexhost-updater${target.executableSuffix}`,
     "app/codexhost-distribution.json",
     "app/desktop-controller.mjs",
@@ -938,6 +939,14 @@ export async function prepareNpmPackage({
     "npm Shim",
     true,
   );
+  if (target.hostPlatform === "win32") {
+    await copyReleaseFile(
+      path.join(rustOutput, "codexhost-node-repl.exe"),
+      path.join(packageRoot, "libexec", "codexhost-node-repl.exe"),
+      "npm Desktop tool proxy",
+      true,
+    );
+  }
   await copyReleaseFile(
     path.join(rustOutput, `codexhost-updater${target.executableSuffix}`),
     path.join(packageRoot, "libexec", `codexhost-updater${target.executableSuffix}`),

--- a/scripts/release/prepare-payload.mjs
+++ b/scripts/release/prepare-payload.mjs
@@ -208,6 +208,7 @@ export function expectedPayloadPaths(target) {
   const paths = [
     `bin/codexhost${target.executableSuffix}`,
     `libexec/codexhost-shim${target.executableSuffix}`,
+    ...(target.hostPlatform === "win32" ? ["libexec/codexhost-node-repl.exe"] : []),
     `libexec/codexhost-updater${target.executableSuffix}`,
     `runtime/node${target.executableSuffix}`,
     "app/codexhost-distribution.json",
@@ -310,6 +311,14 @@ export async function prepareReleasePayload({ target, root = repositoryRoot }) {
     "release Shim",
     true,
   );
+  if (target.hostPlatform === "win32") {
+    await copyReleaseFile(
+      path.join(rustOutput, "codexhost-node-repl.exe"),
+      path.join(payloadRoot, "libexec", "codexhost-node-repl.exe"),
+      "release Desktop tool proxy",
+      true,
+    );
+  }
   await copyReleaseFile(
     path.join(rustOutput, `codexhost-updater${target.executableSuffix}`),
     path.join(payloadRoot, "libexec", `codexhost-updater${target.executableSuffix}`),

--- a/tests/release/npm-package.test.mjs
+++ b/tests/release/npm-package.test.mjs
@@ -636,6 +636,10 @@ describe("npm package release", () => {
       expect(paths).not.toContain("runtime/node");
       expect(paths).toContain("bin/codexhost");
       expect(paths).toContain("libexec/codexhost-shim");
+      expect(expectedNpmPackagePaths(releaseTarget("windows-x64"))).toContain(
+        "libexec/codexhost-node-repl.exe",
+      );
+      expect(paths).not.toContain("libexec/codexhost-node-repl");
       expect(paths).toContain("libexec/codexhost-updater");
       expect(paths).toContain("app/codexhost-distribution.json");
       await mkdir(path.join(root, "runtime"), { recursive: true });

--- a/tests/release/payload.test.mjs
+++ b/tests/release/payload.test.mjs
@@ -75,7 +75,11 @@ describe("release Payload", () => {
       const paths = await validatePayload({ payloadRoot: root, target, root: "/repo/source" });
       expect(paths).toEqual(expectedPayloadPaths(target));
       expect(paths).toHaveLength(19);
-      expect(expectedPayloadPaths(releaseTarget("windows-x64"))).toHaveLength(20);
+      expect(expectedPayloadPaths(releaseTarget("windows-x64"))).toHaveLength(21);
+      expect(expectedPayloadPaths(releaseTarget("windows-x64"))).toContain(
+        "libexec/codexhost-node-repl.exe",
+      );
+      expect(paths).not.toContain("libexec/codexhost-node-repl");
       expect(expectedPayloadPaths(releaseTarget("windows-x64"))).toContain(
         "bin/codexhost-start.exe",
       );


### PR DESCRIPTION
## Summary

Fix two Windows subprocess compatibility boundaries affecting Browser Use / Chrome Control and native Computer Use under a managed Codex Desktop launch.

- Route positively identified nested Desktop helper app-servers to the validated official CLI, without starting another Host Runtime or acquiring its ownership lease. Keep the direct Desktop app-server on the Host Runtime.
- Strip internal Host bootstrap environment from those official CLI children.
- Recover static current-user Windows proxy settings for sparse-environment CLI helpers and the official tool runtime, respecting explicit environment overrides (including empty values).
- Package a small supervised `codexhost-node-repl.exe` proxy and select it through Desktop's supported `CODEX_NODE_REPL_PATH` override. Preserve a user-selected custom runtime and resolve the official runtime only next to Desktop's explicit `NODE_REPL_NODE_PATH`.
- Include regression tests, Windows payload checks, and a compatibility/verification note.

## Evidence and diagnosis

On the unchanged 0.5.0 Windows installation:

1. Native Computer Use returned `codex app-server exited before returning response 1`. Its auxiliary app-server inherited Host bootstrap variables. A controlled official CLI initialization probe with the same routing environment reproduced `STORE_LOCKED` / `Another codexhost process owns Mapping Store`. The new shim initialized the official app-server successfully under the same conditions. Direct Desktop routing remains covered by integration tests.
2. The primary official app-server had working proxy environment, but the MCP tool runtime and its CLI child did not. Browser navigation/discovery could occur while later requests failed with `nodeRepl.fetch request failed`, page-state timeouts, or `Debugger unattached`. The official MCP launcher filters inherited environment variables.
3. A standalone real official node_repl MCP test made the same trusted-service request to a fixed official ChatGPT endpoint. The original launch timed out at 14 seconds; the new wrapper returned HTTP 200 (about 0.51 seconds for tool execution / 2.66 seconds overall). Only status and timing were recorded, never authenticated response content. Untrusted global `fetch` is not treated as an equivalent test.

These protocol/network results establish the fixed boundaries. They do **not** yet establish that every live browser debugger error has the same cause.

## Safety and scope

- No administrator policy, authentication, certificate validation, model restriction, or tool approval is bypassed.
- No signed Desktop/runtime files, user config, credentials, system proxy settings, or browser profile settings are modified.
- PAC/WPAD is intentionally not converted to a global proxy; explicit MCP proxy configuration remains available for those environments.
- Process ancestry checks are bounded and reject missing/reused ancestry. Existing official CLI target validation and process supervision remain in use.
- Runtime behavior changes and wrapper packaging are Windows-only. macOS has not been exercised in this change.

## Validation

- [x] `npm run format:check`
- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm run test:typescript` — 2309 passed, 18 skipped
- [x] `npm run check:rust` — formatting, Clippy with warnings denied, full workspace tests
- [x] Real official CLI initialization red/green comparison
- [x] Real official node_repl trusted-service network red/green comparison
- [x] Release candidate packaging / installed-file verification — `0.5.0-pr163.43e0f91.1`, installed into a new side-by-side candidate directory; launcher, shim, tool wrapper, Host Runtime, controller, and renderer hashes match the release payload
- [x] Installed release-binary protocol probes — official CLI initialization succeeds; the official trusted-service network comparison again times out without the wrapper (14.25 seconds) and returns HTTP 200 with it (0.496 seconds tool execution / 2.676 seconds overall)
- [x] Post-restart normal CodexHost turn and stable single Host owner — confirmed PR163 launcher/shim; the same primary runtime remains the Mapping Store owner after browser and native-tool probes
- [x] Post-restart in-app browser: page read and interaction — Example Domain accessibility tree, click Learn more, read the IANA destination; Google homepage tree also succeeds
- [x] Post-restart Chrome extension: page read and interaction — separate new test tab, Example Domain accessibility tree, click Learn more, read the IANA destination
- [x] Post-restart native Computer Use: foreground window observation and harmless interaction — clicked 2, +, 3, pressed Return, and visually verified both the display and history show 2 + 3 = 5

## Post-restart native-tool status

The user restarted into the packaged PR163 candidate. Official `@oai/sky` app/window enumeration, Calculator launch, target selection, activation, and foreground screenshot capture now succeed; the prior app-server early-exit failure did not recur. Initial inputs were rejected by the normal user-input detection guard. After the user explicitly resumed testing with a quiet foreground window, normal screenshot-grounded clicks on 2, +, 3 and a Return keypress succeeded. Fresh screenshots after each action verified the intermediate states and final 2 + 3 = 5 result. The guard was not disabled or bypassed. The primary Host Runtime and Mapping Store owner remained unchanged after the input test.

Known limitations remain: Calculator accessibility was null, and captures while Calculator was covered showed the covering foreground window rather than an unobscured Calculator. Foreground screenshot-based control is verified; unobscured background capture and accessibility-based native input are not claimed as fixed. Their cause has not been attributed to CodexHost by a controlled comparison, and this PR does not patch the official native helper.

All four GitHub CI jobs passed (Windows, macOS, Ubuntu x64, Linux ARM64). Ready for review of the scoped helper-routing/proxy-inheritance fix, with the native capture/accessibility limitations above explicitly retained. No signed app/runtime, machine configuration, or safety guard was changed during post-restart testing.
