### PR TITLE
fix(grok): present ask_user_question and exit_plan_mode as Host Questions

### DIFF
--- a/docs/grok-question-and-plan-mode.md
+++ b/docs/grok-question-and-plan-mode.md
@@ -1,0 +1,43 @@
+# Grok 选择题与计划确认
+
+Grok Build ACP 通过私有 Client 扩展方法 `_x.ai/ask_user_question` 和 `_x.ai/exit_plan_mode`（同时接受不带下划线前缀的 `x.ai/...`）向 Host 发起交互。codexhost 在 Grok Adapter 内把这两类 RPC 映射成既有的 Host Question，再由 Protocol Core 投影为 Codex Desktop 的 `item/tool/requestUserInput` 卡片。Host、Renderer 和公共契约不增加 Grok 专用分支。
+
+## 选择题
+
+Grok 调用 `ask_user_question` 时，Adapter 展示原生问题正文和选项，而不是普通工具的 Allow / Deny：
+
+- 回答信封使用 Grok 内部 tagged enum：`{ outcome: "accepted", answers, annotations }`。`answers` 的键是问题正文；单选值为字符串，多选值为字符串数组。`annotations` 必须是对象（`{}`），不能是数组。
+- 用户取消或 Turn 被取消时返回 `{ outcome: "skip_interview" }`，而不是 JSON-RPC 错误，避免挂起原生 Turn。
+- initialize 通过 `clientCapabilities._meta` 声明 `x.ai/ask_user_question` 和 `x.ai/exit_plan_mode`。不要声明 ACP `elicitation.form`：Grok 会因此从模型工具表中拿掉 `ask_user_question`。
+
+Codex Desktop 的选择题卡片在点击一个选项后即提交。Adapter 会把 `multiSelect` 记到 Host Question 的 `multiple`，但 Desktop 当前不投影该字段，因此多选在产品上只能回传被点中的那一项。
+
+## 计划确认
+
+Grok 调用 `exit_plan_mode` 时，codexhost 展示独立的 **Review plan** 选择式确认，而不是普通工具的“允许一次”审批：
+
+- 展示 Grok 提供的完整计划正文，不套用普通工具审批的描述截断。
+- **Stay in plan mode（保持规划）** 位于第一个选项，拒绝本次退出规划请求。
+- **Approve plan and exit plan mode（批准计划并退出规划）** 仅在计划正文非空时出现。
+- 取消确认、缺少计划正文、或选择保持规划都返回 `{ approved: false, feedback: "" }`。批准返回 `{ approved: true, feedback: "" }`。
+- Adapter 不读取 `planFilePath` 自行补全文案，也不会在无正文时批准退出。
+
+确认文案目前使用英文，与 Claude Code 计划确认和其他 Adapter 固定交互文案保持一致。
+
+## 所有权与投影
+
+- `packages/adapters/grok/src/acp-transport.ts` 实现 ACP `Client.extMethod`，并在 initialize 时广告 Grok 原生交互能力。
+- `packages/adapters/grok/src/grok-question.ts` 解析选择题参数，并构造 Grok 可反序列化的回答信封。
+- `packages/adapters/grok/src/grok-plan-review.ts` 将计划退出转换成封闭的 Host Question，并把经过验证的回答转换回 `{ approved, feedback }`。
+- 这两类交互都不是 ACP `requestPermission`，也不会写入普通工具审批的 `answers` 参数。
+
+## 验证
+
+定向回归覆盖方法识别、camelCase/snake_case 解析、接受/跳过/取消信封、无计划时禁止批准，以及未知扩展方法不挂起 Turn：
+
+```sh
+npx vitest run --config tests/vitest.config.js \
+  packages/adapters/grok/test/grok-question.test.ts \
+  packages/adapters/grok/test/grok-plan-review.test.ts \
+  packages/adapters/grok/test/grok-adapter.test.ts
+```

--- a/packages/adapters/grok/src/acp-transport.ts
+++ b/packages/adapters/grok/src/acp-transport.ts
@@ -46,6 +46,13 @@ import {
   parseGrokRewindResponse,
   type GrokRewindParams,
 } from "./grok-rewind.js";
+import { grokPlanRejectedResponse } from "./grok-plan-review.js";
+import {
+  GROK_ACP_CLIENT_CAPABILITIES,
+  grokSkipInterviewResponse,
+  isGrokAskUserQuestionMethod,
+  isGrokExitPlanModeMethod,
+} from "./grok-question.js";
 import { decodeGrokPermissionModeId, grokPermissionModeSessionMeta } from "./permission-modes.js";
 
 export type GrokTransportFaultKind =
@@ -165,9 +172,15 @@ export interface GrokOpenResult {
   replay: GrokTransportEvent[];
   signals?: unknown;
 }
+export interface GrokExtensionRequest {
+  method: string;
+  params: Record<string, unknown>;
+}
+
 interface ActivePrompt {
   onEvent(event: GrokTransportEvent): void;
   onPermission(request: GrokPermissionRequest): Promise<RequestPermissionResponse>;
+  onExtension(request: GrokExtensionRequest): Promise<Record<string, unknown>>;
 }
 
 interface ActiveCompact {
@@ -753,6 +766,7 @@ export class GrokAcpTransport {
         ({
           sessionUpdate: (params) => this.#handleUpdate(params),
           requestPermission: (params) => this.#handlePermission(params),
+          extMethod: (method, params) => this.#handleExtensionRequest(method, params),
           extNotification: (method, params) => this.#handleExtensionNotification(method, params),
         }) satisfies Client,
       stream,
@@ -774,7 +788,7 @@ export class GrokAcpTransport {
     const initialize = await withTimeout(
       connection.initialize({
         protocolVersion: PROTOCOL_VERSION,
-        clientCapabilities: {},
+        clientCapabilities: GROK_ACP_CLIENT_CAPABILITIES,
         clientInfo: { name: "codexhost", version: "0.1.6" },
       }),
       this.#options.commandTimeoutMs,
@@ -794,13 +808,14 @@ export class GrokAcpTransport {
     text: string,
     onEvent: ActivePrompt["onEvent"],
     onPermission: ActivePrompt["onPermission"],
+    onExtension: ActivePrompt["onExtension"],
   ): Promise<PromptResponse> {
     const connection = this.#connection;
     if (!connection || !this.#sessionId || this.#closed || this.#closing) {
       throw new GrokTransportError("unavailable", "Grok ACP Session is unavailable");
     }
     if (this.#activePrompt) throw new Error("Grok ACP Session already has an active Prompt");
-    const active = { onEvent, onPermission };
+    const active = { onEvent, onPermission, onExtension };
     this.#activePrompt = active;
     try {
       return await connection.prompt({
@@ -929,6 +944,18 @@ export class GrokAcpTransport {
       return Promise.resolve({ outcome: { outcome: "cancelled" } });
     }
     return this.#activePrompt.onPermission({ request: params, options: params.options });
+  }
+
+  #handleExtensionRequest(
+    method: string,
+    params: Record<string, unknown>,
+  ): Promise<Record<string, unknown>> {
+    if (this.#activePrompt) {
+      return this.#activePrompt.onExtension({ method, params });
+    }
+    if (isGrokAskUserQuestionMethod(method)) return Promise.resolve(grokSkipInterviewResponse());
+    if (isGrokExitPlanModeMethod(method)) return Promise.resolve(grokPlanRejectedResponse());
+    throw RequestError.methodNotFound(method);
   }
 
   #fault(error: GrokTransportError): void {

--- a/packages/adapters/grok/src/grok-adapter.ts
+++ b/packages/adapters/grok/src/grok-adapter.ts
@@ -1,14 +1,16 @@
 import { randomUUID } from "node:crypto";
 import path from "node:path";
 
-import type {
-  PermissionOption,
-  PromptResponse,
-  RequestPermissionResponse,
+import {
+  RequestError,
+  type PermissionOption,
+  type PromptResponse,
+  type RequestPermissionResponse,
 } from "@agentclientprotocol/sdk";
 import {
   HarnessOutputChannel,
   validateHostApprovalResponse,
+  validateHostQuestionResponse,
   type HarnessAdapter,
   type HarnessCommandAccepted,
   type HarnessCommandCapability,
@@ -30,6 +32,7 @@ import {
   type HostItem,
   type HostItemOutcome,
   type HostItemSnapshot,
+  type HostQuestionInteraction,
   type HostReasoningItem,
   type HostThreadSnapshot,
   type HostUsage,
@@ -71,12 +74,29 @@ import {
   GrokTransportError,
   grokNativeSessionDirectory,
   type GrokAcpTransportOptions,
+  type GrokExtensionRequest,
   type GrokNativeSessionLocation,
   type GrokOpenInput,
   type GrokOpenResult,
   type GrokPermissionRequest,
   type GrokTransportEvent,
 } from "./acp-transport.js";
+import {
+  createGrokPlanReview,
+  grokExitPlanModeResponse,
+  grokPlanRejectedResponse,
+  parseGrokExitPlanModeParams,
+  type GrokPlanApprovalRequest,
+} from "./grok-plan-review.js";
+import {
+  createGrokQuestionInteraction,
+  grokAskUserQuestionResponse,
+  grokSkipInterviewResponse,
+  isGrokAskUserQuestionMethod,
+  isGrokExitPlanModeMethod,
+  parseGrokAskUserQuestionParams,
+  type GrokQuestionRequest,
+} from "./grok-question.js";
 import { grokMediaResolveRoots, rewriteLocalMediaMarkdown } from "./local-media-markdown.js";
 import type { GrokCompactResult } from "./grok-manual-compaction.js";
 import { projectGrokFileChanges } from "./grok-file-change.js";
@@ -145,6 +165,7 @@ export interface GrokAcpTransportLike {
     text: string,
     onEvent: (event: GrokTransportEvent) => void,
     onPermission: (request: GrokPermissionRequest) => Promise<RequestPermissionResponse>,
+    onExtension: (request: GrokExtensionRequest) => Promise<Record<string, unknown>>,
   ): Promise<PromptResponse>;
   compact(
     userContext: string | undefined,
@@ -166,6 +187,13 @@ interface ActiveApproval {
   resolve(response: RequestPermissionResponse): void;
 }
 
+interface ActiveQuestion {
+  type: "question" | "planApproval";
+  interaction: HostQuestionInteraction;
+  request: GrokQuestionRequest | GrokPlanApprovalRequest;
+  resolve(response: Record<string, unknown>): void;
+}
+
 interface ActiveTurn {
   command: TurnStartCommand;
   agent: HostAgentMessageItem | null;
@@ -180,6 +208,7 @@ interface ActiveTurn {
   tools: Map<string, ActiveTool>;
   completedItems: HostItemSnapshot[];
   approvals: Map<HostInteractionId, ActiveApproval>;
+  questions: Map<HostInteractionId, ActiveQuestion>;
   cancellationRequested: boolean;
   beforeNativeTurnKeys: Set<string>;
   completion: Promise<void>;
@@ -485,6 +514,7 @@ class GrokHarnessSession implements HarnessSession {
       tools: new Map(),
       completedItems: [],
       approvals: new Map(),
+      questions: new Map(),
       cancellationRequested: false,
       beforeNativeTurnKeys: new Set(
         this.#snapshot.turns.map((turn) => turn.nativeTurnRef.nativeTurnKey),
@@ -499,6 +529,7 @@ class GrokHarnessSession implements HarnessSession {
         text,
         (event) => this.#handleEvent(active, event),
         (request) => this.#requestPermission(active, request),
+        (request) => this.#requestExtension(active, request),
       )
       .then(
         (response) =>
@@ -580,6 +611,7 @@ class GrokHarnessSession implements HarnessSession {
       tools: new Map(),
       completedItems: [],
       approvals: new Map(),
+      questions: new Map(),
       cancellationRequested: false,
       beforeNativeTurnKeys: new Set(),
       completion,
@@ -782,9 +814,7 @@ class GrokHarnessSession implements HarnessSession {
     }
     if (active.cancellationRequested) return { ok: true, value: { cancellationRequested: true } };
     active.cancellationRequested = true;
-    for (const approval of active.approvals.values()) {
-      approval.resolve({ outcome: { outcome: "cancelled" } });
-    }
+    this.#closePendingInteractions(active, "cancelled");
     try {
       await this.#transport.cancel();
       return { ok: true, value: { cancellationRequested: true } };
@@ -797,9 +827,18 @@ class GrokHarnessSession implements HarnessSession {
     command: InteractionRespondCommand,
   ): Promise<HarnessResult<InteractionRespondAccepted>> {
     const active = this.#active;
-    const pending = active?.approvals.get(command.interactionId);
-    if (!active || !pending)
-      return { ok: false, error: invalidState("Grok Approval is not pending") };
+    const approval = active?.approvals.get(command.interactionId);
+    if (active && approval) return this.#respondApproval(active, approval, command);
+    const question = active?.questions.get(command.interactionId);
+    if (active && question) return this.#respondQuestion(active, question, command);
+    return { ok: false, error: invalidState("Grok Interaction is not pending") };
+  }
+
+  #respondApproval(
+    active: ActiveTurn,
+    pending: ActiveApproval,
+    command: InteractionRespondCommand,
+  ): HarnessResult<InteractionRespondAccepted> {
     if (command.response.type !== "approval") {
       return {
         ok: false,
@@ -833,6 +872,38 @@ class GrokHarnessSession implements HarnessSession {
     return { ok: true, value: { accepted: true } };
   }
 
+  #respondQuestion(
+    active: ActiveTurn,
+    pending: ActiveQuestion,
+    command: InteractionRespondCommand,
+  ): HarnessResult<InteractionRespondAccepted> {
+    if (command.response.type !== "question") {
+      return {
+        ok: false,
+        error: {
+          code: "invalidRequest",
+          message: "Grok Question requires a Question Response",
+          retryable: false,
+        },
+      };
+    }
+    const validation = validateHostQuestionResponse(pending.interaction, command.response);
+    if (validation) return { ok: false, error: validation };
+    const native =
+      pending.type === "planApproval"
+        ? grokExitPlanModeResponse(pending.request as GrokPlanApprovalRequest, command.response)
+        : grokAskUserQuestionResponse(pending.request as GrokQuestionRequest, command.response);
+    active.questions.delete(command.interactionId);
+    pending.resolve(native);
+    this.#event({
+      type: "interaction.closed",
+      interactionId: command.interactionId,
+      turnId: active.command.turnId,
+      reason: command.response.cancelled ? "cancelled" : "responded",
+    });
+    return { ok: true, value: { accepted: true } };
+  }
+
   #requestPermission(
     active: ActiveTurn,
     request: GrokPermissionRequest,
@@ -859,6 +930,96 @@ class GrokHarnessSession implements HarnessSession {
       active.approvals.set(interactionId, { interaction, options, resolve });
       this.#channel.emit({ kind: "interaction", interaction });
     });
+  }
+
+  #requestExtension(
+    active: ActiveTurn,
+    request: GrokExtensionRequest,
+  ): Promise<Record<string, unknown>> {
+    if (isGrokAskUserQuestionMethod(request.method)) {
+      const parsed = parseGrokAskUserQuestionParams(request.params);
+      if (!parsed) {
+        throw RequestError.invalidParams(request.params, "Grok Question is invalid");
+      }
+      return this.#requestQuestion(active, parsed);
+    }
+    if (isGrokExitPlanModeMethod(request.method)) {
+      const parsed = parseGrokExitPlanModeParams(request.params);
+      if (!parsed) {
+        throw RequestError.invalidParams(request.params, "Grok Plan approval is invalid");
+      }
+      return this.#requestPlanReview(active, parsed);
+    }
+    throw RequestError.methodNotFound(request.method);
+  }
+
+  #requestQuestion(
+    active: ActiveTurn,
+    request: GrokQuestionRequest,
+  ): Promise<Record<string, unknown>> {
+    if (this.#active !== active || active.cancellationRequested) {
+      return Promise.resolve(grokSkipInterviewResponse());
+    }
+    const interactionId = hostInteractionIdSchema.parse(this.#randomUUID());
+    const interaction = createGrokQuestionInteraction(
+      request,
+      interactionId,
+      active.command.turnId,
+    );
+    return new Promise((resolve) => {
+      active.questions.set(interactionId, {
+        type: "question",
+        interaction,
+        request,
+        resolve,
+      });
+      this.#channel.emit({ kind: "interaction", interaction });
+    });
+  }
+
+  #requestPlanReview(
+    active: ActiveTurn,
+    request: GrokPlanApprovalRequest,
+  ): Promise<Record<string, unknown>> {
+    if (this.#active !== active || active.cancellationRequested) {
+      return Promise.resolve(grokPlanRejectedResponse());
+    }
+    const interactionId = hostInteractionIdSchema.parse(this.#randomUUID());
+    const interaction = createGrokPlanReview(request, interactionId, active.command.turnId);
+    return new Promise((resolve) => {
+      active.questions.set(interactionId, {
+        type: "planApproval",
+        interaction,
+        request,
+        resolve,
+      });
+      this.#channel.emit({ kind: "interaction", interaction });
+    });
+  }
+
+  #closePendingInteractions(active: ActiveTurn, reason: "cancelled" | "superseded"): void {
+    for (const [interactionId, pending] of active.approvals) {
+      active.approvals.delete(interactionId);
+      pending.resolve({ outcome: { outcome: "cancelled" } });
+      this.#event({
+        type: "interaction.closed",
+        interactionId,
+        turnId: active.command.turnId,
+        reason,
+      });
+    }
+    for (const [interactionId, pending] of active.questions) {
+      active.questions.delete(interactionId);
+      pending.resolve(
+        pending.type === "planApproval" ? grokPlanRejectedResponse() : grokSkipInterviewResponse(),
+      );
+      this.#event({
+        type: "interaction.closed",
+        interactionId,
+        turnId: active.command.turnId,
+        reason,
+      });
+    }
   }
 
   #handleEvent(active: ActiveTurn, event: GrokTransportEvent): void {
@@ -1187,16 +1348,7 @@ class GrokHarnessSession implements HarnessSession {
     }
     for (const tool of active.tools.values()) this.#completeItem(active, tool.item, itemOutcome);
     active.tools.clear();
-    for (const [interactionId, pending] of active.approvals) {
-      active.approvals.delete(interactionId);
-      pending.resolve({ outcome: { outcome: "cancelled" } });
-      this.#event({
-        type: "interaction.closed",
-        interactionId,
-        turnId: active.command.turnId,
-        reason: "cancelled",
-      });
-    }
+    this.#closePendingInteractions(active, "cancelled");
     this.#active = null;
     if (usage) this.#publishUsage(usage, active.command.turnId);
     this.#event({
@@ -1225,8 +1377,16 @@ class GrokHarnessSession implements HarnessSession {
     const active = this.#active;
     if (active) {
       active.cancellationRequested = true;
-      for (const approval of active.approvals.values())
+      for (const approval of active.approvals.values()) {
         approval.resolve({ outcome: { outcome: "cancelled" } });
+      }
+      for (const question of active.questions.values()) {
+        question.resolve(
+          question.type === "planApproval"
+            ? grokPlanRejectedResponse()
+            : grokSkipInterviewResponse(),
+        );
+      }
       await this.#transport.cancel().catch(() => undefined);
       await Promise.race([
         active.completion,

--- a/packages/adapters/grok/src/grok-plan-review.ts
+++ b/packages/adapters/grok/src/grok-plan-review.ts
@@ -1,0 +1,100 @@
+import type { HostQuestionInteraction, HostQuestionResponse } from "@codexhost/harness-adapter";
+
+export const GROK_PLAN_DECISION_ID = "plan-decision";
+
+export interface GrokPlanApprovalRequest {
+  sessionId?: string;
+  plan: string | null;
+  planFilePath?: string;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function stringField(value: Record<string, unknown>, ...keys: string[]): string | undefined {
+  for (const key of keys) {
+    const field = value[key];
+    if (typeof field === "string" && field.length > 0) return field;
+  }
+  return undefined;
+}
+
+export function parseGrokExitPlanModeParams(params: unknown): GrokPlanApprovalRequest | null {
+  if (!isRecord(params)) return null;
+  const nested = isRecord(params.input) ? params.input : params;
+  const plan =
+    stringField(nested, "planContent", "plan_content", "plan") ??
+    stringField(params, "planContent", "plan_content", "plan") ??
+    null;
+  const planFilePath =
+    stringField(nested, "planFilePath", "plan_file_path") ??
+    stringField(params, "planFilePath", "plan_file_path");
+  const sessionId = stringField(params, "sessionId", "session_id");
+  return {
+    plan,
+    ...(sessionId ? { sessionId } : {}),
+    ...(planFilePath ? { planFilePath } : {}),
+  };
+}
+
+export function createGrokPlanReview(
+  request: GrokPlanApprovalRequest,
+  interactionId: HostQuestionInteraction["interactionId"],
+  turnId: HostQuestionInteraction["turnId"],
+): HostQuestionInteraction {
+  const warning =
+    "Approving this plan will exit Grok plan mode and let Grok begin implementation. " +
+    "This is not a one-time tool approval.";
+  return {
+    type: "question",
+    interactionId,
+    turnId,
+    title: "Review plan",
+    questions: [
+      {
+        id: GROK_PLAN_DECISION_ID,
+        type: "choice",
+        prompt: request.plan
+          ? `${warning}\n\n${request.plan}`
+          : "Grok did not provide plan text. Stay in plan mode and ask Grok to present the plan before approving it.",
+        options: [
+          {
+            value: "stay",
+            label: "Stay in plan mode",
+            description: "Do not approve the plan or begin implementation.",
+          },
+          ...(request.plan
+            ? [
+                {
+                  value: "approve",
+                  label: "Approve plan and exit plan mode",
+                  description: "Leave plan mode and begin implementation.",
+                },
+              ]
+            : []),
+        ],
+        multiple: false,
+        allowOther: false,
+        optional: false,
+      },
+    ],
+  };
+}
+
+export function grokPlanRejectedResponse(): Record<string, unknown> {
+  return { approved: false, feedback: "" };
+}
+
+export function grokExitPlanModeResponse(
+  request: GrokPlanApprovalRequest,
+  response: HostQuestionResponse,
+): Record<string, unknown> {
+  return {
+    approved:
+      !response.cancelled &&
+      request.plan !== null &&
+      response.answers[GROK_PLAN_DECISION_ID]?.[0] === "approve",
+    feedback: "",
+  };
+}

--- a/packages/adapters/grok/src/grok-question.ts
+++ b/packages/adapters/grok/src/grok-question.ts
@@ -1,0 +1,189 @@
+import type { HostQuestionInteraction, HostQuestionResponse } from "@codexhost/harness-adapter";
+
+export const GROK_ASK_USER_QUESTION_METHODS = [
+  "_x.ai/ask_user_question",
+  "x.ai/ask_user_question",
+] as const;
+
+export const GROK_EXIT_PLAN_MODE_METHODS = ["_x.ai/exit_plan_mode", "x.ai/exit_plan_mode"] as const;
+
+/** Advertise Grok's native question RPCs. Do not set ACP elicitation.form; that drops ask_user_question. */
+export const GROK_ACP_CLIENT_CAPABILITIES = {
+  _meta: {
+    "x.ai/ask_user_question": true,
+    "x.ai/exit_plan_mode": true,
+  },
+} as const;
+
+export interface GrokQuestionOption {
+  label: string;
+  description?: string;
+}
+
+export interface GrokNativeQuestion {
+  question: string;
+  header?: string;
+  options: GrokQuestionOption[];
+  multiSelect: boolean;
+}
+
+export interface GrokQuestionRequest {
+  sessionId?: string;
+  questions: GrokNativeQuestion[];
+  timeoutMs?: number;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function stringField(value: Record<string, unknown>, ...keys: string[]): string | undefined {
+  for (const key of keys) {
+    const field = value[key];
+    if (typeof field === "string" && field.length > 0) return field;
+  }
+  return undefined;
+}
+
+function optionalTimeoutMs(value: Record<string, unknown>): number | undefined {
+  for (const key of ["timeoutMs", "timeout_ms", "timeoutSecs", "timeout_secs"]) {
+    const field = value[key];
+    if (typeof field === "number" && Number.isFinite(field) && field > 0) {
+      return key.endsWith("secs") || key.endsWith("Secs") ? field * 1000 : field;
+    }
+  }
+  return undefined;
+}
+
+export function isGrokAskUserQuestionMethod(method: string): boolean {
+  return (GROK_ASK_USER_QUESTION_METHODS as readonly string[]).includes(method);
+}
+
+export function isGrokExitPlanModeMethod(method: string): boolean {
+  return (GROK_EXIT_PLAN_MODE_METHODS as readonly string[]).includes(method);
+}
+
+function questionsPayload(params: Record<string, unknown>): unknown {
+  if (Array.isArray(params.questions)) return params.questions;
+  if (isRecord(params.input) && Array.isArray(params.input.questions))
+    return params.input.questions;
+  if (isRecord(params.askUserQuestion) && Array.isArray(params.askUserQuestion.questions)) {
+    return params.askUserQuestion.questions;
+  }
+  return undefined;
+}
+
+function parseOption(value: unknown, labels: Set<string>): GrokQuestionOption | null {
+  if (!isRecord(value)) return null;
+  const label = stringField(value, "label");
+  if (!label || labels.has(label)) return null;
+  labels.add(label);
+  const description = stringField(value, "description");
+  const preview = stringField(value, "preview");
+  const combined = [description, preview].filter((part): part is string => part !== undefined);
+  return {
+    label,
+    ...(combined.length > 0 ? { description: combined.join("\n\n") } : {}),
+  };
+}
+
+function parseQuestion(value: unknown, questions: Set<string>): GrokNativeQuestion | null {
+  if (!isRecord(value)) return null;
+  const question = stringField(value, "question");
+  if (!question || questions.has(question)) return null;
+  if (!Array.isArray(value.options) || value.options.length === 0) return null;
+  const labels = new Set<string>();
+  const options: GrokQuestionOption[] = [];
+  for (const option of value.options) {
+    const parsed = parseOption(option, labels);
+    if (!parsed) return null;
+    options.push(parsed);
+  }
+  questions.add(question);
+  const header = stringField(value, "header");
+  return {
+    question,
+    ...(header ? { header } : {}),
+    options,
+    multiSelect: value.multiSelect === true || value.multi_select === true,
+  };
+}
+
+export function parseGrokAskUserQuestionParams(params: unknown): GrokQuestionRequest | null {
+  if (!isRecord(params)) return null;
+  const rawQuestions = questionsPayload(params);
+  if (!Array.isArray(rawQuestions) || rawQuestions.length === 0) return null;
+  const seen = new Set<string>();
+  const questions: GrokNativeQuestion[] = [];
+  for (const value of rawQuestions) {
+    const parsed = parseQuestion(value, seen);
+    if (!parsed) return null;
+    questions.push(parsed);
+  }
+  const sessionId = stringField(params, "sessionId", "session_id");
+  const timeoutMs = optionalTimeoutMs(params);
+  return {
+    questions,
+    ...(sessionId ? { sessionId } : {}),
+    ...(timeoutMs !== undefined ? { timeoutMs } : {}),
+  };
+}
+
+export function grokQuestionId(index: number): string {
+  return `question-${index + 1}`;
+}
+
+export function createGrokQuestionInteraction(
+  request: GrokQuestionRequest,
+  interactionId: HostQuestionInteraction["interactionId"],
+  turnId: HostQuestionInteraction["turnId"],
+  nowMs = Date.now(),
+): HostQuestionInteraction {
+  const first = request.questions[0];
+  const title =
+    request.questions.length === 1 ? (first?.header ?? first?.question ?? "Grok") : "Grok";
+  return {
+    type: "question",
+    interactionId,
+    turnId,
+    title,
+    questions: request.questions.map((question, index) => ({
+      id: grokQuestionId(index),
+      type: "choice",
+      prompt: question.question,
+      options: question.options.map((option) => ({
+        value: option.label,
+        label: option.label,
+        ...(option.description ? { description: option.description } : {}),
+      })),
+      multiple: question.multiSelect,
+      allowOther: true,
+      optional: false,
+    })),
+    ...(request.timeoutMs !== undefined
+      ? { expiresAt: new Date(nowMs + request.timeoutMs).toISOString() }
+      : {}),
+  };
+}
+
+export function grokSkipInterviewResponse(): Record<string, unknown> {
+  return { outcome: "skip_interview" };
+}
+
+export function grokAskUserQuestionResponse(
+  request: GrokQuestionRequest,
+  response: HostQuestionResponse,
+): Record<string, unknown> {
+  if (response.cancelled) return grokSkipInterviewResponse();
+  const answers: Record<string, string | string[]> = {};
+  for (const [index, question] of request.questions.entries()) {
+    const selected = response.answers[grokQuestionId(index)] ?? [];
+    answers[question.question] =
+      question.multiSelect || selected.length !== 1 ? selected : (selected[0] ?? "");
+  }
+  return {
+    outcome: "accepted",
+    answers,
+    annotations: {},
+  };
+}

--- a/packages/adapters/grok/src/index.ts
+++ b/packages/adapters/grok/src/index.ts
@@ -17,6 +17,7 @@ export {
 } from "./acp-transport.js";
 export type {
   GrokAcpTransportOptions,
+  GrokExtensionRequest,
   GrokForkOpenInput,
   GrokNativeSessionLocation,
   GrokOpenInput,
@@ -25,6 +26,22 @@ export type {
   GrokRewindOpenInput,
   GrokTransportEvent,
 } from "./acp-transport.js";
+export {
+  GROK_ACP_CLIENT_CAPABILITIES,
+  GROK_ASK_USER_QUESTION_METHODS,
+  GROK_EXIT_PLAN_MODE_METHODS,
+  createGrokQuestionInteraction,
+  grokAskUserQuestionResponse,
+  grokSkipInterviewResponse,
+  parseGrokAskUserQuestionParams,
+} from "./grok-question.js";
+export {
+  GROK_PLAN_DECISION_ID,
+  createGrokPlanReview,
+  grokExitPlanModeResponse,
+  grokPlanRejectedResponse,
+  parseGrokExitPlanModeParams,
+} from "./grok-plan-review.js";
 export {
   GROK_SESSION_FORK_METHOD,
   buildGrokForkParams,

--- a/packages/adapters/grok/test/grok-adapter.test.ts
+++ b/packages/adapters/grok/test/grok-adapter.test.ts
@@ -23,6 +23,7 @@ import {
   GrokTransportError,
   GROK_SESSION_FORK_METHOD,
   type GrokAcpTransportLike,
+  type GrokExtensionRequest,
   type GrokOpenInput,
   type GrokOpenResult,
   type GrokPermissionRequest,
@@ -77,6 +78,7 @@ class FakeGrokTransport implements GrokAcpTransportLike {
   #onEvent: ((event: GrokTransportEvent) => void) | null = null;
   #onPermission: ((request: GrokPermissionRequest) => Promise<RequestPermissionResponse>) | null =
     null;
+  #onExtension: ((request: GrokExtensionRequest) => Promise<Record<string, unknown>>) | null = null;
   #resolve: ((response: PromptResponse) => void) | null = null;
   #compactResolve: ((result: GrokCompactResult) => void) | null = null;
   #compactOnEvent: ((event: GrokTransportEvent) => void) | null = null;
@@ -156,11 +158,13 @@ class FakeGrokTransport implements GrokAcpTransportLike {
     text: string,
     onEvent: (event: GrokTransportEvent) => void,
     onPermission: (request: GrokPermissionRequest) => Promise<RequestPermissionResponse>,
+    onExtension: (request: GrokExtensionRequest) => Promise<Record<string, unknown>>,
   ): Promise<PromptResponse> {
     this.#activePromptText = text;
     this.#activePromptEvents = [];
     this.#onEvent = onEvent;
     this.#onPermission = onPermission;
+    this.#onExtension = onExtension;
     return new Promise((resolve) => {
       this.#resolve = resolve;
     });
@@ -207,6 +211,14 @@ class FakeGrokTransport implements GrokAcpTransportLike {
       },
       options,
     });
+  }
+
+  async extension(
+    method: string,
+    params: Record<string, unknown>,
+  ): Promise<Record<string, unknown>> {
+    if (!this.#onExtension) throw new Error("No active Grok Prompt");
+    return await this.#onExtension({ method, params });
   }
 
   finish(response: PromptResponse = { stopReason: "end_turn" }, historyUsage?: unknown): void {
@@ -717,6 +729,203 @@ describe("Grok Adapter ACP projection", () => {
       outcome: { outcome: "selected", optionId: "allow-command" },
     });
 
+    transport.finish();
+    for (;;) {
+      if ((await nextEvent(iterator)).type === "turn.completed") break;
+    }
+    await adapter.close();
+  });
+
+  it("projects native ask_user_question as a Host Question and returns accepted answers", async () => {
+    const transport = new FakeGrokTransport();
+    const { adapter, session } = await openedSession(transport);
+    const iterator = session.outputs[Symbol.asyncIterator]();
+    const turnId = hostTurnIdSchema.parse("turn-grok-question");
+    await session.execute({
+      type: "turn.start",
+      turnId,
+      input: [{ type: "text", text: "ask" }],
+    });
+    expect((await nextEvent(iterator)).type).toBe("turn.started");
+
+    const native = transport.extension("_x.ai/ask_user_question", {
+      sessionId: transport.sessionId,
+      questions: [
+        {
+          question: "Which path?",
+          options: [
+            { label: "Alpha", description: "First" },
+            { label: "Beta", description: "Second" },
+          ],
+        },
+      ],
+    });
+    const output = await nextOutput(iterator);
+    if (output.kind !== "interaction" || output.interaction.type !== "question") {
+      throw new Error("Expected Grok Question");
+    }
+    expect(output.interaction).toMatchObject({
+      type: "question",
+      title: "Which path?",
+      questions: [
+        {
+          id: "question-1",
+          type: "choice",
+          prompt: "Which path?",
+          multiple: false,
+          allowOther: true,
+          options: [
+            { value: "Alpha", label: "Alpha" },
+            { value: "Beta", label: "Beta" },
+          ],
+        },
+      ],
+    });
+    await expect(
+      session.execute({
+        type: "interaction.respond",
+        interactionId: output.interaction.interactionId,
+        response: { type: "approval", actionId: "allow-once" },
+      }),
+    ).resolves.toMatchObject({ ok: false, error: { code: "invalidRequest" } });
+    await expect(
+      session.execute({
+        type: "interaction.respond",
+        interactionId: output.interaction.interactionId,
+        response: { type: "question", answers: { "question-1": ["Alpha"] } },
+      }),
+    ).resolves.toEqual({ ok: true, value: { accepted: true } });
+    await expect(native).resolves.toEqual({
+      outcome: "accepted",
+      answers: { "Which path?": "Alpha" },
+      annotations: {},
+    });
+    expect(await nextEvent(iterator)).toMatchObject({
+      type: "interaction.closed",
+      interactionId: output.interaction.interactionId,
+      reason: "responded",
+    });
+    await expect(
+      session.execute({
+        type: "interaction.respond",
+        interactionId: output.interaction.interactionId,
+        response: { type: "question", answers: { "question-1": ["Beta"] } },
+      }),
+    ).resolves.toMatchObject({ ok: false, error: { code: "invalidState" } });
+    transport.finish();
+    for (;;) {
+      if ((await nextEvent(iterator)).type === "turn.completed") break;
+    }
+    await adapter.close();
+  });
+
+  it("skips a pending Grok Question when the user cancels it", async () => {
+    const transport = new FakeGrokTransport();
+    const { adapter, session } = await openedSession(transport);
+    const iterator = session.outputs[Symbol.asyncIterator]();
+    const turnId = hostTurnIdSchema.parse("turn-grok-question-cancel");
+    await session.execute({
+      type: "turn.start",
+      turnId,
+      input: [{ type: "text", text: "ask" }],
+    });
+    expect((await nextEvent(iterator)).type).toBe("turn.started");
+    const native = transport.extension("x.ai/ask_user_question", {
+      questions: [{ question: "Continue?", options: [{ label: "Yes" }, { label: "No" }] }],
+    });
+    const output = await nextOutput(iterator);
+    if (output.kind !== "interaction") throw new Error("Expected Grok Question");
+    await expect(
+      session.execute({
+        type: "interaction.respond",
+        interactionId: output.interaction.interactionId,
+        response: { type: "question", answers: {}, cancelled: true },
+      }),
+    ).resolves.toEqual({ ok: true, value: { accepted: true } });
+    await expect(native).resolves.toEqual({ outcome: "skip_interview" });
+    expect(await nextEvent(iterator)).toMatchObject({
+      type: "interaction.closed",
+      reason: "cancelled",
+    });
+    transport.finish();
+    for (;;) {
+      if ((await nextEvent(iterator)).type === "turn.completed") break;
+    }
+    await adapter.close();
+  });
+
+  it("presents exit_plan_mode as an explicit plan review", async () => {
+    const transport = new FakeGrokTransport();
+    const { adapter, session } = await openedSession(transport);
+    const iterator = session.outputs[Symbol.asyncIterator]();
+    const turnId = hostTurnIdSchema.parse("turn-grok-plan");
+    await session.execute({
+      type: "turn.start",
+      turnId,
+      input: [{ type: "text", text: "plan" }],
+    });
+    expect((await nextEvent(iterator)).type).toBe("turn.started");
+    const plan = "# Implementation plan\nEdit grok-adapter.ts.";
+    const native = transport.extension("_x.ai/exit_plan_mode", {
+      sessionId: transport.sessionId,
+      planContent: plan,
+      planFilePath: "/tmp/plan.md",
+    });
+    const output = await nextOutput(iterator);
+    if (output.kind !== "interaction" || output.interaction.type !== "question") {
+      throw new Error("Expected Grok Plan review");
+    }
+    expect(output.interaction).toMatchObject({
+      type: "question",
+      title: "Review plan",
+      questions: [
+        {
+          id: "plan-decision",
+          type: "choice",
+          multiple: false,
+          allowOther: false,
+          options: [
+            { value: "stay", label: "Stay in plan mode" },
+            { value: "approve", label: "Approve plan and exit plan mode" },
+          ],
+        },
+      ],
+    });
+    const planQuestion = output.interaction.questions[0];
+    if (planQuestion?.type !== "choice") throw new Error("Expected a choice Question");
+    expect(planQuestion.prompt).toContain(plan);
+    await expect(
+      session.execute({
+        type: "interaction.respond",
+        interactionId: output.interaction.interactionId,
+        response: { type: "question", answers: { "plan-decision": ["approve"] } },
+      }),
+    ).resolves.toEqual({ ok: true, value: { accepted: true } });
+    await expect(native).resolves.toEqual({ approved: true, feedback: "" });
+    expect(await nextEvent(iterator)).toMatchObject({
+      type: "interaction.closed",
+      reason: "responded",
+    });
+    transport.finish();
+    for (;;) {
+      if ((await nextEvent(iterator)).type === "turn.completed") break;
+    }
+    await adapter.close();
+  });
+
+  it("rejects an unknown Grok extension method without hanging the Turn", async () => {
+    const transport = new FakeGrokTransport();
+    const { adapter, session } = await openedSession(transport);
+    const iterator = session.outputs[Symbol.asyncIterator]();
+    await session.execute({
+      type: "turn.start",
+      turnId: hostTurnIdSchema.parse("turn-unknown-ext"),
+      input: [{ type: "text", text: "run" }],
+    });
+    expect((await nextEvent(iterator)).type).toBe("turn.started");
+    await expect(transport.extension("_x.ai/mcp/elicit", { sessionId: "session" })).rejects.toThrow(
+      /Method not found/,
+    );
     transport.finish();
     for (;;) {
       if ((await nextEvent(iterator)).type === "turn.completed") break;
@@ -1417,6 +1626,41 @@ describe("Grok Adapter ACP projection", () => {
     }
     expect(fetches).toBeGreaterThan(fetchesAfterOpen);
     expect(adapter.credits()?.usedPercent).toBe(Math.min(fetches * 10, 100));
+    await adapter.close();
+  });
+
+  it("closes pending Grok Questions immediately when the Turn is cancelled", async () => {
+    const transport = new FakeGrokTransport();
+    const { adapter, session } = await openedSession(transport);
+    const iterator = session.outputs[Symbol.asyncIterator]();
+    const turnId = hostTurnIdSchema.parse("turn-cancel-question");
+    await expect(
+      session.execute({ type: "turn.start", turnId, input: [{ type: "text", text: "ask" }] }),
+    ).resolves.toEqual({ ok: true, value: { turnId } });
+    expect((await nextEvent(iterator)).type).toBe("turn.started");
+    const native = transport.extension("_x.ai/ask_user_question", {
+      questions: [{ question: "Continue?", options: [{ label: "Yes" }, { label: "No" }] }],
+    });
+    const interactionOutput = await nextOutput(iterator);
+    if (interactionOutput.kind !== "interaction") throw new Error("Expected Grok Question");
+    await expect(session.execute({ type: "turn.cancel", turnId })).resolves.toEqual({
+      ok: true,
+      value: { cancellationRequested: true },
+    });
+    expect(await nextEvent(iterator)).toMatchObject({
+      type: "interaction.closed",
+      interactionId: interactionOutput.interaction.interactionId,
+      reason: "cancelled",
+    });
+    await expect(native).resolves.toEqual({ outcome: "skip_interview" });
+    transport.finish({ stopReason: "cancelled" });
+    for (;;) {
+      const event = await nextEvent(iterator);
+      if (event.type === "turn.completed") {
+        expect(event).toMatchObject({ turnId, outcome: { status: "cancelled" } });
+        break;
+      }
+    }
     await adapter.close();
   });
 

--- a/packages/adapters/grok/test/grok-plan-review.test.ts
+++ b/packages/adapters/grok/test/grok-plan-review.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from "vitest";
+
+import { hostInteractionIdSchema, hostTurnIdSchema } from "@codexhost/shared-contracts";
+
+import {
+  GROK_PLAN_DECISION_ID,
+  createGrokPlanReview,
+  grokExitPlanModeResponse,
+  grokPlanRejectedResponse,
+  parseGrokExitPlanModeParams,
+} from "../src/grok-plan-review.js";
+
+describe("Grok exit_plan_mode ACP envelope", () => {
+  it("parses camelCase and snake_case plan payloads", () => {
+    expect(
+      parseGrokExitPlanModeParams({
+        sessionId: "session",
+        planContent: "# Plan\nDo the work.",
+        planFilePath: "/tmp/plan.md",
+      }),
+    ).toEqual({
+      sessionId: "session",
+      plan: "# Plan\nDo the work.",
+      planFilePath: "/tmp/plan.md",
+    });
+    expect(
+      parseGrokExitPlanModeParams({
+        session_id: "session",
+        plan_content: "# Plan",
+        plan_file_path: "/tmp/plan.md",
+      }),
+    ).toMatchObject({ plan: "# Plan", planFilePath: "/tmp/plan.md" });
+  });
+
+  it("treats a missing plan as an empty review that cannot be approved", () => {
+    const request = parseGrokExitPlanModeParams({ sessionId: "session" });
+    if (!request) throw new Error("Expected a parsed Grok Plan request");
+    expect(request.plan).toBeNull();
+    const interaction = createGrokPlanReview(
+      request,
+      hostInteractionIdSchema.parse("plan-1"),
+      hostTurnIdSchema.parse("turn-1"),
+    );
+    expect(interaction.questions[0]).toMatchObject({
+      id: GROK_PLAN_DECISION_ID,
+      options: [{ value: "stay" }],
+    });
+    expect(interaction.questions[0]?.prompt).toContain("did not provide plan text");
+    expect(
+      grokExitPlanModeResponse(request, {
+        type: "question",
+        answers: { [GROK_PLAN_DECISION_ID]: ["approve"] },
+      }),
+    ).toEqual(grokPlanRejectedResponse());
+  });
+
+  it("maps approve, stay, and cancel to the native plan decision", () => {
+    const request = parseGrokExitPlanModeParams({ planContent: "# Implement" });
+    if (!request) throw new Error("Expected a parsed Grok Plan request");
+    const interaction = createGrokPlanReview(
+      request,
+      hostInteractionIdSchema.parse("plan-1"),
+      hostTurnIdSchema.parse("turn-1"),
+    );
+    expect(interaction.title).toBe("Review plan");
+    expect(interaction.questions[0]?.prompt).toContain("# Implement");
+    expect(interaction.questions[0]?.prompt).toContain("exit Grok plan mode");
+    expect(
+      grokExitPlanModeResponse(request, {
+        type: "question",
+        answers: { [GROK_PLAN_DECISION_ID]: ["approve"] },
+      }),
+    ).toEqual({ approved: true, feedback: "" });
+    expect(
+      grokExitPlanModeResponse(request, {
+        type: "question",
+        answers: { [GROK_PLAN_DECISION_ID]: ["stay"] },
+      }),
+    ).toEqual({ approved: false, feedback: "" });
+    expect(
+      grokExitPlanModeResponse(request, { type: "question", answers: {}, cancelled: true }),
+    ).toEqual({ approved: false, feedback: "" });
+  });
+});

--- a/packages/adapters/grok/test/grok-question.test.ts
+++ b/packages/adapters/grok/test/grok-question.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, it } from "vitest";
+
+import { hostInteractionIdSchema, hostTurnIdSchema } from "@codexhost/shared-contracts";
+
+import {
+  GROK_ACP_CLIENT_CAPABILITIES,
+  GROK_ASK_USER_QUESTION_METHODS,
+  createGrokQuestionInteraction,
+  grokAskUserQuestionResponse,
+  grokSkipInterviewResponse,
+  parseGrokAskUserQuestionParams,
+} from "../src/grok-question.js";
+
+describe("Grok ask_user_question ACP envelope", () => {
+  it("accepts both underscore-prefixed and bare wire methods", () => {
+    expect(GROK_ASK_USER_QUESTION_METHODS).toEqual([
+      "_x.ai/ask_user_question",
+      "x.ai/ask_user_question",
+    ]);
+  });
+
+  it("advertises Grok question RPCs without ACP elicitation.form", () => {
+    expect(GROK_ACP_CLIENT_CAPABILITIES).toEqual({
+      _meta: {
+        "x.ai/ask_user_question": true,
+        "x.ai/exit_plan_mode": true,
+      },
+    });
+    expect(GROK_ACP_CLIENT_CAPABILITIES).not.toHaveProperty("elicitation");
+  });
+
+  it("parses camelCase and snake_case question payloads", () => {
+    expect(
+      parseGrokAskUserQuestionParams({
+        sessionId: "session",
+        timeoutMs: 30_000,
+        questions: [
+          {
+            question: "Which path?",
+            header: "Path",
+            multiSelect: false,
+            options: [
+              { label: "Alpha", description: "First" },
+              { label: "Beta", preview: "Second preview" },
+            ],
+          },
+        ],
+      }),
+    ).toEqual({
+      sessionId: "session",
+      timeoutMs: 30_000,
+      questions: [
+        {
+          question: "Which path?",
+          header: "Path",
+          multiSelect: false,
+          options: [
+            { label: "Alpha", description: "First" },
+            { label: "Beta", description: "Second preview" },
+          ],
+        },
+      ],
+    });
+    expect(
+      parseGrokAskUserQuestionParams({
+        session_id: "session",
+        timeout_secs: 12,
+        questions: [
+          {
+            question: "Which features?",
+            multi_select: true,
+            options: [{ label: "Search" }, { label: "Edit" }],
+          },
+        ],
+      }),
+    ).toMatchObject({
+      sessionId: "session",
+      timeoutMs: 12_000,
+      questions: [{ question: "Which features?", multiSelect: true }],
+    });
+  });
+
+  it("rejects empty, duplicate, or option-less questions", () => {
+    expect(parseGrokAskUserQuestionParams({})).toBeNull();
+    expect(parseGrokAskUserQuestionParams({ questions: [] })).toBeNull();
+    expect(
+      parseGrokAskUserQuestionParams({
+        questions: [{ question: "Choose", options: [{ label: "A" }, { label: "A" }] }],
+      }),
+    ).toBeNull();
+    expect(
+      parseGrokAskUserQuestionParams({
+        questions: [{ question: "Choose", options: [] }],
+      }),
+    ).toBeNull();
+  });
+
+  it("projects a Host Question and maps answers back to the native envelope", () => {
+    const request = parseGrokAskUserQuestionParams({
+      questions: [
+        {
+          question: "Which path?",
+          options: [{ label: "Alpha" }, { label: "Beta" }],
+        },
+        {
+          question: "Which features?",
+          multiSelect: true,
+          options: [{ label: "Search" }, { label: "Edit" }],
+        },
+      ],
+    });
+    if (!request) throw new Error("Expected a parsed Grok Question");
+    const interaction = createGrokQuestionInteraction(
+      request,
+      hostInteractionIdSchema.parse("q-1"),
+      hostTurnIdSchema.parse("turn-1"),
+      1_000,
+    );
+    expect(interaction).toMatchObject({
+      type: "question",
+      title: "Grok",
+      questions: [
+        { id: "question-1", prompt: "Which path?", multiple: false, allowOther: true },
+        { id: "question-2", prompt: "Which features?", multiple: true },
+      ],
+    });
+    expect(
+      grokAskUserQuestionResponse(request, {
+        type: "question",
+        answers: { "question-1": ["Alpha"], "question-2": ["Search", "Custom"] },
+      }),
+    ).toEqual({
+      outcome: "accepted",
+      answers: {
+        "Which path?": "Alpha",
+        "Which features?": ["Search", "Custom"],
+      },
+      annotations: {},
+    });
+    expect(
+      grokAskUserQuestionResponse(request, { type: "question", answers: {}, cancelled: true }),
+    ).toEqual(grokSkipInterviewResponse());
+    expect(grokSkipInterviewResponse()).toEqual({ outcome: "skip_interview" });
+  });
+});


### PR DESCRIPTION
## Purpose

Grok Build's native choice UI (`ask_user_question`) and plan-approval flow (`exit_plan_mode`) never appeared in Codex Desktop. The ACP client did not implement `extMethod` and advertised no Grok question capabilities, so:

- `_x.ai/ask_user_question` returned **Method not found**, and the model fell back to plain text (or `Tool not available`).
- `_x.ai/exit_plan_mode` was auto-allowed internally, then cancelled with `PermissionCancelled`, which left the turn looking stuck.

This PR maps both private Grok RPCs onto the existing Host Question card (the same projection Claude Code uses for `AskUserQuestion` / `ExitPlanMode`). No Host, Protocol Core, or Renderer changes.

## Scope

**In this PR (Grok Adapter only)**

- ACP `Client.extMethod` for `_x.ai/ask_user_question` and `_x.ai/exit_plan_mode` (also accepts unprefixed `x.ai/...`).
- Initialize `clientCapabilities._meta` flags `x.ai/ask_user_question` and `x.ai/exit_plan_mode`. Does **not** advertise ACP `elicitation.form` — that drops `ask_user_question` from Grok's model tool table.
- Question envelope Grok actually deserializes: `{ outcome: "accepted", answers: { "<question text>": string | string[] }, annotations: {} }` and skip `{ outcome: "skip_interview" }`.
- Plan review card with Stay / Approve, returning `{ approved, feedback }`. Cancel and missing plan text cannot approve.
- Cancel / session close resolve pending questions with skip/reject instead of a JSON-RPC error, so the native turn does not hang.

**Left in the local working tree (not this PR)**

Unrelated Codex account / credits / usage work that was mixed in the same `develop` index:

- `docs/codex-accounts.md`
- `packages/adapters/grok/src/grok-credits.ts`
- `packages/host-runtime/src/account/*`, `app-server-host.ts`
- `packages/renderer-extension/src/renderer-credits-control.ts` and settings accounts UI
- `packages/shared-contracts/src/thread-usage.ts`

## Out of scope

- Codex Desktop multi-select: the Adapter sets Host `multiple: true`, but Desktop `requestUserInput` still submits on the first option click. Same limitation as Claude / Pi.
- Grok TUI "request changes + comments" (`feedback` is always `""`).
- `x.ai/mcp/elicit` and `ChatAboutThis`.
- Desktop auto-answer on `expiresAt`.

## Validation

```sh
npx vitest run --config tests/vitest.config.js \
  packages/adapters/grok/test/grok-question.test.ts \
  packages/adapters/grok/test/grok-plan-review.test.ts \
  packages/adapters/grok/test/grok-adapter.test.ts
```

52 tests passed (question envelope, plan review, adapter projection, cancel, unknown extMethod).

Live Desktop: single-select round-trip verified (user chose an option; Grok echoed it). Plan-approval card renders as **Review plan**, not Allow/Deny.

## Docs

`docs/grok-question-and-plan-mode.md` records the native envelopes, capability flags, and the Desktop multi-select limitation.