### PR TITLE
fix(shim): keep Computer History summarizer on stock CLI

### DIFF
--- a/crates/shim/src/lib.rs
+++ b/crates/shim/src/lib.rs
@@ -2,7 +2,7 @@
 
 use std::env;
 use std::error::Error;
-use std::ffi::OsString;
+use std::ffi::{OsStr, OsString};
 use std::io::{self, Read, Write};
 use std::path::{Path, PathBuf};
 use std::process::{Command, ExitStatus, Stdio};
@@ -35,6 +35,8 @@ const LAUNCHER_PID_ENV: &str = "CODEXHOST_LAUNCHER_PID";
 const NPM_NODE_PATH_ENV: &str = "CODEXHOST_NPM_NODE_PATH";
 const NPM_PACKAGE_ROOT_ENV: &str = "CODEXHOST_NPM_PACKAGE_ROOT";
 const REMOTE_LISTENER_CHILD_ENV: &str = "CODEXHOST_REMOTE_LISTENER_CHILD";
+const INTERNAL_ORIGINATOR_OVERRIDE_ENV: &str = "CODEX_INTERNAL_ORIGINATOR_OVERRIDE";
+const DESKTOP_ORIGINATOR: &str = "Codex Desktop";
 
 /// Optional lifecycle hooks for diagnostics around the byte-transparent proxy core.
 pub trait ProxyObserver {
@@ -326,6 +328,51 @@ pub fn app_server_subcommand_index(arguments: &[OsString]) -> Option<usize> {
     None
 }
 
+/// Returns whether the app-server invocation belongs to the Skysight memory summarizer.
+///
+/// Skysight starts a short-lived stock Codex app-server with the dedicated `openai-memgen`
+/// provider. That auxiliary server must not be replaced by the long-lived codexhost Host Runtime.
+#[must_use]
+fn is_skysight_memory_app_server(arguments: &[OsString]) -> bool {
+    const CONFIG_OPTIONS: &[&str] = &["-c", "--config"];
+
+    let mut index = 0;
+    while index < arguments.len() {
+        let Some(argument) = arguments.get(index).and_then(|value| value.to_str()) else {
+            return false;
+        };
+
+        // Read only real Codex config overrides. Codex accepts them on either side of the
+        // app-server subcommand, so scanning the complete invocation is required for Skysight.
+        // Exact key/value parsing avoids treating an unrelated mention as a memory invocation.
+        let config_value = if CONFIG_OPTIONS.contains(&argument) {
+            index += 1;
+            arguments.get(index).and_then(|value| value.to_str())
+        } else {
+            CONFIG_OPTIONS.iter().find_map(|option| {
+                argument
+                    .strip_prefix(option)
+                    .and_then(|remainder| remainder.strip_prefix('='))
+            })
+        };
+
+        if config_value.is_some_and(|value| {
+            let Some((key, configured_value)) = value.split_once('=') else {
+                return false;
+            };
+            key.trim() == "model_provider"
+                && configured_value
+                    .trim()
+                    .trim_matches(['\'', '"'])
+                    .eq("openai-memgen")
+        }) {
+            return true;
+        }
+        index += 1;
+    }
+    false
+}
+
 /// Returns whether this invocation starts an app-server instance owned by the Host Runtime.
 ///
 /// App-server management commands such as `proxy` and `daemon` must stay on the stock Codex CLI.
@@ -334,6 +381,21 @@ pub fn app_server_subcommand_index(arguments: &[OsString]) -> Option<usize> {
 /// would corrupt the WebSocket transport.
 #[must_use]
 pub fn should_start_host_runtime(arguments: &[OsString]) -> bool {
+    should_start_host_runtime_for_originator(
+        arguments,
+        env::var_os(INTERNAL_ORIGINATOR_OVERRIDE_ENV).as_deref(),
+    )
+}
+
+/// Applies the Host Runtime routing policy for an optional official Codex internal originator.
+///
+/// Official auxiliary services such as Skysight and Computer Use launch isolated app-servers with
+/// an internal originator override. Those one-shot servers must remain on the stock Codex CLI.
+#[must_use]
+fn should_start_host_runtime_for_originator(
+    arguments: &[OsString],
+    internal_originator: Option<&OsStr>,
+) -> bool {
     const VALUE_OPTIONS: &[&str] = &[
         "-c",
         "--config",
@@ -350,9 +412,18 @@ pub fn should_start_host_runtime(arguments: &[OsString]) -> bool {
     ];
     const FLAG_OPTIONS: &[&str] = &["--strict-config", "--stdio", "--analytics-default-enabled"];
 
-    let Some(mut index) = app_server_subcommand_index(arguments).map(|index| index + 1) else {
+    let Some(app_server_index) = app_server_subcommand_index(arguments) else {
         return false;
     };
+    // Internal Codex services own their auxiliary server lifecycle. Intercepting one of these
+    // processes causes the caller to lose its one-shot response, as seen in Skysight summaries.
+    if internal_originator.is_some_and(|originator| {
+        !originator.is_empty() && originator != OsStr::new(DESKTOP_ORIGINATOR)
+    }) || is_skysight_memory_app_server(arguments)
+    {
+        return false;
+    }
+    let mut index = app_server_index + 1;
     while let Some(argument) = arguments.get(index).and_then(|value| value.to_str()) {
         if VALUE_OPTIONS.contains(&argument) {
             if arguments.get(index + 1).is_none() {
@@ -886,7 +957,7 @@ mod tests {
     use super::{PROCESS_TREE_REFRESH_INTERVAL, ShutdownSignals, process_tree_refresh_due};
     use super::{
         app_server_subcommand_index, is_default_remote_unix_listener, select_host_paths,
-        should_start_host_runtime,
+        should_start_host_runtime, should_start_host_runtime_for_originator,
     };
 
     fn arguments(values: &[&str]) -> Vec<OsString> {
@@ -968,6 +1039,57 @@ mod tests {
             "app-server",
             "generate-json-schema",
         ])));
+    }
+
+    #[test]
+    fn keeps_skysight_memory_app_servers_on_the_stock_codex_cli() {
+        assert!(!should_start_host_runtime(&arguments(&[
+            "-c",
+            "model_provider=\"openai-memgen\"",
+            "-c",
+            "model_providers.openai-memgen.name=\"OpenAI\"",
+            "app-server",
+            "--stdio",
+        ])));
+        assert!(!should_start_host_runtime(&arguments(&[
+            "app-server",
+            "--analytics-default-enabled",
+            "--config=model_provider=openai-memgen",
+        ])));
+
+        // A provider definition alone does not select the Skysight memory provider and must not
+        // disable the normal Host Runtime route.
+        assert!(should_start_host_runtime(&arguments(&[
+            "-c",
+            "model_providers.openai-memgen.name=\"OpenAI\"",
+            "app-server",
+            "--stdio",
+        ])));
+        assert!(should_start_host_runtime(&arguments(&[
+            "-c",
+            "model_provider=\"openai\"",
+            "app-server",
+            "--stdio",
+        ])));
+    }
+
+    #[test]
+    fn keeps_internal_codex_auxiliary_app_servers_on_the_stock_cli() {
+        let arguments = arguments(&["app-server", "--stdio"]);
+
+        assert!(!should_start_host_runtime_for_originator(
+            &arguments,
+            Some(std::ffi::OsStr::new("skysight")),
+        ));
+        assert!(should_start_host_runtime_for_originator(&arguments, None));
+        assert!(should_start_host_runtime_for_originator(
+            &arguments,
+            Some(std::ffi::OsStr::new("")),
+        ));
+        assert!(should_start_host_runtime_for_originator(
+            &arguments,
+            Some(std::ffi::OsStr::new("Codex Desktop")),
+        ));
     }
 
     #[test]

--- a/crates/shim/tests/proxy.rs
+++ b/crates/shim/tests/proxy.rs
@@ -307,6 +307,58 @@ fn preserves_arguments_and_removes_recursive_environment() {
 }
 
 #[test]
+fn routes_skysight_memory_app_server_to_the_stock_codex_cli() {
+    let fake_codex = fake_codex_path();
+    let fake_codex_text = fake_codex.to_string_lossy();
+    let output = run_shim(
+        b"",
+        &[
+            "app-server",
+            "--stdio",
+            "-c",
+            "model_provider=\"openai-memgen\"",
+        ],
+        &[
+            (HOST_NODE_PATH_ENV, fake_codex_text.as_ref()),
+            (HOST_RUNTIME_PATH_ENV, fake_codex_text.as_ref()),
+            ("FAKE_CODEX_PRINT_INVOCATION", "1"),
+        ],
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    // Even with a Host Runtime configured, the Skysight-specific provider must execute the stock
+    // CLI directly so its one-shot summary response reaches SkyComputerUseService.
+    assert!(output.status.success(), "{stderr}");
+    assert!(stderr.contains("args=app-server|--stdio|-c|model_provider=\"openai-memgen\""));
+    assert!(stderr.contains("codex_cli_path_present=false"));
+    assert!(output.stdout.is_empty());
+}
+
+#[test]
+fn routes_internal_codex_auxiliary_app_server_to_the_stock_cli() {
+    let fake_codex = fake_codex_path();
+    let fake_codex_text = fake_codex.to_string_lossy();
+    let output = run_shim(
+        b"",
+        &["app-server", "--stdio"],
+        &[
+            (HOST_NODE_PATH_ENV, fake_codex_text.as_ref()),
+            (HOST_RUNTIME_PATH_ENV, fake_codex_text.as_ref()),
+            ("CODEX_INTERNAL_ORIGINATOR_OVERRIDE", "skysight"),
+            ("FAKE_CODEX_PRINT_INVOCATION", "1"),
+        ],
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    // The internal originator marker is an official ownership boundary. It must override an
+    // otherwise valid Host Runtime route without removing the caller's marker from the stock CLI.
+    assert!(output.status.success(), "{stderr}");
+    assert!(stderr.contains("args=app-server|--stdio"));
+    assert!(stderr.contains("codex_cli_path_present=false"));
+    assert!(output.stdout.is_empty());
+}
+
+#[test]
 fn managed_remote_child_receives_inherited_proxy_environment() {
     let output = run_shim(
         b"",


### PR DESCRIPTION
## Summary

Keep Computer History's one-shot summarizer on the stock Codex CLI even when macOS process ancestry is unavailable or no longer identifies it as a nested Desktop helper.

This complements #164 rather than changing its native-helper ancestry rules:

- bypass Host Runtime for a non-empty `CODEX_INTERNAL_ORIGINATOR_OVERRIDE` other than `Codex Desktop`;
- bypass Host Runtime when an `app-server` invocation explicitly selects `model_provider=openai-memgen`;
- preserve the normal Host Runtime route for the Desktop originator, unrelated providers, and provider definitions that are not selected.

Closes #203.

## Validation

- `cargo fmt --all --check`
- `cargo clippy --locked --package codexhost-shim --all-targets --features test-utils -- -D warnings`
- `cargo test --locked --package codexhost-shim --features test-utils`
  - 26 unit tests passed
  - 42 proxy integration tests passed

## Scope

Only Shim routing and focused tests are changed. No Renderer, Host Runtime, remote transport, credentials, private activity content, or session data are included.
