### PR TITLE
feat(deepseek-harness): import Legacy DSH Sessions

### DIFF
--- a/docs/harness-session-import.md
+++ b/docs/harness-session-import.md
@@ -2,12 +2,12 @@
 
 ## 当前范围
 
-设置 → 会话导入可登记 **Pi 原生 v3 Session** 和 **DSH Modern Session**。导入只建立 Host Thread 与原生 Session 的映射，不复制 Transcript、不转换 Harness、不发送用户 Turn；打开后仍通过对应 Adapter 的 `open({ kind: "resume" })` 恢复历史并继续会话。
+设置 → 会话导入可登记 **Pi 原生 v3 Session**、**DSH Modern Session** 和 **DSH Legacy Session**。导入只建立 Host Thread 与原生 Session 的映射，不复制 Transcript、不转换 Harness、不发送用户 Turn；打开后仍通过对应 Adapter 的 `open({ kind: "resume" })` 恢复历史并继续会话。
 
 - 设置页始终使用本地 Host，即使 Composer 当前连接远程工作区。
 - 可选 Harness 来自该 Host 已加载、同时提供发现和解析能力的 Adapter，不使用 Renderer 内置 Harness 名单。
-- 目录表示“实现了导入接口”，不保证当前原生运行时可用。DSH Legacy、旧 Host、缺失插件或不可用存储会明确失败，不伪装成无候选。
-- DSH 仍保留原先本机、codexhost 管理的 exact `dsh-v0.1.2-rc.1` Modern 限定。
+- 目录表示“实现了导入接口”，不保证当前原生运行时可用。旧 Host、缺失插件或不可用存储会明确失败，不伪装成无候选。
+- DSH Modern 保留本机、codexhost 管理的 exact `dsh-v0.1.2-rc.1` 限定；DSH Legacy 通过 `dsh-v0.1.1-rc.2` 的 Host `session.list` 发现会话，并用同一原生 ID 恢复。
 - 本次没有增加远程扫描、CC direct/Broker 导入，也没有完成整个 Agent Picker 的动态插件化。
 
 ## Adapter 契约与职责

--- a/packages/adapters/deepseek-harness/src/deepseek-harness-adapter.ts
+++ b/packages/adapters/deepseek-harness/src/deepseek-harness-adapter.ts
@@ -202,17 +202,22 @@ export class DeepSeekHarnessAdapter implements HarnessAdapter {
     try {
       const selected = await this.#select(false);
       if (this.#closed) return { ok: false, error: closedError() };
-      if (selected.generation !== "modern") {
+      const capability = (
+        selected.adapter as HarnessAdapter & {
+          sessionImport?: HarnessSessionImportCapability;
+        }
+      ).sessionImport;
+      if (!capability) {
         return {
           ok: false,
           error: {
             code: "unsupported",
-            message: "DeepSeek Harness Session import requires the Modern protocol",
+            message: "DeepSeek Harness Session import is unsupported",
             retryable: false,
           },
         };
       }
-      return (selected.adapter as ModernDelegateAdapter).sessionImport.listCandidates();
+      return capability.listCandidates();
     } catch (error) {
       return { ok: false, error: this.#selectionError(error) };
     }

--- a/packages/adapters/deepseek-harness/src/legacy/deepseek-harness-adapter.ts
+++ b/packages/adapters/deepseek-harness/src/legacy/deepseek-harness-adapter.ts
@@ -27,6 +27,7 @@ import {
   type HarnessResult,
   type HarnessSession,
   type HarnessSessionCapabilities,
+  type HarnessSessionImportCapability,
   type HarnessSessionState,
   type HostAgentMessageItem,
   type HostApprovalInteraction,
@@ -67,6 +68,7 @@ import {
   nativeCheckpointRefSchema,
   nativeSessionRefSchema,
   nativeTurnRefSchema,
+  type DeepSeekModernSessionCandidate,
   type HarnessId,
   type HarnessPermissionModeCatalog,
   type HarnessPermissionModeId,
@@ -94,6 +96,7 @@ import {
   projectDeepSeekHistory,
   resolveDeepSeekForkBoundary,
 } from "./history.js";
+import { parseLegacySessionCandidates } from "./session-list.js";
 import {
   decodeDeepSeekHarnessModelRef,
   encodeDeepSeekHarnessModelRef,
@@ -1987,6 +1990,9 @@ class DeepSeekHarnessSession implements HarnessSession, DeepSeekHostSubscriber {
 export class DeepSeekHarnessAdapter implements HarnessAdapter {
   readonly commandCatalog = deepSeekHarnessCommandCatalog();
   readonly harnessId: HarnessId = deepSeekHarnessId;
+  readonly sessionImport: HarnessSessionImportCapability = Object.freeze({
+    listCandidates: () => this.#listSessionImportCandidates(),
+  });
   readonly #connection: DeepSeekHostConnectionLike;
   readonly #dependencies: DeepSeekHarnessAdapterDependencies;
   readonly #options: DeepSeekHarnessAdapterOptions;
@@ -2005,6 +2011,21 @@ export class DeepSeekHarnessAdapter implements HarnessAdapter {
       createConnection: (connectionOptions) => new DeepSeekHostConnection(connectionOptions),
     };
     this.#connection = this.#dependencies.createConnection(options);
+  }
+
+  async #listSessionImportCandidates(): Promise<
+    HarnessResult<readonly DeepSeekModernSessionCandidate[]>
+  > {
+    if (this.#closePromise) {
+      return { ok: false, error: invalidState("DeepSeek Harness Adapter is closing") };
+    }
+    try {
+      await this.#connection.connect();
+      const listed = unwrapRpc(await this.#connection.client.sessions.list({}), "session.list");
+      return { ok: true, value: parseLegacySessionCandidates(listed.items) };
+    } catch (error) {
+      return { ok: false, error: normalizedError(error, "unavailable") };
+    }
   }
 
   async inspect(): Promise<HarnessInspection> {

--- a/packages/adapters/deepseek-harness/src/legacy/session-list.ts
+++ b/packages/adapters/deepseek-harness/src/legacy/session-list.ts
@@ -1,0 +1,74 @@
+import path from "node:path";
+
+import type { SessionSummary } from "@deepseek-ai/dsh-host-apiproxy/api";
+
+import {
+  DEEPSEEK_MODERN_SESSION_CWD_MAX_LENGTH,
+  DEEPSEEK_MODERN_SESSION_ID_MAX_LENGTH,
+  DEEPSEEK_MODERN_SESSION_TITLE_MAX_LENGTH,
+  type DeepSeekModernSessionCandidate,
+} from "@codexhost/shared-contracts";
+
+interface LegacySessionProjections {
+  readonly asOfSeq?: number;
+  readonly values?: Record<string, unknown>;
+}
+
+function validSessionId(value: string): boolean {
+  return (
+    value.trim().length > 0 &&
+    !value.includes("\0") &&
+    value.length <= DEEPSEEK_MODERN_SESSION_ID_MAX_LENGTH
+  );
+}
+
+function canonicalAbsoluteCwd(value: string | undefined): value is string {
+  return (
+    value !== undefined &&
+    value.trim().length > 0 &&
+    !value.includes("\0") &&
+    path.isAbsolute(value) &&
+    path.resolve(value) === value &&
+    value.length <= DEEPSEEK_MODERN_SESSION_CWD_MAX_LENGTH
+  );
+}
+
+function titleFromProjections(value: unknown): string | null {
+  if (typeof value !== "object" || value === null) return null;
+  const projections = value as LegacySessionProjections;
+  if (typeof projections.values !== "object" || projections.values === null) return null;
+  const title = projections.values.title;
+  if (typeof title !== "string") return null;
+  const trimmed = title.trim();
+  return trimmed.length > 0 &&
+    !trimmed.includes("\0") &&
+    trimmed.length <= DEEPSEEK_MODERN_SESSION_TITLE_MAX_LENGTH
+    ? trimmed
+    : null;
+}
+
+/**
+ * Convert a validated Legacy DSH 'session.list' payload into importable
+ * candidates. The Legacy RPC client already enforces the wire schema, so this
+ * converter only applies the codexhost import eligibility rules shared with the
+ * Modern path: skip subagents and blank sessions, and require a canonical
+ * absolute cwd.
+ */
+export function parseLegacySessionCandidates(
+  items: readonly SessionSummary[],
+): DeepSeekModernSessionCandidate[] {
+  const candidates: DeepSeekModernSessionCandidate[] = [];
+  for (const item of items) {
+    if (!validSessionId(item.sessionId)) continue;
+    if (item.origin === "subagent" || item.blank) continue;
+    if (!canonicalAbsoluteCwd(item.cwd)) continue;
+    candidates.push({
+      nativeSessionId: item.sessionId,
+      title: titleFromProjections(item.projections),
+      updatedAt: item.updatedAt,
+      cwd: item.cwd,
+      running: item.running,
+    });
+  }
+  return candidates;
+}

--- a/packages/adapters/deepseek-harness/test/deepseek-harness-adapter.test.ts
+++ b/packages/adapters/deepseek-harness/test/deepseek-harness-adapter.test.ts
@@ -228,7 +228,7 @@ describe("DeepSeek public generation selector", () => {
     await adapter.close();
   });
 
-  it("rejects Session discovery on Legacy without calling its Session API", async () => {
+  it("forwards Session discovery to the selected Legacy generation", async () => {
     const legacy = new FakeAdapter();
     const adapter = new DeepSeekHarnessAdapter(
       {},
@@ -238,15 +238,61 @@ describe("DeepSeek public generation selector", () => {
       },
     );
 
-    await expect(adapter.sessionImport.listCandidates()).resolves.toMatchObject({
-      ok: false,
-      error: { code: "unsupported", retryable: false },
+    await expect(adapter.sessionImport.listCandidates()).resolves.toEqual({
+      ok: true,
+      value: [],
     });
-    await expect(adapter.sessionImport.resolveCandidate("native")).resolves.toMatchObject({
-      ok: false,
-      error: { code: "unsupported" },
+    expect(legacy.listCalls).toBe(1);
+    await adapter.close();
+  });
+
+  it("revalidates Legacy import metadata through the same public resolver", async () => {
+    const legacy = new FakeAdapter();
+    const list = vi
+      .spyOn(legacy.sessionImport, "listCandidates")
+      .mockResolvedValueOnce({
+        ok: true,
+        value: [
+          {
+            nativeSessionId: "legacy-native",
+            cwd: "/project",
+            title: "Legacy session",
+            updatedAt: 2,
+            running: false,
+          },
+        ],
+      })
+      .mockResolvedValueOnce({ ok: true, value: [] });
+    const adapter = new DeepSeekHarnessAdapter(
+      {},
+      {
+        probeExecutable: () => Promise.resolve(legacyExecutable),
+        createLegacyAdapter: () => legacy,
+      },
+    );
+
+    expect(await adapter.sessionImport.resolveCandidate("legacy-native")).toEqual({
+      ok: true,
+      value: {
+        candidate: {
+          nativeSessionId: "legacy-native",
+          cwd: "/project",
+          title: "Legacy session",
+          updatedAt: 2,
+          running: false,
+        },
+        nativeRef: {
+          harnessId: "deepseek-harness",
+          nativeSessionId: "legacy-native",
+          formatVersion: 1,
+        },
+      },
     });
-    expect(legacy.listCalls).toBe(0);
+    expect(await adapter.sessionImport.resolveCandidate("legacy-native")).toMatchObject({
+      ok: false,
+      error: { code: "sessionNotFound" },
+    });
+    expect(list).toHaveBeenCalledTimes(2);
     await adapter.close();
   });
 

--- a/packages/adapters/deepseek-harness/test/legacy/deepseek-harness-adapter.test.ts
+++ b/packages/adapters/deepseek-harness/test/legacy/deepseek-harness-adapter.test.ts
@@ -544,6 +544,62 @@ describe("DeepSeekHarnessAdapter local Host", () => {
     await adapter.close();
   });
 
+  it("lists importable Legacy Sessions from the local Host Session API", async () => {
+    const { adapter, connection } = fixture();
+    connection.calls.list.mockResolvedValueOnce(
+      success({
+        items: [
+          {
+            sessionId: "session-legacy-1",
+            updatedAt: 42,
+            running: false,
+            blank: false,
+            cwd: "/workspace",
+            projections: { asOfSeq: 12, values: { title: "Importable session" } },
+          },
+          {
+            sessionId: "session-blank",
+            updatedAt: 41,
+            running: false,
+            blank: true,
+            cwd: "/workspace",
+          },
+          {
+            sessionId: "session-subagent",
+            updatedAt: 40,
+            running: false,
+            blank: false,
+            origin: "subagent",
+            cwd: "/workspace",
+          },
+          {
+            sessionId: "session-relative-cwd",
+            updatedAt: 39,
+            running: false,
+            blank: false,
+            cwd: "relative/project",
+          },
+        ],
+      }),
+    );
+
+    await expect(adapter.sessionImport.listCandidates()).resolves.toEqual({
+      ok: true,
+      value: [
+        {
+          nativeSessionId: "session-legacy-1",
+          title: "Importable session",
+          updatedAt: 42,
+          cwd: "/workspace",
+          running: false,
+        },
+      ],
+    });
+    expect(connection.connected).toBe(true);
+    expect(connection.calls.list).toHaveBeenCalledWith({});
+    await adapter.close();
+  });
+
   it("publishes stable live and historical Checkpoints for every native Turn outcome", async () => {
     const { adapter, connection } = fixture();
     await expect(adapter.inspect()).resolves.toMatchObject({

--- a/packages/adapters/deepseek-harness/test/legacy/session-list.test.ts
+++ b/packages/adapters/deepseek-harness/test/legacy/session-list.test.ts
@@ -1,0 +1,68 @@
+import type { SessionSummary } from "@deepseek-ai/dsh-host-apiproxy/api";
+import type { SessionId } from "@deepseek-ai/dsh-session/types";
+import { describe, expect, it } from "vitest";
+
+import { parseLegacySessionCandidates } from "../../src/legacy/session-list.js";
+
+function item(overrides: Record<string, unknown> = {}): SessionSummary {
+  return {
+    sessionId: "session-1" as SessionId,
+    updatedAt: 10,
+    running: false,
+    blank: false,
+    cwd: "/workspace",
+    ...overrides,
+  } as SessionSummary;
+}
+
+describe("parseLegacySessionCandidates", () => {
+  it("keeps resumable Legacy Sessions and reads the title projection", () => {
+    expect(
+      parseLegacySessionCandidates([
+        item({
+          projections: { asOfSeq: 5, values: { title: "Project session" } },
+        }),
+      ]),
+    ).toEqual([
+      {
+        nativeSessionId: "session-1",
+        title: "Project session",
+        updatedAt: 10,
+        cwd: "/workspace",
+        running: false,
+      },
+    ]);
+  });
+
+  it("skips subagent, blank, relative, and malformed Sessions", () => {
+    expect(
+      parseLegacySessionCandidates([
+        item({ sessionId: "sub", origin: "subagent" }),
+        item({ sessionId: "blank", blank: true }),
+        item({ sessionId: "relative", cwd: "relative/project" }),
+        item({ sessionId: "missing-cwd", cwd: undefined }),
+        item({ sessionId: "", cwd: "/workspace" }),
+      ]),
+    ).toEqual([]);
+  });
+
+  it("preserves the native running state and null title", () => {
+    expect(
+      parseLegacySessionCandidates([
+        item({
+          sessionId: "running-session",
+          running: true,
+          projections: { asOfSeq: 0, values: {} },
+        }),
+      ]),
+    ).toEqual([
+      {
+        nativeSessionId: "running-session",
+        title: null,
+        updatedAt: 10,
+        cwd: "/workspace",
+        running: true,
+      },
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary

`codexhost` already imported Modern DSH (`dsh-v0.1.2-rc.1`) Sessions, but the public DeepSeek adapter rejected Session discovery on the Legacy generation (`dsh-v0.1.1-rc.2`). This PR enables importing Legacy DSH Sessions by exposing the existing Host `session.list` API through the adapter's Session-import contract.

## Changes

- Add `sessionImport.listCandidates` to the Legacy DeepSeek adapter, backed by the native Host `session.list` RPC.
- Add a Legacy Session parser that:
  - skips subagents, blank Sessions, and Sessions without a canonical absolute cwd;
  - reads the title from the native projection cache when present;
  - preserves the native running state.
- Update the public DeepSeek adapter to delegate Session discovery to whichever generation was selected instead of rejecting Legacy.
- Extend public-adapter and Legacy-adapter tests, add focused parser tests, and update `docs/harness-session-import.md`.

## Validation

- `npm run typecheck`
- `npx vitest run --config tests/vitest.config.js packages/adapters/deepseek-harness/test/deepseek-harness-adapter.test.ts packages/adapters/deepseek-harness/test/legacy/session-list.test.ts packages/adapters/deepseek-harness/test/legacy/deepseek-harness-adapter.test.ts` — 81 tests passed
- `npx eslint` on changed TypeScript files

Import still only maps the Native Session identity; it does not copy Transcripts or start a native Turn. Legacy resume uses the existing `open({ kind: "resume" })` path with the same native Session ID.