### PR TITLE
test: restore CI assertions and cold plugin load budget

### DIFF
--- a/packages/host-runtime/test/installed-harness-plugins.test.ts
+++ b/packages/host-runtime/test/installed-harness-plugins.test.ts
@@ -60,6 +60,7 @@ describe("installed Harness composition", () => {
     },
   );
 
+  // Cold bundle imports can exceed Vitest's 5s default on CI; the loader retains its 10s budget.
   it("loads all seven preinstalled plugin factories without static registration or executable discovery", async () => {
     const registry = await load();
     try {
@@ -82,7 +83,7 @@ describe("installed Harness composition", () => {
     } finally {
       await registry.close();
     }
-  });
+  }, 15_000);
 
   it("provides every built-in command catalog before inspection or Session creation", async () => {
     const expected = {

--- a/packages/renderer-extension/test/settings/localization.test.ts
+++ b/packages/renderer-extension/test/settings/localization.test.ts
@@ -51,12 +51,16 @@ describe("Renderer settings localization", () => {
     expect(chinese.updateDownloadWindowsInstaller).toBe("下载 Windows 安装包");
     expect(chinese.pageLabels.about).toBe("关于");
     expect(chinese.pageLabels["session-import"]).toBe("会话导入");
-    expect(chinese.sessionImportAvailabilityNote).toContain(
-      "当前仅支持导入 DeepSeek Harness Modern 会话",
+    expect(chinese.sessionImportAvailabilityNote).toContain("可选 Harness 来自本地 Host");
+    expect(chinese.sessionImportAvailabilityNote).toContain("先在原生客户端关闭该会话再导入");
+    expect(chinese.sessionImportAvailabilityNote).toContain("避免同时写入");
+    expect(english.sessionImportAvailabilityNote).toContain(
+      "Available Harnesses come from the local Host",
     );
     expect(english.sessionImportAvailabilityNote).toContain(
-      "only DeepSeek Harness Modern sessions",
+      "close the session in its native client before importing",
     );
+    expect(english.sessionImportAvailabilityNote).toContain("avoid concurrent writes");
     expect(chinese.aboutTagline).toBe("在 Codex Desktop 中运行 Pi 和其他 Harness");
     expect(chinese.aboutParagraphs).toHaveLength(3);
     expect(chinese.aboutStarCallout).toContain("请给我们一个 Star");


### PR DESCRIPTION
## Summary

Restore the main CI baseline with two test-only adjustments. No production, runtime, dependency, workflow, or global timeout changes.

- Update both language assertions for the session-import note: available Harnesses come from the local Host; close the native session before importing to avoid concurrent writes. Keep assertions on the safety guidance instead of restoring the obsolete DeepSeek-only product wording.
- Give the seven-preinstalled-plugin cold-load integration test a 15-second budget. Vitest's default 5 seconds was shorter than the production loader's unchanged 10-second budget. Preserve every plugin assertion and the existing loader timeout/late-cleanup regression tests.

## Evidence

Both failures predate #164: [pre-merge main run](https://github.com/BytePioneer-AI/codex-host/actions/runs/33969879763) and [post-merge main run](https://github.com/BytePioneer-AI/codex-host/actions/runs/33971054712) show the same stale localization assertion and intermittent cold-load timeout (Windows before, macOS after).

The localized copy changed in `67fffe9`; the old English and Chinese expectations remained. On the post-merge run, cold loading took 3.59s on ARM64, 4.09s on Windows, 4.14s on Ubuntu, and 5.23s on macOS, where Vitest timed it out.

## Validation

- Reproduced the original localization assertion failure in a fresh worktree at `6651cef` (1 failed / 16 passed across the two target files).
- Updated localization, installed-plugin, and loader tests: 41 passed, including timeout and late-result cleanup coverage.
- Typecheck passed; format and lint passed during `npm run check`.
- First full TypeScript suite: 2463 passed, 19 skipped, 1 unrelated failure in `delegation-control-server.test.ts` (`fetch failed`, cause `bad port`). The two changed suites passed. That untouched test file then passed 4/4 in isolation; an unchanged full-suite rerun passed 2464 tests, with 19 skipped. No retries or port workarounds were added to the code.
- Windows `npm run check:rust`: format, workspace Clippy with `-D warnings`, and workspace Rust tests passed.
- Independent Standards and Spec reviews of `40d6d40` found no actionable findings; these are local reviews, not maintainer approvals.
- Initial PR CI passed the changed tests on all four platforms. Ubuntu and Linux ARM64 completed successfully. macOS then failed the untouched Rust `cleans_an_escaped_descendant_after_the_cli_root_exits` assertion requiring a descendant-cleanup log; Windows failed the untouched Pi `indexes more than 1,000 candidates without confusing total storage with a wire page` test at the 5-second test limit. One unchanged rerun of those two failed jobs was accepted after the workflow completed (an earlier individual-job rerun was rejected while the workflow was active). Both reruns passed. This PR does not modify process-cleanup or Pi tests and does not claim to permanently fix those intermittent failures.
- Final GitHub CI on `40d6d40679b67e763b12394e0a18afa90c39d66c`: all four jobs green ([run](https://github.com/BytePioneer-AI/codex-host/actions/runs/33973998110)): Linux ARM64 2m09s, Ubuntu 2m37s, macOS 2m56s, Windows 3m47s.

This PR is independent of #164. No deployment or Desktop restart is needed for these test-only changes.
