### PR TITLE
feat: integrate Meta Muse Code via native MSP

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@
 
 ## 界面预览
 
-无需切换应用，**Pi、Claude Code、OpenCode、OMP、Grok Build 和 DeepSeek Harness** 都可以在同一个 Codex Desktop 窗口中直接使用。
+无需切换应用，**Pi、Claude Code、OpenCode、OMP、Grok Build、DeepSeek Harness、Antigravity 和 Meta Muse Code** 都可以在同一个 Codex Desktop 窗口中直接使用。Muse 的原生版本、权限与恢复限制见[接入说明](docs/muse-harness.md)。
 
 https://github.com/user-attachments/assets/c48192d7-23ff-4f6e-b61a-6345a655bb76
 

--- a/docs/muse-harness.md
+++ b/docs/muse-harness.md
@@ -1,0 +1,45 @@
+# Meta Muse Code
+
+Muse 插件位于 `packages/adapters/muse`，ID 为 `muse`，通过原生 `muse serve` 的 MSP 接口运行。构建使用公共插件加载器，Desktop 使用共享插件路由；Host 不静态导入 Muse Adapter。
+
+## 使用
+
+安装并登录 Muse Code 后，在 Agent Picker 选择 **Meta Muse Code**。CLI 使用 `muse` 自动发现；需要固定安装时使用 `CODEXHOST_MUSE_COMMAND`。凭据由原生 Muse 读取，不复制到 Host 配置。
+
+本次验证接口为 Muse Code **1.0.3（1.0.3-R2198.1）**。模型目录来自原生 `model/list`。Thinking 使用 MSP 导出的枚举；CLI 帮助中的选项不自动视为 MSP 支持。
+
+默认权限为 `promptUnmatched`：原生规则已允许的操作直接执行，其余在 Desktop 请求批准。另提供 `denyUnmatched`。该版本的默认 `serve` 启动策略拒绝 `onRequest` 和 `allowAll`，故菜单不展示这两种不可用选项。旧引用仍可解码，原生拒绝会明确返回错误，不静默替换权限；不自动回答审批，不关闭 sandbox。
+
+## 会话与故障
+
+- 原生 Session 和 Turn ID 用于持久化、恢复和历史对齐。完整结束的会话可在 Host 重启后继续。
+- `item/delta` 按原生增量追加，以事件 cursor 去重。输出事件持有独立快照，避免异步消费时把最终全文再次追加。
+- 子会话、旧轮次和迟到事件不会完成当前轮次。原生 `turn/completed` 是父轮次终态依据，后台子任务可继续更新自己的状态。
+- 原生取消失败返回错误，不能宣布已经取消。进程故障使活动轮次明确失败，并阻止后续提交到失效进程。RPC 应答默认等待最多 30 秒，超时关闭失联进程。
+- 历史按原生分页顺序及 Turn ID 合并，保留失败、取消和未知终态；缺失结束记录不冒充成功。
+
+当前限制：尚未实现跨 Host 的活动审批接管。恢复结果仍有活动 Turn 或待回答交互时，返回可重试的 `sessionBusy`，保留原始历史及映射。不能将这类恢复称为无缝接管。跨目录 Fork、末轮 Rollback 不支持；未验证的平台、远程 Host 和原生子任务行为不因本机测试通过而自动获得保证。
+
+Host 的跨 Harness 委派目前要求 `unattended-full-access`，而该原生版本不接受相应 `allowAll`。因此 Muse 暂不能作为全自动委派目标：Adapter 在启动进程前返回明确 `unsupported`，不静默降权或伪造审批。普通交互式 Muse Thread 与观察 Muse 自身子任务是不同能力，不能据此前者可用就宣称完整委派对等。
+
+## 验证与更新
+
+在仓库支持的 Node 22 或 24 下执行：
+
+```sh
+npm run build:typescript
+npm run build:renderer
+npx vitest run --config tests/vitest.config.js packages/adapters/muse/test
+```
+
+默认单元测试不访问 Keychain、不发送真实模型请求。已登录本机的完整门禁需要显式启用：
+
+```sh
+CODEXHOST_MUSE_LIVE=1 npx vitest run --config tests/vitest.config.js packages/host-runtime/test/muse-live.test.ts
+```
+
+该门禁从临时插件根目录加载打包后的 Muse，使用真实 Host 路由和临时 Mapping Store，验证中文输出、持久化、Host 重启恢复、固定测试命令审批及取消续聊。官方 Codex 子进程使用测试替身；这不替代实际 Desktop 重启后的运行态核验。可设置 `CODEXHOST_MUSE_LIVE_ARTIFACT_DIR` 保存测试对话与验收记录。
+
+macOS 沙箱可能阻止 Muse 读取它自己的 Keychain 项，报 `keychain item for meta is unreadable (os status -50)`。应区分执行环境限制与账号失效，不读取或导出凭据来规避。
+
+插件和 Renderer 不支持热替换。构建通过后，在所有活动任务结束时运行 `npm start -- --no-build`，再检查新运行态。只覆盖磁盘文件或重载 Renderer 不会更新已加载的插件。单独终止 Controller 或 Host 也可能结束 Desktop 和其中的官方任务，不能当成无中断升级。

--- a/package-lock.json
+++ b/package-lock.json
@@ -218,6 +218,10 @@
       "resolved": "packages/adapters/grok",
       "link": true
     },
+    "node_modules/@codexhost/adapter-muse": {
+      "resolved": "packages/adapters/muse",
+      "link": true
+    },
     "node_modules/@codexhost/adapter-omp": {
       "resolved": "packages/adapters/omp",
       "link": true
@@ -5427,6 +5431,15 @@
         "@codexhost/harness-discovery": "0.0.0",
         "@codexhost/shared-contracts": "0.0.0",
         "diff": "8.0.2"
+      }
+    },
+    "packages/adapters/muse": {
+      "name": "@codexhost/adapter-muse",
+      "version": "0.0.0",
+      "dependencies": {
+        "@codexhost/harness-adapter": "0.0.0",
+        "@codexhost/harness-discovery": "0.0.0",
+        "@codexhost/shared-contracts": "0.0.0"
       }
     },
     "packages/adapters/omp": {

--- a/packages/adapters/muse/assets/icon.svg
+++ b/packages/adapters/muse/assets/icon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" role="img" aria-label="Meta Muse Code">
+  <path fill="#0668E1" d="M12 2.2c-1.9 3.4-4.8 6.4-8.6 8.4 3.8 2 6.7 5 8.6 8.4 1.9-3.4 4.8-6.4 8.6-8.4C16.8 8.6 13.9 5.6 12 2.2z"/>
+  <circle cx="12" cy="10.6" r="2.1" fill="#fff"/>
+</svg>

--- a/packages/adapters/muse/manifest.json
+++ b/packages/adapters/muse/manifest.json
@@ -1,0 +1,10 @@
+{
+  "manifestVersion": 1,
+  "id": "muse",
+  "name": "Meta Muse Code",
+  "version": "0.0.0",
+  "adapterApiVersion": 1,
+  "entry": "./dist/plugin.js",
+  "icon": "./assets/icon.svg",
+  "links": { "installation": "https://www.meta.ai/" }
+}

--- a/packages/adapters/muse/package.json
+++ b/packages/adapters/muse/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "@codexhost/adapter-muse",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "files": [
+    "dist",
+    "manifest.json",
+    "assets"
+  ],
+  "exports": {
+    "./plugin": {
+      "types": "./dist/plugin.d.ts",
+      "import": "./dist/plugin.js"
+    },
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "scripts": {
+    "build": "tsc -b"
+  },
+  "dependencies": {
+    "@codexhost/harness-adapter": "0.0.0",
+    "@codexhost/harness-discovery": "0.0.0",
+    "@codexhost/shared-contracts": "0.0.0"
+  }
+}

--- a/packages/adapters/muse/src/approval.ts
+++ b/packages/adapters/muse/src/approval.ts
@@ -1,0 +1,89 @@
+import type { HostApprovalAction, HostApprovalEffect } from "@codexhost/harness-adapter";
+
+export interface MuseRequirementRef {
+  approvalId: string;
+  sourceIndex: number;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+export function parseMuseRequirementRef(value: unknown): MuseRequirementRef | undefined {
+  if (!isRecord(value)) return undefined;
+  if (typeof value.approvalId !== "string" || value.approvalId.trim().length === 0) {
+    return undefined;
+  }
+  if (typeof value.sourceIndex !== "number" || !Number.isInteger(value.sourceIndex)) {
+    return undefined;
+  }
+  return { approvalId: value.approvalId, sourceIndex: value.sourceIndex };
+}
+
+export function museApprovalEffect(
+  choice: Record<string, unknown>,
+): HostApprovalEffect | undefined {
+  const decision = typeof choice.decision === "string" ? choice.decision : "";
+  const scope = typeof choice.scope === "string" ? choice.scope : "";
+  if (
+    decision === "denied" ||
+    decision === "deniedPolicyAmendment" ||
+    decision === "abort" ||
+    decision === "timedOut"
+  ) {
+    return "deny";
+  }
+  if (decision === "approvedForSession" || (decision === "approved" && scope === "session")) {
+    return "allowForSession";
+  }
+  if (
+    decision === "approvedPolicyAmendment" ||
+    (decision === "approved" && scope === "localPersistent")
+  ) {
+    return "allowAlways";
+  }
+  if (decision === "approved") return "allowOnce";
+  return undefined;
+}
+
+export function mapMuseApprovalActions(choices: unknown): HostApprovalAction[] {
+  if (!Array.isArray(choices)) return [];
+  const byEffect = new Map<HostApprovalEffect, HostApprovalAction>();
+  for (const raw of choices) {
+    if (!isRecord(raw)) continue;
+    const choiceId = typeof raw.choiceId === "string" ? raw.choiceId.trim() : "";
+    if (!choiceId) continue;
+    const effect = museApprovalEffect(raw);
+    if (!effect || byEffect.has(effect)) continue;
+    const label =
+      typeof raw.label === "string" && raw.label.trim().length > 0 ? raw.label.trim() : choiceId;
+    byEffect.set(effect, { id: choiceId, label, effect });
+  }
+  const order: HostApprovalEffect[] = ["allowOnce", "allowForSession", "allowAlways", "deny"];
+  return order.flatMap((effect) => {
+    const action = byEffect.get(effect);
+    return action ? [action] : [];
+  });
+}
+
+export function museApprovalProjectionReady(actions: HostApprovalAction[]): boolean {
+  const allows = actions.some(
+    (action) =>
+      action.effect === "allowOnce" ||
+      action.effect === "allowForSession" ||
+      action.effect === "allowAlways",
+  );
+  return allows && actions.some((action) => action.effect === "deny");
+}
+
+export function museApprovalTitle(params: Record<string, unknown>): string {
+  if (typeof params.toolName === "string" && params.toolName.trim()) return params.toolName.trim();
+  if (typeof params.title === "string" && params.title.trim()) return params.title.trim();
+  return "Muse tool approval";
+}
+
+export function museApprovalDescription(params: Record<string, unknown>): string | undefined {
+  if (typeof params.message === "string" && params.message.trim()) return params.message.trim();
+  if (typeof params.rawArgs === "string" && params.rawArgs.trim()) return params.rawArgs.trim();
+  return undefined;
+}

--- a/packages/adapters/muse/src/command.ts
+++ b/packages/adapters/muse/src/command.ts
@@ -1,0 +1,41 @@
+import path from "node:path";
+
+import {
+  resolveHarnessExecutable,
+  targetPath,
+  VERSION_MANAGER_ROOTS,
+  type HarnessDiscoverySpec,
+} from "@codexhost/harness-discovery";
+
+export const MUSE_COMMAND_ENV = "CODEXHOST_MUSE_COMMAND";
+
+export const museDiscoverySpec: HarnessDiscoverySpec = {
+  id: "muse",
+  command: "muse",
+  commandEnvironmentVariable: MUSE_COMMAND_ENV,
+  installRoots: {
+    posix: ["~/.local/bin", VERSION_MANAGER_ROOTS, "/opt/homebrew/bin", "/usr/local/bin"],
+    windows: ["${LOCALAPPDATA}/muse/bin", "~/.local/bin", VERSION_MANAGER_ROOTS],
+  },
+};
+
+export function resolveMuseExecutable(
+  input: {
+    command?: string;
+    environment?: NodeJS.ProcessEnv;
+    homeDirectory?: string;
+    platform?: NodeJS.Platform;
+  } = {},
+): string | undefined {
+  const platform = input.platform ?? process.platform;
+  const resolution = resolveHarnessExecutable(museDiscoverySpec, {
+    ...(input.command ? { command: input.command } : {}),
+    environment: input.environment ?? process.env,
+    ...(input.homeDirectory ? { homeDirectory: input.homeDirectory } : {}),
+    platform,
+  });
+  if (!resolution) return undefined;
+  return targetPath(platform).isAbsolute(resolution.executable)
+    ? resolution.executable
+    : path.resolve(resolution.executable);
+}

--- a/packages/adapters/muse/src/history.ts
+++ b/packages/adapters/muse/src/history.ts
@@ -1,0 +1,520 @@
+import type {
+  HistoricalTurnOutcome,
+  HostItem,
+  HostItemOutcome,
+  HostSubagentState,
+  HostSubagentStatus,
+  HostThreadSnapshot,
+  HostTurnSnapshot,
+} from "@codexhost/harness-adapter";
+import {
+  hostItemIdSchema,
+  nativeTurnRefSchema,
+  type JsonValue,
+  type NativeSessionRef,
+} from "@codexhost/shared-contracts";
+
+import type { JsonObject, MuseRpc } from "./msp-client.js";
+import { MuseRpcError } from "./msp-client.js";
+
+/** MSP Item text: user/agent use `text`; other kinds fall back to visible surfaces. */
+export function museItemText(item: JsonObject): string {
+  if (typeof item.text === "string" && item.text) return item.text;
+  if (typeof item.displayText === "string" && item.displayText) return item.displayText;
+  if (typeof item.fallbackText === "string" && item.fallbackText) return item.fallbackText;
+  if (typeof item.visibleOutput === "string" && item.visibleOutput) return item.visibleOutput;
+  if (typeof item.message === "string" && item.message) return item.message;
+  if (typeof item.result === "string" && item.result) return item.result;
+  if (Array.isArray(item.summary)) {
+    return item.summary.filter((part): part is string => typeof part === "string").join("\n");
+  }
+  return "";
+}
+
+function itemId(item: JsonObject, fallback: string): string {
+  return typeof item.itemId === "string" && item.itemId.trim() ? item.itemId : fallback;
+}
+
+/** The native turn owns steered inputs too; their submitting command IDs may differ. */
+export function museNativeTurnKey(item: JsonObject, fallbackIndex: number): string {
+  if (typeof item.turnId === "string" && item.turnId.trim()) return item.turnId;
+  if (typeof item.commandId === "string" && item.commandId.trim()) return item.commandId;
+  if (typeof item.itemId === "string" && item.itemId.trim()) return item.itemId;
+  return `turn:${fallbackIndex}`;
+}
+
+export function snapshotFromMuseHistory(
+  nativeRef: NativeSessionRef,
+  history: JsonObject | undefined,
+): HostThreadSnapshot {
+  const rawItems = Array.isArray(history?.items) ? history.items.filter(isRecord) : [];
+  const turns: HostTurnSnapshot[] = [];
+  const turnsById = new Map<string, HostTurnSnapshot>();
+  let current: HostTurnSnapshot | undefined;
+  let index = 0;
+  for (const item of rawItems) {
+    const kind = typeof item.kind === "string" ? item.kind : "";
+    const nativeTurnKey =
+      kind === "userMessage" || (typeof item.turnId === "string" && item.turnId.trim())
+        ? museNativeTurnKey(item, index)
+        : (current?.nativeTurnRef.nativeTurnKey ?? museNativeTurnKey(item, index));
+    current = turnsById.get(nativeTurnKey);
+    if (!current) {
+      current = {
+        nativeTurnRef: nativeTurnRefSchema.parse({
+          harnessId: nativeRef.harnessId,
+          nativeSessionId: nativeRef.nativeSessionId,
+          nativeTurnKey,
+          formatVersion: 1,
+        }),
+        input: [],
+        items: [],
+        outcome: { status: "unknown", reason: "Muse turn/completed was not available in history" },
+      };
+      turns.push(current);
+      turnsById.set(nativeTurnKey, current);
+    }
+    index += 1;
+    if (kind === "userMessage") {
+      current.input.push({ type: "text", text: museItemText(item) });
+      continue;
+    }
+    const mapped = mapMuseHostItem(item, `item-${index}`);
+    if (mapped) current.items.push({ item: mapped, outcome: museHistoryItemOutcome(item) });
+  }
+  const completions = Array.isArray(history?.turnCompletions)
+    ? history.turnCompletions.filter(isRecord)
+    : [];
+  for (const completion of completions) {
+    const turn =
+      typeof completion.turnId === "string" ? turnsById.get(completion.turnId) : undefined;
+    if (turn) turn.outcome = museHistoryTurnOutcome(completion);
+  }
+  return { turns };
+}
+
+export function museHistoryTurnOutcome(completion: JsonObject): HistoricalTurnOutcome {
+  const terminal = completion.terminal;
+  if (terminal === "completed") return { status: "succeeded" };
+  const reason = typeof completion.reason === "string" ? completion.reason : undefined;
+  if (terminal === "cancelled") return { status: "cancelled", ...(reason ? { reason } : {}) };
+  if (terminal === "failed") {
+    const error = isRecord(completion.error) ? completion.error : undefined;
+    return {
+      status: "failed",
+      error: {
+        code: "nativeFailure",
+        message:
+          typeof error?.message === "string" ? error.message : (reason ?? "Muse Turn failed"),
+        retryable: error?.retryable === true,
+      },
+    };
+  }
+  return { status: "unknown", reason: `Unknown Muse turn terminal: ${String(terminal)}` };
+}
+
+export function museHistoryItemOutcome(item: JsonObject): HostItemOutcome {
+  const reason =
+    (typeof item.failureReason === "string" && item.failureReason) ||
+    (typeof item.reason === "string" && item.reason) ||
+    `Muse item ${String(item.status)}`;
+  if (item.status === "cancelled" || item.status === "rejected") {
+    return { status: "cancelled", reason };
+  }
+  if (item.status === "failed" || item.status === "timedOut") {
+    return {
+      status: "failed",
+      error: { code: "nativeFailure", message: reason, retryable: false },
+    };
+  }
+  // Host item snapshots have no unknown/in-progress outcome. Preserve visible
+  // partial/legacy items; only the native turn/completed can confirm turn success.
+  return { status: "succeeded" };
+}
+
+export function mapMuseHostItem(item: JsonObject, fallbackId: string): HostItem | undefined {
+  const kind = typeof item.kind === "string" ? item.kind : "";
+  if (kind === "userMessage") return undefined;
+  const itemIdValue = hostItemIdSchema.parse(itemId(item, fallbackId));
+  if (kind === "agentMessage") {
+    return { type: "agentMessage", itemId: itemIdValue, text: museItemText(item) };
+  }
+  if (kind === "reasoning") {
+    return { type: "reasoning", itemId: itemIdValue, text: museItemText(item) };
+  }
+  if (kind === "toolCall") {
+    const output = museItemText(item);
+    return {
+      type: "toolExecution",
+      itemId: itemIdValue,
+      toolName:
+        typeof item.tool === "string" && item.tool
+          ? item.tool
+          : typeof item.scriptId === "string" && item.scriptId
+            ? item.scriptId
+            : "tool",
+      arguments: museToolArguments(item.args),
+      ...(output ? { output: { content: [{ type: "text" as const, text: output }] } } : {}),
+    };
+  }
+  if (kind === "userShell") {
+    const output = museItemText(item);
+    return {
+      type: "commandExecution",
+      itemId: itemIdValue,
+      command: typeof item.commandText === "string" ? item.commandText : output,
+      ...(output ? { output } : {}),
+      ...(typeof item.exitCode === "number" ? { exitCode: item.exitCode } : {}),
+    };
+  }
+  if (kind === "compaction") {
+    return { type: "contextCompaction", itemId: itemIdValue };
+  }
+  if (kind === "subagent") {
+    const state = museSubagentState(item, itemIdValue);
+    return {
+      type: "subagentDelegation",
+      itemId: itemIdValue,
+      operation: "spawn",
+      ...(typeof item.objective === "string" && item.objective ? { prompt: item.objective } : {}),
+      subagents: [state],
+    };
+  }
+  if (kind === "workflow") {
+    const children = Array.isArray(item.children) ? item.children.filter(isRecord) : [];
+    const subagents = children.flatMap((child) => {
+      const state = workflowChildState(child);
+      return state ? [state] : [];
+    });
+    const summary = museItemText(item);
+    return {
+      type: "subagentDelegation",
+      itemId: itemIdValue,
+      operation: "spawn",
+      ...(summary ? { prompt: summary } : {}),
+      subagents:
+        subagents.length > 0
+          ? subagents
+          : [
+              {
+                subagentId: itemIdValue,
+                nativeSubagentId: itemIdValue,
+                description: summary || "Muse workflow",
+                background: false,
+                status: museItemStatus(item),
+                ...(summary ? { resultSummary: summary } : {}),
+              },
+            ],
+    };
+  }
+  if (kind) {
+    return {
+      type: "toolExecution",
+      itemId: itemIdValue,
+      toolName: kind,
+      arguments: {},
+      ...(museItemText(item)
+        ? { output: { content: [{ type: "text" as const, text: museItemText(item) }] } }
+        : {}),
+    };
+  }
+  return undefined;
+}
+
+function museToolArguments(args: unknown): JsonValue {
+  if (typeof args !== "string") return {};
+  try {
+    return JSON.parse(args) as JsonValue;
+  } catch {
+    // MSP preserves model-authored almost-JSON verbatim; do not discard it.
+    return args;
+  }
+}
+
+const MUSE_RECOVERING_CONTROL = new Set([
+  "accepted",
+  "starting",
+  "running",
+  "recoveryPending",
+  "manualReconciliation",
+]);
+const MUSE_TERMINAL_CONTROL = new Set(["resultReady", "closing", "closed"]);
+
+export function museSubagentControl(item: JsonObject): string {
+  return typeof item.controlStatus === "string" ? item.controlStatus : "";
+}
+
+export function museSubagentIsRecovering(item: JsonObject): boolean {
+  return MUSE_RECOVERING_CONTROL.has(museSubagentControl(item));
+}
+
+export function museSubagentIsTerminal(item: JsonObject): boolean {
+  const control = museSubagentControl(item);
+  if (MUSE_RECOVERING_CONTROL.has(control)) return false;
+  if (MUSE_TERMINAL_CONTROL.has(control)) return true;
+  const status = typeof item.status === "string" ? item.status : "";
+  return status !== "" && status !== "inProgress";
+}
+
+function museResultErrorKind(result: JsonObject | undefined): string {
+  if (!result || typeof result.errorKind !== "string") return "";
+  const kind = result.errorKind.trim();
+  if (!kind || kind === "null" || kind === "none" || kind === "undefined") return "";
+  return kind;
+}
+
+function museItemStatus(item: JsonObject): HostSubagentStatus {
+  const status = typeof item.status === "string" ? item.status : "";
+  const control = museSubagentControl(item);
+  const result = isRecord(item.result) ? item.result : undefined;
+  const errorKind = museResultErrorKind(result);
+  if (museSubagentIsRecovering(item)) return "running";
+  if (status === "cancelled" || status === "rejected" || status === "timedOut")
+    return "interrupted";
+  if (status === "failed" || errorKind) return "failed";
+  if (
+    status === "completed" ||
+    control === "closed" ||
+    control === "resultReady" ||
+    control === "closing"
+  ) {
+    return "completed";
+  }
+  if (status === "inProgress") return "running";
+  return "pending";
+}
+
+function museSubagentSummary(item: JsonObject, status: HostSubagentStatus): string | undefined {
+  const result = isRecord(item.result) ? item.result : undefined;
+  const summary =
+    (typeof result?.summary === "string" && result.summary.trim()) ||
+    (typeof result?.text === "string" && result.text.trim()) ||
+    "";
+  if (summary) return summary;
+  if (status !== "failed" && status !== "interrupted") return undefined;
+  const reason =
+    (typeof item.failureReason === "string" && item.failureReason.trim()) ||
+    (typeof item.fallbackText === "string" && item.fallbackText.trim()) ||
+    (typeof item.reason === "string" && item.reason.trim()) ||
+    museResultErrorKind(result);
+  return reason || undefined;
+}
+
+function museSubagentState(item: JsonObject, fallbackId: string): HostSubagentState {
+  const durableId =
+    (typeof item.subagentId === "string" && item.subagentId.trim()) ||
+    (typeof item.childSessionId === "string" && item.childSessionId.trim()) ||
+    fallbackId;
+  const childSessionId =
+    typeof item.childSessionId === "string" && item.childSessionId.trim()
+      ? item.childSessionId.trim()
+      : "";
+  const status = museItemStatus(item);
+  const summary = museSubagentSummary(item, status);
+  const description =
+    (typeof item.objective === "string" && item.objective.trim()) ||
+    (typeof item.fallbackText === "string" && item.fallbackText.trim()) ||
+    (typeof item.role === "string" && item.role.trim()) ||
+    "Muse subagent";
+  const role = typeof item.role === "string" && item.role.trim() ? item.role.trim() : undefined;
+  const nativeSubagentId =
+    (status === "failed" || status === "interrupted") && !childSessionId ? undefined : durableId;
+  return {
+    subagentId: durableId,
+    ...(nativeSubagentId ? { nativeSubagentId } : {}),
+    description,
+    background: item.background === true,
+    status,
+    ...(role ? { role } : {}),
+    ...(summary ? { resultSummary: summary } : {}),
+  };
+}
+
+function workflowChildState(child: JsonObject): HostSubagentState | undefined {
+  const id = typeof child.childId === "string" && child.childId.trim() ? child.childId.trim() : "";
+  if (!id) return undefined;
+  const terminal = typeof child.terminal === "string" ? child.terminal : "";
+  const status = typeof child.status === "string" ? child.status : "";
+  const hostStatus: HostSubagentStatus =
+    terminal === "failed" || status === "failed"
+      ? "failed"
+      : terminal === "cancelled" || status === "cancelled"
+        ? "interrupted"
+        : terminal === "completed" || status === "completed" || status === "closed"
+          ? "completed"
+          : status === "running" || status === "starting"
+            ? "running"
+            : "pending";
+  const label = typeof child.label === "string" && child.label.trim() ? child.label.trim() : id;
+  return {
+    subagentId: id,
+    nativeSubagentId: id,
+    description: label,
+    background: false,
+    status: hostStatus,
+  };
+}
+
+export function findMuseChildSessionId(
+  history: JsonObject | undefined,
+  nativeId: string,
+): string | undefined {
+  if (!nativeId) return undefined;
+  const items = Array.isArray(history?.items) ? history.items.filter(isRecord) : [];
+  for (const item of items) {
+    const subagentId = typeof item.subagentId === "string" ? item.subagentId : "";
+    const childSessionId = typeof item.childSessionId === "string" ? item.childSessionId : "";
+    const itemIdValue = typeof item.itemId === "string" ? item.itemId : "";
+    if (nativeId === subagentId || nativeId === childSessionId || nativeId === itemIdValue) {
+      return childSessionId || subagentId || itemIdValue;
+    }
+    if (!Array.isArray(item.children)) continue;
+    for (const child of item.children.filter(isRecord)) {
+      const childId = typeof child.childId === "string" ? child.childId : "";
+      if (childId === nativeId) return childId;
+    }
+  }
+  return undefined;
+}
+
+export async function readMuseHistory(
+  rpc: MuseRpc,
+  sessionId: string,
+): Promise<JsonObject | undefined> {
+  let read: JsonObject | undefined;
+  try {
+    const result = await rpc.request("session/read", { sessionId, excludeItems: false });
+    if (isRecord(result.history)) read = result.history;
+  } catch (error) {
+    if (!(error instanceof MuseRpcError) || (error.code !== -32601 && error.code !== -32602)) {
+      throw error;
+    }
+  }
+  const paged = await pageMuseHistory(rpc, sessionId);
+  return mergeMuseHistory(read, paged.items, paged.turnCompletions);
+}
+
+export function mergeMuseHistory(
+  read: JsonObject | undefined,
+  pagedItems: JsonObject[],
+  turnCompletions: JsonObject[] = [],
+): JsonObject | undefined {
+  const readItems = Array.isArray(read?.items) ? read.items.filter(isRecord) : [];
+  const readById = new Map(readItems.map((item) => [item.itemId, item]));
+  const pagedIds = new Set(pagedItems.map((item) => item.itemId));
+  const beforePagedId = new Map<unknown, JsonObject[]>();
+  let pending: JsonObject[] = [];
+  for (const item of readItems) {
+    if (pagedIds.has(item.itemId)) {
+      if (pending.length > 0) beforePagedId.set(item.itemId, pending);
+      pending = [];
+    } else pending.push(item);
+  }
+  const merged = pagedItems.flatMap((item) => [
+    ...(beforePagedId.get(item.itemId) ?? []),
+    latestMuseItem(readById.get(item.itemId), item),
+  ]);
+  // With no common anchor, retain inline history as the prefix (older servers
+  // can serve only supplemental items in view/page). Otherwise append its suffix.
+  if (readItems.some((item) => pagedIds.has(item.itemId))) merged.push(...pending);
+  else merged.unshift(...pending);
+  if (merged.length === 0 && turnCompletions.length === 0) return read;
+  return {
+    ...(read ?? {}),
+    mode: typeof read?.mode === "string" ? read.mode : "inline",
+    items: merged,
+    turnCompletions,
+    snapshot: read?.snapshot ?? null,
+  };
+}
+
+export async function readMuseChildHistory(
+  rpc: MuseRpc,
+  parentSessionId: string,
+  nativeSubagentId: string,
+): Promise<JsonObject | undefined> {
+  const direct = await readMuseHistory(rpc, nativeSubagentId);
+  if (museHistoryHasVisibleItems(direct)) return direct;
+  const parent = await readMuseHistory(rpc, parentSessionId);
+  const childId = findMuseChildSessionId(parent, nativeSubagentId);
+  if (childId && childId !== nativeSubagentId) {
+    const nested = await readMuseHistory(rpc, childId);
+    if (nested) return nested;
+  }
+  return direct;
+}
+
+async function pageMuseHistory(
+  rpc: MuseRpc,
+  sessionId: string,
+): Promise<{ items: JsonObject[]; turnCompletions: JsonObject[] }> {
+  const ordered: JsonObject[] = [];
+  const turnCompletions: JsonObject[] = [];
+  const indexById = new Map<string, number>();
+  let cursor: string | undefined;
+  try {
+    for (let pageIndex = 0; pageIndex < 32; pageIndex += 1) {
+      const page = await rpc.request("view/page", {
+        sessionId,
+        direction: "forward",
+        limit: 1000,
+        ...(cursor ? { cursor } : {}),
+      });
+      const events = Array.isArray(page.events) ? page.events.filter(isRecord) : [];
+      for (const event of events) {
+        const params = isRecord(event.params) ? event.params : {};
+        if (event.method === "turn/completed") turnCompletions.push(params);
+        const item = isRecord(params.item) ? params.item : undefined;
+        if (!item) continue;
+        const id = typeof item.itemId === "string" ? item.itemId : "";
+        const existing = id ? indexById.get(id) : undefined;
+        if (existing !== undefined) ordered[existing] = latestMuseItem(ordered[existing], item);
+        else {
+          if (id) indexById.set(id, ordered.length);
+          ordered.push(item);
+        }
+      }
+      const nextCursor = typeof page.nextCursor === "string" ? page.nextCursor : "";
+      if (!nextCursor || nextCursor === cursor) break;
+      cursor = nextCursor;
+    }
+  } catch (error) {
+    if (error instanceof MuseRpcError && (error.code === -32601 || error.code === -32602)) {
+      return { items: ordered, turnCompletions };
+    }
+    throw error;
+  }
+  return { items: ordered, turnCompletions };
+}
+
+function latestMuseItem(existing: JsonObject | undefined, candidate: JsonObject): JsonObject {
+  if (
+    existing &&
+    typeof existing.revision === "number" &&
+    typeof candidate.revision === "number" &&
+    candidate.revision <= existing.revision
+  ) {
+    return existing;
+  }
+  return candidate;
+}
+
+function museHistoryHasVisibleItems(history: JsonObject | undefined): boolean {
+  const items = Array.isArray(history?.items) ? history.items.filter(isRecord) : [];
+  return items.some((item) => {
+    const kind = typeof item.kind === "string" ? item.kind : "";
+    return (
+      kind === "userMessage" ||
+      kind === "agentMessage" ||
+      kind === "reasoning" ||
+      kind === "toolCall" ||
+      kind === "userShell" ||
+      kind === "subagent" ||
+      kind === "workflow"
+    );
+  });
+}
+
+function isRecord(value: unknown): value is JsonObject {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/packages/adapters/muse/src/index.ts
+++ b/packages/adapters/muse/src/index.ts
@@ -1,0 +1,22 @@
+import { packageMetadata as harnessAdapter } from "@codexhost/harness-adapter";
+import { WORKSPACE_CONTRACT_VERSION } from "@codexhost/shared-contracts";
+
+export { MuseAdapter } from "./muse-adapter.js";
+export type { MuseAdapterOptions } from "./muse-adapter.js";
+export { resolveMuseExecutable } from "./command.js";
+export { parseMuseModelCatalog } from "./model-catalog.js";
+export {
+  mapMuseApprovalActions,
+  museApprovalProjectionReady,
+  parseMuseRequirementRef,
+} from "./approval.js";
+export { MUSE_MSP_NOTIFICATIONS, MUSE_MSP_REQUEST_METHODS } from "./msp-surface.js";
+export { museNativeTurnKey, snapshotFromMuseHistory } from "./history.js";
+export { MUSE_PERMISSION_MODE_CATALOG } from "./permission-modes.js";
+export { uuidv7 } from "./uuid.js";
+
+export const packageMetadata = {
+  name: "@codexhost/adapter-muse",
+  contractVersion: WORKSPACE_CONTRACT_VERSION,
+  adapterContract: harnessAdapter.name,
+} as const;

--- a/packages/adapters/muse/src/model-catalog.ts
+++ b/packages/adapters/muse/src/model-catalog.ts
@@ -1,0 +1,72 @@
+import {
+  harnessModelCatalogSchema,
+  harnessModelRefSchema,
+  harnessThinkingOptionIdSchema,
+  type HarnessModelCatalog,
+  type HarnessModelRef,
+  type HarnessThinkingOptionId,
+} from "@codexhost/shared-contracts";
+
+export const MUSE_THINKING_OPTIONS = [
+  { id: "none", native: "none", label: "None" },
+  { id: "minimal", native: "minimal", label: "Minimal" },
+  { id: "low", native: "low", label: "Low" },
+  { id: "medium", native: "medium", label: "Medium" },
+  { id: "high", native: "high", label: "High" },
+  { id: "xhigh", native: "xhigh", label: "Extra high" },
+  { id: "ultra", native: "ultra", label: "Ultra" },
+] as const;
+
+export const MUSE_DEFAULT_THINKING_OPTION_ID = harnessThinkingOptionIdSchema.parse("high");
+
+export type MuseReasoningEffort = (typeof MUSE_THINKING_OPTIONS)[number]["native"];
+
+export interface MuseModelRow {
+  readonly modelId: string;
+  readonly displayLabel: string;
+  readonly providerId?: string;
+  readonly isDefault?: boolean;
+}
+
+export function museThinkingOptionId(value: string): HarnessThinkingOptionId {
+  return harnessThinkingOptionIdSchema.parse(value);
+}
+
+export function decodeMuseThinkingOptionId(value: HarnessThinkingOptionId): MuseReasoningEffort {
+  const option = MUSE_THINKING_OPTIONS.find((entry) => entry.id === value);
+  if (!option) throw new Error("Muse Thinking option belongs to another Adapter");
+  return option.native;
+}
+
+export function parseMuseModelCatalog(rows: readonly MuseModelRow[]): HarnessModelCatalog {
+  const thinkingOptions = MUSE_THINKING_OPTIONS.map((option) => ({
+    id: harnessThinkingOptionIdSchema.parse(option.id),
+    label: option.label,
+  }));
+  const thinkingIds = thinkingOptions.map((option) => option.id);
+  const models = rows.flatMap((row) => {
+    const ref = harnessModelRefSchema.safeParse({ id: row.modelId });
+    if (!ref.success) return [];
+    return [
+      {
+        ref: ref.data,
+        label: row.displayLabel || row.modelId,
+        supportedThinkingOptionIds: thinkingIds,
+      },
+    ];
+  });
+  const defaultRow = rows.find((row) => row.isDefault) ?? rows[0];
+  const defaultModel = defaultRow
+    ? harnessModelRefSchema.safeParse({ id: defaultRow.modelId }).data
+    : undefined;
+  return harnessModelCatalogSchema.parse({
+    models,
+    ...(defaultModel ? { defaultModel } : {}),
+    thinkingOptions,
+    defaultThinkingOptionId: MUSE_DEFAULT_THINKING_OPTION_ID,
+  });
+}
+
+export function museModelRef(modelId: string): HarnessModelRef {
+  return harnessModelRefSchema.parse({ id: modelId });
+}

--- a/packages/adapters/muse/src/msp-client.ts
+++ b/packages/adapters/muse/src/msp-client.ts
@@ -1,0 +1,320 @@
+import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
+
+import { sanitizeDiagnosticTail, type HarnessError } from "@codexhost/harness-adapter";
+import { commandInvocation } from "@codexhost/harness-discovery";
+
+export type JsonObject = Record<string, unknown>;
+
+export interface MuseRpcNotification {
+  method: string;
+  params?: JsonObject;
+}
+
+export interface MuseRpc {
+  handshake(): Promise<JsonObject>;
+  request(method: string, params?: JsonObject): Promise<JsonObject>;
+  notify(method: string, params?: JsonObject): void;
+  subscribe(handler: (notification: MuseRpcNotification) => void): () => void;
+  /** Reports a terminal transport failure, including one preceding subscription. */
+  subscribeFailure(handler: (error: MuseProcessError) => void): () => void;
+  close(): Promise<void>;
+}
+
+export class MuseRpcError extends Error {
+  readonly code: number;
+  readonly data?: unknown;
+
+  constructor(message: string, code: number, data?: unknown) {
+    super(message);
+    this.name = "MuseRpcError";
+    this.code = code;
+    this.data = data;
+  }
+}
+
+export class MuseProcessError extends Error {
+  readonly harnessError: HarnessError;
+
+  constructor(error: HarnessError) {
+    super(error.message);
+    this.name = "MuseProcessError";
+    this.harnessError = error;
+  }
+}
+
+interface PendingRequest {
+  resolve(value: JsonObject): void;
+  reject(error: unknown): void;
+  timeout: NodeJS.Timeout;
+}
+
+type MuseRpcId = number | string;
+
+function rpcId(value: unknown): MuseRpcId | undefined {
+  if (typeof value === "number" && Number.isFinite(value)) return value;
+  if (typeof value === "string" && value.trim()) return value;
+  return undefined;
+}
+
+export interface MuseServeOptions {
+  executable: string;
+  cwd: string;
+  environment: NodeJS.ProcessEnv;
+  extraArguments?: string[];
+  requestTimeoutMs?: number;
+  closeTimeoutMs?: number;
+}
+
+function isRecord(value: unknown): value is JsonObject {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+export class MuseServeClient implements MuseRpc {
+  #child: ChildProcessWithoutNullStreams;
+  #buffer = "";
+  #nextId = 1;
+  #pending = new Map<MuseRpcId, PendingRequest>();
+  #listeners = new Set<(notification: MuseRpcNotification) => void>();
+  #failureListeners = new Set<(error: MuseProcessError) => void>();
+  #failure: MuseProcessError | null = null;
+  #closed = false;
+  #exited = false;
+  #closePromise: Promise<void> | null = null;
+  #stderr = "";
+  #requestTimeoutMs: number;
+  #closeTimeoutMs: number;
+
+  constructor(options: MuseServeOptions) {
+    this.#requestTimeoutMs = options.requestTimeoutMs ?? 30_000;
+    this.#closeTimeoutMs = options.closeTimeoutMs ?? 1_000;
+    const invocation = commandInvocation(
+      options.executable,
+      ["serve", "--trust-workspace", ...(options.extraArguments ?? [])],
+      options.environment,
+    );
+    this.#child = spawn(invocation.command, invocation.arguments, {
+      cwd: options.cwd,
+      env: options.environment,
+      stdio: ["pipe", "pipe", "pipe"],
+      windowsHide: true,
+      windowsVerbatimArguments: invocation.windowsVerbatimArguments,
+    });
+    this.#child.stdout.setEncoding("utf8");
+    this.#child.stderr.setEncoding("utf8");
+    this.#child.stdout.on("data", (chunk: string) => this.#onStdout(chunk));
+    this.#child.stderr.on("data", (chunk: string) => {
+      this.#stderr = `${this.#stderr}${chunk}`.slice(-4000);
+    });
+    this.#child.on("error", (error) => this.#onProcessError("process", error));
+    this.#child.stdin.on("error", (error) => this.#onProcessError("stdin", error));
+    this.#child.stdout.on("error", (error) => this.#onProcessError("stdout", error));
+    this.#child.stdout.on("end", () => {
+      this.#onProcessError("stdout", new Error("output stream ended"));
+    });
+    this.#child.stderr.on("error", (error) => this.#onProcessError("stderr", error));
+    this.#child.on("exit", (code, signal) => {
+      this.#exited = true;
+      if (this.#closed) return;
+      const error = new MuseProcessError({
+        code: "processExited",
+        message: `Muse serve exited${code === null ? "" : ` with code ${code}`}${signal ? ` (${signal})` : ""}`,
+        retryable: true,
+        ...(this.#stderr ? { diagnostic: sanitizeDiagnosticTail(this.#stderr) } : {}),
+      });
+      this.#failTransport(error);
+    });
+    this.#child.on("close", () => {
+      this.#exited = true;
+    });
+  }
+
+  async handshake(): Promise<JsonObject> {
+    const result = await this.request("initialize", {
+      clientInfo: { name: "codexhost", title: "Codex Host", version: "0.6.0" },
+      capabilities: { experimentalApi: true },
+    });
+    this.notify("initialized");
+    return result;
+  }
+
+  async request(method: string, params?: JsonObject): Promise<JsonObject> {
+    if (this.#failure) throw this.#failure;
+    if (this.#closed) {
+      throw new MuseProcessError({
+        code: "invalidState",
+        message: "Muse serve is closed",
+        retryable: false,
+      });
+    }
+    const id = this.#nextId;
+    this.#nextId += 1;
+    const payload: JsonObject = { jsonrpc: "2.0", id, method };
+    if (params && Object.keys(params).length > 0) payload.params = params;
+    const frame = `${JSON.stringify(payload)}\n`;
+    const result = new Promise<JsonObject>((resolve, reject) => {
+      const timeout = setTimeout(() => {
+        this.#failTransport(
+          new MuseProcessError({
+            code: "protocolError",
+            message: `Muse RPC ${method} timed out after ${this.#requestTimeoutMs}ms`,
+            retryable: true,
+          }),
+        );
+      }, this.#requestTimeoutMs);
+      this.#pending.set(id, { resolve, reject, timeout });
+    });
+    this.#write(frame);
+    return result;
+  }
+
+  notify(method: string, params?: JsonObject): void {
+    if (this.#closed || this.#failure) return;
+    const payload: JsonObject = { jsonrpc: "2.0", method };
+    if (params && Object.keys(params).length > 0) payload.params = params;
+    this.#write(`${JSON.stringify(payload)}\n`);
+  }
+
+  subscribe(handler: (notification: MuseRpcNotification) => void): () => void {
+    this.#listeners.add(handler);
+    return () => this.#listeners.delete(handler);
+  }
+
+  subscribeFailure(handler: (error: MuseProcessError) => void): () => void {
+    this.#failureListeners.add(handler);
+    const failure = this.#failure;
+    if (failure) {
+      queueMicrotask(() => {
+        if (this.#failureListeners.has(handler)) handler(failure);
+      });
+    }
+    return () => this.#failureListeners.delete(handler);
+  }
+
+  close(): Promise<void> {
+    if (this.#closePromise) return this.#closePromise;
+    this.#closed = true;
+    this.#failAll(
+      new MuseProcessError({
+        code: "invalidState",
+        message: "Muse serve closed",
+        retryable: false,
+      }),
+    );
+    this.#closePromise = this.#stopProcess();
+    return this.#closePromise;
+  }
+
+  async #stopProcess(): Promise<void> {
+    if (this.#exited || !this.#child.pid) return;
+    this.#child.stdin.end();
+    this.#child.kill("SIGTERM");
+    if (await this.#waitForExit()) return;
+    this.#child.kill("SIGKILL");
+    if (await this.#waitForExit()) return;
+    throw new MuseProcessError({
+      code: "processExited",
+      message: "Muse serve did not exit after SIGKILL",
+      retryable: true,
+    });
+  }
+
+  #waitForExit(): Promise<boolean> {
+    if (this.#exited) return Promise.resolve(true);
+    return new Promise((resolve) => {
+      const finish = (exited: boolean): void => {
+        clearTimeout(timeout);
+        this.#child.off("exit", onExit);
+        this.#child.off("close", onExit);
+        resolve(exited);
+      };
+      const onExit = (): void => finish(true);
+      const timeout = setTimeout(() => finish(false), this.#closeTimeoutMs);
+      this.#child.once("exit", onExit);
+      this.#child.once("close", onExit);
+    });
+  }
+
+  #write(frame: string): void {
+    try {
+      this.#child.stdin.write(frame, (error) => {
+        if (error) this.#onProcessError("stdin", error);
+      });
+    } catch (error) {
+      this.#onProcessError("stdin", error);
+    }
+  }
+
+  #onProcessError(source: string, error: unknown): void {
+    const message = error instanceof Error ? error.message : String(error);
+    this.#failTransport(
+      new MuseProcessError({
+        code: "processExited",
+        message: `Muse serve ${source} failed: ${sanitizeDiagnosticTail(message)}`,
+        retryable: true,
+        ...(this.#stderr ? { diagnostic: sanitizeDiagnosticTail(this.#stderr) } : {}),
+      }),
+    );
+  }
+
+  #onStdout(chunk: string): void {
+    if (this.#closed) return;
+    this.#buffer += chunk;
+    while (true) {
+      const boundary = this.#buffer.indexOf("\n");
+      if (boundary < 0) return;
+      const line = this.#buffer.slice(0, boundary).trim();
+      this.#buffer = this.#buffer.slice(boundary + 1);
+      if (!line) continue;
+      let frame: unknown;
+      try {
+        frame = JSON.parse(line);
+      } catch {
+        continue;
+      }
+      if (!isRecord(frame) || frame.jsonrpc !== "2.0") continue;
+      const id = rpcId(frame.id);
+      const pending = id === undefined ? undefined : this.#pending.get(id);
+      if (pending && id !== undefined && typeof frame.method !== "string") {
+        this.#pending.delete(id);
+        clearTimeout(pending.timeout);
+        if (isRecord(frame.error)) {
+          pending.reject(
+            new MuseRpcError(
+              typeof frame.error.message === "string" ? frame.error.message : "Muse RPC error",
+              typeof frame.error.code === "number" ? frame.error.code : -32603,
+              frame.error.data,
+            ),
+          );
+          continue;
+        }
+        pending.resolve(isRecord(frame.result) ? frame.result : {});
+        continue;
+      }
+      if (typeof frame.method === "string") {
+        const notification = {
+          method: frame.method,
+          ...(isRecord(frame.params) ? { params: frame.params } : {}),
+        };
+        for (const listener of this.#listeners) listener(notification);
+      }
+    }
+  }
+
+  #failAll(error: Error): void {
+    for (const pending of this.#pending.values()) {
+      clearTimeout(pending.timeout);
+      pending.reject(error);
+    }
+    this.#pending.clear();
+  }
+
+  #failTransport(error: MuseProcessError): void {
+    if (this.#failure || this.#closed) return;
+    this.#failure = error;
+    this.#failAll(error);
+    // Stop ambiguous native work after a lost acknowledgement. Explicit close callers
+    // still receive any shutdown failure through the stored close promise.
+    void this.close().catch(() => {});
+    for (const listener of this.#failureListeners) listener(error);
+  }
+}

--- a/packages/adapters/muse/src/msp-surface.ts
+++ b/packages/adapters/muse/src/msp-surface.ts
@@ -1,0 +1,33 @@
+/** MSP methods this adapter actually sends. Keep in sync with session/adapter call sites. */
+export const MUSE_MSP_REQUEST_METHODS = [
+  "initialize",
+  "model/list",
+  "session/start",
+  "session/resume",
+  "session/fork",
+  "session/read",
+  "session/setModel",
+  "session/setApprovalMode",
+  "turn/start",
+  "turn/cancel",
+  "approval/decide",
+  "userInput/answer",
+  "userInput/cancel",
+  "view/page",
+] as const;
+
+/** MSP notifications this adapter handles. Unlisted events are ignored, not fatal. */
+export const MUSE_MSP_NOTIFICATIONS = [
+  "turn/completed",
+  "item/started",
+  "item/delta",
+  "item/updated",
+  "item/completed",
+  "approval/requested",
+  "approval/updated",
+  "approval/resolved",
+  "userInput/requested",
+  "userInput/settled",
+  "view/gap",
+  "session/approvalModeChanged",
+] as const;

--- a/packages/adapters/muse/src/muse-adapter.ts
+++ b/packages/adapters/muse/src/muse-adapter.ts
@@ -1,0 +1,443 @@
+import path from "node:path";
+
+import type {
+  HarnessAdapter,
+  HarnessError,
+  HarnessInspection,
+  HarnessResult,
+  HarnessSession,
+  HarnessSubagentCapability,
+  HostThreadSnapshot,
+  InspectHarnessInput,
+  OpenSessionInput,
+} from "@codexhost/harness-adapter";
+import {
+  harnessInspectionSchema,
+  nativeCheckpointRefSchema,
+  nativeSessionRefSchema,
+} from "@codexhost/shared-contracts";
+
+import { resolveMuseExecutable } from "./command.js";
+import { readMuseChildHistory, snapshotFromMuseHistory } from "./history.js";
+import {
+  decodeMuseThinkingOptionId,
+  parseMuseModelCatalog,
+  type MuseModelRow,
+} from "./model-catalog.js";
+import {
+  MuseProcessError,
+  MuseRpcError,
+  MuseServeClient,
+  type JsonObject,
+  type MuseRpc,
+} from "./msp-client.js";
+import {
+  MUSE_HARNESS_ID,
+  MUSE_SESSION_CAPABILITIES,
+  MuseHarnessSession,
+  nativeSessionFromResult,
+} from "./muse-session.js";
+import {
+  MUSE_PERMISSION_MODE_CATALOG,
+  musePermissionModeForExecutionPolicy,
+} from "./permission-modes.js";
+import { uuidv7 } from "./uuid.js";
+
+export interface MuseAdapterOptions {
+  command?: string;
+  environment?: NodeJS.ProcessEnv;
+  serveExtraArguments?: string[];
+  createRpc?: (input: {
+    executable: string;
+    cwd: string;
+    environment: NodeJS.ProcessEnv;
+  }) => Promise<MuseRpc> | MuseRpc;
+}
+
+function isRecord(value: unknown): value is JsonObject {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function validateNativeReferences(input: OpenSessionInput): HarnessError | undefined {
+  if (input.kind !== "resume" && input.kind !== "fork") return undefined;
+  const source = nativeSessionRefSchema.safeParse(
+    input.kind === "resume" ? input.nativeRef : input.sourceRef,
+  );
+  if (
+    !source.success ||
+    source.data.harnessId !== MUSE_HARNESS_ID ||
+    source.data.formatVersion !== 1
+  ) {
+    return {
+      code: "invalidRequest",
+      message: "Muse Session reference is invalid or belongs to another Harness",
+      retryable: false,
+    };
+  }
+  if (input.kind === "fork") {
+    const checkpoint = nativeCheckpointRefSchema.safeParse(input.checkpoint);
+    if (
+      !checkpoint.success ||
+      checkpoint.data.harnessId !== MUSE_HARNESS_ID ||
+      checkpoint.data.nativeSessionId !== source.data.nativeSessionId ||
+      checkpoint.data.formatVersion !== source.data.formatVersion
+    ) {
+      return {
+        code: "invalidRequest",
+        message: "Muse Fork checkpoint does not belong to the source Session",
+        retryable: false,
+      };
+    }
+  }
+  return undefined;
+}
+
+function inspectionError(error: unknown, stage: string): HarnessInspection {
+  if (error instanceof MuseProcessError) {
+    return { status: "error", error: { ...error.harnessError, stage } };
+  }
+  if (error instanceof MuseRpcError) {
+    return {
+      status: "error",
+      error: { code: "protocolError", message: error.message, retryable: true, stage },
+    };
+  }
+  return {
+    status: "error",
+    error: {
+      code: "internalError",
+      message: error instanceof Error ? error.message : "Muse inspect failed",
+      retryable: true,
+      stage,
+    },
+  };
+}
+
+export class MuseAdapter implements HarnessAdapter {
+  readonly harnessId = MUSE_HARNESS_ID;
+  readonly subagents: HarnessSubagentCapability = {
+    readSnapshot: async (input) => this.#readSubagentSnapshot(input),
+  };
+  #command?: string;
+  #environment: NodeJS.ProcessEnv;
+  #serveExtraArguments: string[];
+  #createRpc: MuseAdapterOptions["createRpc"];
+  #closed = false;
+  #sessions = new Set<MuseHarnessSession>();
+
+  constructor(options: MuseAdapterOptions = {}) {
+    if (options.command) this.#command = options.command;
+    this.#environment = options.environment ?? process.env;
+    this.#serveExtraArguments = options.serveExtraArguments ?? [];
+    this.#createRpc = options.createRpc;
+  }
+
+  async inspect(input: InspectHarnessInput = {}): Promise<HarnessInspection> {
+    if (this.#closed) {
+      return {
+        status: "unavailable",
+        error: { code: "invalidState", message: "Muse Adapter is closed", retryable: false },
+      };
+    }
+    const cwd = path.resolve(input.cwd ?? process.cwd());
+    const executable = resolveMuseExecutable({
+      ...(this.#command ? { command: this.#command } : {}),
+      environment: this.#environment,
+    });
+    if (!executable) {
+      return {
+        status: "notInstalled",
+        error: {
+          code: "notInstalled",
+          message: "Meta Muse Code CLI (muse) is not installed",
+          retryable: false,
+        },
+      };
+    }
+    let rpc: MuseRpc | undefined;
+    try {
+      rpc = await this.#openRpc(executable, cwd, this.#environment);
+      await rpc.handshake();
+      const listed = await rpc.request("model/list");
+      const rows = Array.isArray(listed.models)
+        ? listed.models.filter(isRecord).map((row): MuseModelRow => ({
+            modelId: String(row.modelId ?? ""),
+            displayLabel: String(row.displayLabel ?? row.modelId ?? ""),
+            ...(typeof row.providerId === "string" ? { providerId: row.providerId } : {}),
+            ...(row.isDefault === true ? { isDefault: true } : {}),
+          }))
+        : [];
+      return harnessInspectionSchema.parse({
+        status: "ready",
+        catalog: parseMuseModelCatalog(rows),
+        permissionModes: MUSE_PERMISSION_MODE_CATALOG,
+        capabilities: MUSE_SESSION_CAPABILITIES,
+      });
+    } catch (error) {
+      return inspectionError(error, "model-catalog");
+    } finally {
+      await rpc?.close();
+    }
+  }
+
+  async open(input: OpenSessionInput): Promise<HarnessResult<HarnessSession>> {
+    if (this.#closed) {
+      return {
+        ok: false,
+        error: { code: "invalidState", message: "Muse Adapter is closed", retryable: false },
+      };
+    }
+    if (input.kind === "rollbackLastTurn") {
+      return {
+        ok: false,
+        error: {
+          code: "unsupported",
+          message: "Muse does not support last-turn rollback",
+          retryable: false,
+        },
+      };
+    }
+    if (input.kind === "create" && input.executionPolicy === "unattended-full-access") {
+      return {
+        ok: false,
+        error: {
+          code: "unsupported",
+          message:
+            "Muse serve does not support unattended full-access delegation under its startup policy; open an interactive Muse Thread instead",
+          retryable: false,
+        },
+      };
+    }
+    const referenceError = validateNativeReferences(input);
+    if (referenceError) return { ok: false, error: referenceError };
+    const executable = resolveMuseExecutable({
+      ...(this.#command ? { command: this.#command } : {}),
+      environment: { ...this.#environment, ...input.environment },
+    });
+    if (!executable) {
+      return {
+        ok: false,
+        error: {
+          code: "notInstalled",
+          message: "Meta Muse Code CLI (muse) is not installed",
+          retryable: false,
+        },
+      };
+    }
+    const environment = { ...this.#environment, ...input.environment };
+    let rpc: MuseRpc | undefined;
+    let adopted = false;
+    try {
+      if (input.kind === "create") {
+        musePermissionModeForExecutionPolicy(input.executionPolicy, input.permissionModeId);
+        if (input.thinkingOptionId) decodeMuseThinkingOptionId(input.thinkingOptionId);
+      }
+      rpc = await this.#openRpc(executable, input.cwd, environment);
+      this.#assertOpen();
+      await rpc.handshake();
+      this.#assertOpen();
+      if (input.kind === "create") {
+        const approvalMode = musePermissionModeForExecutionPolicy(
+          input.executionPolicy,
+          input.permissionModeId,
+        );
+        const result = await rpc.request("session/start", {
+          commandId: uuidv7(),
+          workspaceRoot: path.resolve(input.cwd),
+          // Preserve the native startup default when no mode was selected.
+          ...(input.permissionModeId ? { approvalMode } : {}),
+          ...(input.model ? { modelId: input.model.id } : {}),
+        });
+        this.#assertOpen();
+        const session = new MuseHarnessSession({
+          rpc,
+          native: nativeSessionFromResult(result),
+          ...(input.thinkingOptionId ? { thinkingOptionId: input.thinkingOptionId } : {}),
+        });
+        this.#sessions.add(session);
+        adopted = true;
+        return { ok: true, value: session };
+      }
+      if (input.kind === "resume") {
+        const result = await rpc.request("session/resume", {
+          commandId: uuidv7(),
+          sessionId: input.nativeRef.nativeSessionId,
+          excludeItems: true,
+        });
+        this.#assertOpen();
+        const native = nativeSessionFromResult(result);
+        if (native.sessionId !== input.nativeRef.nativeSessionId) {
+          return {
+            ok: false,
+            error: {
+              code: "sessionNotFound",
+              message: "Muse resumed a different Session",
+              retryable: false,
+            },
+          };
+        }
+        const resumed = isRecord(result.session) ? result.session : result;
+        if (
+          resumed.status === "running" ||
+          (typeof resumed.activeTurnId === "string" && resumed.activeTurnId.length > 0) ||
+          (Array.isArray(result.pendingRequests) && result.pendingRequests.length > 0)
+        ) {
+          return {
+            ok: false,
+            error: {
+              code: "sessionBusy",
+              message: "Muse Session still has an active Turn or pending interaction",
+              retryable: true,
+            },
+          };
+        }
+        const session = new MuseHarnessSession({
+          rpc,
+          native,
+        });
+        this.#sessions.add(session);
+        adopted = true;
+        return { ok: true, value: session };
+      }
+      const result = await rpc.request("session/fork", {
+        commandId: uuidv7(),
+        sessionId: input.sourceRef.nativeSessionId,
+        cutPoint: { lastTurnId: input.checkpoint.checkpointId },
+        excludeItems: true,
+      });
+      this.#assertOpen();
+      const session = new MuseHarnessSession({
+        rpc,
+        native: nativeSessionFromResult(result),
+      });
+      this.#sessions.add(session);
+      adopted = true;
+      return { ok: true, value: session };
+    } catch (error) {
+      if (error instanceof MuseProcessError) return { ok: false, error: error.harnessError };
+      if (error instanceof MuseRpcError) {
+        return {
+          ok: false,
+          error: { code: "nativeFailure", message: error.message, retryable: false },
+        };
+      }
+      return {
+        ok: false,
+        error: {
+          code: "internalError",
+          message: error instanceof Error ? error.message : "Muse failed to open a Session",
+          retryable: false,
+        },
+      };
+    } finally {
+      if (rpc && !adopted) {
+        // Preserve the original open failure if native cleanup also fails.
+        await rpc.close().catch(() => undefined);
+      }
+    }
+  }
+
+  #assertOpen(): void {
+    if (this.#closed) {
+      throw new MuseProcessError({
+        code: "invalidState",
+        message: "Muse Adapter is closed",
+        retryable: false,
+      });
+    }
+  }
+
+  async close(): Promise<void> {
+    if (this.#closed) return;
+    this.#closed = true;
+    await Promise.all([...this.#sessions].map((session) => session.close()));
+    this.#sessions.clear();
+  }
+
+  async #readSubagentSnapshot(input: {
+    parent: { harnessId: string; nativeSessionId: string; formatVersion: number };
+    nativeSubagentId: string;
+    cwd: string;
+  }): Promise<HarnessResult<HostThreadSnapshot>> {
+    if (this.#closed) {
+      return {
+        ok: false,
+        error: { code: "invalidState", message: "Muse Adapter is closed", retryable: false },
+      };
+    }
+    if (input.parent.harnessId !== MUSE_HARNESS_ID || input.nativeSubagentId.trim().length === 0) {
+      return {
+        ok: false,
+        error: {
+          code: "invalidRequest",
+          message: "Muse Subagent reference is invalid",
+          retryable: false,
+        },
+      };
+    }
+    const executable = resolveMuseExecutable({
+      ...(this.#command ? { command: this.#command } : {}),
+      environment: this.#environment,
+    });
+    if (!executable) {
+      return {
+        ok: false,
+        error: {
+          code: "notInstalled",
+          message: "Meta Muse Code CLI (muse) is not installed",
+          retryable: false,
+        },
+      };
+    }
+    let rpc: MuseRpc | undefined;
+    try {
+      rpc = await this.#openRpc(executable, path.resolve(input.cwd), this.#environment);
+      await rpc.handshake();
+      const history = await readMuseChildHistory(
+        rpc,
+        input.parent.nativeSessionId,
+        input.nativeSubagentId,
+      );
+      const parentRef = nativeSessionRefSchema.parse({
+        harnessId: MUSE_HARNESS_ID,
+        nativeSessionId: input.parent.nativeSessionId,
+        formatVersion: input.parent.formatVersion,
+      });
+      return { ok: true, value: snapshotFromMuseHistory(parentRef, history) };
+    } catch (error) {
+      if (error instanceof MuseProcessError) return { ok: false, error: error.harnessError };
+      if (error instanceof MuseRpcError) {
+        return {
+          ok: false,
+          error: { code: "nativeFailure", message: error.message, retryable: false },
+        };
+      }
+      return {
+        ok: false,
+        error: {
+          code: "internalError",
+          message: error instanceof Error ? error.message : "Muse Subagent history failed",
+          retryable: false,
+        },
+      };
+    } finally {
+      await rpc?.close();
+    }
+  }
+
+  async #openRpc(
+    executable: string,
+    cwd: string,
+    environment: NodeJS.ProcessEnv,
+  ): Promise<MuseRpc> {
+    if (this.#createRpc) return this.#createRpc({ executable, cwd, environment });
+    return new MuseServeClient({
+      executable,
+      cwd,
+      environment,
+      ...(this.#serveExtraArguments.length > 0
+        ? { extraArguments: this.#serveExtraArguments }
+        : {}),
+    });
+  }
+}

--- a/packages/adapters/muse/src/muse-session.ts
+++ b/packages/adapters/muse/src/muse-session.ts
@@ -1,0 +1,1328 @@
+import {
+  HarnessOutputChannel,
+  validateHostApprovalResponse,
+  validateHostQuestionResponse,
+  type HarnessError,
+  type HarnessModelRef,
+  type HarnessOutput,
+  type HarnessPermissionModeId,
+  type HarnessResult,
+  type HarnessSession,
+  type HarnessSessionCapabilities,
+  type HarnessSessionState,
+  type HarnessThinkingOptionId,
+  type HostAgentMessageItem,
+  type HostApprovalInteraction,
+  type HostItem,
+  type HostItemOutcome,
+  type HostQuestionInteraction,
+  type HostSubagentDelegationItem,
+  type HostThreadSnapshot,
+  type HostToolExecutionItem,
+  type InteractionRespondAccepted,
+  type InteractionRespondCommand,
+  type ModelSelectCommand,
+  type ModelSelectCompleted,
+  type PermissionModeSelectCommand,
+  type PermissionModeSelectCompleted,
+  type ThinkingSelectCommand,
+  type ThinkingSelectCompleted,
+  type TurnCancelAccepted,
+  type TurnCancelCommand,
+  type TurnOutcome,
+  type TurnStartAccepted,
+  type TurnStartCommand,
+} from "@codexhost/harness-adapter";
+import {
+  harnessIdSchema,
+  harnessSessionCapabilitiesSchema,
+  hostInteractionIdSchema,
+  hostItemIdSchema,
+  nativeCheckpointRefSchema,
+  nativeSessionRefSchema,
+  nativeTurnRefSchema,
+  type NativeSessionRef,
+} from "@codexhost/shared-contracts";
+
+import {
+  mapMuseApprovalActions,
+  museApprovalDescription,
+  museApprovalProjectionReady,
+  museApprovalTitle,
+  parseMuseRequirementRef,
+  type MuseRequirementRef,
+} from "./approval.js";
+import {
+  mapMuseHostItem,
+  museHistoryItemOutcome,
+  museItemText,
+  museSubagentIsRecovering,
+  museSubagentIsTerminal,
+  readMuseHistory,
+  snapshotFromMuseHistory,
+} from "./history.js";
+import { mapMuseUserInputQuestions, museUserInputAnswers } from "./user-input.js";
+import {
+  decodeMuseThinkingOptionId,
+  MUSE_DEFAULT_THINKING_OPTION_ID,
+  museModelRef,
+  museThinkingOptionId,
+  MUSE_THINKING_OPTIONS,
+} from "./model-catalog.js";
+import type { JsonObject, MuseRpc, MuseRpcNotification } from "./msp-client.js";
+import { MuseProcessError, MuseRpcError } from "./msp-client.js";
+import {
+  decodeMusePermissionModeId,
+  MUSE_DEFAULT_PERMISSION_MODE_ID,
+  type MuseApprovalMode,
+} from "./permission-modes.js";
+import { uuidv7 } from "./uuid.js";
+
+export const MUSE_HARNESS_ID = harnessIdSchema.parse("muse");
+
+export const MUSE_SESSION_CAPABILITIES: HarnessSessionCapabilities =
+  harnessSessionCapabilitiesSchema.parse({
+    configuration: {
+      selectModel: true,
+      selectThinkingOption: true,
+      selectPermissionMode: true,
+      permissionModeScope: "live",
+    },
+    history: { fork: true, forkAcrossCwd: false, rollbackLastTurn: false },
+    subagents: { observe: true, readTranscript: true },
+  });
+
+export interface MuseNativeSession {
+  sessionId: string;
+  modelId?: string;
+  approvalMode?: MuseApprovalMode;
+}
+
+interface ActiveTurn {
+  command: TurnStartCommand;
+  nativeTurnId: string;
+  agentItem: HostAgentMessageItem | null;
+  items: Map<string, HostItem>;
+}
+
+interface PendingMuseApproval {
+  interaction: HostApprovalInteraction;
+  nativeApprovalId: string;
+  requirementId: MuseRequirementRef;
+}
+
+interface TrackedMuseSubagent {
+  item: HostSubagentDelegationItem;
+  nativeTurnId: string;
+  revision: number;
+  turnId: TurnStartCommand["turnId"];
+  hostCompleted: boolean;
+}
+
+function isRecord(value: unknown): value is JsonObject {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function resolvePermissionModeId(
+  requested: HarnessPermissionModeId | undefined,
+  native: MuseApprovalMode | undefined,
+): HarnessPermissionModeId {
+  if (requested) {
+    decodeMusePermissionModeId(requested);
+    return requested;
+  }
+  if (native) {
+    decodeMusePermissionModeId(native as HarnessPermissionModeId);
+    return native as HarnessPermissionModeId;
+  }
+  return MUSE_DEFAULT_PERMISSION_MODE_ID;
+}
+
+function museTurnError(params: JsonObject): HarnessError {
+  const error = isRecord(params.error) ? params.error : undefined;
+  const message =
+    (error && typeof error.message === "string" && error.message) ||
+    (typeof params.reason === "string" && params.reason) ||
+    (typeof params.message === "string" && params.message) ||
+    "Muse Turn failed";
+  return {
+    code: "nativeFailure",
+    message,
+    retryable: error && typeof error.retryable === "boolean" ? error.retryable : false,
+  };
+}
+
+function toolOutputText(item: HostToolExecutionItem): string {
+  return (item.output?.content ?? [])
+    .flatMap((part) => (part.type === "text" ? [part.text] : []))
+    .join("");
+}
+
+function asError(error: unknown): HarnessError {
+  if (error instanceof MuseProcessError) return error.harnessError;
+  if (error instanceof MuseRpcError) {
+    if (error.data && isRecord(error.data) && error.data.kind === "sessionNotFound") {
+      return { code: "sessionNotFound", message: error.message, retryable: false };
+    }
+    return { code: "nativeFailure", message: error.message, retryable: false };
+  }
+  return {
+    code: "internalError",
+    message: error instanceof Error ? error.message : "Muse session failed",
+    retryable: false,
+  };
+}
+
+export class MuseHarnessSession implements HarnessSession {
+  readonly harnessId = MUSE_HARNESS_ID;
+  readonly capabilities = MUSE_SESSION_CAPABILITIES;
+  readonly initialState: HarnessSessionState;
+  readonly initialUsage = null;
+  readonly outputs: AsyncIterable<HarnessOutput>;
+  readonly nativeRef: NativeSessionRef;
+
+  #rpc: MuseRpc;
+  #unsubscribe: () => void;
+  #unsubscribeFailure: () => void;
+  #closePromise: Promise<void> | null = null;
+  #channel = new HarnessOutputChannel<HarnessOutput>();
+  #closed = false;
+  #busy = false;
+  #active: ActiveTurn | null = null;
+  #pendingApprovals = new Map<string, PendingMuseApproval>();
+  #pendingQuestions = new Map<string, HostQuestionInteraction>();
+  #inbox: MuseRpcNotification[] | null = null;
+  #seenCursors = new Set<string>();
+  #startedItemIds = new Set<string>();
+  #itemRevisions = new Map<string, number>();
+  #subagents = new Map<string, TrackedMuseSubagent>();
+  #resumedSubagents = new Set<string>();
+  #model: HarnessModelRef | undefined;
+  #thinkingOptionId: HarnessThinkingOptionId;
+  #permissionModeId: HarnessPermissionModeId;
+  #native: MuseNativeSession;
+
+  constructor(input: {
+    rpc: MuseRpc;
+    native: MuseNativeSession;
+    model?: HarnessModelRef;
+    thinkingOptionId?: HarnessThinkingOptionId;
+    permissionModeId?: HarnessPermissionModeId;
+  }) {
+    this.#rpc = input.rpc;
+    this.#native = input.native;
+    this.nativeRef = nativeSessionRefSchema.parse({
+      harnessId: MUSE_HARNESS_ID,
+      nativeSessionId: input.native.sessionId,
+      formatVersion: 1,
+    });
+    this.#model =
+      input.model ?? (input.native.modelId ? museModelRef(input.native.modelId) : undefined);
+    this.#thinkingOptionId = input.thinkingOptionId ?? MUSE_DEFAULT_THINKING_OPTION_ID;
+    this.#permissionModeId = resolvePermissionModeId(
+      input.permissionModeId,
+      input.native.approvalMode,
+    );
+    this.initialState = this.#state();
+    this.outputs = this.#channel.outputs;
+    this.#unsubscribe = this.#rpc.subscribe((notification) => this.#onNotification(notification));
+    this.#unsubscribeFailure = this.#rpc.subscribeFailure((error) =>
+      this.#fault(error.harnessError),
+    );
+  }
+
+  async readSnapshot(): Promise<HarnessResult<HostThreadSnapshot>> {
+    if (this.#closed)
+      return {
+        ok: false,
+        error: { code: "invalidState", message: "Session closed", retryable: false },
+      };
+    if (this.#busy)
+      return {
+        ok: false,
+        error: { code: "sessionBusy", message: "Muse Session is busy", retryable: true },
+      };
+    try {
+      const history = await readMuseHistory(this.#rpc, this.#native.sessionId);
+      const snapshot = snapshotFromMuseHistory(this.nativeRef, history);
+      return { ok: true, value: { ...snapshot, state: this.#state() } };
+    } catch (error) {
+      return { ok: false, error: asError(error) };
+    }
+  }
+
+  async execute(command: TurnStartCommand): Promise<HarnessResult<TurnStartAccepted>>;
+  async execute(command: TurnCancelCommand): Promise<HarnessResult<TurnCancelAccepted>>;
+  async execute(
+    command: InteractionRespondCommand,
+  ): Promise<HarnessResult<InteractionRespondAccepted>>;
+  async execute(command: ModelSelectCommand): Promise<HarnessResult<ModelSelectCompleted>>;
+  async execute(command: ThinkingSelectCommand): Promise<HarnessResult<ThinkingSelectCompleted>>;
+  async execute(
+    command: PermissionModeSelectCommand,
+  ): Promise<HarnessResult<PermissionModeSelectCompleted>>;
+  async execute(
+    command:
+      | TurnStartCommand
+      | TurnCancelCommand
+      | InteractionRespondCommand
+      | ModelSelectCommand
+      | ThinkingSelectCommand
+      | PermissionModeSelectCommand,
+  ): Promise<
+    HarnessResult<
+      | TurnStartAccepted
+      | TurnCancelAccepted
+      | InteractionRespondAccepted
+      | ModelSelectCompleted
+      | ThinkingSelectCompleted
+      | PermissionModeSelectCompleted
+    >
+  > {
+    if (this.#closed) {
+      return {
+        ok: false,
+        error: { code: "invalidState", message: "Session closed", retryable: false },
+      };
+    }
+    try {
+      if (command.type === "turn.start") return await this.#startTurn(command);
+      if (command.type === "turn.cancel") return await this.#cancelTurn(command);
+      if (command.type === "interaction.respond") return await this.#respond(command);
+      if (command.type === "model.select") return await this.#selectModel(command);
+      if (command.type === "thinking.select") return await this.#selectThinking(command);
+      return await this.#selectPermission(command);
+    } catch (error) {
+      if (error instanceof MuseProcessError) this.#fault(error.harnessError);
+      return { ok: false, error: asError(error) };
+    }
+  }
+
+  async close(): Promise<void> {
+    if (!this.#closed) {
+      this.#closed = true;
+      this.#unsubscribe();
+      this.#unsubscribeFailure();
+      if (this.#active) this.#completeTurn({ status: "cancelled", reason: "Session closed" });
+      this.#channel.end();
+      this.#closePromise = this.#rpc.close();
+    }
+    await this.#closePromise;
+  }
+
+  #fault(error: HarnessError): void {
+    if (this.#closed) return;
+    this.#closed = true;
+    this.#unsubscribe();
+    this.#unsubscribeFailure();
+    this.#completeTurn({ status: "failed", error });
+    this.#emit({ kind: "event", event: { type: "session.faulted", error } });
+    this.#channel.end();
+    this.#closePromise = this.#rpc.close();
+    void this.#closePromise.catch(() => undefined);
+  }
+
+  async #startTurn(command: TurnStartCommand): Promise<HarnessResult<TurnStartAccepted>> {
+    if (this.#busy || this.#active) return this.#sessionBusy();
+    this.#busy = true;
+    this.#inbox = [];
+    const text = command.input.map((part) => part.text).join("\n");
+    const commandId = uuidv7();
+    try {
+      const current = await this.#rpc.request("session/read", {
+        sessionId: this.#native.sessionId,
+        excludeItems: true,
+      });
+      const nativeSession = isRecord(current.session) ? current.session : {};
+      if (
+        nativeSession.activeTurnId ||
+        nativeSession.status === "running" ||
+        (Array.isArray(current.pendingRequests) && current.pendingRequests.length > 0)
+      ) {
+        return this.#sessionBusy();
+      }
+      this.#requireOpen();
+      const result = await this.#rpc.request("turn/start", {
+        commandId,
+        sessionId: this.#native.sessionId,
+        input: [{ type: "text", text }],
+        reasoningEffort: decodeMuseThinkingOptionId(this.#thinkingOptionId),
+      });
+      this.#requireOpen();
+      this.#validateAck(result, commandId, "turn/start");
+      const nativeTurnId = result.turnId as string;
+      if (result.disposition === "queued") {
+        // The native default queues on a race with another foreground owner. Reclaim
+        // this exact submission before rejecting it; no Host Turn has started yet.
+        const reclaimCommandId = uuidv7();
+        try {
+          const reclaimed = await this.#rpc.request("turn/unqueue", {
+            commandId: reclaimCommandId,
+            sessionId: this.#native.sessionId,
+            turnId: nativeTurnId,
+          });
+          this.#validateAck(reclaimed, reclaimCommandId, "turn/unqueue", nativeTurnId);
+        } catch (error) {
+          if (error instanceof MuseProcessError) throw error;
+          throw this.#protocolError(
+            `Muse could not reclaim queued Turn: ${asError(error).message}`,
+          );
+        }
+        return this.#sessionBusy();
+      }
+      if (result.disposition !== "started" || result.startedNewTurn !== true) {
+        throw this.#protocolError("Muse turn/start did not acknowledge a fresh started Turn");
+      }
+      this.#active = { command, nativeTurnId, agentItem: null, items: new Map() };
+      const buffered = this.#inbox ?? [];
+      this.#inbox = null;
+      this.#emit({ kind: "event", event: { type: "turn.started", turnId: command.turnId } });
+      for (const notification of buffered) this.#onNotification(notification);
+      return { ok: true, value: { turnId: command.turnId } };
+    } catch (error) {
+      if (error instanceof MuseProcessError) this.#fault(error.harnessError);
+      throw error;
+    } finally {
+      this.#inbox = null;
+      if (!this.#active) this.#busy = false;
+    }
+  }
+
+  #sessionBusy(): HarnessResult<never> {
+    return {
+      ok: false,
+      error: { code: "sessionBusy", message: "Muse Session is busy", retryable: true },
+    };
+  }
+
+  #requireOpen(): void {
+    if (this.#closed) {
+      throw new MuseProcessError({
+        code: "invalidState",
+        message: "Muse Session closed",
+        retryable: false,
+      });
+    }
+  }
+
+  #protocolError(message: string): MuseProcessError {
+    return new MuseProcessError({ code: "protocolError", message, retryable: false });
+  }
+
+  #validateAck(result: JsonObject, commandId: string, method: string, turnId?: string): void {
+    if (
+      result.status !== "accepted" ||
+      result.commandId !== commandId ||
+      typeof result.turnId !== "string" ||
+      !result.turnId.trim() ||
+      (turnId !== undefined && result.turnId !== turnId)
+    ) {
+      throw this.#protocolError(`Muse ${method} returned an invalid acknowledgement`);
+    }
+  }
+
+  async #cancelTurn(command: TurnCancelCommand): Promise<HarnessResult<TurnCancelAccepted>> {
+    if (!this.#active || this.#active.command.turnId !== command.turnId) {
+      return {
+        ok: false,
+        error: { code: "invalidRequest", message: "No matching Muse Turn", retryable: false },
+      };
+    }
+    const nativeTurnId = this.#active.nativeTurnId;
+    const commandId = uuidv7();
+    const result = await this.#rpc.request("turn/cancel", {
+      commandId,
+      sessionId: this.#native.sessionId,
+      turnId: nativeTurnId,
+    });
+    this.#validateAck(result, commandId, "turn/cancel", nativeTurnId);
+    return { ok: true, value: { cancellationRequested: true } };
+  }
+
+  async #respond(command: InteractionRespondCommand): Promise<HarnessResult<{ accepted: true }>> {
+    const pending = this.#pendingApprovals.get(command.interactionId);
+    if (pending) {
+      if (command.response.type !== "approval") {
+        return {
+          ok: false,
+          error: {
+            code: "invalidRequest",
+            message: "Approval response required",
+            retryable: false,
+          },
+        };
+      }
+      const approvalError = validateHostApprovalResponse(pending.interaction, command.response);
+      if (approvalError) return { ok: false, error: approvalError };
+      const decided = await this.#rpc.request("approval/decide", {
+        commandId: uuidv7(),
+        sessionId: this.#native.sessionId,
+        approvalId: pending.nativeApprovalId,
+        choiceId: command.response.actionId,
+        requirementId: pending.requirementId,
+      });
+      if (decided.terminal === false) return { ok: true, value: { accepted: true } };
+      this.#closeApproval(command.interactionId, "responded");
+      return { ok: true, value: { accepted: true } };
+    }
+    const question = this.#pendingQuestions.get(command.interactionId);
+    if (!question) {
+      return {
+        ok: false,
+        error: { code: "invalidRequest", message: "Unknown Muse interaction", retryable: false },
+      };
+    }
+    if (command.response.type !== "question") {
+      return {
+        ok: false,
+        error: { code: "invalidRequest", message: "Question response required", retryable: false },
+      };
+    }
+    if (command.response.cancelled) {
+      const questionError = validateHostQuestionResponse(question, command.response);
+      if (questionError) return { ok: false, error: questionError };
+      await this.#rpc.request("userInput/cancel", {
+        commandId: uuidv7(),
+        sessionId: this.#native.sessionId,
+        userInputId: command.interactionId,
+      });
+      this.#closeQuestion(command.interactionId, "cancelled");
+      return { ok: true, value: { accepted: true } };
+    }
+    const questionError = validateHostQuestionResponse(question, command.response);
+    if (questionError) return { ok: false, error: questionError };
+    await this.#rpc.request("userInput/answer", {
+      commandId: uuidv7(),
+      sessionId: this.#native.sessionId,
+      userInputId: command.interactionId,
+      answers: museUserInputAnswers(question, command.response),
+    });
+    this.#closeQuestion(command.interactionId, "responded");
+    return { ok: true, value: { accepted: true } };
+  }
+
+  async #selectModel(command: ModelSelectCommand): Promise<HarnessResult<{ completed: true }>> {
+    if (this.#busy) {
+      return {
+        ok: false,
+        error: { code: "sessionBusy", message: "Muse Session is busy", retryable: true },
+      };
+    }
+    await this.#rpc.request("session/setModel", {
+      commandId: uuidv7(),
+      sessionId: this.#native.sessionId,
+      model: { modelId: command.model.id },
+    });
+    this.#model = command.model;
+    this.#native = { ...this.#native, modelId: command.model.id };
+    this.#emit({ kind: "event", event: { type: "session.state.changed", state: this.#state() } });
+    return { ok: true, value: { completed: true } };
+  }
+
+  async #selectThinking(
+    command: ThinkingSelectCommand,
+  ): Promise<HarnessResult<{ completed: true }>> {
+    if (this.#busy) {
+      return {
+        ok: false,
+        error: { code: "sessionBusy", message: "Muse Session is busy", retryable: true },
+      };
+    }
+    decodeMuseThinkingOptionId(command.thinkingOptionId);
+    this.#thinkingOptionId = command.thinkingOptionId;
+    this.#emit({ kind: "event", event: { type: "session.state.changed", state: this.#state() } });
+    return { ok: true, value: { completed: true } };
+  }
+
+  async #selectPermission(
+    command: PermissionModeSelectCommand,
+  ): Promise<HarnessResult<{ completed: true }>> {
+    const mode = decodeMusePermissionModeId(command.permissionModeId);
+    const commandId = uuidv7();
+    const result = await this.#rpc.request("session/setApprovalMode", {
+      commandId,
+      sessionId: this.#native.sessionId,
+      mode,
+    });
+    const effectiveMode = isRecord(result.effectiveMode) ? result.effectiveMode.mode : undefined;
+    if (result.status !== "accepted" || result.commandId !== commandId || effectiveMode !== mode) {
+      throw this.#protocolError("Muse session/setApprovalMode did not confirm the requested mode");
+    }
+    this.#permissionModeId = command.permissionModeId;
+    this.#native = { ...this.#native, approvalMode: mode };
+    this.#emit({ kind: "event", event: { type: "session.state.changed", state: this.#state() } });
+    return { ok: true, value: { completed: true } };
+  }
+
+  #onNotification(notification: MuseRpcNotification): void {
+    if (this.#closed || notification.params?.sessionId !== this.#native.sessionId) return;
+    if (this.#inbox) {
+      this.#inbox.push(notification);
+      return;
+    }
+    try {
+      const params = notification.params ?? {};
+      if (!this.#ownsNotification(notification.method, params)) return;
+      const cursor = typeof params.viewCursor === "string" ? params.viewCursor : "";
+      if (cursor && notification.method !== "view/gap") {
+        if (this.#seenCursors.has(cursor)) return;
+        this.#seenCursors.add(cursor);
+      }
+      if (notification.method === "turn/completed") {
+        this.#finishTurn(params);
+        return;
+      }
+      if (notification.method === "item/started") this.#startItem(params);
+      else if (notification.method === "item/delta") this.#deltaItem(params);
+      else if (notification.method === "item/updated") this.#updateItem(params);
+      else if (notification.method === "item/completed") this.#completeItem(params);
+      else if (notification.method === "approval/requested") this.#requestApproval(params);
+      else if (notification.method === "approval/updated") this.#updateApproval(params);
+      else if (notification.method === "approval/resolved") this.#resolveApproval(params);
+      else if (notification.method === "userInput/requested") this.#requestQuestion(params);
+      else if (notification.method === "userInput/settled") this.#settleUserInput(params);
+      else if (notification.method === "view/gap") void this.#fillViewGap(params);
+      else if (notification.method === "session/approvalModeChanged") {
+        this.#applyApprovalMode(params);
+      }
+    } catch {
+      // A malformed item must not drop later turn/approval notifications.
+    }
+  }
+
+  #ownsNotification(method: string, params: JsonObject): boolean {
+    if (method === "item/delta") {
+      return typeof params.itemId === "string" && this.#active?.items.has(params.itemId) === true;
+    }
+    if (method.startsWith("item/")) {
+      if (!isRecord(params.item)) return false;
+      const item = params.item;
+      if (this.#active && item.turnId === this.#active.nativeTurnId) return true;
+      // A known background child may change state after its foreground Turn ends.
+      return (
+        typeof item.itemId === "string" &&
+        this.#subagents.get(item.itemId)?.nativeTurnId === item.turnId
+      );
+    }
+    if (method === "approval/updated") {
+      // MSP refreshes a registered approval by approvalId; unlike requested and
+      // resolved, this event carries no turnId.
+      return (
+        this.#active !== null &&
+        [...this.#pendingApprovals.values()].some(
+          (pending) =>
+            pending.nativeApprovalId === params.approvalId &&
+            pending.interaction.turnId === this.#active?.command.turnId,
+        )
+      );
+    }
+    if (method === "userInput/settled") {
+      const pending =
+        typeof params.userInputId === "string"
+          ? this.#pendingQuestions.get(params.userInputId)
+          : undefined;
+      return pending !== undefined && pending.turnId === this.#active?.command.turnId;
+    }
+    if (
+      method.startsWith("turn/") ||
+      method === "approval/requested" ||
+      method === "approval/resolved" ||
+      method === "userInput/requested"
+    ) {
+      return this.#active !== null && params.turnId === this.#active.nativeTurnId;
+    }
+    return true;
+  }
+
+  #startItem(params: JsonObject): void {
+    const item = isRecord(params.item) ? params.item : params;
+    const itemId = hostItemIdSchema.parse(
+      typeof item.itemId === "string" && item.itemId ? item.itemId : uuidv7(),
+    );
+    if (
+      this.#subagents.has(itemId) ||
+      (typeof item.kind === "string" && (item.kind === "subagent" || item.kind === "workflow"))
+    ) {
+      this.#projectSubagent(item, itemId, "start");
+      return;
+    }
+    const active = this.#active;
+    if (!active) return;
+    if (this.#startedItemIds.has(itemId) || active.items.has(itemId)) {
+      if (active.items.has(itemId)) this.#updateItem(params);
+      return;
+    }
+    this.#startedItemIds.add(itemId);
+    if (typeof item.revision === "number") this.#itemRevisions.set(itemId, item.revision);
+    const hostItem = mapMuseHostItem({ ...item, itemId }, itemId);
+    if (!hostItem) return;
+    if (hostItem.type === "agentMessage") active.agentItem = hostItem;
+    active.items.set(itemId, hostItem);
+    this.#emit({
+      kind: "event",
+      event: { type: "item.started", turnId: active.command.turnId, item: hostItem },
+    });
+    this.#emitSubagentLifecycle(hostItem);
+  }
+
+  #deltaItem(params: JsonObject): void {
+    const active = this.#active;
+    if (!active) return;
+    const itemId = typeof params.itemId === "string" ? params.itemId : "";
+    const item = active.items.get(itemId);
+    const text = typeof params.delta === "string" ? params.delta : "";
+    if (!item || !text) return;
+    const field = typeof params.field === "string" && params.field ? params.field : "text";
+    const asOutput = field === "output";
+    if (item.type === "commandExecution" && (asOutput || field === "text")) {
+      const suffix = text;
+      item.output = `${item.output ?? ""}${suffix}`;
+      this.#emit({
+        kind: "event",
+        event: {
+          type: "item.updated",
+          turnId: active.command.turnId,
+          itemId: item.itemId,
+          update: { type: "output.append", text: suffix },
+        },
+      });
+      return;
+    }
+    if (item.type === "toolExecution" && (asOutput || field === "text")) {
+      const suffix = text;
+      const next = `${toolOutputText(item)}${suffix}`;
+      item.output = { content: [{ type: "text", text: next }] };
+      this.#emit({
+        kind: "event",
+        event: {
+          type: "item.updated",
+          turnId: active.command.turnId,
+          itemId: item.itemId,
+          update: { type: "output.replace", output: item.output },
+        },
+      });
+      return;
+    }
+    if (item.type === "agentMessage" || item.type === "reasoning") {
+      if (item.type === "agentMessage" && field !== "text") return;
+      const suffix = text;
+      item.text += suffix;
+      this.#emit({
+        kind: "event",
+        event: {
+          type: "item.updated",
+          turnId: active.command.turnId,
+          itemId: item.itemId,
+          update: { type: "text.append", text: suffix },
+        },
+      });
+    }
+  }
+
+  #updateItem(params: JsonObject): void {
+    const item = isRecord(params.item) ? params.item : params;
+    const itemId = typeof item.itemId === "string" ? item.itemId : "";
+    if (typeof item.revision === "number") {
+      if (item.revision <= (this.#itemRevisions.get(itemId) ?? 0)) return;
+      this.#itemRevisions.set(itemId, item.revision);
+    }
+    if (
+      this.#subagents.has(itemId) ||
+      (typeof item.kind === "string" && (item.kind === "subagent" || item.kind === "workflow"))
+    ) {
+      this.#projectSubagent(item, itemId || hostItemIdSchema.parse(uuidv7()), "update");
+      return;
+    }
+    const active = this.#active;
+    if (!active) return;
+    if (!active.items.has(itemId)) this.#startItem(params);
+    const hostItem = active.items.get(itemId);
+    if (!hostItem) return;
+    const mapped = mapMuseHostItem(item, hostItem.itemId);
+    if (hostItem.type === "subagentDelegation" && mapped?.type === "subagentDelegation") {
+      this.#projectSubagent(item, hostItem.itemId, "update");
+      return;
+    }
+    const text = museItemText(item);
+    if (!text) return;
+    if (hostItem.type === "agentMessage" || hostItem.type === "reasoning") {
+      const previous = hostItem.text;
+      hostItem.text = text;
+      const suffix = text.startsWith(previous) ? text.slice(previous.length) : previous ? "" : text;
+      if (!suffix) return;
+      this.#emit({
+        kind: "event",
+        event: {
+          type: "item.updated",
+          turnId: active.command.turnId,
+          itemId: hostItem.itemId,
+          update: { type: "text.append", text: suffix },
+        },
+      });
+    } else if (hostItem.type === "commandExecution") {
+      const previous = hostItem.output ?? "";
+      hostItem.output = text;
+      const suffix = text.startsWith(previous) ? text.slice(previous.length) : previous ? "" : text;
+      if (!suffix) return;
+      this.#emit({
+        kind: "event",
+        event: {
+          type: "item.updated",
+          turnId: active.command.turnId,
+          itemId: hostItem.itemId,
+          update: { type: "output.append", text: suffix },
+        },
+      });
+    } else if (hostItem.type === "toolExecution") {
+      hostItem.output = { content: [{ type: "text", text }] };
+      this.#emit({
+        kind: "event",
+        event: {
+          type: "item.updated",
+          turnId: active.command.turnId,
+          itemId: hostItem.itemId,
+          update: { type: "output.replace", output: hostItem.output },
+        },
+      });
+    }
+  }
+
+  #completeItem(params: JsonObject): void {
+    const item = isRecord(params.item) ? params.item : params;
+    const itemId = typeof item.itemId === "string" ? item.itemId : "";
+    if (
+      this.#subagents.has(itemId) ||
+      (typeof item.kind === "string" && (item.kind === "subagent" || item.kind === "workflow"))
+    ) {
+      this.#projectSubagent(item, itemId || hostItemIdSchema.parse(uuidv7()), "complete");
+      return;
+    }
+    const active = this.#active;
+    if (!active) return;
+    if (!active.items.has(itemId)) this.#startItem(params);
+    const hostItem = active.items.get(itemId);
+    if (!hostItem) return;
+    if (hostItem.type === "subagentDelegation") {
+      this.#projectSubagent(item, hostItem.itemId, "complete");
+      return;
+    }
+    const mapped = mapMuseHostItem(item, hostItem.itemId);
+    let completedItem: HostItem = hostItem;
+    if (hostItem.type === "agentMessage" || hostItem.type === "reasoning") {
+      this.#alignStreamedText(hostItem, museItemText(item), active.command.turnId);
+      completedItem = hostItem;
+    } else if (mapped && mapped.type === hostItem.type) {
+      completedItem = mapped;
+      if (completedItem.type === "commandExecution") {
+        const output = museItemText(item);
+        if (output) completedItem.output = output;
+      } else if (completedItem.type === "toolExecution") {
+        const output = museItemText(item);
+        if (output) completedItem.output = { content: [{ type: "text", text: output }] };
+      }
+    }
+    active.items.delete(itemId);
+    if (active.agentItem?.itemId === completedItem.itemId) active.agentItem = null;
+    this.#emit({
+      kind: "event",
+      event: {
+        type: "item.completed",
+        turnId: active.command.turnId,
+        snapshot: { item: completedItem, outcome: museHistoryItemOutcome(item) },
+      },
+    });
+  }
+
+  #requestApproval(params: JsonObject): void {
+    const active = this.#active;
+    if (!active) return;
+    const approvalId =
+      (typeof params.approvalId === "string" && params.approvalId.trim()) ||
+      (typeof params.id === "string" && params.id.trim()) ||
+      "";
+    const requirementId = parseMuseRequirementRef(params.currentRequirementId);
+    const actions = mapMuseApprovalActions(params.availableChoices);
+    if (!approvalId || !requirementId || !museApprovalProjectionReady(actions)) return;
+    const description = museApprovalDescription(params);
+    const interaction: HostApprovalInteraction = {
+      type: "approval",
+      interactionId: hostInteractionIdSchema.parse(`${approvalId}:${requirementId.sourceIndex}`),
+      turnId: active.command.turnId,
+      title: museApprovalTitle(params),
+      ...(description ? { description } : {}),
+      subject: { type: "nativeAction" },
+      actions,
+    };
+    this.#pendingApprovals.set(interaction.interactionId, {
+      interaction,
+      nativeApprovalId: approvalId,
+      requirementId,
+    });
+    this.#emit({ kind: "interaction", interaction });
+  }
+
+  #updateApproval(params: JsonObject): void {
+    const approvalId = typeof params.approvalId === "string" ? params.approvalId : "";
+    if (!approvalId) return;
+    this.#closeApprovals(approvalId, "superseded");
+    this.#requestApproval(params);
+  }
+
+  #resolveApproval(params: JsonObject): void {
+    const approvalId = typeof params.approvalId === "string" ? params.approvalId : "";
+    if (!approvalId) return;
+    const decision = typeof params.decision === "string" ? params.decision : "";
+    const reason =
+      decision === "denied" ||
+      decision === "deniedPolicyAmendment" ||
+      decision === "abort" ||
+      decision === "timedOut"
+        ? "cancelled"
+        : "responded";
+    this.#closeApprovals(approvalId, reason);
+  }
+
+  #closeApprovals(approvalId: string, reason: "responded" | "cancelled" | "superseded"): void {
+    for (const [interactionId, pending] of this.#pendingApprovals) {
+      if (pending.nativeApprovalId !== approvalId) continue;
+      this.#closeApproval(interactionId, reason);
+    }
+  }
+
+  #closeApproval(
+    interactionId: string,
+    reason: "responded" | "cancelled" | "expired" | "superseded",
+  ): void {
+    const pending = this.#pendingApprovals.get(interactionId);
+    if (!pending) return;
+    this.#pendingApprovals.delete(interactionId);
+    this.#emit({
+      kind: "event",
+      event: {
+        type: "interaction.closed",
+        interactionId: pending.interaction.interactionId,
+        turnId: pending.interaction.turnId,
+        reason,
+      },
+    });
+  }
+
+  #closeQuestion(
+    interactionId: string,
+    reason: "responded" | "cancelled" | "expired" | "superseded",
+  ): void {
+    const question = this.#pendingQuestions.get(interactionId);
+    if (!question) return;
+    this.#pendingQuestions.delete(interactionId);
+    this.#emit({
+      kind: "event",
+      event: {
+        type: "interaction.closed",
+        interactionId: question.interactionId,
+        turnId: question.turnId,
+        reason,
+      },
+    });
+  }
+
+  #requestQuestion(params: JsonObject): void {
+    const active = this.#active;
+    if (!active) return;
+    const userInputId =
+      (typeof params.userInputId === "string" && params.userInputId.trim()) ||
+      (typeof params.id === "string" && params.id.trim()) ||
+      uuidv7();
+    const questions = mapMuseUserInputQuestions(params.questions);
+    const interaction: HostQuestionInteraction = {
+      type: "question",
+      interactionId: hostInteractionIdSchema.parse(userInputId),
+      turnId: active.command.turnId,
+      title:
+        (typeof params.toolName === "string" && params.toolName.trim()) ||
+        (typeof params.title === "string" && params.title.trim()) ||
+        "Muse question",
+      questions:
+        questions.length > 0
+          ? questions
+          : [
+              {
+                id: "answer",
+                type: "text",
+                prompt: typeof params.prompt === "string" ? params.prompt : "Answer",
+                multiline: false,
+                secret: false,
+                optional: false,
+              },
+            ],
+    };
+    this.#pendingQuestions.set(interaction.interactionId, interaction);
+    this.#emit({ kind: "interaction", interaction });
+  }
+
+  #settleUserInput(params: JsonObject): void {
+    const userInputId = typeof params.userInputId === "string" ? params.userInputId : "";
+    if (!userInputId) return;
+    const outcome = typeof params.outcome === "string" ? params.outcome : "";
+    this.#closeQuestion(userInputId, outcome === "answered" ? "responded" : "cancelled");
+  }
+
+  #alignStreamedText(
+    hostItem: HostAgentMessageItem | Extract<HostItem, { type: "reasoning" }>,
+    nativeText: string,
+    turnId: TurnStartCommand["turnId"],
+  ): void {
+    if (!nativeText || nativeText === hostItem.text) return;
+    if (!nativeText.startsWith(hostItem.text)) return;
+    const suffix = nativeText.slice(hostItem.text.length);
+    if (!suffix) return;
+    hostItem.text = nativeText;
+    this.#emit({
+      kind: "event",
+      event: {
+        type: "item.updated",
+        turnId,
+        itemId: hostItem.itemId,
+        update: { type: "text.append", text: suffix },
+      },
+    });
+  }
+
+  #finishTurn(params: JsonObject): void {
+    if (!this.#active || params.turnId !== this.#active.nativeTurnId) return;
+    if (params.terminal === "cancelled") this.#completeTurn({ status: "cancelled" });
+    else if (params.terminal === "failed")
+      this.#completeTurn({ status: "failed", error: museTurnError(params) });
+    else if (params.terminal === "completed") this.#completeTurn({ status: "succeeded" });
+    else
+      this.#completeTurn({
+        status: "failed",
+        error: this.#protocolError("Muse returned an unknown Turn terminal").harnessError,
+      });
+  }
+
+  #completeTurn(outcome: TurnOutcome): void {
+    const active = this.#active;
+    if (!active) return;
+    for (const item of active.items.values()) {
+      if (item.type === "subagentDelegation") {
+        const tracked = this.#subagents.get(item.itemId);
+        if (tracked?.hostCompleted) continue;
+        this.#completeSubagentHostItem(item, active.command.turnId, outcome);
+        continue;
+      }
+      this.#emit({
+        kind: "event",
+        event: {
+          type: "item.completed",
+          turnId: active.command.turnId,
+          snapshot: {
+            item,
+            outcome: outcome.status === "failed" ? outcome : { status: outcome.status },
+          },
+        },
+      });
+    }
+    for (const pending of this.#pendingApprovals.values()) {
+      this.#emit({
+        kind: "event",
+        event: {
+          type: "interaction.closed",
+          interactionId: pending.interaction.interactionId,
+          turnId: pending.interaction.turnId,
+          reason: "cancelled",
+        },
+      });
+    }
+    for (const interaction of this.#pendingQuestions.values()) {
+      this.#emit({
+        kind: "event",
+        event: {
+          type: "interaction.closed",
+          interactionId: interaction.interactionId,
+          turnId: interaction.turnId,
+          reason: "cancelled",
+        },
+      });
+    }
+    this.#pendingApprovals.clear();
+    this.#pendingQuestions.clear();
+    this.#seenCursors.clear();
+    this.#startedItemIds.clear();
+    this.#itemRevisions.clear();
+    this.#active = null;
+    this.#busy = false;
+    const nativeTurnRef = nativeTurnRefSchema.parse({
+      harnessId: MUSE_HARNESS_ID,
+      nativeSessionId: this.#native.sessionId,
+      nativeTurnKey: active.nativeTurnId,
+      formatVersion: 1,
+    });
+    const checkpoint = nativeCheckpointRefSchema.parse({
+      harnessId: MUSE_HARNESS_ID,
+      nativeSessionId: this.#native.sessionId,
+      checkpointId: active.nativeTurnId,
+      formatVersion: 1,
+    });
+    this.#emit({
+      kind: "event",
+      event: {
+        type: "turn.completed",
+        turnId: active.command.turnId,
+        nativeTurnRef,
+        outcome: { ...outcome, checkpoint: outcome.checkpoint ?? checkpoint },
+      },
+    });
+    void this.#reconcileSubagents();
+  }
+
+  #state(): HarnessSessionState {
+    return {
+      nativeRef: this.nativeRef,
+      ...(this.#model ? { effectiveModel: this.#model, resolvedModelLabel: this.#model.id } : {}),
+      effectiveThinkingOptionId: this.#thinkingOptionId,
+      availableThinkingOptions: MUSE_THINKING_OPTIONS.map((option) => ({
+        id: museThinkingOptionId(option.id),
+        label: option.label,
+      })),
+      effectivePermissionModeId: this.#permissionModeId,
+    };
+  }
+
+  #applyApprovalMode(params: JsonObject): void {
+    const mode = typeof params.mode === "string" ? params.mode : "";
+    if (!mode) return;
+    try {
+      decodeMusePermissionModeId(mode as HarnessPermissionModeId);
+    } catch {
+      return;
+    }
+    this.#permissionModeId = mode as HarnessPermissionModeId;
+    this.#native = { ...this.#native, approvalMode: mode as MuseApprovalMode };
+    this.#emit({ kind: "event", event: { type: "session.state.changed", state: this.#state() } });
+  }
+
+  async #fillViewGap(params: JsonObject): Promise<void> {
+    const after = typeof params.after === "string" ? params.after : "";
+    const next = typeof params.next === "string" ? params.next : "";
+    const sessionId =
+      typeof params.sessionId === "string" ? params.sessionId : this.#native.sessionId;
+    if (!after || !next) return;
+    let cursor: string | undefined = after;
+    const seen = new Set<string>([after, next]);
+    try {
+      for (let pageIndex = 0; pageIndex < 32 && cursor; pageIndex += 1) {
+        const page = await this.#rpc.request("view/page", {
+          sessionId,
+          cursor,
+          direction: "forward",
+          limit: 1000,
+        });
+        const events = Array.isArray(page.events) ? page.events.filter(isRecord) : [];
+        let reachedNext = false;
+        for (const event of events) {
+          const method = typeof event.method === "string" ? event.method : "";
+          const eventParams = isRecord(event.params) ? event.params : {};
+          const viewCursor =
+            typeof eventParams.viewCursor === "string" ? eventParams.viewCursor : "";
+          if (viewCursor === next) {
+            reachedNext = true;
+            continue;
+          }
+          if (!method || method === "view/gap" || seen.has(viewCursor)) continue;
+          if (viewCursor) seen.add(viewCursor);
+          this.#onNotification({ method, params: eventParams });
+        }
+        const nextCursor = typeof page.nextCursor === "string" ? page.nextCursor : "";
+        if (reachedNext || !nextCursor || nextCursor === next || nextCursor === cursor) break;
+        cursor = nextCursor;
+      }
+    } catch {
+      // Gap fill is best-effort; a missed page must not fault the Session.
+    }
+  }
+
+  #projectSubagent(
+    museItem: JsonObject,
+    itemId: string,
+    source: "start" | "update" | "complete",
+  ): void {
+    const mapped = mapMuseHostItem({ ...museItem, itemId }, itemId);
+    if (!mapped || mapped.type !== "subagentDelegation") return;
+    const existing = this.#subagents.get(itemId);
+    const revision = typeof museItem.revision === "number" ? museItem.revision : 0;
+    if (existing && revision > 0 && revision <= existing.revision) return;
+    const turnId = existing?.turnId ?? this.#active?.command.turnId;
+    const active = this.#active?.command.turnId === turnId ? this.#active : null;
+    if (!turnId) return;
+    const item: HostSubagentDelegationItem = existing
+      ? { ...existing.item, ...mapped, itemId: existing.item.itemId, subagents: mapped.subagents }
+      : mapped;
+    const tracked: TrackedMuseSubagent = existing ?? {
+      item,
+      turnId,
+      nativeTurnId: String(museItem.turnId ?? active?.nativeTurnId ?? ""),
+      revision,
+      hostCompleted: false,
+    };
+    tracked.revision = revision;
+    tracked.item = item;
+    tracked.turnId = turnId;
+    this.#subagents.set(item.itemId, tracked);
+    if (active && !tracked.hostCompleted) active.items.set(item.itemId, item);
+
+    const recovering = museSubagentIsRecovering(museItem);
+    if (recovering) void this.#resumeSubagent(item);
+    const terminal = museSubagentIsTerminal(museItem);
+    const finishHost = source === "complete" ? terminal : false;
+
+    if (!tracked.hostCompleted && active) {
+      if (!existing) {
+        this.#startedItemIds.add(item.itemId);
+        this.#emit({
+          kind: "event",
+          event: { type: "item.started", turnId, item },
+        });
+      } else {
+        this.#emit({
+          kind: "event",
+          event: {
+            type: "item.updated",
+            turnId,
+            itemId: item.itemId,
+            update: { type: "subagents.replace", subagents: item.subagents },
+          },
+        });
+      }
+    }
+    this.#emitSubagentLifecycle(item);
+    if (finishHost && !tracked.hostCompleted && active) {
+      this.#completeSubagentHostItem(item, turnId, this.#subagentOutcome(item));
+    }
+  }
+
+  #completeSubagentHostItem(
+    item: HostSubagentDelegationItem,
+    turnId: TurnStartCommand["turnId"],
+    outcome: TurnOutcome | HostItemOutcome,
+  ): void {
+    const tracked = this.#subagents.get(item.itemId);
+    if (tracked?.hostCompleted) return;
+    const hostOutcome: HostItemOutcome =
+      outcome.status === "failed"
+        ? outcome
+        : outcome.status === "cancelled"
+          ? { status: "cancelled", reason: "reason" in outcome ? outcome.reason : "Cancelled" }
+          : this.#subagentOutcome(item);
+    if (tracked) tracked.hostCompleted = true;
+    this.#active?.items.delete(item.itemId);
+    this.#emit({
+      kind: "event",
+      event: {
+        type: "item.completed",
+        turnId,
+        snapshot: { item, outcome: hostOutcome },
+      },
+    });
+    this.#emitSubagentLifecycle(item);
+  }
+
+  #subagentOutcome(item: HostSubagentDelegationItem): HostItemOutcome {
+    if (
+      item.subagents.some(
+        (subagent) => subagent.status === "running" || subagent.status === "pending",
+      )
+    ) {
+      return { status: "succeeded" };
+    }
+    if (item.subagents.every((subagent) => subagent.status === "failed")) {
+      const message =
+        item.subagents.find((subagent) => subagent.resultSummary)?.resultSummary ??
+        "Muse Subagent failed";
+      return {
+        status: "failed",
+        error: { code: "nativeFailure", message, retryable: false },
+      };
+    }
+    if (item.subagents.some((subagent) => subagent.status === "interrupted")) {
+      return { status: "cancelled", reason: "Muse Subagent interrupted" };
+    }
+    return { status: "succeeded" };
+  }
+
+  #resumeSubagent(item: HostSubagentDelegationItem): void {
+    if (this.#closed) return;
+    for (const subagent of item.subagents) {
+      const subagentId = subagent.nativeSubagentId ?? subagent.subagentId;
+      if (!subagentId || this.#resumedSubagents.has(subagentId)) continue;
+      this.#resumedSubagents.add(subagentId);
+      void this.#rpc
+        .request("subagent/resume", {
+          commandId: uuidv7(),
+          sessionId: this.#native.sessionId,
+          subagentId,
+        })
+        .then(() => this.#reconcileSubagents())
+        .catch(() => undefined);
+    }
+  }
+
+  async #reconcileSubagents(): Promise<void> {
+    if (this.#closed) return;
+    try {
+      const history = await readMuseHistory(this.#rpc, this.#native.sessionId);
+      if (this.#closed) return;
+      const items = Array.isArray(history?.items) ? history.items.filter(isRecord) : [];
+      for (const item of items) {
+        const kind = typeof item.kind === "string" ? item.kind : "";
+        if (kind !== "subagent" && kind !== "workflow") continue;
+        if (item.turnId !== this.#active?.nativeTurnId && !this.#subagents.has(String(item.itemId)))
+          continue;
+        const itemId =
+          typeof item.itemId === "string" && item.itemId
+            ? item.itemId
+            : hostItemIdSchema.parse(uuidv7());
+        this.#projectSubagent(item, itemId, museSubagentIsTerminal(item) ? "complete" : "update");
+      }
+    } catch {
+      // History reconcile is best-effort; live notifications remain authoritative.
+    }
+  }
+
+  #emitSubagentLifecycle(item: HostItem): void {
+    if (item.type !== "subagentDelegation") return;
+    for (const subagent of item.subagents) {
+      const nativeSubagentId = subagent.nativeSubagentId ?? subagent.subagentId;
+      this.#emit({
+        kind: "event",
+        event: {
+          type: "subagent.state.changed",
+          nativeSubagentId,
+          status: subagent.status,
+          ...(subagent.resultSummary ? { resultSummary: subagent.resultSummary } : {}),
+        },
+      });
+      this.#emit({
+        kind: "event",
+        event: { type: "subagent.transcript.changed", nativeSubagentId },
+      });
+    }
+  }
+
+  #emit(output: HarnessOutput): void {
+    // The channel is asynchronous. Later native deltas must not mutate an Item
+    // already queued as item.started, or the Desktop projector appends it twice.
+    this.#channel.emit(structuredClone(output));
+  }
+}
+
+export function nativeSessionFromResult(result: JsonObject): MuseNativeSession {
+  const session = isRecord(result.session) ? result.session : result;
+  const approval = isRecord(session.approvalMode)
+    ? session.approvalMode.mode
+    : session.approvalMode;
+  return {
+    sessionId: String(session.sessionId ?? ""),
+    ...(typeof session.modelId === "string" ? { modelId: session.modelId } : {}),
+    ...(typeof approval === "string" ? { approvalMode: approval as MuseApprovalMode } : {}),
+  };
+}

--- a/packages/adapters/muse/src/permission-modes.ts
+++ b/packages/adapters/muse/src/permission-modes.ts
@@ -1,0 +1,52 @@
+import {
+  harnessPermissionModeCatalogSchema,
+  harnessPermissionModeIdSchema,
+  type HarnessPermissionModeCatalog,
+  type HarnessPermissionModeId,
+} from "@codexhost/shared-contracts";
+
+export type MuseApprovalMode = "onRequest" | "promptUnmatched" | "denyUnmatched" | "allowAll";
+
+export const MUSE_DEFAULT_PERMISSION_MODE_ID =
+  harnessPermissionModeIdSchema.parse("promptUnmatched");
+
+export const MUSE_PERMISSION_MODE_CATALOG: HarnessPermissionModeCatalog =
+  harnessPermissionModeCatalogSchema.parse({
+    // Muse 1.0.3 serve's sealed startup policy rejects onRequest and allowAll.
+    // Keep decoding them below for existing native Sessions, without offering
+    // choices that this transport cannot apply.
+    modes: [
+      {
+        id: "promptUnmatched",
+        label: "Prompt unmatched",
+        description: "Allow configured tools; ask when a call is not covered.",
+      },
+      {
+        id: "denyUnmatched",
+        label: "Deny unmatched",
+        description: "Allow configured tools; deny anything else.",
+      },
+    ],
+    defaultModeId: MUSE_DEFAULT_PERMISSION_MODE_ID,
+  });
+
+export function decodeMusePermissionModeId(value: HarnessPermissionModeId): MuseApprovalMode {
+  const parsed = harnessPermissionModeIdSchema.parse(value);
+  if (
+    parsed !== "onRequest" &&
+    parsed !== "promptUnmatched" &&
+    parsed !== "denyUnmatched" &&
+    parsed !== "allowAll"
+  ) {
+    throw new Error("Muse Permission Mode belongs to another Adapter");
+  }
+  return parsed as MuseApprovalMode;
+}
+
+export function musePermissionModeForExecutionPolicy(
+  policy: "default" | "unattended-full-access" | undefined,
+  requested?: HarnessPermissionModeId,
+): MuseApprovalMode {
+  if (policy === "unattended-full-access") return "allowAll";
+  return decodeMusePermissionModeId(requested ?? MUSE_DEFAULT_PERMISSION_MODE_ID);
+}

--- a/packages/adapters/muse/src/plugin.ts
+++ b/packages/adapters/muse/src/plugin.ts
@@ -1,0 +1,12 @@
+import type { HarnessPluginContext } from "@codexhost/harness-adapter/plugin";
+
+import { MUSE_COMMAND_ENV } from "./command.js";
+import { MuseAdapter } from "./muse-adapter.js";
+
+export function createHarnessAdapter(context: HarnessPluginContext): MuseAdapter {
+  const environment = { ...context.environment };
+  return new MuseAdapter({
+    ...(environment[MUSE_COMMAND_ENV] ? { command: environment[MUSE_COMMAND_ENV] } : {}),
+    environment,
+  });
+}

--- a/packages/adapters/muse/src/user-input.ts
+++ b/packages/adapters/muse/src/user-input.ts
@@ -1,0 +1,79 @@
+import type {
+  HostQuestion,
+  HostQuestionInteraction,
+  HostQuestionResponse,
+} from "@codexhost/harness-adapter";
+
+import type { JsonObject } from "./msp-client.js";
+
+function isRecord(value: unknown): value is JsonObject {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+export function mapMuseUserInputQuestions(raw: unknown): HostQuestion[] {
+  if (!Array.isArray(raw)) return [];
+  const questions: HostQuestion[] = [];
+  for (const [index, entry] of raw.entries()) {
+    if (!isRecord(entry)) continue;
+    const id =
+      (typeof entry.id === "string" && entry.id.trim()) ||
+      (typeof entry.questionId === "string" && entry.questionId.trim()) ||
+      `q${index}`;
+    const prompt =
+      (typeof entry.question === "string" && entry.question.trim()) ||
+      (typeof entry.header === "string" && entry.header.trim()) ||
+      (typeof entry.prompt === "string" && entry.prompt.trim()) ||
+      "Answer";
+    const optionsRaw = Array.isArray(entry.options) ? entry.options.filter(isRecord) : [];
+    const selection = isRecord(entry.selection) ? entry.selection : {};
+    const multiple = selection.mode === "multiple";
+    if (optionsRaw.length > 0) {
+      questions.push({
+        id,
+        type: "choice",
+        prompt,
+        options: optionsRaw.map((option, optionIndex) => {
+          const label =
+            typeof option.label === "string" && option.label.trim()
+              ? option.label.trim()
+              : `option-${optionIndex}`;
+          return {
+            value: label,
+            label,
+            ...(typeof option.description === "string" && option.description.trim()
+              ? { description: option.description.trim() }
+              : {}),
+          };
+        }),
+        multiple,
+        allowOther: false,
+        optional: false,
+      });
+      continue;
+    }
+    questions.push({
+      id,
+      type: "text",
+      prompt,
+      multiline: false,
+      secret: false,
+      optional: false,
+    });
+  }
+  return questions;
+}
+
+export function museUserInputAnswers(
+  interaction: HostQuestionInteraction,
+  response: HostQuestionResponse,
+): JsonObject[] {
+  return interaction.questions.map((entry) => {
+    const raw = response.answers[entry.id] ?? [];
+    if (entry.type === "choice") {
+      return entry.multiple
+        ? { questionId: entry.id, selectedLabels: raw }
+        : { questionId: entry.id, selectedLabel: raw[0] ?? "" };
+    }
+    return { questionId: entry.id, freeText: raw[0] ?? "" };
+  });
+}

--- a/packages/adapters/muse/src/uuid.ts
+++ b/packages/adapters/muse/src/uuid.ts
@@ -1,0 +1,17 @@
+import { randomBytes } from "node:crypto";
+
+/** MSP command IDs are UUIDv7. */
+export function uuidv7(): string {
+  const timestamp = Date.now();
+  const bytes = Uint8Array.from(randomBytes(16));
+  bytes[0] = (timestamp / 2 ** 40) & 0xff;
+  bytes[1] = (timestamp / 2 ** 32) & 0xff;
+  bytes[2] = (timestamp / 2 ** 24) & 0xff;
+  bytes[3] = (timestamp / 2 ** 16) & 0xff;
+  bytes[4] = (timestamp / 2 ** 8) & 0xff;
+  bytes[5] = timestamp & 0xff;
+  bytes[6] = ((bytes[6] ?? 0) & 0x0f) | 0x70;
+  bytes[8] = ((bytes[8] ?? 0) & 0x3f) | 0x80;
+  const hex = Buffer.from(bytes).toString("hex");
+  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`;
+}

--- a/packages/adapters/muse/test/msp-client.test.ts
+++ b/packages/adapters/muse/test/msp-client.test.ts
@@ -1,0 +1,212 @@
+import { EventEmitter } from "node:events";
+import { PassThrough } from "node:stream";
+import * as childProcess from "node:child_process";
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { MuseServeClient, type JsonObject } from "../src/msp-client.js";
+
+vi.mock("node:child_process", async (importOriginal) => ({
+  ...(await importOriginal<typeof childProcess>()),
+  spawn: vi.fn(),
+}));
+
+class FakeMuseProcess extends EventEmitter {
+  readonly stdin = new PassThrough();
+  readonly stdout = new PassThrough();
+  readonly stderr = new PassThrough();
+  readonly pid = 42_000;
+  exitCode: number | null = null;
+  signalCode: NodeJS.Signals | null = null;
+  readonly requests: JsonObject[] = [];
+  readonly kill = vi.fn<(signal?: NodeJS.Signals) => boolean>(() => true);
+
+  constructor() {
+    super();
+    this.stdin.on("data", (chunk: Buffer) => {
+      this.requests.push(JSON.parse(chunk.toString()) as JsonObject);
+    });
+  }
+
+  respond(id: unknown, result: JsonObject = {}): void {
+    this.stdout.write(`${JSON.stringify({ jsonrpc: "2.0", id, result })}\n`);
+  }
+
+  exit(code: number | null, signal: NodeJS.Signals | null = null): void {
+    this.exitCode = code;
+    this.signalCode = signal;
+    this.emit("exit", code, signal);
+    this.emit("close", code, signal);
+  }
+}
+
+describe("Muse serve transport", () => {
+  let child: FakeMuseProcess;
+  let client: MuseServeClient;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    child = new FakeMuseProcess();
+    vi.mocked(childProcess.spawn).mockReturnValue(
+      child as unknown as childProcess.ChildProcessWithoutNullStreams,
+    );
+    client = new MuseServeClient({
+      executable: "/synthetic/muse",
+      cwd: "/synthetic/workspace",
+      environment: {},
+      requestTimeoutMs: 100,
+      closeTimeoutMs: 20,
+    });
+  });
+
+  afterEach(async () => {
+    child.exit(0);
+    const closing = client.close().catch(() => {});
+    await vi.runAllTimersAsync();
+    await closing;
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it("frames split replies and acknowledges initialization", async () => {
+    const handshake = client.handshake();
+    child.stdout.write('{"jsonrpc":"2.0","id":1,"result":');
+    child.stdout.write('{"version":"1.0.3"}}\n');
+    await expect(handshake).resolves.toEqual({ version: "1.0.3" });
+    expect(child.requests.at(-1)).toEqual({ jsonrpc: "2.0", method: "initialized" });
+    await vi.advanceTimersByTimeAsync(100);
+    const request = client.request("model/list");
+    child.respond(child.requests.at(-1)?.id, { models: [] });
+    await expect(request).resolves.toEqual({ models: [] });
+  });
+
+  it("rejects spawn errors and rejects subsequent requests with the same failure", async () => {
+    const failure = vi.fn();
+    client.subscribeFailure(failure);
+    const pending = expect(client.handshake()).rejects.toMatchObject({
+      harnessError: { code: "processExited" },
+    });
+    child.emit("error", new Error("spawn /synthetic/muse ENOENT"));
+    await pending;
+    await expect(client.request("model/list")).rejects.toBe(failure.mock.calls[0]?.[0]);
+    expect(failure).toHaveBeenCalledOnce();
+  });
+
+  it("notifies an acknowledged Turn when its process exits, once", async () => {
+    const failure = vi.fn();
+    client.subscribeFailure(failure);
+    const accepted = client.request("turn/start");
+    child.respond(1, { status: "accepted" });
+    await accepted;
+    child.stderr.write("native process failed\n");
+    child.exit(17);
+    child.stdin.emit("error", new Error("write EPIPE"));
+    expect(failure).toHaveBeenCalledOnce();
+    expect(failure.mock.calls[0]?.[0]).toMatchObject({
+      harnessError: {
+        code: "processExited",
+        message: "Muse serve exited with code 17",
+        diagnostic: "native process failed\n",
+      },
+    });
+    await expect(client.request("session/read")).rejects.toBe(failure.mock.calls[0]?.[0]);
+  });
+
+  it("delivers a preexisting process failure to a new subscriber", async () => {
+    child.exit(1);
+    const failure = vi.fn();
+    client.subscribeFailure(failure);
+    await vi.runAllTicks();
+    expect(failure).toHaveBeenCalledOnce();
+    const unsubscribed = vi.fn();
+    client.subscribeFailure(unsubscribed)();
+    await vi.runAllTicks();
+    expect(unsubscribed).not.toHaveBeenCalled();
+  });
+
+  it("fails pending requests on stdin stream errors", async () => {
+    const pending = expect(client.request("session/read")).rejects.toMatchObject({
+      harnessError: { code: "processExited", message: expect.stringContaining("write EPIPE") },
+    });
+    child.stdin.emit("error", new Error("write EPIPE"));
+    await pending;
+  });
+
+  it("fails an active connection when stdout ends and ignores late notifications", () => {
+    const failure = vi.fn();
+    const notification = vi.fn();
+    client.subscribeFailure(failure);
+    client.subscribe(notification);
+    child.stdout.emit("end");
+    child.stdout.write('{"jsonrpc":"2.0","method":"turn/completed"}\n');
+    expect(failure).toHaveBeenCalledOnce();
+    expect(notification).not.toHaveBeenCalled();
+  });
+
+  it("handles write callback failures before an error event", async () => {
+    vi.spyOn(child.stdin, "write").mockImplementation((...args: unknown[]) => {
+      const callback = args.at(-1) as ((error: Error) => void) | undefined;
+      callback?.(new Error("write EPIPE"));
+      return false;
+    });
+    await expect(client.request("model/list")).rejects.toMatchObject({
+      harnessError: { code: "processExited", message: expect.stringContaining("write EPIPE") },
+    });
+  });
+
+  it("handles synchronous writes and notification pipe failures", async () => {
+    const failure = vi.fn();
+    client.subscribeFailure(failure);
+    vi.spyOn(child.stdin, "write").mockImplementation(() => {
+      throw new Error("stream is destroyed");
+    });
+    expect(() => client.notify("initialized")).not.toThrow();
+    expect(failure).toHaveBeenCalledOnce();
+    await expect(client.request("model/list")).rejects.toBe(failure.mock.calls[0]?.[0]);
+  });
+
+  it("expires an unacknowledged request and makes the transport terminal", async () => {
+    const failure = vi.fn();
+    client.subscribeFailure(failure);
+    const pending = expect(client.request("turn/start")).rejects.toMatchObject({
+      harnessError: { code: "protocolError", message: expect.stringContaining("turn/start") },
+    });
+    await vi.advanceTimersByTimeAsync(100);
+    await pending;
+    expect(failure).toHaveBeenCalledOnce();
+    await expect(client.request("session/read")).rejects.toBe(failure.mock.calls[0]?.[0]);
+  });
+
+  it("closes only after reaping the child and escalates past ignored SIGTERM", async () => {
+    const failure = vi.fn();
+    client.subscribeFailure(failure);
+    const closed = vi.fn();
+    const closing = client.close().then(closed);
+    const closingAgain = client.close();
+    expect(child.kill).toHaveBeenCalledWith("SIGTERM");
+    await vi.advanceTimersByTimeAsync(20);
+    expect(child.kill).toHaveBeenCalledWith("SIGKILL");
+    expect(closed).not.toHaveBeenCalled();
+    child.exit(null, "SIGKILL");
+    await Promise.all([closing, closingAgain]);
+    expect(failure).not.toHaveBeenCalled();
+    expect(child.kill).toHaveBeenCalledTimes(2);
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it("rejects a close that cannot reap the process", async () => {
+    const closing = expect(client.close()).rejects.toMatchObject({
+      harnessError: { code: "processExited", message: expect.stringContaining("did not exit") },
+    });
+    await vi.advanceTimersByTimeAsync(40);
+    await closing;
+    child.exit(0);
+  });
+
+  it("closes an already exited process without waiting or signaling again", async () => {
+    child.exit(0);
+    await client.close();
+    expect(child.kill).not.toHaveBeenCalled();
+    expect(vi.getTimerCount()).toBe(0);
+  });
+});

--- a/packages/adapters/muse/test/muse-adapter.test.ts
+++ b/packages/adapters/muse/test/muse-adapter.test.ts
@@ -1,0 +1,1386 @@
+import { describe, expect, it } from "vitest";
+import type {
+  HostApprovalInteraction,
+  HostQuestionInteraction,
+  TurnCompletedEvent,
+} from "@codexhost/harness-adapter";
+import {
+  harnessPermissionModeIdSchema,
+  hostInteractionIdSchema,
+  hostTurnIdSchema,
+  nativeSessionRefSchema,
+} from "@codexhost/shared-contracts";
+
+import {
+  mapMuseApprovalActions,
+  museApprovalProjectionReady,
+  parseMuseRequirementRef,
+} from "../src/approval.js";
+import { mapMuseUserInputQuestions } from "../src/user-input.js";
+import {
+  findMuseChildSessionId,
+  mapMuseHostItem,
+  mergeMuseHistory,
+  museNativeTurnKey,
+  snapshotFromMuseHistory,
+} from "../src/history.js";
+import { MuseRpcError } from "../src/msp-client.js";
+import { parseMuseModelCatalog } from "../src/model-catalog.js";
+import { MuseAdapter } from "../src/muse-adapter.js";
+import type { JsonObject, MuseRpc, MuseRpcNotification } from "../src/msp-client.js";
+import {
+  decodeMusePermissionModeId,
+  musePermissionModeForExecutionPolicy,
+} from "../src/permission-modes.js";
+import { uuidv7 } from "../src/uuid.js";
+
+class FakeMuseRpc implements MuseRpc {
+  notifications: MuseRpcNotification[] = [];
+  listeners = new Set<(notification: MuseRpcNotification) => void>();
+  requests: Array<{ method: string; params?: JsonObject }> = [];
+  sessionId = "muse-session-1";
+  closed = false;
+  turnBusy = false;
+  lastCommandId: string | undefined;
+  approvalDecideTerminal = true;
+  emitOnTurnStart: MuseRpcNotification[] = [];
+  viewPageEvents: Array<{ method: string; params: JsonObject }> = [];
+  viewPageNextCursor: string | null = null;
+  sessionHistories = new Map<string, JsonObject>();
+  cancelThrows = false;
+  cursor = 0;
+  revisions = new Map<string, number>();
+
+  async handshake(): Promise<JsonObject> {
+    return { serverInfo: { name: "muse", version: "1.0.3" } };
+  }
+
+  async request(method: string, params?: JsonObject): Promise<JsonObject> {
+    this.requests.push({ method, ...(params ? { params } : {}) });
+    if (method === "model/list") {
+      return {
+        models: [
+          { modelId: "muse-spark-1.3", displayLabel: "Muse Spark 1.3", isDefault: false },
+          { modelId: "muse-spark-1.3-contributor", displayLabel: "Contributor", isDefault: true },
+        ],
+      };
+    }
+    if (method === "session/start" || method === "session/resume" || method === "session/fork") {
+      return {
+        session: {
+          activeTurnId: null,
+          status: "idle",
+          sessionId: this.sessionId,
+          modelId: "muse-spark-1.3-contributor",
+          approvalMode: { mode: "onRequest" },
+        },
+      };
+    }
+    if (method === "session/read") {
+      const sessionId = typeof params?.sessionId === "string" ? params.sessionId : this.sessionId;
+      const override = this.sessionHistories.get(sessionId);
+      if (override) return { history: override, session: {}, viewCursor: "c", pendingRequests: [] };
+      if (sessionId !== this.sessionId) {
+        return {
+          history: { mode: "inline", items: [], snapshot: null },
+          session: {},
+          viewCursor: "c",
+          pendingRequests: [],
+        };
+      }
+      const commandId = this.lastCommandId ?? "c1";
+      return {
+        session: { activeTurnId: null, status: "idle" },
+        history: {
+          mode: "inline",
+          items: [
+            { kind: "userMessage", itemId: "u1", commandId, text: "hello" },
+            { kind: "agentMessage", itemId: "a1", text: "world" },
+          ],
+          snapshot: null,
+        },
+      };
+    }
+    if (method === "turn/start") {
+      this.turnBusy = true;
+      const commandId =
+        typeof params?.commandId === "string" && params.commandId ? params.commandId : "c1";
+      this.lastCommandId = commandId;
+      for (const notification of this.emitOnTurnStart) this.emit(notification);
+      return {
+        turnId: commandId,
+        startedNewTurn: true,
+        disposition: "started",
+        status: "accepted",
+        commandId,
+      };
+    }
+    if (method === "turn/cancel") {
+      if (this.cancelThrows) {
+        throw new MuseRpcError("Muse Turn already completed", -32602, { kind: "invalidParams" });
+      }
+      this.emit({ method: "turn/completed", params: { terminal: "cancelled" } });
+      return { status: "accepted", commandId: params?.commandId, turnId: params?.turnId };
+    }
+    if (method === "approval/decide") {
+      const requirement = params?.requirementId;
+      if (
+        !requirement ||
+        typeof requirement !== "object" ||
+        Array.isArray(requirement) ||
+        typeof (requirement as JsonObject).approvalId !== "string" ||
+        typeof (requirement as JsonObject).sourceIndex !== "number"
+      ) {
+        throw new MuseRpcError("approvalRequirementStale", -32053, {
+          kind: "approvalRequirementStale",
+        });
+      }
+      if (params?.choiceId !== "choice-allow-once" && params?.choiceId !== "choice-deny") {
+        throw new MuseRpcError("approvalChoiceInvalid", -32052, { kind: "approvalChoiceInvalid" });
+      }
+      return {
+        approvalId: params?.approvalId,
+        commandId: params?.commandId,
+        status: "accepted",
+        terminal: this.approvalDecideTerminal,
+      };
+    }
+    if (method === "session/setApprovalMode") {
+      return {
+        applyOutcome: "completed",
+        commandId: params?.commandId,
+        status: "accepted",
+        effectiveMode: { mode: params?.mode, source: "approvalReconfigure" },
+      };
+    }
+    if (method === "view/page") {
+      return {
+        events: this.viewPageEvents.map((event) => this.scoped(event)),
+        nextCursor: this.viewPageNextCursor,
+      };
+    }
+    return {};
+  }
+
+  notify(): void {}
+
+  subscribe(handler: (notification: MuseRpcNotification) => void): () => void {
+    this.listeners.add(handler);
+    return () => this.listeners.delete(handler);
+  }
+
+  subscribeFailure(): () => void {
+    return () => undefined;
+  }
+
+  scoped(notification: MuseRpcNotification): MuseRpcNotification {
+    const params: JsonObject = {
+      sessionId: this.sessionId,
+      viewCursor: `fake-${++this.cursor}`,
+      ...notification.params,
+    };
+    const turnId = this.lastCommandId ?? "c1";
+    if (
+      notification.method.startsWith("turn/") ||
+      notification.method === "approval/requested" ||
+      notification.method === "approval/resolved" ||
+      notification.method === "userInput/requested"
+    ) {
+      params.turnId ??= turnId;
+    }
+    if (params.item && typeof params.item === "object" && !Array.isArray(params.item)) {
+      const item = params.item as JsonObject;
+      const itemId = String(item.itemId);
+      const revision =
+        notification.method === "item/started" ? 1 : (this.revisions.get(itemId) ?? 1) + 1;
+      this.revisions.set(itemId, revision);
+      params.item = { turnId, revision, ...item };
+    }
+    return { ...notification, params };
+  }
+
+  emit(notification: MuseRpcNotification): void {
+    const scoped = this.scoped(notification);
+    this.notifications.push(scoped);
+    for (const listener of this.listeners) listener(scoped);
+  }
+
+  async close(): Promise<void> {
+    this.closed = true;
+  }
+}
+
+const NATIVE_APPROVAL_CHOICES = [
+  {
+    choiceId: "choice-allow-once",
+    decision: "approved",
+    label: "Allow once",
+    scope: "once",
+  },
+  {
+    choiceId: "choice-deny",
+    decision: "denied",
+    label: "Deny",
+    scope: "once",
+  },
+];
+
+describe("muse adapter", () => {
+  it("maps native approval choices onto Host actions", () => {
+    const actions = mapMuseApprovalActions([
+      ...NATIVE_APPROVAL_CHOICES,
+      {
+        choiceId: "choice-session",
+        decision: "approvedForSession",
+        label: "Allow for session",
+        scope: "session",
+      },
+    ]);
+    expect(actions.map((action) => action.effect)).toEqual([
+      "allowOnce",
+      "allowForSession",
+      "deny",
+    ]);
+    expect(
+      museApprovalProjectionReady(
+        mapMuseApprovalActions([
+          {
+            choiceId: "choice-always",
+            decision: "approvedPolicyAmendment",
+            label: "Always allow",
+            scope: "localPersistent",
+          },
+          {
+            choiceId: "choice-deny",
+            decision: "denied",
+            label: "Deny",
+            scope: "once",
+          },
+        ]),
+      ),
+    ).toBe(true);
+    expect(actions[0]?.id).toBe("choice-allow-once");
+    expect(museApprovalProjectionReady(actions)).toBe(true);
+    expect(parseMuseRequirementRef({ approvalId: "appr-1", sourceIndex: 0 })).toEqual({
+      approvalId: "appr-1",
+      sourceIndex: 0,
+    });
+    expect(parseMuseRequirementRef("appr-1")).toBeUndefined();
+  });
+
+  it("maps Always + Deny without inventing an Allow once id", () => {
+    const actions = mapMuseApprovalActions([
+      {
+        choiceId: "choice-always",
+        decision: "approvedPolicyAmendment",
+        label: "Always allow",
+        scope: "localPersistent",
+      },
+      {
+        choiceId: "choice-deny",
+        decision: "denied",
+        label: "Deny",
+        scope: "once",
+      },
+    ]);
+    expect(actions.map((action) => action.effect)).toEqual(["allowAlways", "deny"]);
+    expect(museApprovalProjectionReady(actions)).toBe(true);
+  });
+
+  it("uses commandId as the snapshot Native Turn key", () => {
+    const nativeRef = nativeSessionRefSchema.parse({
+      harnessId: "muse",
+      nativeSessionId: "session-1",
+      formatVersion: 1,
+    });
+    const item = {
+      kind: "userMessage",
+      commandId: "cmd-1",
+      itemId: "u1",
+      turnId: "cmd-1",
+      text: "hello",
+    };
+    expect(museNativeTurnKey(item, 0)).toBe("cmd-1");
+    const snapshot = snapshotFromMuseHistory(nativeRef, {
+      items: [item, { kind: "agentMessage", itemId: "a1", text: "ok" }],
+    });
+    expect(snapshot.turns[0]?.nativeTurnRef.nativeTurnKey).toBe("cmd-1");
+    expect(snapshot.turns[0]?.input[0]?.text).toBe("hello");
+    const childOnly = snapshotFromMuseHistory(nativeRef, {
+      items: [{ kind: "agentMessage", itemId: "a2", text: "child reply", turnId: "t-child" }],
+    });
+    expect(childOnly.turns[0]?.items[0]?.item).toMatchObject({
+      type: "agentMessage",
+      text: "child reply",
+    });
+    expect(
+      findMuseChildSessionId(
+        {
+          items: [
+            {
+              kind: "subagent",
+              itemId: "child-1",
+              subagentId: "sub-1",
+              childSessionId: "sess-child",
+            },
+          ],
+        },
+        "sub-1",
+      ),
+    ).toBe("sess-child");
+    expect(snapshot.turns[0]?.items[0]?.item).toMatchObject({ type: "agentMessage", text: "ok" });
+    const merged = mergeMuseHistory(
+      {
+        items: [
+          { kind: "userMessage", itemId: "u1", commandId: "cmd-1", text: "hello" },
+          { kind: "toolCall", itemId: "t1", tool: "bash" },
+        ],
+      },
+      [{ kind: "agentMessage", itemId: "a1", text: "folded answer" }],
+    );
+    expect(snapshotFromMuseHistory(nativeRef, merged).turns[0]?.items.at(-1)?.item).toMatchObject({
+      type: "agentMessage",
+      text: "folded answer",
+    });
+  });
+
+  it("parses the native model catalog and permission modes", () => {
+    const catalog = parseMuseModelCatalog([
+      { modelId: "muse-spark-1.3-contributor", displayLabel: "Contributor", isDefault: true },
+    ]);
+    expect(catalog.defaultModel?.id).toBe("muse-spark-1.3-contributor");
+    expect(catalog.thinkingOptions.map((option) => option.id)).toContain("high");
+    expect(decodeMusePermissionModeId(harnessPermissionModeIdSchema.parse("allowAll"))).toBe(
+      "allowAll",
+    );
+    expect(musePermissionModeForExecutionPolicy("unattended-full-access")).toBe("allowAll");
+  });
+
+  it("mints UUIDv7 command ids", () => {
+    const id = uuidv7();
+    expect(id).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/u);
+  });
+
+  it("reports notInstalled when the CLI is missing", async () => {
+    const adapter = new MuseAdapter({
+      command: "muse-missing-binary",
+      environment: { PATH: "/missing" },
+    });
+    const inspection = await adapter.inspect({ cwd: process.cwd() });
+    expect(inspection.status).toBe("notInstalled");
+  });
+
+  it("omits default approvalMode on session/start so serve's sealed mode applies", async () => {
+    const hosts: FakeMuseRpc[] = [];
+    const adapter = new MuseAdapter({
+      command: process.execPath,
+      environment: process.env,
+      createRpc: async () => {
+        const rpc = new FakeMuseRpc();
+        hosts.push(rpc);
+        return rpc;
+      },
+    });
+    const opened = await adapter.open({ kind: "create", cwd: process.cwd() });
+    expect(opened.ok).toBe(true);
+    const started = hosts.at(-1)?.requests.find((request) => request.method === "session/start");
+    expect(started?.params).not.toHaveProperty("approvalMode");
+    await adapter.close();
+  });
+
+  it("inspects, creates, turns, snapshots, and rejects rollback", async () => {
+    const hosts: FakeMuseRpc[] = [];
+    const adapter = new MuseAdapter({
+      command: process.execPath,
+      environment: process.env,
+      createRpc: async () => {
+        const rpc = new FakeMuseRpc();
+        hosts.push(rpc);
+        return rpc;
+      },
+    });
+    const inspection = await adapter.inspect({ cwd: process.cwd() });
+    expect(inspection.status).toBe("ready");
+    if (inspection.status !== "ready") throw new Error("expected ready");
+    expect(inspection.catalog.models.length).toBeGreaterThan(0);
+
+    const opened = await adapter.open({ kind: "create", cwd: process.cwd() });
+    expect(opened.ok).toBe(true);
+    if (!opened.ok) throw new Error("expected session");
+    const session = opened.value;
+    const outputs: string[] = [];
+    let completedEvent: TurnCompletedEvent | undefined;
+    const completed = new Promise<void>((resolve) => {
+      void (async () => {
+        for await (const output of session.outputs) {
+          if (output.kind === "event") outputs.push(output.event.type);
+          if (output.kind === "event" && output.event.type === "turn.completed") {
+            completedEvent = output.event;
+            resolve();
+          }
+        }
+      })();
+    });
+    const accepted = await session.execute({
+      type: "turn.start",
+      turnId: hostTurnIdSchema.parse("turn-1"),
+      input: [{ type: "text", text: "hello" }],
+    });
+    expect(accepted.ok).toBe(true);
+    const sessionRpc = hosts.at(-1);
+    if (!sessionRpc) throw new Error("expected session rpc");
+    sessionRpc.emit({
+      method: "item/started",
+      params: { item: { kind: "agentMessage", itemId: "a-live" } },
+    });
+    sessionRpc.emit({ method: "item/delta", params: { itemId: "a-live", delta: "hi" } });
+    sessionRpc.emit({
+      method: "item/completed",
+      params: { item: { kind: "agentMessage", itemId: "a-live", text: "hi" } },
+    });
+    sessionRpc.emit({ method: "turn/completed", params: { terminal: "completed" } });
+    await completed;
+    expect(outputs).toContain("turn.started");
+    expect(outputs).toContain("item.started");
+    expect(outputs).toContain("turn.completed");
+    const commandId = sessionRpc.lastCommandId;
+    if (!commandId) throw new Error("expected Muse commandId");
+    expect(completedEvent?.nativeTurnRef?.nativeTurnKey).toBe(commandId);
+    expect(completedEvent?.outcome.checkpoint?.checkpointId).toBe(commandId);
+    const snapshot = await session.readSnapshot();
+    expect(snapshot.ok).toBe(true);
+    if (!snapshot.ok) throw new Error("expected snapshot");
+    expect(snapshot.value.turns).toHaveLength(1);
+    expect(snapshot.value.turns[0]?.nativeTurnRef.nativeTurnKey).toBe(commandId);
+    const nativeRef = session.initialState.nativeRef;
+    if (!nativeRef) throw new Error("expected native session identity");
+    const rollback = await adapter.open({
+      kind: "rollbackLastTurn",
+      sourceRef: nativeRef,
+      cwd: process.cwd(),
+    });
+    expect(rollback.ok).toBe(false);
+    if (!rollback.ok) expect(rollback.error.code).toBe("unsupported");
+    await session.close();
+    await adapter.close();
+    expect(hosts.some((host) => host.closed)).toBe(true);
+  });
+
+  it("maps MSP turn/completed.terminal failed onto a failed Host outcome", async () => {
+    const hosts: FakeMuseRpc[] = [];
+    const adapter = new MuseAdapter({
+      command: process.execPath,
+      environment: process.env,
+      createRpc: async () => {
+        const rpc = new FakeMuseRpc();
+        hosts.push(rpc);
+        return rpc;
+      },
+    });
+    const opened = await adapter.open({ kind: "create", cwd: process.cwd() });
+    expect(opened.ok).toBe(true);
+    if (!opened.ok) throw new Error("expected session");
+    const session = opened.value;
+    let completedEvent: TurnCompletedEvent | undefined;
+    const completed = new Promise<void>((resolve) => {
+      void (async () => {
+        for await (const output of session.outputs) {
+          if (output.kind === "event" && output.event.type === "turn.completed") {
+            completedEvent = output.event;
+            resolve();
+          }
+        }
+      })();
+    });
+    const accepted = await session.execute({
+      type: "turn.start",
+      turnId: hostTurnIdSchema.parse("turn-failed"),
+      input: [{ type: "text", text: "hello" }],
+    });
+    expect(accepted.ok).toBe(true);
+    const sessionRpc = hosts.at(-1);
+    if (!sessionRpc) throw new Error("expected session rpc");
+    sessionRpc.emit({
+      method: "turn/completed",
+      params: {
+        terminal: "failed",
+        error: {
+          kind: "modelError",
+          message: "model `muse-spark-1.3-contributor` does not exist or you lack access",
+          retryable: false,
+        },
+      },
+    });
+    await completed;
+    expect(completedEvent?.outcome.status).toBe("failed");
+    if (completedEvent?.outcome.status !== "failed") throw new Error("expected failed outcome");
+    expect(completedEvent.outcome.error.message).toContain("does not exist or you lack access");
+    expect(completedEvent.nativeTurnRef?.nativeTurnKey).toBe(sessionRpc.lastCommandId);
+    await session.close();
+    await adapter.close();
+  });
+
+  it("forwards native approval choiceId and requirementId on Allow once", async () => {
+    const hosts: FakeMuseRpc[] = [];
+    const adapter = new MuseAdapter({
+      command: process.execPath,
+      environment: process.env,
+      createRpc: async () => {
+        const rpc = new FakeMuseRpc();
+        hosts.push(rpc);
+        return rpc;
+      },
+    });
+    const opened = await adapter.open({ kind: "create", cwd: process.cwd() });
+    expect(opened.ok).toBe(true);
+    if (!opened.ok) throw new Error("expected session");
+    const session = opened.value;
+    let interaction: HostApprovalInteraction | undefined;
+    const seen = new Promise<void>((resolve) => {
+      void (async () => {
+        for await (const output of session.outputs) {
+          if (output.kind === "interaction" && output.interaction.type === "approval") {
+            interaction = output.interaction;
+            resolve();
+          }
+        }
+      })();
+    });
+    const accepted = await session.execute({
+      type: "turn.start",
+      turnId: hostTurnIdSchema.parse("turn-approve"),
+      input: [{ type: "text", text: "run a tool" }],
+    });
+    expect(accepted.ok).toBe(true);
+    const permission = await session.execute({
+      type: "permissionMode.select",
+      permissionModeId: harnessPermissionModeIdSchema.parse("allowAll"),
+    });
+    expect(permission.ok).toBe(true);
+    const sessionRpc = hosts.at(-1);
+    if (!sessionRpc) throw new Error("expected session rpc");
+    expect(
+      sessionRpc.requests.some(
+        (request) =>
+          request.method === "session/setApprovalMode" && request.params?.mode === "allowAll",
+      ),
+    ).toBe(true);
+    sessionRpc.emit({
+      method: "approval/requested",
+      params: {
+        approvalId: "appr-1",
+        availableChoices: NATIVE_APPROVAL_CHOICES,
+        currentRequirementId: { approvalId: "appr-1", sourceIndex: 0 },
+        toolName: "bash",
+        rawArgs: "ls",
+      },
+    });
+    await seen;
+    expect(interaction?.actions.map((action) => action.id)).toEqual([
+      "choice-allow-once",
+      "choice-deny",
+    ]);
+    const responded = await session.execute({
+      type: "interaction.respond",
+      interactionId: hostInteractionIdSchema.parse(interaction?.interactionId ?? ""),
+      response: { type: "approval", actionId: "choice-allow-once" },
+    });
+    expect(responded.ok).toBe(true);
+    const decide = sessionRpc.requests.find((request) => request.method === "approval/decide");
+    expect(decide?.params).toMatchObject({
+      approvalId: "appr-1",
+      choiceId: "choice-allow-once",
+      requirementId: { approvalId: "appr-1", sourceIndex: 0 },
+    });
+    expect(typeof decide?.params?.requirementId).toBe("object");
+    await session.close();
+    await adapter.close();
+  });
+
+  it("does not invent Allow once when native approval choices are missing", async () => {
+    const hosts: FakeMuseRpc[] = [];
+    const adapter = new MuseAdapter({
+      command: process.execPath,
+      environment: process.env,
+      createRpc: async () => {
+        const rpc = new FakeMuseRpc();
+        hosts.push(rpc);
+        return rpc;
+      },
+    });
+    const opened = await adapter.open({ kind: "create", cwd: process.cwd() });
+    expect(opened.ok).toBe(true);
+    if (!opened.ok) throw new Error("expected session");
+    const session = opened.value;
+    const interactions: string[] = [];
+    void (async () => {
+      for await (const output of session.outputs) {
+        if (output.kind === "interaction") interactions.push(output.interaction.type);
+      }
+    })();
+    const accepted = await session.execute({
+      type: "turn.start",
+      turnId: hostTurnIdSchema.parse("turn-skip-approval"),
+      input: [{ type: "text", text: "run a tool" }],
+    });
+    expect(accepted.ok).toBe(true);
+    const sessionRpc = hosts.at(-1);
+    if (!sessionRpc) throw new Error("expected session rpc");
+    sessionRpc.emit({
+      method: "approval/requested",
+      params: { approvalId: "appr-missing" },
+    });
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    expect(interactions).toEqual([]);
+    await session.close();
+    await adapter.close();
+  });
+
+  it("maps MSP userInput questions onto Host choice questions", () => {
+    const questions = mapMuseUserInputQuestions([
+      {
+        id: "q1",
+        header: "Pick",
+        question: "Which file?",
+        options: [{ label: "a.ts" }, { label: "b.ts" }],
+        selection: { mode: "single" },
+      },
+    ]);
+    expect(questions).toHaveLength(1);
+    expect(questions[0]).toMatchObject({
+      id: "q1",
+      type: "choice",
+      prompt: "Which file?",
+      multiple: false,
+    });
+    if (questions[0]?.type !== "choice") throw new Error("expected choice");
+    expect(questions[0].options.map((option) => option.value)).toEqual(["a.ts", "b.ts"]);
+  });
+
+  it("answers Muse userInput with selectedLabel instead of freeText", async () => {
+    const hosts: FakeMuseRpc[] = [];
+    const adapter = new MuseAdapter({
+      command: process.execPath,
+      environment: process.env,
+      createRpc: async () => {
+        const rpc = new FakeMuseRpc();
+        hosts.push(rpc);
+        return rpc;
+      },
+    });
+    const opened = await adapter.open({ kind: "create", cwd: process.cwd() });
+    expect(opened.ok).toBe(true);
+    if (!opened.ok) throw new Error("expected session");
+    const session = opened.value;
+    let interaction: HostQuestionInteraction | undefined;
+    const seen = new Promise<void>((resolve) => {
+      void (async () => {
+        for await (const output of session.outputs) {
+          if (output.kind === "interaction" && output.interaction.type === "question") {
+            interaction = output.interaction;
+            resolve();
+          }
+        }
+      })();
+    });
+    const accepted = await session.execute({
+      type: "turn.start",
+      turnId: hostTurnIdSchema.parse("turn-ask"),
+      input: [{ type: "text", text: "ask me" }],
+    });
+    expect(accepted.ok).toBe(true);
+    const sessionRpc = hosts.at(-1);
+    if (!sessionRpc) throw new Error("expected session rpc");
+    sessionRpc.emit({
+      method: "userInput/requested",
+      params: {
+        userInputId: "ask-1",
+        toolName: "ask",
+        questions: [
+          {
+            id: "q1",
+            header: "Pick",
+            question: "Which file?",
+            options: [{ label: "a.ts" }, { label: "b.ts" }],
+            selection: { mode: "single" },
+          },
+        ],
+      },
+    });
+    await seen;
+    const responded = await session.execute({
+      type: "interaction.respond",
+      interactionId: hostInteractionIdSchema.parse(interaction?.interactionId ?? ""),
+      response: { type: "question", answers: { q1: ["a.ts"] } },
+    });
+    expect(responded.ok).toBe(true);
+    const answered = sessionRpc.requests.find((request) => request.method === "userInput/answer");
+    expect(answered?.params?.answers).toEqual([{ questionId: "q1", selectedLabel: "a.ts" }]);
+    await session.close();
+    await adapter.close();
+  });
+
+  it("keeps a multi-stage approval open until Muse resolves it", async () => {
+    const hosts: FakeMuseRpc[] = [];
+    const adapter = new MuseAdapter({
+      command: process.execPath,
+      environment: process.env,
+      createRpc: async () => {
+        const rpc = new FakeMuseRpc();
+        rpc.approvalDecideTerminal = false;
+        hosts.push(rpc);
+        return rpc;
+      },
+    });
+    const opened = await adapter.open({ kind: "create", cwd: process.cwd() });
+    expect(opened.ok).toBe(true);
+    if (!opened.ok) throw new Error("expected session");
+    const session = opened.value;
+    let interaction: HostApprovalInteraction | undefined;
+    const closed: string[] = [];
+    const seen = new Promise<void>((resolve) => {
+      void (async () => {
+        for await (const output of session.outputs) {
+          if (output.kind === "interaction" && output.interaction.type === "approval") {
+            interaction = output.interaction;
+            resolve();
+          }
+          if (output.kind === "event" && output.event.type === "interaction.closed") {
+            closed.push(output.event.reason);
+          }
+        }
+      })();
+    });
+    const accepted = await session.execute({
+      type: "turn.start",
+      turnId: hostTurnIdSchema.parse("turn-stage"),
+      input: [{ type: "text", text: "run a tool" }],
+    });
+    expect(accepted.ok).toBe(true);
+    const sessionRpc = hosts.at(-1);
+    if (!sessionRpc) throw new Error("expected session rpc");
+    sessionRpc.emit({
+      method: "approval/requested",
+      params: {
+        approvalId: "appr-1",
+        availableChoices: NATIVE_APPROVAL_CHOICES,
+        currentRequirementId: { approvalId: "appr-1", sourceIndex: 0 },
+        toolName: "bash",
+      },
+    });
+    await seen;
+    const responded = await session.execute({
+      type: "interaction.respond",
+      interactionId: hostInteractionIdSchema.parse(interaction?.interactionId ?? ""),
+      response: { type: "approval", actionId: "choice-allow-once" },
+    });
+    expect(responded.ok).toBe(true);
+    expect(closed).toEqual([]);
+    sessionRpc.emit({
+      method: "approval/resolved",
+      params: { approvalId: "appr-1", decision: "approved" },
+    });
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    expect(closed).toEqual(["responded"]);
+    await session.close();
+    await adapter.close();
+  });
+
+  it("does not drop Muse notifications that arrive before turn/start acks", async () => {
+    const hosts: FakeMuseRpc[] = [];
+    const adapter = new MuseAdapter({
+      command: process.execPath,
+      environment: process.env,
+      createRpc: async () => {
+        const rpc = new FakeMuseRpc();
+        rpc.emitOnTurnStart = [
+          {
+            method: "item/started",
+            params: { item: { kind: "agentMessage", itemId: "a-early", text: "" } },
+          },
+          { method: "item/delta", params: { itemId: "a-early", delta: "hi" } },
+          { method: "turn/completed", params: { terminal: "completed" } },
+        ];
+        hosts.push(rpc);
+        return rpc;
+      },
+    });
+    const opened = await adapter.open({ kind: "create", cwd: process.cwd() });
+    expect(opened.ok).toBe(true);
+    if (!opened.ok) throw new Error("expected session");
+    const session = opened.value;
+    let completedEvent: TurnCompletedEvent | undefined;
+    const completed = new Promise<void>((resolve) => {
+      void (async () => {
+        for await (const output of session.outputs) {
+          if (output.kind === "event" && output.event.type === "turn.completed") {
+            completedEvent = output.event;
+            resolve();
+          }
+        }
+      })();
+    });
+    const accepted = await session.execute({
+      type: "turn.start",
+      turnId: hostTurnIdSchema.parse("turn-early"),
+      input: [{ type: "text", text: "hello" }],
+    });
+    expect(accepted.ok).toBe(true);
+    await completed;
+    expect(completedEvent?.outcome.status).toBe("succeeded");
+    expect(completedEvent?.nativeTurnRef?.nativeTurnKey).toBe(hosts.at(-1)?.lastCommandId);
+    await session.close();
+    await adapter.close();
+  });
+
+  it("projects Muse subagent items as Host subagentDelegation", async () => {
+    const hosts: FakeMuseRpc[] = [];
+    const adapter = new MuseAdapter({
+      command: process.execPath,
+      environment: process.env,
+      createRpc: async () => {
+        const rpc = new FakeMuseRpc();
+        hosts.push(rpc);
+        return rpc;
+      },
+    });
+    const opened = await adapter.open({ kind: "create", cwd: process.cwd() });
+    expect(opened.ok).toBe(true);
+    if (!opened.ok) throw new Error("expected session");
+    const session = opened.value;
+    let startedType: string | undefined;
+    const seen = new Promise<void>((resolve) => {
+      void (async () => {
+        for await (const output of session.outputs) {
+          if (output.kind === "event" && output.event.type === "item.started") {
+            startedType = output.event.item.type;
+            resolve();
+          }
+        }
+      })();
+    });
+    const accepted = await session.execute({
+      type: "turn.start",
+      turnId: hostTurnIdSchema.parse("turn-subagent"),
+      input: [{ type: "text", text: "spawn" }],
+    });
+    expect(accepted.ok).toBe(true);
+    const sessionRpc = hosts.at(-1);
+    if (!sessionRpc) throw new Error("expected session rpc");
+    sessionRpc.emit({
+      method: "item/started",
+      params: {
+        item: {
+          kind: "subagent",
+          itemId: "child-1",
+          subagentId: "sub-1",
+          objective: "inspect files",
+          role: "explorer",
+          controlStatus: "running",
+          status: "inProgress",
+        },
+      },
+    });
+    await seen;
+    expect(startedType).toBe("subagentDelegation");
+    const mapped = mapMuseHostItem(
+      {
+        kind: "subagent",
+        itemId: "child-1",
+        subagentId: "sub-1",
+        objective: "inspect files",
+        result: { summary: "done", artifactRefs: [], evidenceRefs: [] },
+        status: "completed",
+      },
+      "child-1",
+    );
+    expect(mapped).toMatchObject({
+      type: "subagentDelegation",
+      subagents: [{ nativeSubagentId: "sub-1", status: "completed", resultSummary: "done" }],
+    });
+    const workflow = mapMuseHostItem(
+      {
+        kind: "workflow",
+        itemId: "wf-1",
+        message: "finished",
+        children: [{ childId: "c1", label: "step", status: "completed", terminal: "completed" }],
+      },
+      "wf-1",
+    );
+    expect(workflow).toMatchObject({
+      type: "subagentDelegation",
+      subagents: [{ nativeSubagentId: "c1", status: "completed" }],
+    });
+    const recovering = mapMuseHostItem(
+      {
+        kind: "subagent",
+        itemId: "child-2",
+        subagentId: "sub-2",
+        controlStatus: "recoveryPending",
+        status: "failed",
+        failureReason: "provider-private history is incompatible with the active route",
+      },
+      "child-2",
+    );
+    expect(recovering).toMatchObject({
+      type: "subagentDelegation",
+      subagents: [{ nativeSubagentId: "sub-2", status: "running" }],
+    });
+    expect(
+      recovering && "subagents" in recovering ? recovering.subagents[0]?.resultSummary : undefined,
+    ).toBeUndefined();
+    const failed = mapMuseHostItem(
+      {
+        kind: "subagent",
+        itemId: "child-3",
+        subagentId: "sub-3",
+        controlStatus: "closed",
+        status: "failed",
+        failureReason: "provider-private history is incompatible with the active route",
+        result: { errorKind: "nativeFailure", artifactRefs: [], evidenceRefs: [] },
+      },
+      "child-3",
+    );
+    expect(failed).toMatchObject({
+      type: "subagentDelegation",
+      subagents: [
+        {
+          subagentId: "sub-3",
+          status: "failed",
+          resultSummary: "provider-private history is incompatible with the active route",
+        },
+      ],
+    });
+    expect(
+      failed && "subagents" in failed ? failed.subagents[0]?.nativeSubagentId : "present",
+    ).toBe(undefined);
+    await session.close();
+    await adapter.close();
+  });
+
+  it("resumes a recovering Muse subagent while the native parent Turn remains active", async () => {
+    const hosts: FakeMuseRpc[] = [];
+    const adapter = new MuseAdapter({
+      command: process.execPath,
+      environment: process.env,
+      createRpc: async () => {
+        const rpc = new FakeMuseRpc();
+        hosts.push(rpc);
+        return rpc;
+      },
+    });
+    const opened = await adapter.open({ kind: "create", cwd: process.cwd() });
+    expect(opened.ok).toBe(true);
+    if (!opened.ok) throw new Error("expected session");
+    const session = opened.value;
+    const states: string[] = [];
+    let completedEvent: TurnCompletedEvent | undefined;
+    let completedItemStatus: string | undefined;
+    let completedSummary: string | undefined;
+    const completed = new Promise<void>((resolve) => {
+      void (async () => {
+        for await (const output of session.outputs) {
+          if (output.kind === "event" && output.event.type === "subagent.state.changed") {
+            states.push(output.event.status);
+          }
+          if (
+            output.kind === "event" &&
+            output.event.type === "item.completed" &&
+            output.event.snapshot.item.type === "subagentDelegation"
+          ) {
+            completedItemStatus = output.event.snapshot.item.subagents[0]?.status;
+            completedSummary = output.event.snapshot.item.subagents[0]?.resultSummary;
+          }
+          if (output.kind === "event" && output.event.type === "turn.completed") {
+            completedEvent = output.event;
+            resolve();
+          }
+        }
+      })();
+    });
+    const accepted = await session.execute({
+      type: "turn.start",
+      turnId: hostTurnIdSchema.parse("turn-subagent-recover"),
+      input: [{ type: "text", text: "spawn" }],
+    });
+    expect(accepted.ok).toBe(true);
+    const sessionRpc = hosts.at(-1);
+    if (!sessionRpc) throw new Error("expected session rpc");
+    sessionRpc.emit({
+      method: "item/started",
+      params: {
+        item: {
+          kind: "subagent",
+          itemId: "child-1",
+          subagentId: "sub-1",
+          objective: "inspect files",
+          controlStatus: "running",
+          status: "inProgress",
+        },
+      },
+    });
+    sessionRpc.emit({
+      method: "item/updated",
+      params: {
+        item: {
+          kind: "subagent",
+          itemId: "child-1",
+          subagentId: "sub-1",
+          objective: "inspect files",
+          controlStatus: "recoveryPending",
+          status: "failed",
+          failureReason: "reasoning replay",
+        },
+      },
+    });
+    await Promise.resolve();
+    expect(sessionRpc.requests.some((request) => request.method === "subagent/resume")).toBe(true);
+    expect(completedEvent).toBeUndefined();
+    sessionRpc.emit({
+      method: "item/completed",
+      params: {
+        item: {
+          kind: "subagent",
+          itemId: "child-1",
+          subagentId: "sub-1",
+          childSessionId: "muse-child-session",
+          objective: "inspect files",
+          controlStatus: "resultReady",
+          status: "completed",
+          result: { summary: "read execute()", artifactRefs: [], evidenceRefs: [] },
+        },
+      },
+    });
+    sessionRpc.emit({ method: "turn/completed", params: { terminal: "completed" } });
+    await completed;
+    expect(states).toContain("running");
+    expect(states.at(-1)).toBe("completed");
+    expect(completedItemStatus).toBe("completed");
+    expect(completedSummary).toBe("read execute()");
+    expect(completedEvent?.outcome.status).toBe("succeeded");
+    await session.close();
+    await adapter.close();
+  });
+
+  it("replays dropped view/gap events from view/page", async () => {
+    const hosts: FakeMuseRpc[] = [];
+    const adapter = new MuseAdapter({
+      command: process.execPath,
+      environment: process.env,
+      createRpc: async () => {
+        const rpc = new FakeMuseRpc();
+        rpc.viewPageEvents = [
+          {
+            method: "item/started",
+            params: {
+              item: { kind: "agentMessage", itemId: "gap-agent" },
+              viewCursor: "c3",
+            },
+          },
+          {
+            method: "item/delta",
+            params: { itemId: "gap-agent", delta: "recovered", viewCursor: "c4" },
+          },
+        ];
+        hosts.push(rpc);
+        return rpc;
+      },
+    });
+    const opened = await adapter.open({ kind: "create", cwd: process.cwd() });
+    expect(opened.ok).toBe(true);
+    if (!opened.ok) throw new Error("expected session");
+    const session = opened.value;
+    const recovered: string[] = [];
+    const seen = new Promise<void>((resolve) => {
+      void (async () => {
+        for await (const output of session.outputs) {
+          if (output.kind === "event") recovered.push(output.event.type);
+          if (output.kind === "event" && output.event.type === "item.updated") resolve();
+        }
+      })();
+    });
+    const accepted = await session.execute({
+      type: "turn.start",
+      turnId: hostTurnIdSchema.parse("turn-gap"),
+      input: [{ type: "text", text: "hello" }],
+    });
+    expect(accepted.ok).toBe(true);
+    const sessionRpc = hosts.at(-1);
+    if (!sessionRpc) throw new Error("expected session rpc");
+    sessionRpc.emit({
+      method: "view/gap",
+      params: { after: "c1", next: "c9", sessionId: sessionRpc.sessionId },
+    });
+    await seen;
+    expect(recovered).toEqual(expect.arrayContaining(["item.started", "item.updated"]));
+    expect(
+      sessionRpc.requests.some(
+        (request) =>
+          request.method === "view/page" &&
+          request.params?.cursor === "c1" &&
+          request.params?.direction === "forward",
+      ),
+    ).toBe(true);
+    await session.close();
+    await adapter.close();
+  });
+
+  it("reads a Muse child session transcript through subagents.readSnapshot", async () => {
+    const hosts: FakeMuseRpc[] = [];
+    const adapter = new MuseAdapter({
+      command: process.execPath,
+      environment: process.env,
+      createRpc: async () => {
+        const rpc = new FakeMuseRpc();
+        rpc.sessionHistories.set("muse-session-1", {
+          items: [
+            {
+              kind: "subagent",
+              itemId: "i1",
+              subagentId: "sub-1",
+              childSessionId: "sess-child",
+            },
+          ],
+        });
+        rpc.sessionHistories.set("sess-child", {
+          items: [
+            { kind: "userMessage", itemId: "u1", commandId: "c1", text: "inspect" },
+            { kind: "agentMessage", itemId: "a1", text: "child done" },
+          ],
+        });
+        hosts.push(rpc);
+        return rpc;
+      },
+    });
+    const snapshot = await adapter.subagents.readSnapshot({
+      parent: nativeSessionRefSchema.parse({
+        harnessId: "muse",
+        nativeSessionId: "muse-session-1",
+        formatVersion: 1,
+      }),
+      nativeSubagentId: "sub-1",
+      cwd: process.cwd(),
+    });
+    expect(snapshot.ok).toBe(true);
+    if (!snapshot.ok) throw new Error("expected child snapshot");
+    expect(snapshot.value.turns[0]?.input[0]?.text).toBe("inspect");
+    expect(snapshot.value.turns[0]?.items[0]?.item).toMatchObject({
+      type: "agentMessage",
+      text: "child done",
+    });
+    await adapter.close();
+  });
+
+  it("does not drop turn.completed after a duplicate item/started", async () => {
+    const hosts: FakeMuseRpc[] = [];
+    const adapter = new MuseAdapter({
+      command: process.execPath,
+      environment: process.env,
+      createRpc: async () => {
+        const rpc = new FakeMuseRpc();
+        hosts.push(rpc);
+        return rpc;
+      },
+    });
+    const opened = await adapter.open({ kind: "create", cwd: process.cwd() });
+    expect(opened.ok).toBe(true);
+    if (!opened.ok) throw new Error("expected session");
+    const session = opened.value;
+    let completedEvent: TurnCompletedEvent | undefined;
+    const completed = new Promise<void>((resolve) => {
+      void (async () => {
+        for await (const output of session.outputs) {
+          if (output.kind === "event" && output.event.type === "turn.completed") {
+            completedEvent = output.event;
+            resolve();
+          }
+        }
+      })();
+    });
+    const accepted = await session.execute({
+      type: "turn.start",
+      turnId: hostTurnIdSchema.parse("turn-dup"),
+      input: [{ type: "text", text: "hello" }],
+    });
+    expect(accepted.ok).toBe(true);
+    const sessionRpc = hosts.at(-1);
+    if (!sessionRpc) throw new Error("expected session rpc");
+    sessionRpc.emit({
+      method: "item/started",
+      params: { item: { kind: "agentMessage", itemId: "a-dup" }, viewCursor: "c-start" },
+    });
+    sessionRpc.emit({
+      method: "item/started",
+      params: { item: { kind: "agentMessage", itemId: "a-dup" }, viewCursor: "c-start-dup" },
+    });
+    sessionRpc.emit({
+      method: "item/started",
+      params: { item: { kind: "agentMessage", itemId: "a-dup" }, viewCursor: "c-start" },
+    });
+    sessionRpc.emit({
+      method: "turn/completed",
+      params: { terminal: "completed", viewCursor: "c-end" },
+    });
+    await completed;
+    expect(completedEvent?.outcome.status).toBe("succeeded");
+    await session.close();
+    await adapter.close();
+  });
+
+  it("merges view/page agentMessage into snapshots when session/read omits it", async () => {
+    const adapter = new MuseAdapter({
+      command: process.execPath,
+      environment: process.env,
+      createRpc: async () => {
+        const rpc = new FakeMuseRpc();
+        rpc.sessionHistories.set("muse-session-1", {
+          items: [
+            { kind: "userMessage", itemId: "u1", commandId: "c1", text: "hello" },
+            { kind: "toolCall", itemId: "t1", tool: "bash", status: "completed" },
+          ],
+        });
+        rpc.viewPageEvents = [
+          {
+            method: "item/completed",
+            params: { item: { kind: "agentMessage", itemId: "a1", text: "from page" } },
+          },
+        ];
+        return rpc;
+      },
+    });
+    const opened = await adapter.open({ kind: "create", cwd: process.cwd() });
+    expect(opened.ok).toBe(true);
+    if (!opened.ok) throw new Error("expected session");
+    const snapshot = await opened.value.readSnapshot();
+    expect(snapshot.ok).toBe(true);
+    if (!snapshot.ok) throw new Error("expected snapshot");
+    expect(snapshot.value.turns[0]?.items.at(-1)?.item).toMatchObject({
+      type: "agentMessage",
+      text: "from page",
+    });
+    await opened.value.close();
+    await adapter.close();
+  });
+
+  it("keeps a native Turn active after a failed cancel", async () => {
+    const hosts: FakeMuseRpc[] = [];
+    const adapter = new MuseAdapter({
+      command: process.execPath,
+      environment: process.env,
+      createRpc: async () => {
+        const rpc = new FakeMuseRpc();
+        rpc.cancelThrows = true;
+        hosts.push(rpc);
+        return rpc;
+      },
+    });
+    const opened = await adapter.open({ kind: "create", cwd: process.cwd() });
+    expect(opened.ok).toBe(true);
+    if (!opened.ok) throw new Error("expected session");
+    const session = opened.value;
+    const texts: string[] = [];
+    let completedEvent: TurnCompletedEvent | undefined;
+    const completed = new Promise<void>((resolve) => {
+      void (async () => {
+        for await (const output of session.outputs) {
+          if (output.kind === "event" && output.event.type === "item.updated") {
+            const update = output.event.update;
+            if (update.type === "text.append") texts.push(update.text);
+          }
+          if (output.kind === "event" && output.event.type === "turn.completed") {
+            completedEvent = output.event;
+            resolve();
+          }
+        }
+      })();
+    });
+    const accepted = await session.execute({
+      type: "turn.start",
+      turnId: hostTurnIdSchema.parse("turn-hello"),
+      input: [{ type: "text", text: "你好" }],
+    });
+    expect(accepted.ok).toBe(true);
+    const sessionRpc = hosts.at(-1);
+    if (!sessionRpc) throw new Error("expected session rpc");
+    sessionRpc.emit({
+      method: "item/started",
+      params: { item: { kind: "agentMessage", itemId: "a-hi", text: "" } },
+    });
+    sessionRpc.emit({ method: "item/delta", params: { itemId: "a-hi", delta: "你好" } });
+    const cancelled = await session.execute({
+      type: "turn.cancel",
+      turnId: hostTurnIdSchema.parse("turn-hello"),
+    });
+    expect(cancelled.ok).toBe(false);
+    expect(completedEvent).toBeUndefined();
+    sessionRpc.emit({ method: "turn/completed", params: { terminal: "completed" } });
+    await completed;
+    expect(texts.join("")).toBe("你好");
+    expect(completedEvent?.outcome.status).toBe("succeeded");
+    await session.close();
+    await adapter.close();
+  });
+
+  it("keeps streamed agent text when native completion snapshot is shorter", async () => {
+    const hosts: FakeMuseRpc[] = [];
+    const adapter = new MuseAdapter({
+      command: process.execPath,
+      environment: process.env,
+      createRpc: async () => {
+        const rpc = new FakeMuseRpc();
+        hosts.push(rpc);
+        return rpc;
+      },
+    });
+    const opened = await adapter.open({ kind: "create", cwd: process.cwd() });
+    expect(opened.ok).toBe(true);
+    if (!opened.ok) throw new Error("expected session");
+    const session = opened.value;
+    const texts: string[] = [];
+    let completedText = "";
+    let completedEvent: TurnCompletedEvent | undefined;
+    const completed = new Promise<void>((resolve) => {
+      void (async () => {
+        for await (const output of session.outputs) {
+          if (output.kind === "event" && output.event.type === "item.updated") {
+            const update = output.event.update;
+            if (update.type === "text.append") texts.push(update.text);
+          }
+          if (output.kind === "event" && output.event.type === "item.completed") {
+            const item = output.event.snapshot.item;
+            if (item.type === "agentMessage") completedText = item.text;
+          }
+          if (output.kind === "event" && output.event.type === "turn.completed") {
+            completedEvent = output.event;
+            resolve();
+          }
+        }
+      })();
+    });
+    const accepted = await session.execute({
+      type: "turn.start",
+      turnId: hostTurnIdSchema.parse("turn-hello"),
+      input: [{ type: "text", text: "你好" }],
+    });
+    expect(accepted.ok).toBe(true);
+    const sessionRpc = hosts.at(-1);
+    if (!sessionRpc) throw new Error("expected session rpc");
+    sessionRpc.emit({
+      method: "item/started",
+      params: { item: { kind: "agentMessage", itemId: "a-hi", text: "" } },
+    });
+    sessionRpc.emit({ method: "item/delta", params: { itemId: "a-hi", delta: "你好" } });
+    sessionRpc.emit({ method: "item/delta", params: { itemId: "a-hi", delta: "！" } });
+    sessionRpc.emit({
+      method: "item/completed",
+      params: { item: { kind: "agentMessage", itemId: "a-hi", text: "你好" } },
+    });
+    sessionRpc.emit({ method: "turn/completed", params: { terminal: "completed" } });
+    await completed;
+    expect(texts.join("")).toBe("你好！");
+    expect(completedText).toBe("你好！");
+    expect(completedEvent?.outcome.status).toBe("succeeded");
+    await session.close();
+    await adapter.close();
+  });
+});

--- a/packages/adapters/muse/test/muse-catalog.test.ts
+++ b/packages/adapters/muse/test/muse-catalog.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import { harnessPermissionModeIdSchema } from "@codexhost/shared-contracts";
+
+import {
+  MUSE_DEFAULT_PERMISSION_MODE_ID,
+  MUSE_PERMISSION_MODE_CATALOG,
+  decodeMusePermissionModeId,
+  musePermissionModeForExecutionPolicy,
+} from "../src/permission-modes.js";
+
+describe("Muse permission catalog", () => {
+  it("uses the native prompt-unmatched default for an unconfigured Session", () => {
+    expect(MUSE_PERMISSION_MODE_CATALOG.defaultModeId).toBe("promptUnmatched");
+    expect(MUSE_DEFAULT_PERMISSION_MODE_ID).toBe("promptUnmatched");
+    expect(musePermissionModeForExecutionPolicy(undefined)).toBe("promptUnmatched");
+    expect(musePermissionModeForExecutionPolicy("default")).toBe("promptUnmatched");
+  });
+
+  it("only advertises modes selectable under the native serve startup policy", () => {
+    expect(MUSE_PERMISSION_MODE_CATALOG.modes.map((entry) => entry.id)).toEqual([
+      "promptUnmatched",
+      "denyUnmatched",
+    ]);
+  });
+
+  it.each(["onRequest", "promptUnmatched", "denyUnmatched", "allowAll"])(
+    "preserves the explicit %s selection for native policy enforcement",
+    (mode) => {
+      const permissionModeId = harnessPermissionModeIdSchema.parse(mode);
+      expect(decodeMusePermissionModeId(permissionModeId)).toBe(mode);
+      expect(musePermissionModeForExecutionPolicy("default", permissionModeId)).toBe(mode);
+    },
+  );
+
+  it("does not silently downgrade unattended full access to a prompt mode", () => {
+    expect(musePermissionModeForExecutionPolicy("unattended-full-access")).toBe("allowAll");
+  });
+});

--- a/packages/adapters/muse/test/muse-history.test.ts
+++ b/packages/adapters/muse/test/muse-history.test.ts
@@ -1,0 +1,261 @@
+import { describe, expect, it, vi } from "vitest";
+import type { HostThreadSnapshot } from "@codexhost/harness-adapter";
+import { nativeSessionRefSchema } from "@codexhost/shared-contracts";
+
+import { mapMuseHostItem, readMuseHistory, snapshotFromMuseHistory } from "../src/history.js";
+import { MuseRpcError, type JsonObject, type MuseRpc } from "../src/msp-client.js";
+
+const nativeRef = nativeSessionRefSchema.parse({
+  harnessId: "muse",
+  nativeSessionId: "session-1",
+  formatVersion: 1,
+});
+
+function item(kind: string, itemId: string, turnId: string, extra: JsonObject = {}): JsonObject {
+  return { kind, itemId, turnId, revision: 1, status: "completed", ...extra };
+}
+
+function itemEvent(value: JsonObject): JsonObject {
+  return { method: "item/completed", params: { item: value } };
+}
+
+function terminal(turnId: string, status: string, extra: JsonObject = {}): JsonObject {
+  return { method: "turn/completed", params: { turnId, terminal: status, ...extra } };
+}
+
+function historyRpc(items: JsonObject[], pages: JsonObject[][]): MuseRpc {
+  let pageIndex = 0;
+  return {
+    handshake: async () => ({}),
+    request: vi.fn(async (method: string): Promise<JsonObject> => {
+      if (method === "session/read") return { history: { mode: "inline", items } };
+      if (method !== "view/page") throw new Error(`Unexpected request: ${method}`);
+      const events = pages[pageIndex++] ?? [];
+      return { events, nextCursor: pageIndex < pages.length ? `cursor-${pageIndex}` : null };
+    }),
+    notify: () => undefined,
+    subscribe: () => () => undefined,
+    subscribeFailure: () => () => undefined,
+    close: async () => undefined,
+  };
+}
+
+async function readSnapshot(rpc: MuseRpc): Promise<HostThreadSnapshot> {
+  return snapshotFromMuseHistory(nativeRef, await readMuseHistory(rpc, "session-1"));
+}
+
+describe("Muse durable history", () => {
+  it("keeps native user messages as turn input without emitting a second tool item", () => {
+    const user = item("userMessage", "user-1", "turn-1", { text: "hello" });
+
+    expect(mapMuseHostItem(user, "fallback")).toBeUndefined();
+    const snapshot = snapshotFromMuseHistory(nativeRef, { items: [user] });
+    expect(snapshot.turns[0]?.input).toEqual([{ type: "text", text: "hello" }]);
+    expect(snapshot.turns[0]?.items).toEqual([]);
+  });
+
+  it("decodes native JSON tool arguments for the Host command projector", () => {
+    const tool = item("toolCall", "tool-1", "turn-1", {
+      tool: "bash",
+      args: '{"command":"printf hello","timeout_ms":1000}',
+    });
+
+    expect(mapMuseHostItem(tool, "fallback")).toMatchObject({
+      type: "toolExecution",
+      toolName: "bash",
+      arguments: { command: "printf hello", timeout_ms: 1000 },
+    });
+  });
+
+  it("preserves almost-JSON tool arguments verbatim and generic unknown item kinds", () => {
+    const args = '{"command":"printf hello",';
+    expect(
+      mapMuseHostItem(item("toolCall", "tool-1", "turn-1", { tool: "bash", args }), "fallback"),
+    ).toMatchObject({ type: "toolExecution", arguments: args });
+    expect(
+      mapMuseHostItem(
+        item("futureKind", "future-1", "turn-1", { fallbackText: "details" }),
+        "fallback",
+      ),
+    ).toMatchObject({
+      type: "toolExecution",
+      toolName: "futureKind",
+      output: { content: [{ type: "text", text: "details" }] },
+    });
+  });
+
+  it("keeps paged replies between the correct user turns across page boundaries", async () => {
+    const firstUser = item("userMessage", "user-1", "turn-1", { text: "first" });
+    const secondUser = item("userMessage", "user-2", "turn-2", { text: "second" });
+    const firstReply = item("agentMessage", "reply-1", "turn-1", { text: "first answer" });
+    const secondReply = item("agentMessage", "reply-2", "turn-2", { text: "second answer" });
+    const rpc = historyRpc(
+      [firstUser, secondUser],
+      [
+        [itemEvent(firstUser), itemEvent(firstReply), terminal("turn-1", "completed")],
+        [itemEvent(secondUser), itemEvent(secondReply), terminal("turn-2", "completed")],
+      ],
+    );
+
+    const history = await readMuseHistory(rpc, "session-1");
+    const snapshot = snapshotFromMuseHistory(nativeRef, history);
+
+    expect((history?.items as JsonObject[]).map((item) => item.itemId)).toEqual([
+      "user-1",
+      "reply-1",
+      "user-2",
+      "reply-2",
+    ]);
+    expect(snapshot.turns.map((turn) => turn.items.map(({ item }) => item.itemId))).toEqual([
+      ["reply-1"],
+      ["reply-2"],
+    ]);
+    expect(snapshot.turns.map((turn) => turn.outcome.status)).toEqual(["succeeded", "succeeded"]);
+    expect(rpc.request).toHaveBeenLastCalledWith("view/page", {
+      sessionId: "session-1",
+      direction: "forward",
+      limit: 1000,
+      cursor: "cursor-1",
+    });
+  });
+
+  it("uses the native turn id to join steered input and late items to their owning turn", async () => {
+    const rpc = historyRpc(
+      [],
+      [
+        [
+          itemEvent(
+            item("userMessage", "user-1", "native-1", { commandId: "command-1", text: "start" }),
+          ),
+          itemEvent(
+            item("userMessage", "steer-1", "native-1", {
+              commandId: "command-2",
+              text: "also",
+              steered: true,
+            }),
+          ),
+          terminal("native-1", "completed"),
+          itemEvent(item("userMessage", "user-2", "native-2", { text: "next" })),
+          itemEvent(item("toolCall", "late-tool", "native-1", { tool: "bash" })),
+          terminal("native-2", "cancelled"),
+        ],
+      ],
+    );
+
+    const snapshot = await readSnapshot(rpc);
+
+    expect(snapshot.turns).toHaveLength(2);
+    expect(snapshot.turns[0]?.nativeTurnRef.nativeTurnKey).toBe("native-1");
+    expect(snapshot.turns[0]?.input).toEqual([
+      { type: "text", text: "start" },
+      { type: "text", text: "also" },
+    ]);
+    expect(snapshot.turns[0]?.items[0]?.item.itemId).toBe("late-tool");
+    expect(snapshot.turns[1]?.items).toEqual([]);
+  });
+
+  it("preserves failures, cancellations and unknown or missing native turn terminals", async () => {
+    const users = ["failed", "cancelled", "future", "running"].map((turnId) =>
+      item("userMessage", `user-${turnId}`, turnId, { text: turnId }),
+    );
+    const rpc = historyRpc(users, [
+      [
+        ...users.map(itemEvent),
+        terminal("failed", "failed", {
+          error: { kind: "modelError", message: "provider failed", retryable: true },
+        }),
+        terminal("cancelled", "cancelled", { reason: "stopped by user" }),
+        terminal("future", "newNativeTerminal"),
+      ],
+    ]);
+
+    const snapshot = await readSnapshot(rpc);
+
+    expect(snapshot.turns.map((turn) => turn.outcome)).toEqual([
+      {
+        status: "failed",
+        error: { code: "nativeFailure", message: "provider failed", retryable: true },
+      },
+      { status: "cancelled", reason: "stopped by user" },
+      { status: "unknown", reason: expect.stringContaining("newNativeTerminal") },
+      { status: "unknown", reason: expect.any(String) },
+    ]);
+  });
+
+  it("maps item terminal failures and cancellation without losing partial text", async () => {
+    const rpc = historyRpc(
+      [
+        item("userMessage", "user-1", "turn-1", { text: "run tools" }),
+        item("toolCall", "failed-tool", "turn-1", {
+          status: "failed",
+          failureReason: "command failed",
+          tool: "bash",
+        }),
+        item("toolCall", "cancelled-tool", "turn-1", {
+          status: "cancelled",
+          failureReason: "cancelled by user",
+          tool: "bash",
+        }),
+        item("agentMessage", "partial", "turn-1", { status: "inProgress", text: "partial reply" }),
+      ],
+      [],
+    );
+
+    const snapshot = await readSnapshot(rpc);
+
+    expect(snapshot.turns[0]?.outcome.status).toBe("unknown");
+    expect(snapshot.turns[0]?.items[0]?.outcome).toMatchObject({
+      status: "failed",
+      error: { message: "command failed" },
+    });
+    expect(snapshot.turns[0]?.items[1]?.outcome).toEqual({
+      status: "cancelled",
+      reason: "cancelled by user",
+    });
+    expect(snapshot.turns[0]?.items[2]?.item).toMatchObject({ text: "partial reply" });
+  });
+
+  it("applies item revisions monotonically while preserving their first position", async () => {
+    const user = item("userMessage", "user-1", "turn-1", { text: "hello" });
+    const current = item("agentMessage", "reply-1", "turn-1", {
+      text: "latest answer",
+      revision: 3,
+    });
+    const rpc = historyRpc(
+      [user, current],
+      [
+        [
+          itemEvent(user),
+          itemEvent({ ...current, text: "old answer", revision: 1 }),
+          itemEvent({ ...current, text: "older replay", revision: 2 }),
+          terminal("turn-1", "completed"),
+        ],
+      ],
+    );
+
+    const snapshot = await readSnapshot(rpc);
+
+    expect(snapshot.turns[0]?.items).toHaveLength(1);
+    expect(snapshot.turns[0]?.items[0]?.item).toMatchObject({ text: "latest answer" });
+  });
+
+  it("keeps session/read history visible and unconfirmed when paging is unavailable", async () => {
+    const rpc = historyRpc([], []);
+    rpc.request = async (method) => {
+      if (method === "view/page") throw new MuseRpcError("not implemented", -32601);
+      return {
+        history: {
+          items: [
+            { kind: "userMessage", itemId: "user-1", commandId: "command-1", text: "hello" },
+            { kind: "agentMessage", itemId: "reply-1", text: "legacy reply" },
+          ],
+        },
+      };
+    };
+
+    const snapshot = await readSnapshot(rpc);
+
+    expect(snapshot.turns[0]?.outcome.status).toBe("unknown");
+    expect(snapshot.turns[0]?.items[0]?.item).toMatchObject({ text: "legacy reply" });
+  });
+});

--- a/packages/adapters/muse/test/muse-lifecycle.test.ts
+++ b/packages/adapters/muse/test/muse-lifecycle.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it } from "vitest";
+import { nativeSessionRefSchema } from "@codexhost/shared-contracts";
+
+import { MuseAdapter } from "../src/muse-adapter.js";
+import type { JsonObject, MuseRpc } from "../src/msp-client.js";
+
+function lifecycleRpc(result: JsonObject): MuseRpc & { closed: boolean } {
+  return {
+    closed: false,
+    async handshake() {
+      return {};
+    },
+    async request() {
+      return result;
+    },
+    notify() {},
+    subscribe() {
+      return () => {};
+    },
+    subscribeFailure() {
+      return () => {};
+    },
+    async close() {
+      this.closed = true;
+    },
+  };
+}
+
+const nativeRef = nativeSessionRefSchema.parse({
+  harnessId: "muse",
+  nativeSessionId: "original",
+  formatVersion: 1,
+});
+
+describe("Muse Session opening", () => {
+  it("rejects unattended delegation before starting a native process", async () => {
+    let starts = 0;
+    const adapter = new MuseAdapter({
+      command: process.execPath,
+      createRpc: () => {
+        starts += 1;
+        return lifecycleRpc({ session: { sessionId: "original" } });
+      },
+    });
+    const result = await adapter.open({
+      kind: "create",
+      cwd: process.cwd(),
+      executionPolicy: "unattended-full-access",
+    });
+    expect(result).toMatchObject({ ok: false, error: { code: "unsupported", retryable: false } });
+    expect(starts).toBe(0);
+    await adapter.close();
+  });
+
+  it("rejects another Harness before starting a native process", async () => {
+    let starts = 0;
+    const adapter = new MuseAdapter({
+      command: process.execPath,
+      createRpc: () => {
+        starts += 1;
+        return lifecycleRpc({});
+      },
+    });
+    const result = await adapter.open({
+      kind: "resume",
+      cwd: process.cwd(),
+      nativeRef: {
+        ...nativeRef,
+        harnessId: nativeSessionRefSchema.parse({ ...nativeRef, harnessId: "pi" }).harnessId,
+      },
+    });
+    expect(result).toMatchObject({ ok: false, error: { code: "invalidRequest" } });
+    expect(starts).toBe(0);
+    await adapter.close();
+  });
+
+  it("closes the native process when resume returns a different identity", async () => {
+    const rpc = lifecycleRpc({ session: { sessionId: "different" } });
+    const adapter = new MuseAdapter({ command: process.execPath, createRpc: () => rpc });
+    const result = await adapter.open({ kind: "resume", cwd: process.cwd(), nativeRef });
+    expect(result).toMatchObject({ ok: false, error: { code: "sessionNotFound" } });
+    expect(rpc.closed).toBe(true);
+    await adapter.close();
+  });
+
+  it.each([
+    {
+      session: { sessionId: "original", status: "running", activeTurnId: "old-turn" },
+      pendingRequests: [],
+    },
+    {
+      session: { sessionId: "original", status: "idle", activeTurnId: null },
+      pendingRequests: [{ kind: "approval", requestId: "old-approval" }],
+    },
+  ])("does not silently resume an unresolved native operation as idle", async (native) => {
+    const rpc = lifecycleRpc(native);
+    const adapter = new MuseAdapter({ command: process.execPath, createRpc: () => rpc });
+    const result = await adapter.open({ kind: "resume", cwd: process.cwd(), nativeRef });
+    expect(result).toMatchObject({ ok: false, error: { code: "sessionBusy", retryable: true } });
+    expect(rpc.closed).toBe(true);
+    await adapter.close();
+  });
+
+  it("does not publish a Session that finishes opening after Adapter close", async () => {
+    let release!: () => void;
+    const ready = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const rpc = lifecycleRpc({ session: { sessionId: "original" } });
+    rpc.handshake = async () => {
+      await ready;
+      return {};
+    };
+    const adapter = new MuseAdapter({ command: process.execPath, createRpc: () => rpc });
+    const opening = adapter.open({ kind: "create", cwd: process.cwd() });
+    await Promise.resolve();
+    await adapter.close();
+    release();
+    expect(await opening).toMatchObject({ ok: false, error: { code: "invalidState" } });
+    expect(rpc.closed).toBe(true);
+  });
+});

--- a/packages/adapters/muse/test/muse-live-echo.test.ts
+++ b/packages/adapters/muse/test/muse-live-echo.test.ts
@@ -1,0 +1,34 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import { resolveMuseExecutable } from "../src/command.js";
+import { MuseAdapter } from "../src/muse-adapter.js";
+
+describe.skipIf(process.env.CODEXHOST_MUSE_LIVE !== "1")("muse live serve", () => {
+  it("inspects and creates a Session through real muse serve", async () => {
+    const executable = resolveMuseExecutable({ environment: process.env });
+    expect(executable, "Install and log in to Muse before running the live gate").toBeTruthy();
+    const cwd = mkdtempSync(path.join(tmpdir(), "muse-live-"));
+    const adapter = new MuseAdapter({
+      environment: process.env,
+      serveExtraArguments: ["--no-session-log"],
+    });
+    try {
+      const inspection = await adapter.inspect({ cwd });
+      expect(inspection.status).toBe("ready");
+      const opened = await adapter.open({ kind: "create", cwd });
+      expect(opened.ok).toBe(true);
+      if (!opened.ok) throw new Error(opened.error.message);
+      const session = opened.value;
+      expect(session.initialState.nativeRef?.nativeSessionId).toBeTruthy();
+      const snapshot = await session.readSnapshot();
+      expect(snapshot.ok).toBe(true);
+    } finally {
+      await adapter.close();
+      rmSync(cwd, { recursive: true, force: true });
+    }
+  }, 10_000);
+});

--- a/packages/adapters/muse/test/muse-msp-surface.test.ts
+++ b/packages/adapters/muse/test/muse-msp-surface.test.ts
@@ -1,0 +1,28 @@
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import { resolveMuseExecutable } from "../src/command.js";
+import { MUSE_MSP_NOTIFICATIONS, MUSE_MSP_REQUEST_METHODS } from "../src/msp-surface.js";
+
+describe("muse MSP surface", () => {
+  it("only uses methods and notifications present on this muse binary", () => {
+    const executable = resolveMuseExecutable({ environment: process.env });
+    if (!executable) return;
+    const out = mkdtempSync(path.join(tmpdir(), "muse-schema-"));
+    execFileSync(executable, ["schema", "generate-json-schema", "--out", out], {
+      encoding: "utf8",
+    });
+    const schema = JSON.parse(readFileSync(path.join(out, "msp.schema.json"), "utf8")) as {
+      methods?: Record<string, unknown>;
+      notifications?: Record<string, unknown>;
+    };
+    const methods = Object.keys(schema.methods ?? {});
+    const notifications = Object.keys(schema.notifications ?? {});
+    expect(methods).toEqual(expect.arrayContaining([...MUSE_MSP_REQUEST_METHODS]));
+    expect(notifications).toEqual(expect.arrayContaining([...MUSE_MSP_NOTIFICATIONS]));
+  });
+});

--- a/packages/adapters/muse/test/muse-session.test.ts
+++ b/packages/adapters/muse/test/muse-session.test.ts
@@ -1,0 +1,501 @@
+import { setImmediate } from "node:timers/promises";
+import { describe, expect, it } from "vitest";
+import type { HarnessOutput, TurnStartCommand } from "@codexhost/harness-adapter";
+import { hostTurnIdSchema } from "@codexhost/shared-contracts";
+import { CodexTurnProjector } from "@codexhost/protocol-core";
+import { MuseHarnessSession } from "../src/muse-session.js";
+import {
+  MuseProcessError,
+  MuseRpcError,
+  type JsonObject,
+  type MuseRpc,
+  type MuseRpcNotification,
+} from "../src/msp-client.js";
+
+class SessionRpc implements MuseRpc {
+  listeners = new Set<(notification: MuseRpcNotification) => void>();
+  failures = new Set<(error: MuseProcessError) => void>();
+  requests: Array<{ method: string; params: JsonObject }> = [];
+  startResult: JsonObject = {};
+  sessionState: JsonObject = { activeTurnId: null, status: "idle" };
+  cancelError: Error | undefined;
+  closed = false;
+  nativeTurnId = "";
+
+  async handshake() {
+    return {};
+  }
+  notify() {}
+  async request(method: string, params: JsonObject = {}): Promise<JsonObject> {
+    this.requests.push({ method, params });
+    if (method === "session/read")
+      return { session: this.sessionState, history: { mode: "inline", items: [] } };
+    if (method === "turn/start") {
+      this.nativeTurnId = String(this.startResult.turnId ?? params.commandId);
+      return {
+        commandId: params.commandId,
+        status: "accepted",
+        disposition: "started",
+        startedNewTurn: true,
+        turnId: this.nativeTurnId,
+        ...this.startResult,
+      };
+    }
+    if (method === "turn/cancel" && this.cancelError) throw this.cancelError;
+    return { commandId: params.commandId, status: "accepted", turnId: params.turnId };
+  }
+  subscribe(handler: (notification: MuseRpcNotification) => void) {
+    this.listeners.add(handler);
+    return () => {
+      this.listeners.delete(handler);
+    };
+  }
+  subscribeFailure(handler: (error: MuseProcessError) => void) {
+    this.failures.add(handler);
+    return () => {
+      this.failures.delete(handler);
+    };
+  }
+  emit(method: string, params: JsonObject) {
+    for (const listener of this.listeners) listener({ method, params });
+  }
+  fail() {
+    for (const listener of this.failures)
+      listener(
+        new MuseProcessError({ code: "nativeFailure", message: "Muse exited 1", retryable: false }),
+      );
+  }
+  async close() {
+    this.closed = true;
+  }
+}
+
+function fixture() {
+  const rpc = new SessionRpc();
+  const session = new MuseHarnessSession({ rpc, native: { sessionId: "parent" } });
+  const outputs: HarnessOutput[] = [];
+  const consume = (async () => {
+    for await (const output of session.outputs) outputs.push(output);
+  })();
+  const command: TurnStartCommand = {
+    type: "turn.start",
+    turnId: hostTurnIdSchema.parse("host-turn"),
+    input: [{ type: "text", text: "hello" }],
+  };
+  const item = (text = "", turnId = rpc.nativeTurnId) => ({
+    kind: "agentMessage",
+    itemId: "reply",
+    turnId,
+    revision: 1,
+    status: "inProgress",
+    text,
+  });
+  const emit = (method: string, params: JsonObject = {}) =>
+    rpc.emit(method, { sessionId: "parent", ...params });
+  const terminal = (params: JsonObject = {}) =>
+    emit("turn/completed", {
+      turnId: rpc.nativeTurnId,
+      terminal: "completed",
+      viewCursor: "terminal",
+      ...params,
+    });
+  const finish = async () => {
+    await session.close();
+    await consume;
+  };
+  return { rpc, session, outputs, command, item, emit, terminal, finish };
+}
+
+function events(outputs: HarnessOutput[]) {
+  return outputs.flatMap((output) => (output.kind === "event" ? [output.event] : []));
+}
+
+describe("Muse native Session lifecycle", () => {
+  it("projects each streamed character once even when the consumer runs after every native event", async () => {
+    const f = fixture();
+    expect((await f.session.execute(f.command)).ok).toBe(true);
+    f.emit("item/started", { item: f.item(), viewCursor: "1" });
+    f.emit("item/delta", { itemId: "reply", delta: "你好", viewCursor: "2" });
+    f.emit("item/completed", {
+      item: { ...f.item("你好"), status: "completed", revision: 2 },
+      viewCursor: "3",
+    });
+    f.terminal();
+    await setImmediate();
+    const projector = new CodexTurnProjector({
+      threadId: "thread",
+      turnId: f.command.turnId,
+      cwd: "/tmp",
+      startedAtMs: 0,
+    });
+    const messages = events(f.outputs).flatMap((event) =>
+      "turnId" in event && event.type !== "turn.autonomous.started"
+        ? projector.project(event).messages
+        : [],
+    );
+    const text = messages
+      .filter((message) => message.method === "item/agentMessage/delta")
+      .map((message) => (message.params as JsonObject).delta)
+      .join("");
+    expect(text).toBe("你好");
+    expect(events(f.outputs).find((event) => event.type === "item.started")).toMatchObject({
+      item: { text: "" },
+    });
+    await f.finish();
+  });
+
+  it("keeps legitimate repeated appends and deduplicates only the replayed view cursor", async () => {
+    const f = fixture();
+    await f.session.execute(f.command);
+    f.emit("item/started", { item: f.item("ha"), viewCursor: "1" });
+    f.emit("item/delta", { itemId: "reply", delta: "ha", viewCursor: "2" });
+    f.emit("item/delta", { itemId: "reply", delta: "ha", viewCursor: "3" });
+    f.emit("item/delta", { itemId: "reply", delta: "ha", viewCursor: "3" });
+    f.emit("item/completed", {
+      item: { ...f.item("hahaha"), revision: 2, status: "completed" },
+      viewCursor: "4",
+    });
+    f.terminal();
+    await setImmediate();
+    expect(events(f.outputs).find((event) => event.type === "item.completed")).toMatchObject({
+      snapshot: { item: { text: "hahaha" } },
+    });
+    await f.finish();
+  });
+
+  it("ignores child sessions and stale turns, including a late terminal after cancel and restart", async () => {
+    const f = fixture();
+    await f.session.execute(f.command);
+    const previousNative = f.rpc.nativeTurnId;
+    f.rpc.emit("turn/completed", {
+      sessionId: "child",
+      turnId: previousNative,
+      terminal: "completed",
+    });
+    f.emit("item/started", { item: f.item("stale", "older"), viewCursor: "stale" });
+    await setImmediate();
+    expect(events(f.outputs).map((event) => event.type)).toEqual(["turn.started"]);
+    expect((await f.session.execute({ type: "turn.cancel", turnId: f.command.turnId })).ok).toBe(
+      true,
+    );
+    f.terminal({ terminal: "cancelled" });
+    await setImmediate();
+    const next = { ...f.command, turnId: hostTurnIdSchema.parse("next") };
+    expect((await f.session.execute(next)).ok).toBe(true);
+    f.emit("turn/completed", { turnId: previousNative, terminal: "completed" });
+    f.emit("item/started", { item: f.item("late", previousNative) });
+    await setImmediate();
+    expect(events(f.outputs).filter((event) => event.type === "turn.completed")).toHaveLength(1);
+    expect(events(f.outputs).filter((event) => event.type === "item.started")).toHaveLength(0);
+    f.terminal();
+    await f.finish();
+  });
+
+  it("reports native cancel errors without inventing a cancelled terminal", async () => {
+    const f = fixture();
+    await f.session.execute(f.command);
+    f.rpc.cancelError = new MuseRpcError("cancel denied", -32602);
+    const cancelled = await f.session.execute({ type: "turn.cancel", turnId: f.command.turnId });
+    expect(cancelled).toMatchObject({ ok: false, error: { message: "cancel denied" } });
+    await setImmediate();
+    expect(events(f.outputs).filter((event) => event.type === "turn.completed")).toHaveLength(0);
+    expect(await f.session.execute(f.command)).toMatchObject({
+      ok: false,
+      error: { code: "sessionBusy" },
+    });
+    f.terminal();
+    await f.finish();
+  });
+
+  it("settles a process failure once and prevents all late output", async () => {
+    const f = fixture();
+    await f.session.execute(f.command);
+    f.emit("item/started", { item: f.item() });
+    f.rpc.fail();
+    f.rpc.fail();
+    f.emit("item/delta", { itemId: "reply", delta: "late" });
+    f.terminal();
+    await setImmediate();
+    expect(events(f.outputs).map((event) => event.type)).toEqual([
+      "turn.started",
+      "item.started",
+      "item.completed",
+      "turn.completed",
+      "session.faulted",
+    ]);
+    expect(events(f.outputs).find((event) => event.type === "turn.completed")).toMatchObject({
+      outcome: { status: "failed" },
+    });
+    expect(await f.session.execute(f.command)).toMatchObject({ ok: false });
+    expect(f.rpc.closed).toBe(true);
+    await f.finish();
+  });
+
+  it("ends the parent at its native terminal while a background child can still change state", async () => {
+    const f = fixture();
+    await f.session.execute(f.command);
+    const nativeTurnId = f.rpc.nativeTurnId;
+    const child = {
+      kind: "subagent",
+      itemId: "child-item",
+      turnId: nativeTurnId,
+      subagentId: "child",
+      childSessionId: "child-session",
+      revision: 1,
+      status: "inProgress",
+      controlStatus: "running",
+    };
+    f.emit("item/started", { item: child });
+    f.terminal();
+    await setImmediate();
+    expect(events(f.outputs).filter((event) => event.type === "turn.completed")).toHaveLength(1);
+    await f.session.execute({ ...f.command, turnId: hostTurnIdSchema.parse("next") });
+    f.emit("item/completed", {
+      item: { ...child, revision: 2, status: "completed", controlStatus: "resultReady" },
+    });
+    await setImmediate();
+    const afterRestart = events(f.outputs).slice(
+      events(f.outputs).findIndex((event) => event.type === "turn.completed") + 2,
+    );
+    expect(
+      afterRestart.some(
+        (event) => event.type === "subagent.state.changed" && event.status === "completed",
+      ),
+    ).toBe(true);
+    expect(
+      afterRestart.some(
+        (event) => event.type === "item.updated" || event.type === "item.completed",
+      ),
+    ).toBe(false);
+    f.terminal();
+    await f.finish();
+  });
+
+  it("refreshes only an owned approval when native approval/updated has no turnId", async () => {
+    const f = fixture();
+    await f.session.execute(f.command);
+    const sourceRange = {
+      first: { id: "event", sequence: 1 },
+      last: { id: "event", sequence: 1 },
+      stream: { kind: "session", id: "parent" },
+    };
+    const availableChoices = [
+      { choiceId: "allow", decision: "approved", label: "Allow once", scope: "once" },
+      { choiceId: "deny", decision: "denied", label: "Deny", scope: "once" },
+    ];
+    const subject = { kind: "shell", command: "printf hello" };
+    f.emit("approval/requested", {
+      approvalId: "approval",
+      availableChoices,
+      currentRequirementId: { approvalId: "approval", sourceIndex: 0 },
+      itemId: "tool",
+      judgeEscalated: false,
+      protectedWrite: false,
+      rawArgs: "{}",
+      sourceRange,
+      subject,
+      taskId: "task",
+      toolCallId: "call",
+      toolName: "shell",
+      turnId: f.rpc.nativeTurnId,
+      viewCursor: "request",
+    });
+    const updated = {
+      approvalId: "approval",
+      availableChoices,
+      currentRequirementId: { approvalId: "approval", sourceIndex: 1 },
+      change: { kind: "requirementChanged" },
+      sourceRange,
+      subject,
+      viewCursor: "refresh",
+    };
+    expect(updated).not.toHaveProperty("turnId");
+    f.emit("approval/updated", { ...updated, approvalId: "unowned", viewCursor: "unowned" });
+    f.emit("approval/updated", updated);
+    await setImmediate();
+    const interactions = f.outputs.flatMap((output) =>
+      output.kind === "interaction" ? [output.interaction] : [],
+    );
+    expect(interactions.map((interaction) => interaction.interactionId)).toEqual([
+      "approval:0",
+      "approval:1",
+    ]);
+    expect(events(f.outputs).filter((event) => event.type === "interaction.closed")).toMatchObject([
+      { interactionId: "approval:0", reason: "superseded" },
+    ]);
+    const refreshed = interactions.at(-1);
+    if (!refreshed) throw new Error("Expected refreshed approval");
+    expect(
+      await f.session.execute({
+        type: "interaction.respond",
+        interactionId: refreshed.interactionId,
+        response: { type: "approval", actionId: "allow" },
+      }),
+    ).toMatchObject({ ok: true });
+    expect(
+      f.rpc.requests.find((request) => request.method === "approval/decide")?.params.requirementId,
+    ).toEqual({ approvalId: "approval", sourceIndex: 1 });
+    f.terminal();
+    await f.session.execute({ ...f.command, turnId: hostTurnIdSchema.parse("next") });
+    f.emit("approval/updated", { ...updated, viewCursor: "late" });
+    await setImmediate();
+    expect(f.outputs.filter((output) => output.kind === "interaction")).toHaveLength(2);
+    await f.finish();
+  });
+
+  it("settles an owned question without a native turnId and ignores unknown question IDs", async () => {
+    const f = fixture();
+    await f.session.execute(f.command);
+    f.emit("userInput/requested", {
+      itemId: "tool",
+      questions: [
+        {
+          id: "answer",
+          header: "Choose",
+          question: "Which?",
+          options: [{ label: "one" }],
+          selection: { mode: "single" },
+        },
+      ],
+      toolCallId: "call",
+      toolName: "ask",
+      turnId: f.rpc.nativeTurnId,
+      userInputId: "question",
+      viewCursor: "request",
+    });
+    const settled = {
+      answers: [],
+      clarification: null,
+      decidedByCommandId: null,
+      outcome: "cancelled",
+      reason: null,
+      sourceRange: {
+        first: { id: "event", sequence: 1 },
+        last: { id: "event", sequence: 1 },
+        stream: { kind: "session", id: "parent" },
+      },
+      userInputId: "question",
+      viewCursor: "settled",
+    };
+    expect(settled).not.toHaveProperty("turnId");
+    f.emit("userInput/settled", { ...settled, userInputId: "unknown", viewCursor: "unowned" });
+    f.emit("userInput/settled", settled);
+    await setImmediate();
+    expect(events(f.outputs).filter((event) => event.type === "interaction.closed")).toMatchObject([
+      { interactionId: "question", reason: "cancelled" },
+    ]);
+    await f.finish();
+  });
+
+  it("closes a pending interaction on process failure and rejects its late response", async () => {
+    const f = fixture();
+    await f.session.execute(f.command);
+    f.emit("userInput/requested", {
+      turnId: f.rpc.nativeTurnId,
+      userInputId: "question",
+      toolName: "ask",
+      questions: [],
+    });
+    f.rpc.fail();
+    await setImmediate();
+    expect(events(f.outputs).filter((event) => event.type === "interaction.closed")).toHaveLength(
+      1,
+    );
+    const interaction = f.outputs.find((output) => output.kind === "interaction");
+    if (!interaction || interaction.kind !== "interaction") throw new Error("Expected question");
+    expect(
+      await f.session.execute({
+        type: "interaction.respond",
+        interactionId: interaction.interaction.interactionId,
+        response: { type: "question", answers: {} },
+      }),
+    ).toMatchObject({ ok: false });
+    expect(f.rpc.requests.some((request) => request.method === "userInput/answer")).toBe(false);
+    await f.finish();
+  });
+
+  it.each(["failed", "cancelled", "rejected", "timedOut"])(
+    "preserves native %s item outcomes and reasons without failing a successful parent Turn",
+    async (status) => {
+      const f = fixture();
+      await f.session.execute(f.command);
+      const failures = [
+        { failureReason: "native failure detail", reason: "less specific reason" },
+        { reason: "native fallback reason" },
+      ];
+      for (const [index, reasons] of failures.entries()) {
+        f.emit("item/completed", {
+          item: {
+            kind: "toolCall",
+            itemId: `tool-${index}`,
+            turnId: f.rpc.nativeTurnId,
+            revision: 2,
+            tool: "shell",
+            status,
+            ...reasons,
+          },
+          viewCursor: `completion-${index}`,
+        });
+      }
+      f.terminal();
+      await setImmediate();
+      const expected = ["native failure detail", "native fallback reason"].map((reason) =>
+        status === "cancelled" || status === "rejected"
+          ? { status: "cancelled", reason }
+          : {
+              status: "failed",
+              error: { code: "nativeFailure", message: reason, retryable: false },
+            },
+      );
+      const outcomes = events(f.outputs).flatMap((event) =>
+        event.type === "item.completed" ? [event.snapshot.outcome] : [],
+      );
+      expect(outcomes).toEqual(expected);
+      expect(events(f.outputs).find((event) => event.type === "turn.completed")).toMatchObject({
+        outcome: { status: "succeeded" },
+      });
+      await f.finish();
+    },
+  );
+
+  it("reclaims a queued input instead of projecting it as an already running turn", async () => {
+    const f = fixture();
+    f.rpc.startResult = { disposition: "queued", startedNewTurn: false, turnId: "queued-native" };
+    expect(await f.session.execute(f.command)).toMatchObject({
+      ok: false,
+      error: { code: "sessionBusy" },
+    });
+    expect(f.rpc.requests.find((request) => request.method === "turn/unqueue")?.params.turnId).toBe(
+      "queued-native",
+    );
+    await setImmediate();
+    expect(events(f.outputs)).toEqual([]);
+    await f.finish();
+  });
+
+  it.each([{ status: "noop" }, { turnId: "" }, { disposition: "steered" }])(
+    "rejects an invalid fresh-turn acknowledgement %j",
+    async (ack) => {
+      const f = fixture();
+      f.rpc.startResult = ack;
+      expect(await f.session.execute(f.command)).toMatchObject({
+        ok: false,
+        error: { code: "protocolError" },
+      });
+      await setImmediate();
+      expect(events(f.outputs).filter((event) => event.type === "turn.started")).toHaveLength(0);
+      await f.finish();
+    },
+  );
+
+  it("does not submit into a session whose native foreground is still running", async () => {
+    const f = fixture();
+    f.rpc.sessionState = { activeTurnId: "other-client", status: "running" };
+    expect(await f.session.execute(f.command)).toMatchObject({
+      ok: false,
+      error: { code: "sessionBusy" },
+    });
+    expect(f.rpc.requests.some((request) => request.method === "turn/start")).toBe(false);
+    await f.finish();
+  });
+});

--- a/packages/adapters/muse/tsconfig.json
+++ b/packages/adapters/muse/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "composite": true,
+    "types": ["node"],
+    "rootDir": "src",
+    "outDir": "dist",
+    "tsBuildInfoFile": "dist/tsconfig.tsbuildinfo"
+  },
+  "references": [
+    { "path": "../../shared-contracts/tsconfig.json" },
+    { "path": "../../harness-adapter/tsconfig.json" },
+    { "path": "../../harness-discovery/tsconfig.json" }
+  ],
+  "include": ["src/**/*.ts"]
+}

--- a/packages/desktop-control/src/production-controller.ts
+++ b/packages/desktop-control/src/production-controller.ts
@@ -251,6 +251,7 @@ export async function runDesktopController(
           "grok",
           "omp",
           "antigravity",
+          "muse",
         ],
         timeoutMs: PRODUCTION_INSTALL_TIMEOUT_MS,
       },

--- a/packages/desktop-control/test/production-controller.test.ts
+++ b/packages/desktop-control/test/production-controller.test.ts
@@ -150,6 +150,7 @@ describe("production Desktop Controller", () => {
         "grok",
         "omp",
         "antigravity",
+        "muse",
       ],
       timeoutMs: 90_000,
     });

--- a/packages/harness-adapter/src/testing.ts
+++ b/packages/harness-adapter/src/testing.ts
@@ -180,6 +180,7 @@ export class FakeHarnessSession implements HarnessSession {
     options: { itemId?: HostItemId; title?: string; expiresAt?: string };
   } | null = null;
   #nextRejection: HarnessError | null = null;
+  #nextCancelRejection: HarnessError | null = null;
   #state: HarnessSessionState;
   #snapshot: HostThreadSnapshot;
   #turnOrdinal = 0;
@@ -328,6 +329,30 @@ export class FakeHarnessSession implements HarnessSession {
 
   rejectNextTurn(error: HarnessError): void {
     this.#nextRejection = error;
+  }
+
+  rejectNextCancel(
+    error: HarnessError = {
+      code: "invalidRequest",
+      message: "No matching Turn",
+      retryable: false,
+    },
+  ): void {
+    this.#nextCancelRejection = error;
+  }
+
+  completeAgentMessageWithText(text: string): void {
+    const active = this.#requireActive();
+    const item = [...active.items.values()].find(
+      (candidate): candidate is HostAgentMessageItem => candidate.type === "agentMessage",
+    );
+    if (!item) throw new Error("Fake Harness Session has no Agent Message Item");
+    active.items.delete(item.itemId);
+    this.#event({
+      type: "item.completed",
+      turnId: active.command.turnId,
+      snapshot: { item: { ...item, text }, outcome: { status: "succeeded" } },
+    });
   }
 
   rejectNextModelSelection(error: HarnessError): void {
@@ -871,6 +896,11 @@ export class FakeHarnessSession implements HarnessSession {
   }
 
   #cancel(command: TurnCancelCommand): HarnessResult<TurnCancelAccepted> {
+    if (this.#nextCancelRejection) {
+      const error = this.#nextCancelRejection;
+      this.#nextCancelRejection = null;
+      return { ok: false, error };
+    }
     const active = this.#active;
     if (!active || active.command.turnId !== command.turnId) {
       return { ok: false, error: invalidState("Turn Cancel must reference the active Turn") };

--- a/packages/host-runtime/src/app-server-host.ts
+++ b/packages/host-runtime/src/app-server-host.ts
@@ -9,6 +9,7 @@ import type { Readable, Writable } from "node:stream";
 
 import type {
   HarnessAdapter,
+  HarnessError,
   HarnessOutput,
   HarnessSession,
   HostApprovalInteraction,
@@ -194,6 +195,7 @@ import {
   transportModelIdForHarness,
   type CodexApprovalProjection,
   type CodexQuestionProjection,
+  type CodexTurnProjection,
   type DecodedThreadForkRequest,
   type DecodedThreadListRequest,
   type DecodedThreadRevertRequest,
@@ -242,6 +244,7 @@ interface TurnProjectionGate {
 
 interface ProjectedTurn {
   projector: CodexTurnProjector;
+  projectionError?: HarnessError;
 }
 
 type HostApprovalRequestId = number;
@@ -3827,17 +3830,17 @@ export class AppServerHost {
       resolve: cancellationGate.resolve,
     };
     thread.responseGates.set(turnId, gate);
-    const result = await thread.session.execute({ type: "turn.cancel", turnId });
-    if (!result.ok) {
-      try {
-        await this.#writer.json(rpcError(request, -32074, result.error.message));
-      } finally {
-        gate.resolve();
-      }
-      return;
+    let response: JsonObject;
+    try {
+      const result = await thread.session.execute({ type: "turn.cancel", turnId });
+      response = result.ok
+        ? rpcEnvelope(request, { result: {} })
+        : rpcError(request, -32074, result.error.message);
+    } catch (error) {
+      response = rpcError(request, -32074, errorMessage(error));
     }
     try {
-      await this.#writer.json(rpcEnvelope(request, { result: {} }));
+      await this.#writer.json(response);
     } finally {
       gate.resolve();
     }
@@ -3846,7 +3849,21 @@ export class AppServerHost {
   async #consumeHarnessOutputs(thread: ExternalThread): Promise<void> {
     try {
       for await (const output of thread.session.outputs) {
-        await this.#projectHarnessOutput(thread, output);
+        try {
+          await this.#projectHarnessOutput(thread, output);
+        } catch (error) {
+          this.#diagnose(error);
+          const value = output.kind === "event" ? output.event : output.interaction;
+          const projection: ProjectedTurn | undefined =
+            "turnId" in value ? thread.projectedTurns.get(value.turnId) : undefined;
+          if (projection) {
+            projection.projectionError ??= {
+              code: "internalError",
+              message: `External Turn output could not be projected: ${errorMessage(error)}`,
+              retryable: false,
+            };
+          }
+        }
       }
     } catch (error) {
       this.#diagnose(error);
@@ -4044,7 +4061,26 @@ export class AppServerHost {
         };
       }
     }
-    const result = projection.projector.project(event as ProjectableHostEvent);
+    if (event.type === "turn.completed" && projection.projectionError) {
+      event = { ...event, outcome: { status: "failed", error: projection.projectionError } };
+    }
+    let result: CodexTurnProjection;
+    try {
+      result = projection.projector.project(event as ProjectableHostEvent);
+    } catch (error) {
+      if (event.type !== "turn.completed") throw error;
+      this.#diagnose(error);
+      projection.projectionError ??= {
+        code: "internalError",
+        message: `External Turn output could not be projected: ${errorMessage(error)}`,
+        retryable: false,
+      };
+      event = { ...event, outcome: { status: "failed", error: projection.projectionError } };
+      result = this.#recoverFailedTurnCompletion(thread.id, projection, {
+        turnId: event.turnId,
+        error: projection.projectionError,
+      });
+    }
     if (event.type === "turn.started") {
       await this.#setThreadStatus(thread, { type: "active", activeFlags: [] });
     }
@@ -4528,6 +4564,50 @@ export class AppServerHost {
       emittedAtMs: Date.now(),
       params: { threadId: thread.id, status },
     });
+  }
+
+  #recoverFailedTurnCompletion(
+    threadId: string,
+    projection: ProjectedTurn,
+    failure: { turnId: HostTurnId; error: HarnessError },
+  ): CodexTurnProjection {
+    const emittedAtMs = Date.now();
+    const pending = projection.projector.pendingTurn();
+    const error = {
+      message: failure.error.message,
+      codexErrorInfo: "other",
+      additionalDetails: null,
+    };
+    const startedAtMs =
+      typeof pending.startedAt === "number" && pending.startedAt > 0
+        ? pending.startedAt * 1000
+        : emittedAtMs;
+    const turn: JsonObject = {
+      ...pending,
+      status: "failed",
+      completedAt: Math.floor(emittedAtMs / 1000),
+      durationMs: Math.max(0, emittedAtMs - startedAtMs),
+      error,
+    };
+    return {
+      completedTurn: turn,
+      messages: [
+        {
+          method: "error",
+          params: {
+            error,
+            willRetry: false,
+            threadId,
+            turnId: failure.turnId,
+          },
+        },
+        {
+          method: "turn/completed",
+          emittedAtMs,
+          params: { threadId, turn },
+        },
+      ],
+    };
   }
 
   #projectedTurn(thread: ExternalThread, turnId: HostTurnId): ProjectedTurn {

--- a/packages/host-runtime/test/app-server-host.test.ts
+++ b/packages/host-runtime/test/app-server-host.test.ts
@@ -17,6 +17,7 @@ import { FakeHarnessAdapter, FakeHarnessSession } from "@codexhost/harness-adapt
 import { MappingStore } from "@codexhost/mapping-store";
 import {
   CLAUDE_CODE_NATIVE_TRANSPORT_MODEL_ID,
+  CodexTurnProjector,
   encodeClaudeTransportModel,
   encodeGrokTransportModel,
   encodePiTransportModel,
@@ -7062,6 +7063,157 @@ describe("AppServerHost HarnessAdapter projection", () => {
     expect(questionClosedIndex).toBeGreaterThan(responseIndex);
     expect(turnIndex).toBeGreaterThan(questionClosedIndex);
     await stopFixture(fixture);
+  });
+
+  it("fails an external Turn visibly when textual Item completion does not match streamed text", async () => {
+    const fixture = createFixture();
+    const threadId = await startPiThread(fixture);
+    const turnId = await startPiTurn(fixture, threadId);
+    const session = fixture.adapter.sessions[0];
+    if (!session) throw new Error("Fake Pi Session was not opened");
+    await fixture.collector.waitFor((message) => turnEvent(message, "turn/started", turnId));
+    session.appendText("你好");
+    await fixture.collector.waitFor((message) => method(message, "item/agentMessage/delta"));
+    session.completeAgentMessageWithText("你好你好");
+    session.succeedTurn();
+    await expect(
+      fixture.collector.waitFor((message) => turnEvent(message, "turn/completed", turnId)),
+    ).resolves.toMatchObject({
+      params: {
+        turn: {
+          status: "failed",
+          error: { message: expect.stringContaining("textual Item completion") },
+        },
+      },
+    });
+    expect(fixture.collector.messages.find((message) => method(message, "error"))).toMatchObject({
+      params: { threadId, turnId, willRetry: false },
+    });
+    await expect(
+      fixture.mappingStore.getThread(hostThreadIdSchema.parse(threadId)),
+    ).resolves.toMatchObject({
+      nativeSessionRef: { nativeSessionId: session.initialState.nativeRef?.nativeSessionId },
+    });
+    writeRequest(fixture.desktopInput, {
+      id: 3,
+      method: "turn/start",
+      params: { threadId, input: [{ type: "text", text: "next" }] },
+    });
+    await expect(
+      fixture.collector.waitFor((message) => requestId(message, 3)),
+    ).resolves.toMatchObject({ result: { turn: { status: "inProgress" } } });
+    fixture.adapter.sessions[0]?.succeedTurn();
+    await stopFixture(fixture);
+  });
+
+  it("keeps an external Turn active when native cancellation fails", async () => {
+    const fixture = createFixture();
+    const threadId = await startPiThread(fixture);
+    const turnId = await startPiTurn(fixture, threadId);
+    const session = fixture.adapter.sessions[0];
+    if (!session) throw new Error("Fake Pi Session was not opened");
+    await fixture.collector.waitFor((message) => turnEvent(message, "turn/started", turnId));
+    session.rejectNextCancel();
+    writeRequest(fixture.desktopInput, {
+      id: 3,
+      method: "turn/interrupt",
+      params: { threadId, turnId },
+    });
+    await expect(fixture.collector.waitFor((message) => requestId(message, 3))).resolves.toEqual({
+      id: 3,
+      error: { code: -32074, message: "No matching Turn" },
+    });
+    writeRequest(fixture.desktopInput, {
+      id: 4,
+      method: "turn/start",
+      params: { threadId, input: [{ type: "text", text: "must remain busy" }] },
+    });
+    await expect(
+      fixture.collector.waitFor((message) => requestId(message, 4)),
+    ).resolves.toMatchObject({ error: { code: -32072 } });
+    expect(
+      fixture.collector.messages.some((message) => turnEvent(message, "turn/completed", turnId)),
+    ).toBe(false);
+    session.appendText("still running");
+    await fixture.collector.waitFor((message) => method(message, "item/agentMessage/delta"));
+    session.succeedTurn();
+    await expect(
+      fixture.collector.waitFor((message) => turnEvent(message, "turn/completed", turnId)),
+    ).resolves.toMatchObject({ params: { turn: { status: "completed" } } });
+    await stopFixture(fixture);
+  });
+
+  it.each(["item.completed", "turn.completed"])(
+    "reports a visible failed Turn after %s projection throws",
+    async (eventType) => {
+      const fixture = createFixture();
+      const threadId = await startPiThread(fixture);
+      const turnId = await startPiTurn(fixture, threadId);
+      const session = fixture.adapter.sessions[0];
+      if (!session) throw new Error("Fake Pi Session was not opened");
+      await fixture.collector.waitFor((message) => turnEvent(message, "turn/started", turnId));
+      const project = CodexTurnProjector.prototype.project;
+      const projection = vi
+        .spyOn(CodexTurnProjector.prototype, "project")
+        .mockImplementation(function (this: CodexTurnProjector, event, emittedAtMs) {
+          const result = project.call(this, event, emittedAtMs);
+          if (event.type === eventType) throw new Error("Synthetic projection failure");
+          return result;
+        });
+      try {
+        session.appendText("answer");
+        session.succeedTurn();
+        await expect(
+          fixture.collector.waitFor((message) => turnEvent(message, "turn/completed", turnId)),
+        ).resolves.toMatchObject({
+          params: {
+            turn: {
+              status: "failed",
+              error: { message: expect.stringContaining("Synthetic projection failure") },
+            },
+          },
+        });
+        const errorIndex = fixture.collector.messages.findIndex((message) =>
+          method(message, "error"),
+        );
+        const terminalIndex = fixture.collector.messages.findIndex((message) =>
+          turnEvent(message, "turn/completed", turnId),
+        );
+        expect(errorIndex).toBeGreaterThanOrEqual(0);
+        expect(terminalIndex).toBeGreaterThan(errorIndex);
+      } finally {
+        projection.mockRestore();
+        await stopFixture(fixture);
+      }
+    },
+  );
+
+  it("reports thrown cancellation errors without blocking later native output", async () => {
+    const fixture = createFixture();
+    const threadId = await startPiThread(fixture);
+    const turnId = await startPiTurn(fixture, threadId);
+    const session = fixture.adapter.sessions[0];
+    if (!session) throw new Error("Fake Pi Session was not opened");
+    await fixture.collector.waitFor((message) => turnEvent(message, "turn/started", turnId));
+    vi.spyOn(session, "execute").mockRejectedValueOnce(new Error("Synthetic cancellation failure"));
+    try {
+      writeRequest(fixture.desktopInput, {
+        id: 3,
+        method: "turn/interrupt",
+        params: { threadId, turnId },
+      });
+      await expect(fixture.collector.waitFor((message) => requestId(message, 3))).resolves.toEqual({
+        id: 3,
+        error: { code: -32074, message: "Synthetic cancellation failure" },
+      });
+      session.appendText("still running");
+      session.succeedTurn();
+      await expect(
+        fixture.collector.waitFor((message) => turnEvent(message, "turn/completed", turnId)),
+      ).resolves.toMatchObject({ params: { turn: { status: "completed" } } });
+    } finally {
+      await stopFixture(fixture);
+    }
   });
 
   it("rejects an interrupt that does not reference the active Pi Turn", async () => {

--- a/packages/host-runtime/test/harness-plugin-loader.test.ts
+++ b/packages/host-runtime/test/harness-plugin-loader.test.ts
@@ -71,19 +71,25 @@ afterEach(async () => {
 });
 
 describe("Harness plugin discovery and loading", () => {
-  it.each(["pi", "claude-code", "deepseek-harness", "opencode", "grok", "omp", "antigravity"])(
-    "ships a valid %s manifest and resolvable compiled resources",
-    async (id) => {
-      const location = path.resolve("packages/adapters", id);
-      const manifest = harnessPluginManifestSchema.parse(
-        JSON.parse(await readFile(path.join(location, "manifest.json"), "utf8")),
-      );
-      expect(manifest.id).toBe(id);
-      await expect(pluginResourcePath(location, manifest.entry)).resolves.toMatch(/\.js$/u);
-      if (manifest.icon)
-        await expect(readPluginIcon(location, manifest.icon)).resolves.toMatch(/^data:image\//u);
-    },
-  );
+  it.each([
+    "pi",
+    "claude-code",
+    "deepseek-harness",
+    "opencode",
+    "grok",
+    "omp",
+    "antigravity",
+    "muse",
+  ])("ships a valid %s manifest and resolvable compiled resources", async (id) => {
+    const location = path.resolve("packages/adapters", id);
+    const manifest = harnessPluginManifestSchema.parse(
+      JSON.parse(await readFile(path.join(location, "manifest.json"), "utf8")),
+    );
+    expect(manifest.id).toBe(id);
+    await expect(pluginResourcePath(location, manifest.entry)).resolves.toMatch(/\.js$/u);
+    if (manifest.icon)
+      await expect(readPluginIcon(location, manifest.icon)).resolves.toMatch(/^data:image\//u);
+  });
 
   it("invokes optional plugin warmup without blocking loading and can request cold instances", async () => {
     const directory = await root(["sample-agent"]);

--- a/packages/host-runtime/test/muse-live.test.ts
+++ b/packages/host-runtime/test/muse-live.test.ts
@@ -1,0 +1,498 @@
+import type { ChildProcessWithoutNullStreams, spawn } from "node:child_process";
+import { EventEmitter } from "node:events";
+import { cpSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { PassThrough } from "node:stream";
+
+import { describe, expect, it } from "vitest";
+import { MappingStore } from "@codexhost/mapping-store";
+import type { JsonObject } from "@codexhost/protocol-core";
+import {
+  encodeHarnessPluginRoute,
+  harnessInspectionSchema,
+  harnessPluginRouteSchema,
+  hostThreadIdSchema,
+} from "@codexhost/shared-contracts";
+
+import { AccountRepository, AppServerHost, ThreadAccountStore } from "../src/index.js";
+
+// Run after build:typescript with Node 24 and a normally authenticated Muse CLI:
+// CODEXHOST_MUSE_LIVE=1 npx vitest run --config tests/vitest.config.js packages/host-runtime/test/muse-live.test.ts
+// Only the official Codex process is synthetic. Muse, the packaged plugin, routing,
+// streamed output, persistence, shutdown and resume all use their production paths.
+// Native safety defaults remain enabled. Only one explicitly checked printf
+// approval is answered once; unexpected approval requests fail this gate.
+const live = process.env.CODEXHOST_MUSE_LIVE === "1";
+const responseTimeoutMs = 90_000;
+
+class FakeOfficialProcess extends EventEmitter {
+  readonly stdin = new PassThrough();
+  readonly stdout = new PassThrough();
+  readonly stderr = new PassThrough();
+
+  constructor() {
+    super();
+    this.stdin.once("finish", () => {
+      this.stdout.end();
+      this.emit("exit", 0, null);
+    });
+  }
+
+  kill(): boolean {
+    return true;
+  }
+}
+
+function object(value: unknown): JsonObject {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error("Expected a JSON object from Host");
+  }
+  return value as JsonObject;
+}
+
+function string(value: unknown): string {
+  if (typeof value !== "string" || value.length === 0) {
+    throw new Error("Expected a non-empty string from Host");
+  }
+  return value;
+}
+
+function turnEvent(message: JsonObject, method: string, turnId: string): boolean {
+  if (message.method !== method) return false;
+  const params = object(message.params);
+  return params.turnId === turnId || object(params.turn ?? {}).id === turnId;
+}
+
+class HostOutput {
+  readonly messages: JsonObject[] = [];
+  readonly #waiters = new Set<{
+    predicate: (message: JsonObject) => boolean;
+    resolve: (message: JsonObject) => void;
+    reject: (error: Error) => void;
+    timer: ReturnType<typeof setTimeout>;
+  }>();
+  #buffer = "";
+  #failure?: Error;
+  #expectedApprovals = 0;
+
+  constructor(stream: PassThrough) {
+    stream.setEncoding("utf8");
+    stream.on("data", (chunk: string) => {
+      this.#buffer += chunk;
+      let newline = this.#buffer.indexOf("\n");
+      while (newline >= 0) {
+        const message = object(JSON.parse(this.#buffer.slice(0, newline)));
+        this.#buffer = this.#buffer.slice(newline + 1);
+        this.messages.push(message);
+        if (message.id !== undefined && typeof message.method === "string") {
+          if (message.method === "mcpServer/elicitation/request" && this.#expectedApprovals > 0) {
+            this.#expectedApprovals -= 1;
+          } else {
+            this.#failure = new Error(`Unexpected Muse approval request: ${message.method}`);
+          }
+        }
+        for (const waiter of this.#waiters) {
+          if (this.#failure || waiter.predicate(message)) {
+            this.#waiters.delete(waiter);
+            clearTimeout(waiter.timer);
+            if (this.#failure) waiter.reject(this.#failure);
+            else waiter.resolve(message);
+          }
+        }
+        newline = this.#buffer.indexOf("\n");
+      }
+    });
+  }
+
+  expectOneApproval(): void {
+    this.#expectedApprovals = 1;
+  }
+
+  endApprovalWindow(): void {
+    this.#expectedApprovals = 0;
+  }
+
+  waitFor(predicate: (message: JsonObject) => boolean): Promise<JsonObject> {
+    if (this.#failure) return Promise.reject(this.#failure);
+    const existing = this.messages.find(predicate);
+    if (existing) return Promise.resolve(existing);
+    return new Promise((resolve, reject) => {
+      const waiter = {
+        predicate,
+        resolve,
+        reject,
+        timer: setTimeout(() => {
+          this.#waiters.delete(waiter);
+          reject(new Error("Timed out waiting for live Muse Host output"));
+        }, responseTimeoutMs),
+      };
+      this.#waiters.add(waiter);
+    });
+  }
+
+  close(): void {
+    for (const waiter of this.#waiters) {
+      clearTimeout(waiter.timer);
+      waiter.reject(new Error("Live Muse Host fixture closed"));
+    }
+    this.#waiters.clear();
+  }
+}
+
+function createHost(directory: string, pluginRoot: string) {
+  const desktopInput = new PassThrough();
+  const desktopOutput = new PassThrough();
+  const diagnosticOutput = new PassThrough();
+  // Drain diagnostics without printing user paths, configuration or credentials.
+  diagnosticOutput.resume();
+  const output = new HostOutput(desktopOutput);
+  const official = new FakeOfficialProcess();
+  const mappingStore = new MappingStore({ directory: path.join(directory, "mapping") });
+  const accountDirectory = path.join(directory, "accounts");
+  const host = new AppServerHost({
+    stockCodexPath: "/synthetic/codex",
+    arguments: ["app-server"],
+    defaultAgent: "codex",
+    desktopInput,
+    desktopOutput,
+    diagnosticOutput,
+    mappingStore,
+    environment: { ...process.env, CODEXHOST_DATA_DIR: directory },
+    pluginRoots: [pluginRoot],
+    externalAdapters: new Map(),
+    spawnOfficial: (() =>
+      official as unknown as ChildProcessWithoutNullStreams) as unknown as typeof spawn,
+    accountRepository: new AccountRepository({
+      directory: accountDirectory,
+      defaultAccount: {
+        accountId: "default",
+        codexHome: path.join(directory, "codex-home"),
+      },
+    }),
+    threadAccountStore: new ThreadAccountStore({ directory: accountDirectory }),
+  });
+  const running = host.run();
+  // Attach a handler immediately; close() still observes the original rejection.
+  void running.catch(() => undefined);
+  let requestId = 0;
+  let closed = false;
+  return {
+    output,
+    mappingStore,
+    respond(id: string | number, result: JsonObject): void {
+      desktopInput.write(`${JSON.stringify({ id, result })}\n`);
+    },
+    async request(method: string, params: JsonObject): Promise<JsonObject> {
+      const id = ++requestId;
+      desktopInput.write(`${JSON.stringify({ id, method, params })}\n`);
+      const response = await output.waitFor((message) => message.id === id);
+      if (response.error) {
+        throw new Error(`Host ${method} failed: ${JSON.stringify(response.error)}`);
+      }
+      return object(response.result);
+    },
+    async close(): Promise<void> {
+      if (closed) return;
+      closed = true;
+      desktopInput.end();
+      let timer: ReturnType<typeof setTimeout> | undefined;
+      try {
+        const exitCode = await Promise.race([
+          running,
+          new Promise<never>((_, reject) => {
+            timer = setTimeout(
+              () => reject(new Error("Live Host shutdown exceeded 15 seconds")),
+              15_000,
+            );
+          }),
+        ]);
+        expect(exitCode).toBe(0);
+        expect(official.stdin.readableLength).toBe(0);
+      } finally {
+        clearTimeout(timer);
+        output.close();
+      }
+    },
+  };
+}
+
+type LiveHost = ReturnType<typeof createHost>;
+
+function isBashItem(item: JsonObject): boolean {
+  return item.type === "commandExecution";
+}
+
+function verifyPrintfItem(item: JsonObject, workspace: string): void {
+  expect(item).toMatchObject({
+    type: "commandExecution",
+    command: "printf MUSE_TOOL_OK",
+    cwd: workspace,
+  });
+}
+
+async function startTurn(host: LiveHost, threadId: string, text: string): Promise<string> {
+  const started = await host.request("turn/start", {
+    threadId,
+    input: [{ type: "text", text }],
+  });
+  const turnId = string(object(started.turn).id);
+  await host.output.waitFor((message) => turnEvent(message, "turn/started", turnId));
+  return turnId;
+}
+
+async function verifyAnswer(host: LiveHost, threadId: string, turnId: string, answer: string) {
+  const completed = await host.output.waitFor((message) =>
+    turnEvent(message, "turn/completed", turnId),
+  );
+  expect(completed).toMatchObject({ params: { turn: { status: "completed" } } });
+  const read = await host.request("thread/read", { threadId, includeTurns: true });
+  const turns = object(read.thread).turns;
+  expect(Array.isArray(turns)).toBe(true);
+  const persistedTurn = (turns as JsonObject[]).find((turn) => turn.id === turnId);
+  expect(persistedTurn).toMatchObject({ status: "completed" });
+  const items = object(persistedTurn).items as JsonObject[];
+  const answers = items.filter((item) => item.type === "agentMessage");
+  expect(answers.map((item) => string(item.text).trim())).toEqual([answer]);
+
+  const events = host.output.messages;
+  expect(
+    events.some((message) => {
+      if (message.method !== "item/started" && message.method !== "item/completed") return false;
+      const item = object(object(message.params).item);
+      return item.type === "dynamicToolCall" && item.tool === "userMessage";
+    }),
+  ).toBe(false);
+  expect(events.filter((message) => turnEvent(message, "turn/completed", turnId))).toHaveLength(1);
+  const completedAnswers = events
+    .filter((message) => turnEvent(message, "item/completed", turnId))
+    .map((message) => object(object(message.params).item))
+    .filter((item) => item.type === "agentMessage");
+  expect(completedAnswers.map((item) => string(item.text).trim())).toEqual([answer]);
+  const deltas = events
+    .filter((message) => turnEvent(message, "item/agentMessage/delta", turnId))
+    .map((message) => string(object(message.params).delta))
+    .join("");
+  expect(deltas.trim()).toBe(answer);
+  const mapping = await host.mappingStore.getThread(hostThreadIdSchema.parse(threadId));
+  expect(mapping?.turnMappings.filter((turn) => turn.hostTurnId === turnId)).toHaveLength(1);
+  return object(persistedTurn);
+}
+
+describe.skipIf(!live)("packaged Muse plugin live Host integration", () => {
+  it("streams once, persists, resumes after Host shutdown, and recovers after cancellation", async () => {
+    const directory = mkdtempSync(path.join(tmpdir(), "codexhost-muse-host-live-"));
+    const pluginRoot = path.join(directory, "plugins");
+    const workspace = path.join(directory, "workspace");
+    mkdirSync(pluginRoot);
+    mkdirSync(workspace);
+    cpSync(path.resolve("packages/host-runtime/dist/plugins/muse"), path.join(pluginRoot, "muse"), {
+      recursive: true,
+    });
+    writeFileSync(
+      path.join(pluginRoot, "enabled.json"),
+      JSON.stringify({ version: 1, enabled: ["muse"] }),
+    );
+    let host = createHost(directory, pluginRoot);
+    const receipts: Record<string, unknown> = {
+      workspace,
+      safety: "native-defaults",
+      firstHost: [],
+    };
+    let passed = false;
+    const artifactDirectory = process.env.CODEXHOST_MUSE_LIVE_ARTIFACT_DIR;
+    const saveReceipt = (): void => {
+      if (!artifactDirectory) return;
+      mkdirSync(artifactDirectory, { recursive: true });
+      writeFileSync(
+        path.join(artifactDirectory, "muse-host-live.json"),
+        JSON.stringify({ passed, ...receipts, finalHostOutput: host.output.messages }, null, 2),
+        { mode: 0o600 },
+      );
+    };
+    const stage = (name: string): void => {
+      receipts.stage = name;
+      receipts.updatedAt = new Date().toISOString();
+      console.info(`[muse-live] ${name}`);
+      saveReceipt();
+    };
+    try {
+      stage("plugin-and-model-inspection");
+      const listed = await host.request("codexhost/harness/plugins/list", {});
+      expect(listed).toMatchObject({ plugins: [{ id: "muse", name: "Meta Muse Code" }] });
+      const inspection = harnessInspectionSchema.parse(
+        await host.request("codexhost/harness/inspect", { harnessId: "muse", cwd: workspace }),
+      );
+      expect(inspection.status).toBe("ready");
+      if (inspection.status !== "ready") throw new Error("Live Muse is not ready");
+      expect(inspection.catalog.models.length).toBeGreaterThan(0);
+      const defaultPermissionMode = inspection.permissionModes?.defaultModeId;
+      expect(defaultPermissionMode).toBeTruthy();
+      expect(defaultPermissionMode).not.toBe("allowAll");
+      const model = encodeHarnessPluginRoute(
+        harnessPluginRouteSchema.parse({
+          harnessId: "muse",
+          permissionModeId: defaultPermissionMode,
+        }),
+      );
+      const created = await host.request("thread/start", { model, cwd: workspace });
+      const threadId = string(object(created.thread).id);
+      const initialMapping = await host.mappingStore.getThread(hostThreadIdSchema.parse(threadId));
+      expect(initialMapping).toMatchObject({ harnessId: "muse", state: "ready" });
+      const nativeSessionId = string(initialMapping?.nativeSessionRef?.nativeSessionId);
+      receipts.threadId = threadId;
+      receipts.nativeSessionId = nativeSessionId;
+      receipts.modelCatalog = inspection.catalog;
+
+      stage("first-chinese-turn");
+      const firstTurn = await startTurn(
+        host,
+        threadId,
+        "只回复这四个汉字：接入正常。不要添加标点、解释或任何其他内容，不要调用工具。",
+      );
+      await verifyAnswer(host, threadId, firstTurn, "接入正常");
+      receipts.firstHost = host.output.messages;
+      stage("first-host-shutdown");
+      await host.close();
+
+      host = createHost(directory, pluginRoot);
+      stage("resume-and-memory-turn");
+      const resumed = await host.request("thread/resume", { threadId });
+      expect(resumed).toMatchObject({ thread: { id: threadId, turns: [{ id: firstTurn }] } });
+      const resumedMapping = await host.mappingStore.getThread(hostThreadIdSchema.parse(threadId));
+      expect(resumedMapping?.nativeSessionRef?.nativeSessionId).toBe(nativeSessionId);
+      const secondTurn = await startTurn(
+        host,
+        threadId,
+        "你上一轮回复的四个汉字是什么？只回复那四个字，不要添加标点或解释，不要调用工具。",
+      );
+      await verifyAnswer(host, threadId, secondTurn, "接入正常");
+
+      stage("printf-tool-turn");
+      host.output.expectOneApproval();
+      const toolTurn = await startTurn(
+        host,
+        threadId,
+        "请只使用 bash 工具在当前工作目录执行一次命令：printf MUSE_TOOL_OK。" +
+          "命令必须逐字照写，不要读取文件，不要执行其他命令。等待审批后执行。" +
+          "最后只回复工具的实际输出，不要解释。",
+      );
+      const approvalOrTerminal = await host.output.waitFor(
+        (message) =>
+          (message.method === "mcpServer/elicitation/request" &&
+            object(message.params).turnId === toolTurn) ||
+          turnEvent(message, "turn/completed", toolTurn),
+      );
+      const commandStarted = await host.output.waitFor(
+        (message) =>
+          turnEvent(message, "item/started", toolTurn) &&
+          isBashItem(object(object(message.params).item)),
+      );
+      verifyPrintfItem(object(object(commandStarted.params).item), workspace);
+      if (approvalOrTerminal.method === "mcpServer/elicitation/request") {
+        const approval = approvalOrTerminal;
+        expect(approval).toMatchObject({ params: { threadId, turnId: toolTurn, mode: "form" } });
+        if (typeof approval.id !== "number" && typeof approval.id !== "string") {
+          throw new Error("Muse tool approval has no Host request ID");
+        }
+        // This is the only approval reply in the gate. No session/persistent grant.
+        host.respond(approval.id, { action: "accept", content: {}, _meta: null });
+        await host.output.waitFor(
+          (message) =>
+            message.method === "serverRequest/resolved" &&
+            object(message.params).requestId === approval.id,
+        );
+        receipts.approval = { status: "acceptedOnce", request: approval };
+      } else {
+        receipts.approval = { status: "notRequested" };
+      }
+      host.output.endApprovalWindow();
+      const persistedToolTurn = await verifyAnswer(host, threadId, toolTurn, "MUSE_TOOL_OK");
+      const commandCompleted = host.output.messages.filter(
+        (message) =>
+          turnEvent(message, "item/completed", toolTurn) &&
+          isBashItem(object(object(message.params).item)),
+      );
+      expect(commandCompleted).toHaveLength(1);
+      const completedItem = object(object(object(commandCompleted[0]).params).item);
+      verifyPrintfItem(completedItem, workspace);
+      expect(completedItem).toMatchObject({
+        status: "completed",
+        exitCode: 0,
+      });
+      const toolOutput = host.output.messages
+        .filter(
+          (message) =>
+            turnEvent(message, "item/commandExecution/outputDelta", toolTurn) &&
+            object(message.params).itemId === completedItem.id,
+        )
+        .map((message) => string(object(message.params).delta))
+        .join("");
+      expect(toolOutput).toBe("MUSE_TOOL_OK");
+      const persistedTool = (persistedToolTurn.items as JsonObject[]).find(
+        (item) => item.id === completedItem.id,
+      );
+      expect(persistedTool).toMatchObject({
+        type: "commandExecution",
+        command: "printf MUSE_TOOL_OK",
+        status: "completed",
+        exitCode: 0,
+        aggregatedOutput: "MUSE_TOOL_OK",
+      });
+      receipts.tool = { completedItem, streamedOutput: toolOutput, persistedTool };
+
+      stage("cancel-turn-and-persistence");
+      const cancelledTurn = await startTurn(
+        host,
+        threadId,
+        "不要调用任何工具。请写一篇详细的五千字中文文章，解释归并排序并逐步推导其复杂度。",
+      );
+      await host.request("turn/interrupt", { threadId, turnId: cancelledTurn });
+      const interrupted = await host.output.waitFor((message) =>
+        turnEvent(message, "turn/completed", cancelledTurn),
+      );
+      expect(interrupted).toMatchObject({ params: { turn: { status: "interrupted" } } });
+      const cancelledRead = await host.request("thread/read", { threadId, includeTurns: true });
+      expect(
+        (object(cancelledRead.thread).turns as JsonObject[]).find(
+          (turn) => turn.id === cancelledTurn,
+        ),
+      ).toMatchObject({ status: "interrupted" });
+      const cancelledMapping = await host.mappingStore.getThread(
+        hostThreadIdSchema.parse(threadId),
+      );
+      expect(
+        cancelledMapping?.turnMappings.filter((turn) => turn.hostTurnId === cancelledTurn),
+      ).toHaveLength(1);
+      stage("followup-after-cancel");
+      const followupTurn = await startTurn(
+        host,
+        threadId,
+        "只回复这四个汉字：恢复正常。不要添加标点、解释或其他内容，不要调用工具。",
+      );
+      await verifyAnswer(host, threadId, followupTurn, "恢复正常");
+      expect(
+        host.output.messages.filter((message) =>
+          turnEvent(message, "turn/completed", cancelledTurn),
+        ),
+      ).toHaveLength(1);
+      receipts.mapping = await host.mappingStore.getThread(hostThreadIdSchema.parse(threadId));
+      receipts.secondHost = host.output.messages;
+      stage("final-host-shutdown");
+      await host.close();
+      passed = true;
+      stage("passed");
+    } catch (error) {
+      receipts.error = error instanceof Error ? error.message : String(error);
+      stage("failed");
+      throw error;
+    } finally {
+      try {
+        await host.close();
+      } finally {
+        saveReceipt();
+        rmSync(directory, { recursive: true, force: true });
+      }
+    }
+  }, 360_000);
+});

--- a/packages/protocol-core/src/codex-approval.ts
+++ b/packages/protocol-core/src/codex-approval.ts
@@ -109,9 +109,15 @@ export function projectCodexApprovalRequest(input: {
     throw new Error("Host Approval subject is unsupported");
   }
   validateActions(interaction);
-  const allow = requiredActionForEffect(interaction, "allowOnce");
+  const allowOnce = optionalActionForEffect(interaction, "allowOnce");
   const allowForSession = optionalActionForEffect(interaction, "allowForSession");
   const allowAlways = optionalActionForEffect(interaction, "allowAlways");
+  const allow = allowOnce ?? allowForSession ?? allowAlways;
+  if (!allow) {
+    throw new Error(
+      "Host Approval must declare an allowOnce, allowForSession, or allowAlways action",
+    );
+  }
   const deny = requiredActionForEffect(interaction, "deny");
 
   const serverName = boundedText(input.serverName, "server name", SERVER_NAME_MAX_LENGTH);

--- a/packages/protocol-core/test/codex-approval.test.ts
+++ b/packages/protocol-core/test/codex-approval.test.ts
@@ -120,7 +120,7 @@ describe("Codex native Approval wire projection", () => {
     );
   });
 
-  it("requires exactly one bounded Allow Once and Deny action", () => {
+  it("requires a Deny action and at least one allow effect", () => {
     expect(() =>
       projectCodexApprovalRequest({
         threadId: "thread-1",
@@ -129,7 +129,16 @@ describe("Codex native Approval wire projection", () => {
         }),
         serverName: "Claude Code",
       }),
-    ).toThrow("exactly one allowOnce action");
+    ).toThrow("allowOnce, allowForSession, or allowAlways");
+    expect(() =>
+      projectCodexApprovalRequest({
+        threadId: "thread-1",
+        interaction: interaction({
+          actions: [{ id: "allow", label: "Allow once", effect: "allowOnce" }],
+        }),
+        serverName: "Claude Code",
+      }),
+    ).toThrow("exactly one deny action");
     expect(() =>
       projectCodexApprovalRequest({
         threadId: "thread-1",
@@ -137,6 +146,34 @@ describe("Codex native Approval wire projection", () => {
         serverName: "Claude Code",
       }),
     ).toThrow("title must contain at least 1 character");
+  });
+
+  it("projects Always + Deny without a dedicated Allow once action", () => {
+    const projected = projectCodexApprovalRequest({
+      threadId: "thread-1",
+      interaction: interaction({
+        actions: [
+          { id: "choice-always", label: "Always allow", effect: "allowAlways" },
+          { id: "choice-deny", label: "Deny", effect: "deny" },
+        ],
+      }),
+      serverName: "Meta Muse Code",
+    });
+    expect(projected.parseResponse({ action: "accept", content: {}, _meta: null })).toEqual({
+      type: "approval",
+      actionId: "choice-always",
+    });
+    expect(
+      projected.parseResponse({
+        action: "accept",
+        content: {},
+        _meta: { persist: "always" },
+      }),
+    ).toEqual({ type: "approval", actionId: "choice-always" });
+    expect(projected.parseResponse({ action: "decline" })).toEqual({
+      type: "approval",
+      actionId: "choice-deny",
+    });
   });
 
   it("truncates long display text instead of rejecting the Approval", () => {

--- a/packages/renderer-extension/src/agent-selection-state.ts
+++ b/packages/renderer-extension/src/agent-selection-state.ts
@@ -13,6 +13,7 @@ export const KNOWN_RENDERER_AGENTS = [
   "grok",
   "omp",
   "antigravity",
+  "muse",
 ] as const;
 export const DEFAULT_RENDERER_AGENTS = KNOWN_RENDERER_AGENTS;
 export type RendererAgent = (typeof KNOWN_RENDERER_AGENTS)[number];
@@ -39,6 +40,8 @@ export interface DraftComposerState {
   ompThinkingOptionId?: HarnessThinkingOptionId;
   antigravityModel?: HarnessModelRef;
   antigravityThinkingOptionId?: HarnessThinkingOptionId;
+  museModel?: HarnessModelRef;
+  museThinkingOptionId?: HarnessThinkingOptionId;
   permissionModeByAgent?: Partial<Record<ExternalRendererAgent, HarnessPermissionModeId>>;
 }
 
@@ -206,6 +209,7 @@ export class DraftAgentController<Composer extends object> {
     if (agent === "grok" && model) state.grokModel = model;
     if (agent === "omp" && model) state.ompModel = model;
     if (agent === "antigravity" && model) state.antigravityModel = model;
+    if (agent === "muse" && model) state.museModel = model;
     if (agent === "pi" && thinkingOptionId) state.piThinkingOptionId = thinkingOptionId;
     else if (agent === "pi") delete state.piThinkingOptionId;
     if (agent === "claude-code" && thinkingOptionId) {
@@ -221,6 +225,9 @@ export class DraftAgentController<Composer extends object> {
     if (agent === "antigravity" && thinkingOptionId) {
       state.antigravityThinkingOptionId = thinkingOptionId;
     } else if (agent === "antigravity") delete state.antigravityThinkingOptionId;
+    if (agent === "muse" && thinkingOptionId) {
+      state.museThinkingOptionId = thinkingOptionId;
+    } else if (agent === "muse") delete state.museThinkingOptionId;
     if (agent !== "codex") {
       const permissionModeByAgent: NonNullable<DraftComposerState["permissionModeByAgent"]> = {};
       for (const candidate of [
@@ -231,6 +238,7 @@ export class DraftAgentController<Composer extends object> {
         "grok",
         "omp",
         "antigravity",
+        "muse",
       ] as const) {
         const current = state.permissionModeByAgent?.[candidate];
         if (candidate !== agent && current) permissionModeByAgent[candidate] = current;
@@ -253,7 +261,8 @@ export class DraftAgentController<Composer extends object> {
     if (agent === "opencode") return state.openCodeModel;
     if (agent === "grok") return state.grokModel;
     if (agent === "omp") return state.ompModel;
-    return state.antigravityModel;
+    if (agent === "antigravity") return state.antigravityModel;
+    return state.museModel;
   }
 
   thinkingOptionForAgent(
@@ -266,7 +275,8 @@ export class DraftAgentController<Composer extends object> {
     if (agent === "grok") return state.grokThinkingOptionId;
     if (agent === "opencode") return state.openCodeThinkingOptionId;
     if (agent === "omp") return state.ompThinkingOptionId;
-    return agent === "antigravity" ? state.antigravityThinkingOptionId : undefined;
+    if (agent === "antigravity") return state.antigravityThinkingOptionId;
+    return agent === "muse" ? state.museThinkingOptionId : undefined;
   }
 
   permissionModeForAgent(
@@ -301,7 +311,8 @@ export class DraftAgentController<Composer extends object> {
     else if (agent === "opencode") state.openCodeModel = model;
     else if (agent === "grok") state.grokModel = model;
     else if (agent === "omp") state.ompModel = model;
-    else state.antigravityModel = model;
+    else if (agent === "antigravity") state.antigravityModel = model;
+    else state.museModel = model;
     return state;
   }
 
@@ -349,6 +360,10 @@ export class DraftAgentController<Composer extends object> {
       state.antigravityThinkingOptionId = thinkingOptionId;
     } else if (agent === "antigravity") {
       delete state.antigravityThinkingOptionId;
+    } else if (agent === "muse" && thinkingOptionId) {
+      state.museThinkingOptionId = thinkingOptionId;
+    } else if (agent === "muse") {
+      delete state.museThinkingOptionId;
     }
     return state;
   }

--- a/packages/renderer-extension/src/renderer-agent-icon.ts
+++ b/packages/renderer-extension/src/renderer-agent-icon.ts
@@ -14,6 +14,7 @@ export const RENDERER_AGENT_LABELS: Record<RendererAgent, string> = {
   grok: "Grok",
   omp: "Oh My Pi",
   antigravity: "Antigravity CLI",
+  muse: "Meta Muse Code",
 };
 
 const PI_PATHS = [
@@ -118,6 +119,18 @@ export function createRendererAgentIcon(
     image.style.objectFit = "contain";
     image.style.flex = "none";
     return image;
+  }
+  if (agent === "muse") {
+    return createSvgIcon(
+      [
+        {
+          d: "M12 2.2c-1.9 3.4-4.8 6.4-8.6 8.4 3.8 2 6.7 5 8.6 8.4 1.9-3.4 4.8-6.4 8.6-8.4C16.8 8.6 13.9 5.6 12 2.2z",
+        },
+      ],
+      "#0668E1",
+      size,
+      ownerDocument,
+    );
   }
   const mark = ownerDocument.createElement("img");
   mark.src = grokAgentIconUrl;

--- a/packages/renderer-extension/src/renderer-agent-picker.ts
+++ b/packages/renderer-extension/src/renderer-agent-picker.ts
@@ -76,6 +76,7 @@ export const RENDERER_AGENT_INSTALL_URLS: Readonly<Record<ExternalRendererAgent,
   grok: "https://grok.com/",
   omp: "https://github.com/can1357/oh-my-pi",
   antigravity: "https://antigravity.google/product/antigravity-cli",
+  muse: "https://www.meta.ai/",
 };
 
 type AgentAvailability = Partial<Record<ExternalRendererAgent, RendererAgentAvailability>>;

--- a/packages/renderer-extension/src/renderer-binding-probe.ts
+++ b/packages/renderer-extension/src/renderer-binding-probe.ts
@@ -1,4 +1,5 @@
 import {
+  decodeHarnessPluginRoute,
   harnessIdSchema,
   permissionModeFixedAtCreate,
   type HarnessCommandDescriptor,
@@ -93,6 +94,7 @@ const externalHarnessIds = {
   grok: harnessIdSchema.parse("grok"),
   omp: harnessIdSchema.parse("omp"),
   antigravity: harnessIdSchema.parse("antigravity"),
+  muse: harnessIdSchema.parse("muse"),
 } as const;
 
 const externalAgents: readonly ExternalRendererAgent[] = [
@@ -103,6 +105,7 @@ const externalAgents: readonly ExternalRendererAgent[] = [
   "grok",
   "omp",
   "antigravity",
+  "muse",
 ];
 type HarnessAvailability = Partial<Record<ExternalRendererAgent, RendererAgentAvailability>>;
 type HarnessAvailabilityErrors = Record<ExternalRendererAgent, CodexhostError | undefined>;
@@ -452,6 +455,23 @@ export function restoredThreadOwnership(inspection: ThreadInspection): RestoredT
       ...(permissionModeId ? { permissionModeId } : {}),
     };
   }
+  if (inspection.harnessId === "muse") {
+    const transportSelection = decodeHarnessPluginRoute(inspection.transportModelId);
+    if (!transportSelection || transportSelection.harnessId !== "muse") {
+      throw new Error("Meta Muse Code Thread reported an incompatible transport Model");
+    }
+    const model = inspection.effectiveModel ?? transportSelection.model;
+    const thinkingOptionId =
+      selectableThinkingOptionId(inspection) ?? transportSelection.thinkingOptionId;
+    const permissionModeId =
+      inspection.effectivePermissionModeId ?? transportSelection.permissionModeId;
+    return {
+      agent: "muse",
+      ...(model ? { model } : {}),
+      ...(thinkingOptionId ? { thinkingOptionId } : {}),
+      ...(permissionModeId ? { permissionModeId } : {}),
+    };
+  }
   throw new Error("Thread owner is not a Renderer Agent");
 }
 
@@ -681,6 +701,7 @@ export function installRendererBindingProbe(
       grok: undefined,
       omp: undefined,
       antigravity: undefined,
+      muse: undefined,
     },
     webUi: Object.fromEntries(
       externalAgents.map((agent) => [agent, false]),

--- a/packages/renderer-extension/src/renderer-harness-localization.ts
+++ b/packages/renderer-extension/src/renderer-harness-localization.ts
@@ -71,6 +71,10 @@ const CHINESE_PERMISSION_MODE_LABELS = new Map<string, string>([
   ["Full access (dangerous)", "完全访问（危险）"],
   ["Configured permissions", "使用已配置权限"],
   ["Skip permissions", "跳过权限检查"],
+  ["On request", "按请求询问"],
+  ["Prompt unmatched", "未匹配时询问"],
+  ["Deny unmatched", "未匹配时拒绝"],
+  ["Allow all", "全部允许"],
 ]);
 
 const CHINESE_PERMISSION_MODE_DESCRIPTIONS = new Map<string, string>([

--- a/packages/renderer-extension/src/renderer-sidebar-agent-icons.ts
+++ b/packages/renderer-extension/src/renderer-sidebar-agent-icons.ts
@@ -139,6 +139,7 @@ export function rendererAgentForThreadOwnership(
   if (ownership.harnessId === "grok") return "grok";
   if (ownership.harnessId === "omp") return "omp";
   if (ownership.harnessId === "antigravity") return "antigravity";
+  if (ownership.harnessId === "muse") return "muse";
   return null;
 }
 

--- a/packages/renderer-extension/src/settings/connections-page.ts
+++ b/packages/renderer-extension/src/settings/connections-page.ts
@@ -23,6 +23,7 @@ const HARNESS_INSTALL_URLS: Readonly<Record<ExternalRendererAgent, string>> = Ob
   grok: "https://grok.com/",
   omp: "https://github.com/can1357/oh-my-pi",
   antigravity: "https://antigravity.google/product/antigravity-cli",
+  muse: "https://www.meta.ai/",
 });
 
 export interface RendererConnectionAgentSnapshot {

--- a/packages/renderer-extension/src/versioned-renderer-adapter.ts
+++ b/packages/renderer-extension/src/versioned-renderer-adapter.ts
@@ -1,4 +1,6 @@
 import {
+  encodeHarnessPluginRoute,
+  harnessPluginIdSchema,
   harnessModelRefSchema,
   harnessPermissionModeIdSchema,
   harnessThinkingOptionIdSchema,
@@ -141,7 +143,8 @@ function transportModelIdForAgent(agent: RendererAgent): string | null {
   if (agent === "grok") return GROK_TRANSPORT_MODEL_ID;
   if (agent === "omp") return OMP_TRANSPORT_MODEL_ID;
   if (agent === "antigravity") return ANTIGRAVITY_TRANSPORT_MODEL_ID;
-  return null;
+  if (agent === "codex") return null;
+  return encodeHarnessPluginRoute({ harnessId: harnessPluginIdSchema.parse(agent) });
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -922,7 +925,16 @@ export function modelSelectionForAgent(
                 ? ompTransportModelId(model, thinkingOptionId, permissionModeId)
                 : agent === "antigravity"
                   ? antigravityTransportModelId(model, permissionModeId, thinkingOptionId)
-                  : transportModelIdForAgent(agent);
+                  : agent === "codex"
+                    ? null
+                    : model || thinkingOptionId || permissionModeId
+                      ? encodeHarnessPluginRoute({
+                          harnessId: harnessPluginIdSchema.parse(agent),
+                          ...(model ? { model } : {}),
+                          ...(thinkingOptionId ? { thinkingOptionId } : {}),
+                          ...(permissionModeId ? { permissionModeId } : {}),
+                        })
+                      : transportModelIdForAgent(agent);
   return transportModelId ? { model: transportModelId, reasoningEffort } : officialSelection;
 }
 

--- a/packages/renderer-extension/test/renderer-binding-probe.test.ts
+++ b/packages/renderer-extension/test/renderer-binding-probe.test.ts
@@ -1,8 +1,10 @@
 import {
+  encodeHarnessPluginRoute,
   harnessModelCatalogSchema,
   harnessModelRefSchema,
   harnessPermissionModeCatalogSchema,
   harnessPermissionModeIdSchema,
+  harnessPluginIdSchema,
   harnessThinkingOptionIdSchema,
 } from "@codexhost/shared-contracts";
 import { describe, expect, it, vi } from "vitest";
@@ -122,6 +124,7 @@ describe("Renderer Composer DOM behavior", () => {
           grok: "ready",
           omp: "ready",
           antigravity: "ready",
+          muse: "ready",
         },
         {
           pi: undefined,
@@ -135,6 +138,7 @@ describe("Renderer Composer DOM behavior", () => {
           grok: undefined,
           omp: undefined,
           antigravity: undefined,
+          muse: undefined,
         },
       ),
     ).toEqual([]);
@@ -149,6 +153,7 @@ describe("Renderer Composer DOM behavior", () => {
           grok: "ready",
           omp: "ready",
           antigravity: "ready",
+          muse: "ready",
         },
         {
           pi: undefined,
@@ -162,6 +167,7 @@ describe("Renderer Composer DOM behavior", () => {
           grok: undefined,
           omp: undefined,
           antigravity: undefined,
+          muse: undefined,
         },
       ),
     ).toEqual(["deepseek-harness"]);
@@ -176,6 +182,7 @@ describe("Renderer Composer DOM behavior", () => {
           grok: "ready",
           omp: "ready",
           antigravity: "ready",
+          muse: "ready",
         },
         {
           pi: undefined,
@@ -189,6 +196,7 @@ describe("Renderer Composer DOM behavior", () => {
           grok: undefined,
           omp: undefined,
           antigravity: undefined,
+          muse: undefined,
         },
       ),
     ).toEqual(["deepseek-harness"]);
@@ -205,6 +213,7 @@ describe("Renderer Composer DOM behavior", () => {
           grok: "checking",
           omp: "checking",
           antigravity: "checking",
+          muse: "checking",
         },
         {
           pi: undefined,
@@ -214,9 +223,10 @@ describe("Renderer Composer DOM behavior", () => {
           grok: undefined,
           omp: undefined,
           antigravity: undefined,
+          muse: undefined,
         },
       ),
-    ).toEqual(["pi", "claude-code", "deepseek-harness", "opencode", "grok", "omp", "antigravity"]);
+    ).toEqual(["pi", "claude-code", "deepseek-harness", "opencode", "grok", "omp", "antigravity", "muse"]);
 
     expect(
       passiveHarnessAvailabilityAgents(
@@ -228,6 +238,7 @@ describe("Renderer Composer DOM behavior", () => {
           grok: "ready",
           omp: "ready",
           antigravity: "ready",
+          muse: "ready",
         },
         {
           pi: undefined,
@@ -241,6 +252,7 @@ describe("Renderer Composer DOM behavior", () => {
           grok: undefined,
           omp: undefined,
           antigravity: undefined,
+          muse: undefined,
         },
       ),
     ).toEqual([]);
@@ -255,6 +267,7 @@ describe("Renderer Composer DOM behavior", () => {
           grok: "ready",
           omp: "ready",
           antigravity: "ready",
+          muse: "ready",
         },
         {
           pi: undefined,
@@ -268,6 +281,7 @@ describe("Renderer Composer DOM behavior", () => {
           grok: undefined,
           omp: undefined,
           antigravity: undefined,
+          muse: undefined,
         },
       ),
     ).toEqual(["deepseek-harness"]);
@@ -1057,6 +1071,65 @@ describe("Renderer Composer DOM behavior", () => {
     expect(isOwnershipSubmissionBlocked("error")).toBe(true);
     expect(isOwnershipSubmissionBlocked("ready")).toBe(false);
     expect(isOwnershipSubmissionBlocked("not-required")).toBe(false);
+  });
+
+  it("restores Muse configuration from its shared route and prefers confirmed Thread state", () => {
+    const model = harnessModelRefSchema.parse({ id: "muse-spark-1.3-contributor" });
+    const thinkingOptionId = harnessThinkingOptionIdSchema.parse("high");
+    const permissionModeId = harnessPermissionModeIdSchema.parse("onRequest");
+    const inspection = {
+      owner: "external" as const,
+      harnessId: "muse",
+      transportModelId: encodeHarnessPluginRoute({
+        harnessId: harnessPluginIdSchema.parse("muse"),
+        model,
+        thinkingOptionId,
+        permissionModeId,
+      }),
+      history: { fork: true, forkAcrossCwd: false, rollbackLastTurn: false },
+      locked: true as const,
+    };
+
+    expect(restoredThreadOwnership(inspection)).toEqual({
+      agent: "muse",
+      model,
+      thinkingOptionId,
+      permissionModeId,
+    });
+    const effectiveModel = harnessModelRefSchema.parse({ id: "muse-spark-1.3" });
+    const effectiveThinkingOptionId = harnessThinkingOptionIdSchema.parse("none");
+    const effectivePermissionModeId = harnessPermissionModeIdSchema.parse("allowAll");
+    expect(
+      restoredThreadOwnership({
+        ...inspection,
+        effectiveModel,
+        effectiveThinkingOptionId,
+        availableThinkingOptions: [{ id: effectiveThinkingOptionId, label: "None" }],
+        effectivePermissionModeId,
+      }),
+    ).toEqual({
+      agent: "muse",
+      model: effectiveModel,
+      thinkingOptionId: effectiveThinkingOptionId,
+      permissionModeId: effectivePermissionModeId,
+    });
+  });
+
+  it("rejects Muse ownership with a missing, malformed, or foreign plugin route", () => {
+    const foreignRoute = encodeHarnessPluginRoute({
+      harnessId: harnessPluginIdSchema.parse("another-plugin"),
+    });
+    for (const transportModelId of ["official-model", "codexhost/plugin-v1@invalid", foreignRoute]) {
+      expect(() =>
+        restoredThreadOwnership({
+          owner: "external",
+          harnessId: "muse",
+          transportModelId,
+          history: { fork: true, forkAcrossCwd: false, rollbackLastTurn: false },
+          locked: true,
+        }),
+      ).toThrow();
+    }
   });
 
   it("resolves Draft Thinking from the selected Model's in-memory Catalog entry", () => {

--- a/packages/renderer-extension/test/versioned-renderer-adapter.test.ts
+++ b/packages/renderer-extension/test/versioned-renderer-adapter.test.ts
@@ -1,4 +1,5 @@
 import {
+  decodeHarnessPluginRoute,
   harnessModelRefSchema,
   harnessPermissionModeIdSchema,
   harnessThinkingOptionIdSchema,
@@ -542,6 +543,33 @@ describe("current Codex Renderer Agent adapter", () => {
       decodePiTransportModelId(`${PI_TRANSPORT_MODEL_ID}@${model.id}@${thinkingOptionId}`),
     ).toEqual({ model, thinkingOptionId });
   });
+
+  it.each(["onRequest", "allowAll"])(
+    "routes Muse Model, Thinking, and %s permissions through the shared plugin carrier",
+    (permission) => {
+      const model = harnessModelRefSchema.parse({ id: "muse-spark-1.3-contributor" });
+      const thinkingOptionId = harnessThinkingOptionIdSchema.parse("high");
+      const permissionModeId = harnessPermissionModeIdSchema.parse(permission);
+      const selected = modelSelectionForAgent(
+        { model: "official-model", reasoningEffort: "low" },
+        "low",
+        "muse",
+        model,
+        thinkingOptionId,
+        permissionModeId,
+      );
+
+      expect(decodeHarnessPluginRoute(selected?.model)).toEqual({
+        harnessId: "muse",
+        model,
+        thinkingOptionId,
+        permissionModeId,
+      });
+      expect(decodeHarnessPluginRoute(modelSelectionForAgent(null, null, "muse")?.model)).toEqual({
+        harnessId: "muse",
+      });
+    },
+  );
 
   it("encodes OMP Model, Permission Mode, and Thinking in the transport carrier", () => {
     const model = harnessModelRefSchema.parse({ id: "omp-model-v1.synthetic" });

--- a/scripts/release/harness-plugins.json
+++ b/scripts/release/harness-plugins.json
@@ -6,7 +6,8 @@
     "packages/adapters/opencode",
     "packages/adapters/grok",
     "packages/adapters/omp",
-    "packages/adapters/antigravity"
+    "packages/adapters/antigravity",
+    "packages/adapters/muse"
   ],
   "runtimePackages": [
     "@agentclientprotocol/sdk",

--- a/tests/release/production-renderer.test.mjs
+++ b/tests/release/production-renderer.test.mjs
@@ -47,6 +47,7 @@ describe("production Renderer release chain", () => {
     expect(RENDERER_PROBE_AGENTS).toContain("opencode");
     expect(RENDERER_PROBE_AGENTS).toContain("grok");
     expect(RENDERER_PROBE_AGENTS).toContain("antigravity");
+    expect(RENDERER_PROBE_AGENTS).toContain("muse");
     expect(status.selections).toEqual([
       { composerId: "composer-grok", agent: "grok", phase: "draft" },
     ]);

--- a/tools/renderer-binding/run.mjs
+++ b/tools/renderer-binding/run.mjs
@@ -22,6 +22,7 @@ export const RENDERER_PROBE_AGENTS = Object.freeze([
   "opencode",
   "grok",
   "antigravity",
+  "muse",
 ]);
 
 function usage() {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,6 +16,7 @@
     { "path": "./packages/adapters/grok/tsconfig.json" },
     { "path": "./packages/adapters/omp/tsconfig.json" },
     { "path": "./packages/adapters/antigravity/tsconfig.json" },
+    { "path": "./packages/adapters/muse/tsconfig.json" },
     { "path": "./packages/host-runtime/tsconfig.json" },
     { "path": "./packages/renderer-extension/tsconfig.json" }
   ]


### PR DESCRIPTION
将 Meta Muse Code 作为独立 Harness 接入 CodexHost，通过原生 `muse serve` MSP 接口运行，并接入 Desktop 的 Agent、模型、权限和历史恢复路径。修复流式文本重复、取消失败假成功、异常退出后持续等待及历史终态失真，让普通交互式 Muse Thread 可以创建、续聊、取消并在 Host 重启后恢复。

## What Changed

- 新增 Muse Adapter、原生协议传输、Manifest、打包与预装配置，沿用公共插件 Loader 和共享路由。
- 按原生 Session/Turn/Item 身份关联事件，使用独立输出快照；正确处理工具参数、审批更新、历史顺序和失败/取消状态。
- Host 取消失败如实返回错误；投影损坏时报告可见失败并保留持久映射，避免把失败包装为成功。增加相关公共行为和 Renderer 回归。
- 使用与 Muse 1.0.3 启动策略一致的权限菜单；完整范围与限制见 `docs/muse-harness.md`。

## Testing

- Node 24：`npm run typecheck` 通过。
- Muse、Host、Loader、审批投影、Renderer、Controller 及相关发行测试：347 passed，1 个显式启用的原生检查默认跳过。
- `npm run build:typescript`、`npm run build:renderer`、`npm run lint`、格式及 `git diff --check` 通过。
- 本机 Muse Code 1.0.3（1.0.3-R2198.1）真实门禁通过：打包插件加载、中文流式输出、持久映射、Host 重启恢复、固定 `printf` 工具输出、取消和取消后续聊，共 5 轮。官方 Codex 子进程为测试替身，Muse 与 Host 路由为真实实现。
- 默认原生安全策略直接放行了该安全 `printf` 命令，真实门禁未发生审批点击；审批协议及无 `turnId` 更新由回归测试覆盖。
- 同目录原生 Fork 和历史只读恢复已验证；GitGuardian 暂存区扫描通过，未检出 secrets。

## Risks

- Muse 1.0.3 默认 `serve` 启动策略拒绝 `onRequest` / `allowAll`；菜单提供 `promptUnmatched` / `denyUnmatched`，旧显式引用不静默降权。
- 暂不支持 Host 要求 `unattended-full-access` 的全自动委派，启动前返回明确 `unsupported`。
- 尚不支持跨 Host 接管活动审批；存在活动 Turn 或待回答交互时恢复返回可重试 `sessionBusy`，保留原始数据。
- 不支持跨目录 Fork 或末轮 Rollback；其他平台、远程 Host 和完整原生子任务行为未获本次实测保证。

## Follow-ups

按 `docs/muse-harness.md` 的能力边界交付；本 PR 不扩展全自动委派、活动交互接管或插件热替换。
