### PR TITLE
fix(macos): restore browser and native Computer Use helpers

### DIFF
--- a/crates/platform/src/installation.rs
+++ b/crates/platform/src/installation.rs
@@ -1,4 +1,4 @@
-#[cfg(target_os = "windows")]
+#[cfg(any(target_os = "windows", target_os = "macos"))]
 use std::env;
 #[cfg(any(target_os = "windows", target_os = "macos", target_os = "linux"))]
 use std::fs::File;
@@ -56,11 +56,12 @@ pub(super) fn sha256_file(path: &Path) -> Result<String, PlatformError> {
     }
     Ok(format!("sha256:{:x}", digest.finalize()))
 }
+#[cfg(any(target_os = "windows", target_os = "macos"))]
+use super::CUSTOM_INSTALL_ROOT_ENV;
 #[cfg(target_os = "windows")]
 use super::{
-    CUSTOM_INSTALL_ROOT_ENV, PROBE_APP_USER_MODEL_ID_ENV, PROBE_DESKTOP_VERSION_ENV,
-    PROBE_INSTALL_ROOT_ENV, PROBE_PACKAGE_FAMILY_ENV, PROBE_PACKAGE_FULL_NAME_ENV,
-    PROBE_PACKAGE_NAME_ENV,
+    PROBE_APP_USER_MODEL_ID_ENV, PROBE_DESKTOP_VERSION_ENV, PROBE_INSTALL_ROOT_ENV,
+    PROBE_PACKAGE_FAMILY_ENV, PROBE_PACKAGE_FULL_NAME_ENV, PROBE_PACKAGE_NAME_ENV,
 };
 
 #[cfg(target_os = "windows")]
@@ -317,7 +318,7 @@ fn windows_installation(
 /// This is deliberately independent of the Gate A `CODEXHOST_PROBE_*` set: it
 /// names an installation root on its own, so an unpacked Desktop can be located
 /// without supplying package identity and version as well.
-#[cfg(target_os = "windows")]
+#[cfg(any(target_os = "windows", target_os = "macos"))]
 fn custom_install_root(
     value: impl Fn(&'static str) -> Option<std::ffi::OsString>,
 ) -> Option<PathBuf> {
@@ -1009,6 +1010,17 @@ pub fn discover_codex_desktop() -> Result<DesktopInstallation, PlatformError> {
         candidates.push(applications.join("ChatGPT.app"));
     }
     discover_from_candidates(candidates)
+}
+
+/// Resolve a helper's official CLI from a validated Desktop bundle, never PATH.
+/// An explicit installation root is authoritative, including when invalid.
+#[cfg(target_os = "macos")]
+pub fn discover_desktop_managed_codex_cli() -> Result<PathBuf, PlatformError> {
+    let installation = match custom_install_root(env::var_os) {
+        Some(root) => inspect_bundle(&root)?,
+        None => discover_codex_desktop()?,
+    };
+    Ok(installation.executable_codex_cli)
 }
 
 #[cfg(not(any(target_os = "windows", target_os = "macos", target_os = "linux")))]

--- a/crates/platform/src/installation.rs
+++ b/crates/platform/src/installation.rs
@@ -1023,6 +1023,12 @@ pub fn discover_desktop_managed_codex_cli() -> Result<PathBuf, PlatformError> {
     Ok(installation.executable_codex_cli)
 }
 
+/// Inspect an explicit macOS bundle without selecting another installation.
+#[cfg(target_os = "macos")]
+pub fn discover_codex_desktop_from_root(root: &Path) -> Result<DesktopInstallation, PlatformError> {
+    inspect_bundle(root)
+}
+
 #[cfg(not(any(target_os = "windows", target_os = "macos", target_os = "linux")))]
 pub fn discover_codex_desktop() -> Result<DesktopInstallation, PlatformError> {
     Err(PlatformError::Unsupported(

--- a/crates/platform/src/lib.rs
+++ b/crates/platform/src/lib.rs
@@ -44,7 +44,9 @@ pub use desktop_launch::{DesktopSession, launch_desktop_session};
 #[cfg(not(target_os = "linux"))]
 pub use installation::discover_codex_desktop;
 #[cfg(target_os = "windows")]
-pub use installation::{discover_codex_desktop_from_root, discover_desktop_managed_codex_cli};
+pub use installation::discover_codex_desktop_from_root;
+#[cfg(any(target_os = "windows", target_os = "macos"))]
+pub use installation::discover_desktop_managed_codex_cli;
 #[cfg(target_os = "linux")]
 pub use linux_installation::discover_codex_desktop;
 pub use macos_native_harness_broker::{

--- a/crates/platform/src/lib.rs
+++ b/crates/platform/src/lib.rs
@@ -43,7 +43,7 @@ pub use desktop_launch::{
 pub use desktop_launch::{DesktopSession, launch_desktop_session};
 #[cfg(not(target_os = "linux"))]
 pub use installation::discover_codex_desktop;
-#[cfg(target_os = "windows")]
+#[cfg(any(target_os = "windows", target_os = "macos"))]
 pub use installation::discover_codex_desktop_from_root;
 #[cfg(any(target_os = "windows", target_os = "macos"))]
 pub use installation::discover_desktop_managed_codex_cli;

--- a/crates/shim/src/desktop_invocation.rs
+++ b/crates/shim/src/desktop_invocation.rs
@@ -4,7 +4,7 @@
 #[cfg(any(target_os = "windows", test))]
 use codexhost_platform::ProcessSnapshot;
 
-pub(crate) fn is_desktop_helper() -> bool {
+pub(crate) fn is_desktop_helper(_stock_codex_path: &std::path::Path) -> bool {
     #[cfg(target_os = "windows")]
     {
         let Some(launcher_id) = std::env::var(super::LAUNCHER_PID_ENV)
@@ -18,8 +18,50 @@ pub(crate) fn is_desktop_helper() -> bool {
             codexhost_platform::process_snapshot(id).ok()
         })
     }
-    #[cfg(not(target_os = "windows"))]
+    #[cfg(target_os = "macos")]
+    {
+        is_macos_desktop_helper(_stock_codex_path).unwrap_or(false)
+    }
+    #[cfg(not(any(target_os = "windows", target_os = "macos")))]
     false
+}
+
+#[cfg(target_os = "macos")]
+fn is_macos_desktop_helper(stock_codex_path: &std::path::Path) -> Option<bool> {
+    use codexhost_platform::{discover_codex_desktop_from_root, process_snapshot};
+    use std::path::PathBuf;
+
+    let launcher_id = std::env::var(super::LAUNCHER_PID_ENV).ok()?.parse().ok()?;
+    let launcher = process_snapshot(launcher_id).ok()?;
+    let expected_launcher = PathBuf::from(std::env::var_os("CODEXHOST_LAUNCHER_EXECUTABLE")?)
+        .canonicalize()
+        .ok()?;
+    if launcher.executable != expected_launcher {
+        return None;
+    }
+    // LaunchServices reparents Desktop to launchd, so the launcher cannot be an
+    // ancestor. Match the exact Desktop in the already-resolved official CLI's
+    // validated bundle instead; direct Desktop -> shim must still start Host.
+    let bundle = stock_codex_path.parent()?.parent()?.parent()?;
+    let installation = discover_codex_desktop_from_root(bundle).ok()?;
+    if installation.executable_codex_cli != stock_codex_path {
+        return None;
+    }
+    let mut child = process_snapshot(std::process::id()).ok()?;
+    for depth in 1..=32 {
+        if child.parent_id <= 1 || child.parent_id == child.id {
+            return None;
+        }
+        let parent = process_snapshot(child.parent_id).ok()?;
+        if parent.started_at_micros > child.started_at_micros {
+            return None;
+        }
+        if parent.executable == installation.desktop_executable {
+            return (parent.started_at_micros >= launcher.started_at_micros).then_some(depth > 1);
+        }
+        child = parent;
+    }
+    None
 }
 
 #[cfg(any(target_os = "windows", test))]

--- a/crates/shim/src/lib.rs
+++ b/crates/shim/src/lib.rs
@@ -9,7 +9,7 @@ use std::process::{Command, ExitStatus, Stdio};
 use std::thread;
 use std::time::{Duration, Instant};
 
-#[cfg(target_os = "windows")]
+#[cfg(any(target_os = "windows", target_os = "macos"))]
 use codexhost_platform::discover_desktop_managed_codex_cli;
 use codexhost_platform::{
     CODEX_CLI_PATH_ENV, STOCK_CODEX_PATH_ENV, canonical_existing_file,
@@ -707,7 +707,7 @@ fn child_command(
 }
 
 /// Resolve the official CLI for both the launcher-managed process tree and
-/// Windows Desktop helpers that persist only the standard `CODEX_CLI_PATH`
+/// Desktop helpers that persist only the standard `CODEX_CLI_PATH`
 /// override.
 ///
 /// The launcher-provided path remains authoritative. Installation discovery is
@@ -717,10 +717,10 @@ fn resolve_stock_codex_path(current_executable: &Path) -> ShimResult<PathBuf> {
     let stock_codex_path = match env::var_os(STOCK_CODEX_PATH_ENV) {
         Some(configured) => PathBuf::from(configured),
         None => {
-            #[cfg(not(target_os = "windows"))]
+            #[cfg(not(any(target_os = "windows", target_os = "macos")))]
             return Err(format!("{STOCK_CODEX_PATH_ENV} is required").into());
 
-            #[cfg(target_os = "windows")]
+            #[cfg(any(target_os = "windows", target_os = "macos"))]
             {
                 let cli_override = env::var_os(CODEX_CLI_PATH_ENV)
                     .map(PathBuf::from)

--- a/crates/shim/src/lib.rs
+++ b/crates/shim/src/lib.rs
@@ -758,7 +758,7 @@ pub fn run_proxy_with_observer(
 
     let started = Instant::now();
     let shutdown_signals = ShutdownSignals::install()?;
-    let desktop_helper = desktop_invocation::is_desktop_helper();
+    let desktop_helper = desktop_invocation::is_desktop_helper(&stock_codex_path);
     let local_host_runtime = !desktop_helper
         && should_start_host_runtime(arguments)
         && host_runtime_paths_are_configured()

--- a/crates/shim/tests/fixtures/fake-codex-cli.rs
+++ b/crates/shim/tests/fixtures/fake-codex-cli.rs
@@ -194,14 +194,37 @@ fn run_orphan_shim_launcher() -> bool {
 #[allow(clippy::zombie_processes)]
 fn main() {
     let arguments = env::args().skip(1).collect::<Vec<_>>();
+    #[cfg(target_os = "macos")]
+    if let Some(desktop) = env::var_os("FAKE_CODEX_DETACHED_DESKTOP") {
+        Command::new(desktop)
+            .args(&arguments)
+            .env_remove("FAKE_CODEX_DETACHED_DESKTOP")
+            .env("FAKE_CODEX_WAIT_FOR_REPARENT", "1")
+            .spawn()
+            .expect("launch detached Desktop fixture");
+        return;
+    }
+    #[cfg(target_os = "macos")]
+    if env::var_os("FAKE_CODEX_WAIT_FOR_REPARENT").is_some() {
+        for _ in 0..100 {
+            if nix::unistd::getppid().as_raw() == 1 {
+                break;
+            }
+            thread::sleep(Duration::from_millis(5));
+        }
+        assert_eq!(nix::unistd::getppid().as_raw(), 1);
+    }
     if let Some(shim) = env::var_os("FAKE_CODEX_HELPER_SHIM") {
         let depth = environment_u64("FAKE_CODEX_HELPER_DEPTH", 0);
         let mut command = Command::new(if depth == 0 {
             PathBuf::from(shim)
         } else {
-            env::current_exe().expect("fake helper executable")
+            env::var_os("FAKE_CODEX_HELPER_EXECUTABLE")
+                .map(PathBuf::from)
+                .unwrap_or_else(|| env::current_exe().expect("fake helper executable"))
         });
         command.args(&arguments);
+        command.env_remove("FAKE_CODEX_WAIT_FOR_REPARENT");
         if depth == 0 {
             command.env_remove("FAKE_CODEX_HELPER_SHIM");
         } else {

--- a/crates/shim/tests/proxy.rs
+++ b/crates/shim/tests/proxy.rs
@@ -485,12 +485,13 @@ fn macos_native_helpers_do_not_become_host_runtime_owners() {
         if detached {
             command.env("FAKE_CODEX_DETACHED_DESKTOP", &desktop);
         }
-        let output = command
+        let mut child = command
             .args(["app-server", "--listen", "stdio://"])
             .env("FAKE_CODEX_HELPER_SHIM", shim_path())
             .env("FAKE_CODEX_HELPER_DEPTH", depth.to_string())
             .env("FAKE_CODEX_HELPER_EXECUTABLE", fake_codex_path())
             .env("FAKE_CODEX_PRINT_INVOCATION", "1")
+            .env("FAKE_CODEX_ROUTE_RESPONSE", "1")
             .env("CODEXHOST_LAUNCHER_PID", process::id().to_string())
             .env(
                 "CODEXHOST_LAUNCHER_EXECUTABLE",
@@ -507,9 +508,25 @@ fn macos_native_helpers_do_not_become_host_runtime_owners() {
             .env(CODEX_CLI_PATH_ENV, shim_path())
             .env(HOST_NODE_PATH_ENV, fake_codex_path())
             .env(HOST_RUNTIME_PATH_ENV, fake_codex_path())
-            .stdin(Stdio::null())
-            .output()
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
             .unwrap();
+        // Keep the fixture alive until the shim has published its process
+        // identity, as a real app-server does while exchanging requests.
+        let mut stdin = child.stdin.take().unwrap();
+        stdin.write_all(b"x").unwrap();
+        let mut response = [0_u8; 8];
+        child
+            .stdout
+            .as_mut()
+            .unwrap()
+            .read_exact(&mut response)
+            .unwrap();
+        assert_eq!(&response, b"response");
+        drop(stdin);
+        let output = child.wait_with_output().unwrap();
         let stderr = String::from_utf8_lossy(&output.stderr);
         assert!(output.status.success(), "depth={depth}: {stderr}");
         assert_eq!(

--- a/crates/shim/tests/proxy.rs
+++ b/crates/shim/tests/proxy.rs
@@ -13,7 +13,7 @@ use std::time::Duration;
 #[cfg(any(target_os = "windows", target_os = "macos", target_os = "linux"))]
 use std::time::Instant;
 
-#[cfg(target_os = "windows")]
+#[cfg(any(target_os = "windows", target_os = "macos"))]
 use codexhost_platform::CUSTOM_INSTALL_ROOT_ENV;
 #[cfg(any(target_os = "macos", target_os = "linux"))]
 use codexhost_platform::parent_process_id;
@@ -398,7 +398,7 @@ fn rejects_missing_official_cli_without_falling_back_to_path() {
     assert!(String::from_utf8_lossy(&output.stderr).contains("does not exist"));
 }
 
-#[cfg(target_os = "windows")]
+#[cfg(any(target_os = "windows", target_os = "macos"))]
 #[test]
 fn rejects_missing_stock_cli_when_cli_override_does_not_name_the_running_shim() {
     let output = Command::new(shim_path())
@@ -410,6 +410,51 @@ fn rejects_missing_stock_cli_when_cli_override_does_not_name_the_running_shim() 
     assert!(!output.status.success());
     assert!(output.stdout.is_empty());
     assert!(String::from_utf8_lossy(&output.stderr).contains("does not identify the running Shim"));
+}
+
+#[cfg(target_os = "macos")]
+#[test]
+fn macos_browser_helper_preserving_only_cli_override_reaches_official_cli() {
+    let directory = temporary_directory();
+    let bundle = directory.join("ChatGPT.app");
+    fs::create_dir_all(bundle.join("Contents/MacOS")).unwrap();
+    fs::create_dir_all(bundle.join("Contents/Resources")).unwrap();
+    fs::write(
+        bundle.join("Contents/Info.plist"),
+        concat!(
+            "<?xml version=\"1.0\" encoding=\"UTF-8\"?><plist version=\"1.0\"><dict>",
+            "<key>CFBundleIdentifier</key><string>com.openai.codex</string>",
+            "<key>CFBundleExecutable</key><string>ChatGPT</string>",
+            "<key>CFBundleShortVersionString</key><string>1.0.0</string>",
+            "<key>CFBundleVersion</key><string>1</string></dict></plist>"
+        ),
+    )
+    .unwrap();
+    fs::write(bundle.join("Contents/Resources/app.asar"), b"fixture").unwrap();
+    fs::copy(fake_codex_path(), bundle.join("Contents/MacOS/ChatGPT")).unwrap();
+    fs::copy(fake_codex_path(), bundle.join("Contents/Resources/codex")).unwrap();
+    let mut command = Command::new(shim_path());
+    for (key, _) in std::env::vars_os() {
+        if key.to_string_lossy().starts_with("CODEXHOST_") {
+            command.env_remove(key);
+        }
+    }
+    let output = command
+        .args(["app-server", "--listen", "stdio://"])
+        .env(CODEX_CLI_PATH_ENV, shim_path())
+        .env(CUSTOM_INSTALL_ROOT_ENV, &bundle)
+        .env("FAKE_CODEX_PRINT_INVOCATION", "1")
+        .stdin(Stdio::null())
+        .output()
+        .unwrap();
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(output.status.success(), "{stderr}");
+    assert!(
+        stderr.contains("args=app-server|--listen|stdio://"),
+        "{stderr}"
+    );
+    assert!(stderr.contains("codex_cli_path_present=false"), "{stderr}");
+    fs::remove_dir_all(directory).unwrap();
 }
 
 #[test]
@@ -480,7 +525,7 @@ fn discovers_official_cli_when_browser_helper_preserves_only_codex_cli_path() {
     .expect("remove portable Codex installation");
 }
 
-#[cfg(target_os = "windows")]
+#[cfg(any(target_os = "windows", target_os = "macos"))]
 #[test]
 fn browser_helper_fallback_does_not_guess_an_official_cli_from_path() {
     let missing_installation = temporary_directory().join("missing-portable-codex");

--- a/crates/shim/tests/proxy.rs
+++ b/crates/shim/tests/proxy.rs
@@ -413,9 +413,7 @@ fn rejects_missing_stock_cli_when_cli_override_does_not_name_the_running_shim() 
 }
 
 #[cfg(target_os = "macos")]
-#[test]
-fn macos_browser_helper_preserving_only_cli_override_reaches_official_cli() {
-    let directory = temporary_directory();
+fn macos_fixture_bundle(directory: &std::path::Path) -> PathBuf {
     let bundle = directory.join("ChatGPT.app");
     fs::create_dir_all(bundle.join("Contents/MacOS")).unwrap();
     fs::create_dir_all(bundle.join("Contents/Resources")).unwrap();
@@ -433,6 +431,14 @@ fn macos_browser_helper_preserving_only_cli_override_reaches_official_cli() {
     fs::write(bundle.join("Contents/Resources/app.asar"), b"fixture").unwrap();
     fs::copy(fake_codex_path(), bundle.join("Contents/MacOS/ChatGPT")).unwrap();
     fs::copy(fake_codex_path(), bundle.join("Contents/Resources/codex")).unwrap();
+    bundle
+}
+
+#[cfg(target_os = "macos")]
+#[test]
+fn macos_browser_helper_preserving_only_cli_override_reaches_official_cli() {
+    let directory = temporary_directory();
+    let bundle = macos_fixture_bundle(&directory);
     let mut command = Command::new(shim_path());
     for (key, _) in std::env::vars_os() {
         if key.to_string_lossy().starts_with("CODEXHOST_") {
@@ -455,6 +461,67 @@ fn macos_browser_helper_preserving_only_cli_override_reaches_official_cli() {
     );
     assert!(stderr.contains("codex_cli_path_present=false"), "{stderr}");
     fs::remove_dir_all(directory).unwrap();
+}
+
+#[cfg(target_os = "macos")]
+#[test]
+fn macos_native_helpers_do_not_become_host_runtime_owners() {
+    for (depth, detached) in [
+        (0, false),
+        (1, false),
+        (2, false),
+        (0, true),
+        (1, true),
+        (2, true),
+    ] {
+        let directory = temporary_directory();
+        let bundle = macos_fixture_bundle(&directory);
+        let desktop = bundle.join("Contents/MacOS/ChatGPT");
+        let mut command = Command::new(if detached {
+            fake_codex_path()
+        } else {
+            desktop.clone()
+        });
+        if detached {
+            command.env("FAKE_CODEX_DETACHED_DESKTOP", &desktop);
+        }
+        let output = command
+            .args(["app-server", "--listen", "stdio://"])
+            .env("FAKE_CODEX_HELPER_SHIM", shim_path())
+            .env("FAKE_CODEX_HELPER_DEPTH", depth.to_string())
+            .env("FAKE_CODEX_HELPER_EXECUTABLE", fake_codex_path())
+            .env("FAKE_CODEX_PRINT_INVOCATION", "1")
+            .env("CODEXHOST_LAUNCHER_PID", process::id().to_string())
+            .env(
+                "CODEXHOST_LAUNCHER_EXECUTABLE",
+                std::env::current_exe().unwrap(),
+            )
+            .env("CODEXHOST_DATA_DIR", &directory)
+            .env_remove("CODEXHOST_NPM_NODE_PATH")
+            .env_remove("CODEXHOST_NPM_PACKAGE_ROOT")
+            .env_remove(REMOTE_SSH_MANAGED_ENV)
+            .env(
+                STOCK_CODEX_PATH_ENV,
+                bundle.join("Contents/Resources/codex"),
+            )
+            .env(CODEX_CLI_PATH_ENV, shim_path())
+            .env(HOST_NODE_PATH_ENV, fake_codex_path())
+            .env(HOST_RUNTIME_PATH_ENV, fake_codex_path())
+            .stdin(Stdio::null())
+            .output()
+            .unwrap();
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        assert!(output.status.success(), "depth={depth}: {stderr}");
+        assert_eq!(
+            stderr.contains("args=app-server|--listen|stdio://"),
+            depth > 0,
+            "only auxiliary helpers may use stock CLI: depth={depth}, {stderr}"
+        );
+        if depth > 0 {
+            assert!(!directory.join("local-host-runtime-owner.lock").exists());
+        }
+        fs::remove_dir_all(directory).unwrap();
+    }
 }
 
 #[test]

--- a/docs/macos-native-tools.md
+++ b/docs/macos-native-tools.md
@@ -1,0 +1,48 @@
+# macOS native tool compatibility
+
+codexhost keeps the Desktop's main app-server on the Host Runtime while routing
+private native-tool app-servers to the official CLI. Tool policy, authentication,
+and approvals remain owned by the official CLI and Desktop.
+
+Two independent macOS helper paths need different handling:
+
+- Browser helpers may preserve only `CODEX_CLI_PATH`. When that path resolves to
+  the exact running Shim, it can discover the CLI inside a validated official
+  Desktop bundle. An explicit `CODEXHOST_INSTALL_ROOT` remains authoritative;
+  a missing/invalid bundle is an error. Discovery never falls back to `PATH`.
+- Native Computer Use inherits the managed Desktop's full environment. Desktop
+  launched via LaunchServices is reparented to `launchd`, so Windows-style ancestry
+  to the Launcher cannot identify these helpers. On macOS the Shim verifies the
+  live Launcher executable, then walks a bounded, start-time-checked ancestry to
+  the exact Desktop executable in the resolved official CLI's validated bundle.
+  A direct Desktop child retains Host routing; only a deeper descendant uses the
+  stock CLI with `CODEXHOST_*` bootstrap state removed. Missing or stale identity
+  evidence retains existing explicit Host/SSH routing.
+
+For a candidate switch, preserve the previous runtime and confirm that both the
+Desktop process chain and the installed Remote Host refer to the new package.
+After Desktop synchronizes its MCP configuration, reconnect idle remote tasks or
+restart the managed Remote Host during an authorized maintenance window: a tool
+process created earlier can retain an old `CODEX_CLI_PATH` even when the file on
+disk now names the new candidate. Resetting the JavaScript kernel alone does not
+necessarily recreate that process environment.
+
+Validate real Chrome navigation and page reads separately from native app
+enumeration and input. A successful CLI handshake alone does not prove either
+tool works. Likewise, Chrome availability does not establish in-app browser
+availability. IAB discovery requires a backend matching the calling session's
+metadata; do not synthesize session IDs, disable matching, or use another backend
+as evidence of IAB success. Report an unavailable IAB independently.
+
+Focused macOS regressions:
+
+```sh
+cargo test --locked -p codexhost-shim --features test-utils --test proxy macos_
+cargo test --locked -p codexhost-shim --features test-utils --test proxy browser_helper
+cargo test --locked -p codexhost-shim --features test-utils --test proxy rejects_missing_stock_cli
+```
+
+The native-helper test exchanges bytes through real Shim processes at direct and
+nested depths, including a Desktop fixture reparented to `launchd`. It asserts
+that the main app-server retains Host routing and helpers do not acquire Host
+ownership. The existing lease and SSH lifecycle regressions remain required.


### PR DESCRIPTION
## Summary

Restore macOS Chrome policy-verification startup and native Computer Use while preserving codexhost's main Desktop and SSH Host routing.

Related to #160. The user has verified in-app browsing in a local Mac Desktop task (navigation, reading, and button interaction). This PR does **not** claim to fix #130 / remote in-app browser discovery: the SSH test task still does not expose a matching IAB backend. Browser session matching is unchanged.

## Root causes and changes

1. Isolated browser helpers preserve only `CODEX_CLI_PATH`. The macOS Shim previously exited with `CODEXHOST_STOCK_CODEX_PATH is required` before the official CLI could verify policy. Extend the exact-self-override fallback to macOS using validated official Desktop bundle discovery; explicit invalid installation roots and unrelated CLI overrides remain errors, and PATH is never searched.
2. Native Computer Use inherits the full managed Desktop environment. Its auxiliary app-server entered Host ownership instead of using the stock CLI. macOS LaunchServices reparents Desktop to launchd, so the Windows launcher-ancestor heuristic does not apply. Verify the live Launcher executable and bounded, start-time-checked ancestry to the exact Desktop in the official CLI's validated bundle. Direct Desktop children retain Host routing; only nested helpers use stock with Host bootstrap variables removed.

Official policy, authentication, approvals, app-use restrictions, and browser session matching remain unchanged. No official app/plugin binary or live credentials are included.

## Validation

- Reproduced real Mac helper startup: old candidate exits in 5ms with missing stock-path error; supplying just the explicit stock path initializes successfully. Fixed Shim initializes with only its standard CLI override.
- Regression test observed failing before fix, then passing for isolated helper startup. Negative tests cover unrelated overrides, missing stock override, and absent installation without PATH fallback.
- Real process regression verifies direct and nested native helper routing, including a Desktop fixture reparented to launchd, and no helper Host ownership lock.
- Windows: `npm run format:check`, `npm run lint`, `npm run typecheck`, `npm run test:typescript` (2309 passed, 18 skipped), `npm run check:rust` passed.
- macOS: workspace Clippy `-D warnings` and all workspace Rust tests passed, including 40 Shim process tests. TypeScript and renderer build plus arm64 release packaging passed.
- macOS deployed diagnostic candidate `0.5.0-macos-native.2`: native getState/application enumeration passed; Calculator UI click sequence `2 + 3 =` read back `5`; Chrome created Example Domain, read accessibility content, clicked Learn more, and read the IANA destination. No policy bypass.
- Actual desktop Launcher/Shim/Controller/Host Runtime and Remote Host use the candidate. One desktop Controller and one desktop Host Runtime; Remote Host ready and Aqua broker running with matching plist. SSH debug task resumed across restarts and completed multiple real tool turns. Remote initialize/thread-read/configRequirements-read passed.
- User-provided local Mac Desktop test and screenshot: opened Example Domain, read page content, navigated to the Add/Remove Elements test page, and clicked Add Element to display a new Delete button. This confirms a successful local task submission and local IAB interaction; evidence is user-provided, distinct from the agent-run SSH tests above. The screenshot is not uploaded because it contains unrelated task names.
- GitHub CI on head `54cded050f2fea9faf7bda831a529fe4487fcf2a`: Ubuntu 22.04, macOS 14, Windows, and Linux ARM64 all passed. Two independent local code-review passes were reconciled against the current head with no remaining evidenced blockers; these are not GitHub maintainer approvals.

## Verification boundaries

- Local Desktop IAB and task submission passed via the user's direct test. Local task resume across a restart was not separately exercised; SSH task resume was exercised. No further restart was performed solely to extend local coverage.
- SSH IAB exposure remains unverified/unavailable in the dedicated test task, not a demonstrated universal SSH limitation. No alternative UI-control or session-matching bypass is used.
- Other Harness implementations were not changed; this verification does not claim a fresh end-to-end run of every optional Harness.

The previous stable and PR163 candidates are preserved for rollback. This is a candidate deployment, not a stable release.
