### PR TITLE
fix: price Claude Opus 5 and Claude Fable 5 requests

### DIFF
--- a/packages/adapters/claude-code/src/usage-estimate.ts
+++ b/packages/adapters/claude-code/src/usage-estimate.ts
@@ -15,8 +15,13 @@ function normalizedModel(model: string): string {
 
 function firstPartyPrice(model: string): ClaudeTokenPrice | null {
   const value = normalizedModel(model);
-  if (/claude-opus-4-(5|6|7|8)(?:-|$)/u.test(value)) {
+  if (/claude-opus-(?:5|4-(?:5|6|7|8))(?:-|$)/u.test(value)) {
     return { input: 5, cacheWrite: 6.25, cacheRead: 0.5, output: 25 };
+  }
+  if (/claude-fable-5(?:-1)?(?:-|$)/u.test(value)) {
+    return value.includes("fable-5-1")
+      ? { input: 10, cacheWrite: 12.5, cacheRead: 0.25, output: 50 }
+      : { input: 10, cacheWrite: 12.5, cacheRead: 1, output: 50 };
   }
   if (/claude-opus-4-(0|1)(?:-|$)/u.test(value) || /claude-opus-4-2025/u.test(value)) {
     return { input: 15, cacheWrite: 18.75, cacheRead: 1.5, output: 75 };

--- a/packages/adapters/claude-code/test/usage-estimate.test.ts
+++ b/packages/adapters/claude-code/test/usage-estimate.test.ts
@@ -17,6 +17,24 @@ describe("Claude request cost estimate", () => {
     expect(estimateClaudeRequestCostUsd(usage)).toBeCloseTo(0.3 + 0.075 + 0.15 + 0.15, 12);
   });
 
+  it("prices Claude Opus 5 at the Opus tier", () => {
+    expect(estimateClaudeRequestCostUsd({ ...usage, model: "claude-opus-5" })).toBeCloseTo(
+      0.5 + 0.125 + 0.25 + 0.25,
+      12,
+    );
+  });
+
+  it("prices Claude Fable 5 and Claude Fable 5.1 apart on their cache read rate", () => {
+    expect(estimateClaudeRequestCostUsd({ ...usage, model: "claude-fable-5" })).toBeCloseTo(
+      1 + 0.25 + 0.5 + 0.5,
+      12,
+    );
+    expect(estimateClaudeRequestCostUsd({ ...usage, model: "claude-fable-5-1" })).toBeCloseTo(
+      1 + 0.25 + 0.125 + 0.5,
+      12,
+    );
+  });
+
   it("does not price an unknown model or third-party Provider", () => {
     const usageWithoutModel = {
       requestId: usage.requestId,


### PR DESCRIPTION
## Summary

- The hardcoded first-party price table stops at the Claude 4.x generation plus Sonnet 5, so `firstPartyPrice` returns `null` for `claude-opus-5`, `claude-fable-5` and `claude-fable-5-1`.
- `estimateClaudeRequestCostUsd` then returns `undefined`, `estimatedCostAvailable` stays false, and the Usage popover shows no cost for a Turn on any of those models until the native `total_cost_usd` arrives with the Result.
- Opus 5 bills at the same rates as Opus 4.5-4.8, so it joins that branch rather than adding a new one.
- Fable 5 and Fable 5.1 share every rate except cache reads: Fable 5.1 is priced at 0.025x base input ($0.25/MTok) where every other model uses the standard 0.1x multiplier. One pattern matches both; the branch prices them apart.
- Rates are taken from the official pricing page as of 2026-09-06.
- No long-context tier is modelled: the 1M-token context window is billed at standard rates on Claude 4.6 and later, so there is nothing to add.
- An unknown model still returns `undefined` rather than a guessed price; that test is untouched.

## Testing

CI does not run on fork PRs before approval, so these are local results on `upstream/main` @ b71507e.

- `npx vitest run --config tests/vitest.config.js packages/adapters/claude-code/test/usage-estimate.test.ts` - 4 passed
- `npx vitest run --config tests/vitest.config.js` - 2476 passed, 9 skipped, 0 failed
- `npm run typecheck` - clean
- `npm run lint` - clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
