### PR TITLE
fix: route unknown thread to single runtime for official read

### DIFF
--- a/packages/host-runtime/src/delegation-control-registry.ts
+++ b/packages/host-runtime/src/delegation-control-registry.ts
@@ -110,7 +110,7 @@ export class DelegationControlRegistry implements DelegationControlApi {
         { matchingRuntimeCount: 0 },
       );
     }
-    // ponytail: single runtime handles unknown threads so official read can return THREAD_NOT_FOUND
+    // When only one runtime session exists, forward unknown thread IDs to it so it can attempt official fallback (or return THREAD_NOT_FOUND).
     if (registrations.length === 1) return registrations[0] as DelegationControlRegistration;
     throw new DelegationControlError("THREAD_NOT_FOUND", "Thread was not found", {
       matchingRuntimeCount: 0,

--- a/packages/host-runtime/src/delegation-control-registry.ts
+++ b/packages/host-runtime/src/delegation-control-registry.ts
@@ -93,10 +93,28 @@ export class DelegationControlRegistry implements DelegationControlApi {
   }
 
   async #registrationForThread(threadId: string): Promise<DelegationControlRegistration> {
-    return only(
-      await this.#matching((registration) => registration.ownsThread(threadId)),
-      "Thread is not owned by exactly one active Host Runtime session",
-    );
+    const registrations = [...this.#registrations];
+    const matches = await this.#matching((registration) => registration.ownsThread(threadId));
+    if (matches.length === 1) return matches[0] as DelegationControlRegistration;
+    if (matches.length > 1) {
+      throw new DelegationControlError(
+        "PARENT_THREAD_AMBIGUOUS",
+        "Thread is not owned by exactly one active Host Runtime session",
+        { matchingRuntimeCount: matches.length },
+      );
+    }
+    if (registrations.length === 0) {
+      throw new DelegationControlError(
+        "PARENT_THREAD_AMBIGUOUS",
+        "Thread is not owned by exactly one active Host Runtime session",
+        { matchingRuntimeCount: 0 },
+      );
+    }
+    // ponytail: single runtime handles unknown threads so official read can return THREAD_NOT_FOUND
+    if (registrations.length === 1) return registrations[0] as DelegationControlRegistration;
+    throw new DelegationControlError("THREAD_NOT_FOUND", "Thread was not found", {
+      matchingRuntimeCount: 0,
+    });
   }
 
   #compareThreads(


### PR DESCRIPTION
Reading a valid but inactive official thread failed with PARENT_THREAD_AMBIGUOUS matchingRuntimeCount 0 because the registry blocked unknown IDs before the coordinator could try the official broker.

Change DelegationControlRegistry to route unknown thread IDs to the sole runtime when only one host session exists, so official read can return data or THREAD_NOT_FOUND. With many runtimes, unknown IDs now return THREAD_NOT_FOUND instead of ambiguous.

Checks: delegation-control-registry.test.ts 3 passed, new fallback case single routes to read and multi returns THREAD_NOT_FOUND 2 passed.