### PR TITLE
fix: release the per-frame race promise in #forwardOfficial

### DIFF
--- a/packages/host-runtime/src/app-server-host.ts
+++ b/packages/host-runtime/src/app-server-host.ts
@@ -124,7 +124,6 @@ const THREAD_USAGE_UPDATED_METHOD = "codexhost/thread/usage/updated";
 // that reading briefly cached so concurrent Composer inspections coalesce.
 const OFFICIAL_RATE_LIMIT_TTL_MS = 15_000;
 const OFFICIAL_OUTPUT_DRAIN_TIMEOUT_MS = 250;
-const NEVER_SETTLES = new Promise<never>(() => undefined);
 
 function delay(milliseconds: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, milliseconds));
@@ -1204,11 +1203,12 @@ export class AppServerHost {
           this.#diagnose(error);
         }
         this.#routeObservationTracker.bindOfficialResponse(parsed);
+        const write = this.#writer.frame(frame);
         const prematureOutputEnd = following.then((result) => {
-          if (!result.done || this.#closeRequested || this.#desktopInputEnded) return NEVER_SETTLES;
+          if (!result.done || this.#closeRequested || this.#desktopInputEnded) return write;
           throw new Error("official app-server output closed before Desktop input ended");
         });
-        await Promise.race([this.#writer.frame(frame), prematureOutputEnd]);
+        await Promise.race([write, prematureOutputEnd]);
         current = await following;
       }
     } finally {


### PR DESCRIPTION
## Summary

- Every frame forwarded from the official app-server built a derived promise from `following.then(...)`, whose callback returned the module-level `NEVER_SETTLES` on the normal path.
- Returning a thenable from `.then()` subscribes the derived promise's resolve/reject pair to it, and `NEVER_SETTLES` by construction never settles - so its reaction list grew by one entry per forwarded frame and never shrank.
- It was declared at module scope, so a single list was shared by every `AppServerHost` in the process, including every Desktop session in remote-control mode. A long streaming session forwards hundreds of thousands of frames, and the retained resolve/reject pairs are only released when the process exits.
- The fix returns the frame's own write promise instead: the derived promise settles together with the write, the reaction is released each iteration, and `Promise.race` already holds that same promise, so no new retention is introduced. `NEVER_SETTLES` has no other use (`grep` gives one call site) and is removed.
- Race semantics are unchanged. On the normal path the race still resolves exactly when the write resolves; a premature output end with Desktop input still open still rejects with the same error.
- The duplicate check that already detects a premature close stays the primary detector - this race exists only to unblock a write that would otherwise hang.

No test accompanies this: the change has no observable behaviour difference, and the retention it removes is only measurable under a forced GC, which the vitest config does not expose. Happy to add one if you would rather gate it behind `--expose-gc`.

## Testing

CI does not run on fork PRs before approval, so these are local results on `upstream/main` @ b71507e.

- `npx vitest run --config tests/vitest.config.js` - 2474 passed, 9 skipped, 0 failed
- `npm run typecheck` - clean
- `npm run lint` - clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
