### PR TITLE
fix: remove superseded Mapping Store lock files on startup

### DIFF
--- a/openspec/specs/external-thread-mapping-store/spec.md
+++ b/openspec/specs/external-thread-mapping-store/spec.md
@@ -50,7 +50,11 @@ Mapping Store SHALL support replacing a ready derived Thread's NativeSessionRef,
 - **THEN** the prior ready Native Session, full mapping set, Fork source, and indexes SHALL remain authoritative
 
 ### Requirement: Startup recovers bounded incomplete state
-Initialization SHALL remove abandoned temp files, recover a bad primary from its valid backup, isolate unrecoverable records, remove creating records without Native identity, and rebuild all indexes before serving Host operations.
+Initialization SHALL remove abandoned temp files and lock files superseded by an earlier run, recover a bad primary from its valid backup, isolate unrecoverable records, remove creating records without Native identity, and rebuild all indexes before serving Host operations.
+
+#### Scenario: A dead owner's lock was renamed aside
+- **WHEN** initialization takes the Store lock from an owner that cannot be proven live
+- **THEN** it SHALL leave no superseded lock file behind, including the one it just renamed aside
 
 #### Scenario: Primary record is malformed
 - **WHEN** its latest backup is valid

--- a/packages/mapping-store/src/mapping-store.ts
+++ b/packages/mapping-store/src/mapping-store.ts
@@ -241,7 +241,7 @@ export class MappingStore {
     ]);
     await this.#acquireLock();
     try {
-      await this.#cleanupTemps();
+      await this.#cleanupResidue();
       const names = (await readdir(this.#threadsDirectory)).filter((name) =>
         name.endsWith(".json"),
       );
@@ -788,10 +788,11 @@ export class MappingStore {
     return parsed.data as StoredThreadRecordV1;
   }
 
-  async #cleanupTemps(): Promise<void> {
-    const [threadNames, delegationNames] = await Promise.all([
+  async #cleanupResidue(): Promise<void> {
+    const [threadNames, delegationNames, rootNames] = await Promise.all([
       readdir(this.#threadsDirectory),
       readdir(this.#delegationsDirectory),
+      readdir(this.#directory),
     ]);
     await Promise.all([
       ...threadNames
@@ -800,6 +801,10 @@ export class MappingStore {
       ...delegationNames
         .filter((name) => name.includes(".tmp-"))
         .map((name) => rm(path.join(this.#delegationsDirectory, name), { force: true })),
+      // Renamed aside by #acquireLock; nothing reads them back, and they accumulate one per run.
+      ...rootNames
+        .filter((name) => name.startsWith(`${path.basename(this.#lockPath)}.stale-`))
+        .map((name) => rm(path.join(this.#directory, name), { force: true })),
     ]);
   }
 

--- a/packages/mapping-store/test/index.test.ts
+++ b/packages/mapping-store/test/index.test.ts
@@ -1,4 +1,4 @@
-import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readdir, readFile, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 
@@ -887,6 +887,20 @@ describe("mapping-store package", () => {
       expect.objectContaining<Partial<MappingStoreError>>({ code: "STORE_LOCKED" }),
     );
     await first.close();
+  });
+
+  it("removes lock files left aside by earlier runs", async () => {
+    const directory = await temporaryStoreDirectory();
+    await mkdir(directory, { recursive: true });
+    await writeFile(path.join(directory, "store.lock.stale-1"), "{}\n", "utf8");
+    await writeFile(path.join(directory, "store.lock.stale-2"), "{}\n", "utf8");
+    // An unparsable lock cannot prove a live owner, so initialization renames it aside.
+    await writeFile(path.join(directory, "store.lock"), "not json\n", "utf8");
+
+    const store = new MappingStore({ directory, instanceId: "recovered" });
+    await store.initialize();
+    expect((await readdir(directory)).filter((name) => name.startsWith("store.lock."))).toEqual([]);
+    await store.close();
   });
 
   it("recovers a Windows lock whose PID was reused by another executable", async () => {


### PR DESCRIPTION
## Summary

- `store.lock.stale-<ms>` files are created by exactly one line - the rename that moves a dead owner's lock aside before taking a new one - and nothing in the repository ever removes them. Nothing reads them back either, so the Store directory grows by one file per run, forever.
- This is not a crash artefact but the normal path: `close()` releases the lock only when it is reached, and the desktop Host Runtime installs no `SIGINT`/`SIGTERM` handler (that exists only in the remote unix branch), so a Node process terminated with the Desktop process tree never runs its cleanup. On one machine that had been running the app for a while there were 14 of these, roughly one per session.
- `#cleanupTemps()` already runs at startup under the freshly acquired lock, but only sweeps `.tmp-` files inside `threads/` and `delegations/`. This widens it to the Store root and renames it to match what it now does.
- The sweep includes the file this run just created, so the steady state is zero rather than one.
- Removal is best-effort (`rm({ force: true })`), like the temp-file sweep beside it.
- `openspec/specs/external-thread-mapping-store/spec.md` is updated in the same change: the "Startup recovers bounded incomplete state" requirement is rewritten to cover superseded lock files, with a scenario for it.

Adding a signal handler to the main runtime path would be a separate change with its own semantics - racing the existing stdin-EOF exit, draining in-flight writes, `#writeTail` - and is deliberately not bundled here.

## Testing

CI does not run on fork PRs before approval, so these are local results on `upstream/main` @ b71507e.

- `npx vitest run --config tests/vitest.config.js packages/mapping-store/test/index.test.ts` - 28 passed (1 new)
- `npx vitest run --config tests/vitest.config.js` - 2475 passed, 9 skipped, 0 failed
- `npm run typecheck` - clean
- `npm run lint` - clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
