### PR TITLE
fix: preserve native Codex tools and configuration; reconcile Antigravity results

### DIFF
--- a/docs/antigravity-turn-results.md
+++ b/docs/antigravity-turn-results.md
@@ -1,0 +1,28 @@
+# Antigravity responses followed by ERROR
+
+The reported native conversation contained an initial `Permission denied on
+resource project test` error followed by two completed planner responses, with
+no new error steps. Host history nevertheless recorded generic `ERROR` results
+for both later Turns. This is consistent with a historical cascade error being
+included in the CLI's result status.
+
+The Adapter checks the native `GetCascadeTrajectory` response only for a generic
+`ERROR` after a completed streamed agent response. It projects success only when:
+
+- The cascade is idle and its ID matches the result.
+- The native user-input count matches the result's Turn count.
+- An error step exists before the latest user input.
+- Every step since that input is done, without an error step or error details.
+- The last native step is a planner response at the same index as the completed
+  response observed in this invocation's stream.
+- There is no explicit result error, stderr diagnostic, permission denial, or
+  cancellation.
+
+If native evidence is unavailable or inconsistent, the original failure remains.
+Receiving response text alone never establishes success. The Adapter does not
+alter the native conversation or remove its earlier error.
+
+Validation uses reconstructed trajectory fixtures and a fake CLI to cover both
+the successful reconciliation and unavailable native evidence. A live replay
+through the built Host is still needed to establish Desktop acceptance; the
+original conversation was inspected read-only and was not replayed or modified.

--- a/docs/native-app-tools.md
+++ b/docs/native-app-tools.md
@@ -1,0 +1,15 @@
+# Native Codex app tools
+
+The official app-server must receive `CODEX_CLI_PATH` pointing to the stock
+Codex executable, not the Host shim. Bundled MCP launchers use its resource
+directory to discover the signed Node runtime when no explicit runtime is set.
+Host-only launch and routing variables are still removed.
+
+If `codex_app` fails with `Codex app tools pipe closed`, check the Desktop log
+for `dynamic_app_tools_peer_rejected reason=missing-code-signing-identity`.
+A fallback to a system Node can cause this rejection. Preserve the official
+runtime discovery path; do not disable Desktop peer signature verification.
+
+The environment regression tests cover the stock CLI replacement and removal
+of Host routing. Desktop acceptance additionally requires launching the built
+Host and successfully invoking the native task tools.

--- a/docs/native-session-configuration.md
+++ b/docs/native-session-configuration.md
@@ -1,0 +1,22 @@
+# Native Codex session configuration
+
+Host must leave native configuration resolution to official Codex. The official
+`ThreadStartParams` schema permits `model` to be omitted or null; these requests
+must reach the official app-server without an external Harness route.
+
+Previously, the Host decoder required a string Model and returned
+`thread/start params.model must be text` before the official server could use
+its configured default. This error was also present in the local Desktop logs.
+The decoder now leaves omitted/null Models unrouted and forwards the original
+request, including its config, permission settings, and instructions.
+
+The audit did not find code deleting native session settings or rewriting
+`config.toml`. Local official app-server arguments are forwarded, Host environment
+filtering retains `HOME` and `CODEX_HOME`, and the renderer's draft Harness carrier
+does not write native Model preferences. Native `thread/resume` and `turn/start`
+requests and responses remain on the official path.
+
+Regression coverage verifies default Model requests and preservation of native
+session settings in resume/continue traffic. This establishes protocol behavior,
+not recovery of previously lost settings or live Desktop acceptance. No user
+configuration files or saved conversations were changed during this audit.

--- a/packages/adapters/antigravity/src/antigravity-adapter.ts
+++ b/packages/adapters/antigravity/src/antigravity-adapter.ts
@@ -89,7 +89,12 @@ import {
 import { fetchAntigravityQuota, type AntigravityQuotaSnapshot } from "./quota.js";
 import { AntigravityQuestionBridge } from "./question-bridge.js";
 import { AntigravitySubagents } from "./subagents.js";
-import { nativeSubagentIdSchema, readSubagentTranscript } from "./subagent-transcript.js";
+import {
+  nativeSubagentIdSchema,
+  readSubagentTranscript,
+  subagentRpc,
+} from "./subagent-transcript.js";
+import { hasHistoricalAntigravityError } from "./turn-result.js";
 import {
   antigravityToolErrorMessage,
   isAntigravityPermissionDenial,
@@ -129,6 +134,7 @@ interface ActiveTurn {
   stderr: string;
   cancellationRequested: boolean;
   receivedResult: boolean;
+  completedResponseStep: number | null;
   /** agy's own effective permission mode, as reported by the `init` event. */
   nativePermissionMode: string | null;
   /** First tool denial of the Turn, kept to explain an otherwise empty result. */
@@ -770,6 +776,7 @@ class AntigravitySession implements HarnessSession {
       stderr: "",
       cancellationRequested: false,
       receivedResult: false,
+      completedResponseStep: null,
       nativePermissionMode: null,
       permissionDenial: null,
       latestUsage: null,
@@ -962,13 +969,36 @@ class AntigravitySession implements HarnessSession {
       checkpointId: safeTurnId,
       formatVersion: 1,
     });
+    let historicalError = false;
+    if (
+      !active.cancellationRequested &&
+      !active.permissionDenial &&
+      !active.stderr.trim() &&
+      event.result.status === "ERROR" &&
+      !event.result.error?.trim() &&
+      active.completedResponseStep !== null &&
+      convId === this.#nativeRef?.nativeSessionId
+    ) {
+      const port = await this.#languageServerPort(active);
+      if (port !== null) {
+        try {
+          historicalError = hasHistoricalAntigravityError(
+            await subagentRpc(port, convId, "GetCascadeTrajectory"),
+            event.result,
+            active.completedResponseStep,
+          );
+        } catch {
+          // Unavailable or incomplete native evidence must retain the CLI failure.
+        }
+      }
+    }
     if (active.cancellationRequested) {
       this.#completeTurn(
         active,
         { status: "cancelled", reason: "Cancelled by user", checkpoint },
         nativeTurnRef,
       );
-    } else if (event.result.status === "SUCCESS") {
+    } else if (event.result.status === "SUCCESS" || historicalError) {
       if (active.permissionDenial !== null && !active.agentItem) {
         this.#completeTurn(
           active,
@@ -1033,6 +1063,7 @@ class AntigravitySession implements HarnessSession {
       step = { ...step, step_type: "tool" };
     }
     if (step.step_type === "agent_response") {
+      active.completedResponseStep = step.state === "DONE" ? step.step_index : null;
       if (typeof step.text_delta === "string" && step.text_delta.length > 0) {
         this.#appendOrSyncAgentText(active, step.text_delta, true);
         return;

--- a/packages/adapters/antigravity/src/turn-result.ts
+++ b/packages/adapters/antigravity/src/turn-result.ts
@@ -1,0 +1,39 @@
+import { isRecord, type AntigravityResultEvent } from "./stream-events.js";
+
+/** Confirm an old cascade error without treating a partial response as success. */
+export function hasHistoricalAntigravityError(
+  value: unknown,
+  result: AntigravityResultEvent["result"],
+  completedResponseStep: number | null,
+): boolean {
+  if (
+    result.status !== "ERROR" ||
+    result.error?.trim() ||
+    !result.response?.trim() ||
+    completedResponseStep === null ||
+    !isRecord(value) ||
+    value.status !== "CASCADE_RUN_STATUS_IDLE" ||
+    !isRecord(value.trajectory) ||
+    value.trajectory.cascadeId !== result.conversation_id ||
+    !Array.isArray(value.trajectory.steps)
+  )
+    return false;
+  const steps = value.trajectory.steps;
+  if (!steps.every(isRecord) || completedResponseStep !== steps.length - 1) return false;
+  const starts = steps.flatMap((step, index) =>
+    step.type === "CORTEX_STEP_TYPE_USER_INPUT" ? [index] : [],
+  );
+  const start = starts.at(-1);
+  if (start === undefined || starts.length < 2 || starts.length !== result.num_turns) return false;
+  const current = steps.slice(start);
+  return (
+    steps.slice(0, start).some((step) => step.type === "CORTEX_STEP_TYPE_ERROR") &&
+    current.every(
+      (step) =>
+        step.status === "CORTEX_STEP_STATUS_DONE" &&
+        step.type !== "CORTEX_STEP_TYPE_ERROR" &&
+        step.errorDetails == null,
+    ) &&
+    current.at(-1)?.type === "CORTEX_STEP_TYPE_PLANNER_RESPONSE"
+  );
+}

--- a/packages/adapters/antigravity/test/antigravity-adapter.test.ts
+++ b/packages/adapters/antigravity/test/antigravity-adapter.test.ts
@@ -10,7 +10,9 @@ import {
   harnessThinkingOptionIdSchema,
   hostTurnIdSchema,
 } from "@codexhost/shared-contracts";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
+
+import * as nativeTrajectory from "../src/subagent-transcript.js";
 
 import {
   ANTIGRAVITY_WORKSPACE_FILE_INSTRUCTION,
@@ -469,7 +471,10 @@ describe("Antigravity Adapter", () => {
   });
 
   describe("Session Lifecycle & Tool Streaming", () => {
-    async function fakeStreamingAgy(streamLines: readonly string[]): Promise<{
+    async function fakeStreamingAgy(
+      streamLines: readonly string[],
+      writeLog = false,
+    ): Promise<{
       command: string;
       cwd: string;
       cleanup(): Promise<void>;
@@ -488,6 +493,10 @@ if (process.argv.includes("models")) {
   process.exit(0);
 }
 for (const line of lines) {
+  if (${writeLog} && process.argv.includes("--log-file")) {
+    require("node:fs").writeFileSync(process.argv[process.argv.indexOf("--log-file") + 1],
+      "Language server listening on random port at 12345 for HTTPS (gRPC)");
+  }
   process.stdout.write(line + "\\n");
 }
 `;
@@ -708,6 +717,73 @@ for (const line of lines) {
         await cleanup();
       }
     });
+
+    it.each([true, false])(
+      "checks native evidence before correcting a historical ERROR (%s)",
+      async (available) => {
+        const rpc = vi.spyOn(nativeTrajectory, "subagentRpc").mockImplementation(async () => {
+          if (!available) throw new Error("native trajectory unavailable");
+          return {
+            status: "CASCADE_RUN_STATUS_IDLE",
+            trajectory: {
+              cascadeId: "conv-history",
+              steps: ["USER_INPUT", "ERROR", "USER_INPUT", "PLANNER_RESPONSE"].map((type) => ({
+                type: `CORTEX_STEP_TYPE_${type}`,
+                status: "CORTEX_STEP_STATUS_DONE",
+              })),
+            },
+          };
+        });
+        const { command, cwd, cleanup } = await fakeStreamingAgy(
+          [
+            JSON.stringify({ event: "init", conversation_id: "conv-history" }),
+            JSON.stringify({
+              event: "step_update",
+              step_update: {
+                conversation_id: "conv-history",
+                step_index: 3,
+                state: "DONE",
+                step_type: "agent_response",
+                text: "Hello!",
+              },
+            }),
+            JSON.stringify({
+              event: "result",
+              result: {
+                conversation_id: "conv-history",
+                status: "ERROR",
+                response: "Hello!",
+                num_turns: 2,
+              },
+            }),
+          ],
+          true,
+        );
+        const adapter = new AntigravityAdapter({ command });
+        try {
+          const opened = await adapter.open({ kind: "create", cwd });
+          if (!opened.ok) throw new Error(opened.error.message);
+          const session = opened.value;
+          const iterator = session.outputs[Symbol.asyncIterator]();
+          await session.execute({
+            type: "turn.start",
+            turnId: hostTurnIdSchema.parse("history-error"),
+            input: [{ type: "text", text: "hi" }],
+          });
+          let event: HostEvent;
+          do {
+            event = await nextEvent(iterator);
+          } while (event.type !== "turn.completed");
+          expect(event).toMatchObject({ outcome: { status: available ? "succeeded" : "failed" } });
+          expect(rpc).toHaveBeenCalledWith(12345, "conv-history", "GetCascadeTrajectory");
+          await session.close();
+        } finally {
+          rpc.mockRestore();
+          await adapter.close();
+          await cleanup();
+        }
+      },
+    );
 
     it("emits turn.completed with failed outcome on CLI error", async () => {
       const streamLines = [

--- a/packages/adapters/antigravity/test/turn-result.test.ts
+++ b/packages/adapters/antigravity/test/turn-result.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "vitest";
+
+import { hasHistoricalAntigravityError } from "../src/turn-result.js";
+
+const step = (type: string) => ({
+  type: `CORTEX_STEP_TYPE_${type}`,
+  status: "CORTEX_STEP_STATUS_DONE",
+});
+// Reconstructed from the reported native conversation: the first Turn had a
+// project permission error, followed by a completed reply in the next Turn.
+const trajectory = () => ({
+  status: "CASCADE_RUN_STATUS_IDLE",
+  trajectory: {
+    cascadeId: "conversation",
+    steps: [step("USER_INPUT"), step("ERROR"), step("USER_INPUT"), step("PLANNER_RESPONSE")],
+  },
+});
+const result = {
+  conversation_id: "conversation",
+  status: "ERROR",
+  response: "Hello! How can I help you today?",
+  num_turns: 2,
+};
+
+describe("Antigravity historical result errors", () => {
+  it("requires a native completed current Turn after a historical error", () => {
+    expect(hasHistoricalAntigravityError(trajectory(), result, 3)).toBe(true);
+  });
+
+  it.each(["ERROR", "RUNNING", "UNSPECIFIED"])("retains a current %s step", (status) => {
+    const value = trajectory();
+    value.trajectory.steps[3] = {
+      ...step("PLANNER_RESPONSE"),
+      status: `CORTEX_STEP_STATUS_${status}`,
+    };
+    expect(hasHistoricalAntigravityError(value, result, 3)).toBe(false);
+  });
+
+  it("retains a current cascade error even when the error step itself is DONE", () => {
+    const value = trajectory();
+    value.trajectory.steps.splice(3, 0, step("ERROR"));
+    expect(hasHistoricalAntigravityError(value, result, 4)).toBe(false);
+  });
+
+  it("does not infer success from response text or missing evidence", () => {
+    for (const value of [null, {}, { trajectory: {} }]) {
+      expect(hasHistoricalAntigravityError(value, result, 3)).toBe(false);
+    }
+    expect(hasHistoricalAntigravityError(trajectory(), result, null)).toBe(false);
+    expect(hasHistoricalAntigravityError(trajectory(), result, 2)).toBe(false);
+    expect(hasHistoricalAntigravityError(trajectory(), { ...result, response: "" }, 3)).toBe(false);
+    expect(
+      hasHistoricalAntigravityError(trajectory(), { ...result, error: "stream lost" }, 3),
+    ).toBe(false);
+  });
+
+  it("rejects a different session, stale Turn count, or running cascade", () => {
+    expect(
+      hasHistoricalAntigravityError(trajectory(), { ...result, conversation_id: "other" }, 3),
+    ).toBe(false);
+    expect(hasHistoricalAntigravityError(trajectory(), { ...result, num_turns: 3 }, 3)).toBe(false);
+    expect(
+      hasHistoricalAntigravityError(
+        { ...trajectory(), status: "CASCADE_RUN_STATUS_RUNNING" },
+        result,
+        3,
+      ),
+    ).toBe(false);
+  });
+
+  it("requires an old error and a terminal planner response", () => {
+    const value = trajectory();
+    value.trajectory.steps[1] = step("PLANNER_RESPONSE");
+    expect(hasHistoricalAntigravityError(value, result, 3)).toBe(false);
+    value.trajectory.steps[1] = step("ERROR");
+    value.trajectory.steps[3] = step("CODE_ACTION");
+    expect(hasHistoricalAntigravityError(value, result, 3)).toBe(false);
+  });
+
+  it("retains native error details in the current Turn", () => {
+    const value = trajectory();
+    value.trajectory.steps[3] = Object.assign(step("PLANNER_RESPONSE"), {
+      errorDetails: { message: "failure" },
+    });
+    expect(hasHistoricalAntigravityError(value, result, 3)).toBe(false);
+  });
+});

--- a/packages/host-runtime/src/app-server-host.ts
+++ b/packages/host-runtime/src/app-server-host.ts
@@ -281,9 +281,15 @@ export function officialEnvironment(source: NodeJS.ProcessEnv): NodeJS.ProcessEn
     "CODEXHOST_NPM_LAUNCHER_PATH",
     "CODEXHOST_NPM_PACKAGE_ROOT",
   ]);
-  return Object.fromEntries(
+  const environment = Object.fromEntries(
     Object.entries(source).filter(([key]) => !internal.has(key) || allowed.has(key)),
   );
+  // Bundled MCP launchers resolve the signed Node runtime beside the official
+  // CLI. Removing this path makes them fall back to an unsigned system Node.
+  if (source.CODEXHOST_STOCK_CODEX_PATH) {
+    environment.CODEX_CLI_PATH = source.CODEXHOST_STOCK_CODEX_PATH;
+  }
+  return environment;
 }
 
 function rpcEnvelope(request: JsonRpcRequest, value: JsonObject): JsonObject {

--- a/packages/host-runtime/test/app-server-host.test.ts
+++ b/packages/host-runtime/test/app-server-host.test.ts
@@ -6658,6 +6658,82 @@ describe("AppServerHost HarnessAdapter projection", () => {
     await stopFixture(fixture);
   });
 
+  it.each([{}, { model: null }])(
+    "preserves native default Model and configuration (%j)",
+    async (model) => {
+      const fixture = createFixture();
+      const officialRequests = new JsonLineCollector(fixture.official.stdin);
+      const request = {
+        id: 901,
+        method: "thread/start",
+        params: {
+          ...model,
+          cwd: "/native/project",
+          config: {
+            model: "configured-model",
+            model_reasoning_effort: "high",
+            futureSetting: { value: 7 },
+          },
+          approvalPolicy: "on-request",
+          sandbox: "workspace-write",
+          developerInstructions: "Preserve native instructions",
+        },
+      };
+      try {
+        writeRequest(fixture.desktopInput, request);
+        await expect(officialRequests.waitFor((value) => value.id === 901)).resolves.toEqual(
+          request,
+        );
+        expect(fixture.adapter.sessions).toHaveLength(0);
+      } finally {
+        await stopFixture(fixture);
+      }
+    },
+  );
+
+  it.each(["thread/resume", "turn/start"])(
+    "preserves native session settings in %s and its response",
+    async (method) => {
+      const fixture = createFixture();
+      const officialRequests = new JsonLineCollector(fixture.official.stdin);
+      const request = {
+        id: 902,
+        method,
+        params: {
+          threadId: "official-thread",
+          model: "native-model",
+          effort: "high",
+          approvalPolicy: "on-request",
+          config: { model_reasoning_effort: "high" },
+          developerInstructions: "Keep native session instructions",
+        },
+      };
+      const response = {
+        id: 902,
+        result: {
+          model: "native-model",
+          reasoningEffort: "high",
+          approvalPolicy: "on-request",
+          sandbox: { type: "workspaceWrite", networkAccess: false },
+          thread: { id: "official-thread", futureSessionSetting: "preserved" },
+        },
+      };
+      try {
+        writeRequest(fixture.desktopInput, request);
+        await expect(officialRequests.waitFor((value) => value.id === 902)).resolves.toEqual(
+          request,
+        );
+        fixture.official.stdout.write(`${JSON.stringify(response)}\n`);
+        await expect(fixture.collector.waitFor((value) => value.id === 902)).resolves.toEqual(
+          response,
+        );
+        expect(fixture.adapter.sessions).toHaveLength(0);
+      } finally {
+        await stopFixture(fixture);
+      }
+    },
+  );
+
   it("forwards Codex-owned requests without opening a Pi Session", async () => {
     const fixture = createFixture();
     fixture.official.stdin.once("data", (chunk: Buffer) => {

--- a/packages/host-runtime/test/official-environment.test.ts
+++ b/packages/host-runtime/test/official-environment.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+
+import { officialEnvironment } from "../src/app-server-host.js";
+
+describe("official tool runtime discovery", () => {
+  it("replaces the shim with the bundled CLI while stripping Host routing", () => {
+    expect(
+      officialEnvironment({
+        CODEX_CLI_PATH: "/host/shim",
+        CODEXHOST_STOCK_CODEX_PATH: "/Applications/Codex.app/Contents/Resources/codex",
+        CODEXHOST_HOST_NODE_PATH: "/opt/homebrew/bin/node",
+        CODEX_APP_TOOLS_PIPE_PATH: "/tmp/desktop-tools.sock",
+      }),
+    ).toEqual({
+      CODEX_CLI_PATH: "/Applications/Codex.app/Contents/Resources/codex",
+      CODEX_APP_TOOLS_PIPE_PATH: "/tmp/desktop-tools.sock",
+    });
+  });
+
+  it("does not retain a shim override without an official CLI path", () => {
+    expect(officialEnvironment({ CODEX_CLI_PATH: "/host/shim" })).toEqual({});
+  });
+});

--- a/packages/protocol-core/src/model-routing.ts
+++ b/packages/protocol-core/src/model-routing.ts
@@ -586,7 +586,13 @@ export function decodeExternalTransportModel(
 
 export function decodeCreateRoute(request: JsonRpcRequest): CreateRoute | null {
   if (request.method !== "thread/start") return null;
-  if (!isJsonObject(request.params) || typeof request.params.model !== "string") {
+  if (!isJsonObject(request.params)) {
+    throw new Error("thread/start params must be an object");
+  }
+  // A missing/null Model asks official Codex to resolve its configured default.
+  // There is no external transport carrier to route in that case.
+  if (request.params.model === undefined || request.params.model === null) return null;
+  if (typeof request.params.model !== "string") {
     throw new Error("thread/start params.model must be text");
   }
 

--- a/packages/protocol-core/test/model-routing.test.ts
+++ b/packages/protocol-core/test/model-routing.test.ts
@@ -100,6 +100,12 @@ describe("external Harness transport model routing", () => {
     expect(decodeCreateRoute({ id: 4, method: "model/list", params: {} })).toBeNull();
   });
 
+  it("leaves default Model resolution to official Codex", () => {
+    for (const params of [{}, { model: null }, { config: { model: "configured-model" } }]) {
+      expect(decodeCreateRoute({ id: 3, method: "thread/start", params })).toBeNull();
+    }
+  });
+
   it("round-trips a bounded opaque selected Pi Model Ref", () => {
     const model = harnessModelRefSchema.parse({ id: "pi-model-v1.cHJvdmlkZXItaWQ" });
     const transportModelId = encodePiTransportModel(model);


### PR DESCRIPTION
This change addresses three native compatibility failures while preserving official Codex configuration and Harness ownership boundaries described in the README.

- Preserve the stock Codex CLI path for bundled MCP launchers so native app tools can locate the signed Node runtime instead of falling back to an unsigned system Node.
- Reconcile a generic Antigravity ERROR only when native trajectory evidence confirms an old error and a fully completed current Turn matching this invocation's streamed response. Explicit errors, missing evidence, and cancellation remain failures.
- Forward thread/start requests with an omitted or null Model to official Codex so its default configuration can take effect. Cover native resume and continue configuration passthrough.

The fixes are kept in three separate commits. No user configuration or historical conversation data was modified. There are no linked issue numbers.

Validation performed:
- TypeScript and Harness plugin build; renderer build; native Rust build on macOS arm64.
- npm run typecheck, focused ESLint and Prettier checks, package boundary check, and git diff --check.
- Native environment/remote-control tests: 11 passed, 1 skipped.
- Antigravity Adapter/result tests: 37 passed (run outside the restricted sandbox because the offline question bridge requires a loopback listener).
- Model routing tests: 33 passed; native configuration passthrough tests: 4 passed.

Live Desktop acceptance is still pending. The Antigravity regression fixtures reconstruct the observed trajectory; they are not a live replay. No full test-suite or cross-platform acceptance claim is made.
