### PR TITLE
fix: 修复 Claude Code 编辑后的持久化、恢复与关闭竞态

### DIFF
--- a/docs/claude-code-edit-recovery.md
+++ b/docs/claude-code-edit-recovery.md
@@ -1,0 +1,13 @@
+# Claude Code edit recovery
+
+Editing the last message retains the earlier native history in an independent Session. When no earlier Turn remains, codexhost persists an empty Session reservation before returning the edit result. Closing before resend and reopening the Thread preserves that identity and its Model, Thinking and Permission Mode.
+
+Reservations live under `CLAUDE_CONFIG_DIR/codexhost/pending-sessions` (default `~/.claude/codexhost/pending-sessions`). A creation claim prevents two wrappers from independently starting the same reserved Session. A missing transcript after native input was submitted is an error, not an empty conversation. Do not remove reservation metadata to repair a missing transcript.
+
+Native interruption markers belong to their matching human prompt; literal user text is retained. An immediate history read waits for known completed native messages to reach the transcript and returns a retryable busy error if persistence remains delayed.
+
+The Claude transport waits for its owned Unix process group and observed background tasks during close. Failed termination or output drain is reported to the caller. This does not stop unrelated CLIs or establish lifecycle guarantees for other Harnesses. Windows process-tree handling requires platform validation.
+
+Empty reservations are a new Adapter-owned format. Versions without this reader cannot recover those empty identities; retain metadata/transcripts and use a compatible version when rolling back an installation. Optional saved selection hints in resume and rollback also require the matching Broker build for brokered Sessions. Existing native transcript identities keep their original format.
+
+Hard cancellation keeps the active Turn and its Transport owned until close succeeds. A late native terminal cannot bypass that wait. If shutdown fails, the Session faults and cannot start another Turn or confirm a history replacement.

--- a/openspec/changes/fix-claude-durable-edit-recovery/.openspec.yaml
+++ b/openspec/changes/fix-claude-durable-edit-recovery/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-09-08

--- a/openspec/changes/fix-claude-durable-edit-recovery/design.md
+++ b/openspec/changes/fix-claude-durable-edit-recovery/design.md
@@ -1,0 +1,25 @@
+## Context
+
+Depends on fix/claude-history-reliability. Upstream 0.6.0 already declares rollback support; the missing behavior is persistence and recovery of an empty result, not capability discovery.
+
+## Decisions
+
+A pending Native Session Ref has locator {pendingSession: 1}. Store versioned metadata under CLAUDE_CONFIG_DIR/codexhost/pending-sessions with owner-only permissions, synced writes and an exclusive creation claim. Missing transcript alone never proves an empty Session. Unclaimed, validated metadata can resume in create mode. Claimed metadata requires actual native history; it cannot silently recreate missing history.
+
+Persist Model, Thinking and Permission Mode before publishing configuration. Pass current settings through optional rollback fields so fixed or lazily created Sessions receive them before startup. Broker accepts these fields; deployments using them need the matching Broker build. Old callers and unextended Adapters remain valid.
+
+Native Fork must retain equivalent ordered content/outcomes/checkpoint availability while assigning independent identity, and must preserve the source. An interrupted human message can serve as a boundary even without assistant output. Delete only the candidate on failed derivation validation.
+
+Track initialization until it settles. Close the transport before waiting on configuration/startup so those RPCs can unblock. A claim may be released only if this wrapper owns it, no input was submitted and shutdown succeeded. Unix SDK spawns own process groups; shutdown checks group absence after TERM/KILL, including a wrapper whose root exited. Background stop receipts require native terminal evidence. Windows uses taskkill with its platform limitations explicitly unverified here.
+
+Real CLI testing reproduced configuration loss after cold resume: lazy native state lacked Model/Thinking, and restoring Permission Mode published defaults. Optional saved Model/Thinking hints now travel on resume as well. Claude applies them before other configuration commands; durable pending metadata takes precedence. Other Adapters retain their native resume behavior.
+
+## Scope and risks
+
+No global native isolation is promised. Other services, independently attached clients and other Harnesses are not terminated. Host transaction admission and commit recovery are handled separately. Adapter Session methods necessarily own startup and configuration state; persistence and process-group logic are separate focused modules to avoid adding those responsibilities to the large existing Session module.
+
+Pending format is additive; older Adapter versions do not understand empty pending identities. Preserve metadata and transcripts when downgrading; use a compatible reader to continue those Threads. This change does not delete source history or roll back worktree files.
+
+## Validation
+
+Adapter regressions cover first/multiple Turn edits, cold resume before and after resend, saved settings, competing claims, spawn failure, close failure, missing metadata/transcripts and delayed flush. Transport tests cover stop acknowledgement versus terminal, output drain and orphaned wrapper children. Broker tests carry optional settings across the socket. Real native CLI gates use disposable workspaces and local deterministic responses; internal authenticated tests are recorded separately.

--- a/openspec/changes/fix-claude-durable-edit-recovery/proposal.md
+++ b/openspec/changes/fix-claude-durable-edit-recovery/proposal.md
@@ -1,0 +1,25 @@
+## Why
+
+Editing the only Claude Turn produces an identity with no native transcript. Without durable metadata, closing before resend makes that identity unrecoverable. Native Wrapper shutdown can also outlive the root process.
+
+## What Changes
+
+- Persist empty replacement identity, working directory and configuration in Adapter-owned metadata.
+- Exclusively claim native creation and release only unused claims after confirmed shutdown.
+- Validate exact native Fork prefixes, including interrupted Turns without assistant output.
+- Wait for owned process groups and native background task terminals, propagating shutdown failures.
+- Add optional current settings to rollback input, with Host forwarding and Broker validation.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `claude-code-text-session`: durable empty edit recovery and owned resource shutdown.
+
+## Impact
+
+Claude Adapter, rollback input type, Broker validator and Host configuration forwarding. The new fields are optional; existing Adapter declarations remain valid. No mandatory replacementFence or changes to other Harness native lifecycle are introduced.

--- a/openspec/changes/fix-claude-durable-edit-recovery/specs/claude-code-text-session/spec.md
+++ b/openspec/changes/fix-claude-durable-edit-recovery/specs/claude-code-text-session/spec.md
@@ -1,0 +1,72 @@
+## ADDED Requirements
+
+### Requirement: Empty edited Claude Sessions are durably recoverable
+
+The Adapter SHALL persist an empty replacement identity and configuration before reporting it usable, and SHALL distinguish an unstarted reservation from a missing started transcript.
+
+#### Scenario: Exit before resend
+
+- **WHEN** the sole Turn is edited and the Session closes before sending replacement input
+- **THEN** another Adapter resumes the same empty identity and current configuration
+
+#### Scenario: Competing native starts
+
+- **WHEN** two wrappers attempt to start the same reservation
+- **THEN** exactly one acquires the creation claim
+
+#### Scenario: Startup fails before input
+
+- **WHEN** startup fails and owned resources close successfully before input submission
+- **THEN** the claim can be released for retry
+
+#### Scenario: Started transcript disappears
+
+- **WHEN** a claimed Session has no native transcript
+- **THEN** recovery fails instead of creating an empty Session
+
+### Requirement: Claude shutdown reports unconfirmed resource termination
+
+The Adapter SHALL await owned process termination and output drain, and SHALL report failure when shutdown cannot be confirmed.
+
+#### Scenario: The Wrapper root exits first
+
+- **WHEN** an owned Unix child remains after the Wrapper exits
+- **THEN** close stops the process group before resolving
+
+#### Scenario: A background stop receipt lacks a terminal
+
+- **WHEN** a native background task acknowledges stop without a terminal notification
+- **THEN** close fails within its bounded timeout
+
+### Requirement: Rollback preserves configuration before native startup
+
+The Host SHALL pass current Model, Thinking and Permission Mode in optional rollback input fields, and the Claude Adapter SHALL persist these for empty recovery.
+
+#### Scenario: Brokered rollback
+
+- **WHEN** the Host requests rollback with current settings through the Broker
+- **THEN** the same optional settings reach the Adapter
+
+### Requirement: Lazy resume retains saved selection
+
+The Host SHALL provide saved Model and Thinking hints on resume, and Claude SHALL apply them before a later configuration command can publish defaults.
+
+#### Scenario: Cold resume followed by edit
+
+- **WHEN** a native Claude Session resumes without eagerly reporting Model and Thinking
+- **THEN** restoring Permission Mode retains the saved Model and Thinking
+
+#### Scenario: Pending metadata differs from a hint
+
+- **WHEN** durable empty Session configuration differs from stale resume hints
+- **THEN** the durable configuration remains authoritative
+
+### Requirement: Escalated cancellation retains shutdown ownership
+
+The Adapter SHALL retain the active Turn and its Transport until escalated cancellation confirms native shutdown.
+
+#### Scenario: Native close is delayed or fails
+
+- **WHEN** interrupt escalation starts Transport close and close has not succeeded
+- **THEN** another Turn and history reads remain unavailable, a late native terminal cannot publish successful cancellation, and Session close cannot report successful shutdown
+- **AND** failed close faults the Session while retaining the Transport for explicit cleanup

--- a/openspec/changes/fix-claude-durable-edit-recovery/tasks.md
+++ b/openspec/changes/fix-claude-durable-edit-recovery/tasks.md
@@ -1,0 +1,7 @@
+## Implementation and validation
+
+- [x] 1. Implement durable reservations, claims and cold recovery.
+- [x] 2. Preserve native Fork history and current rollback settings.
+- [x] 3. Track startup and propagate native shutdown failures.
+- [x] 4. Validate unit/Broker/Host regressions and real CLI gates.
+- [x] 5. Run type/lint/format/boundary/spec checks and record results.

--- a/openspec/changes/fix-claude-durable-edit-recovery/validation.md
+++ b/openspec/changes/fix-claude-durable-edit-recovery/validation.md
@@ -1,0 +1,9 @@
+# 验证记录
+
+独立分支基于上游 `e8f8ecd`。
+
+- `npm run typecheck`：通过。
+- Claude Code Adapter 与 Harness Broker 回归测试：14 个文件通过，258 个用例通过；真实 CLI 测试 1 个文件、3 个用例因未启用环境而跳过。
+- 变更文件 ESLint、Prettier 与 `git diff --check`：通过。
+
+上述结果不覆盖未启用的真实 CLI、Windows 或第三方客户端并发行为。

--- a/openspec/changes/fix-claude-history-reliability/.openspec.yaml
+++ b/openspec/changes/fix-claude-history-reliability/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-09-08

--- a/openspec/changes/fix-claude-history-reliability/design.md
+++ b/openspec/changes/fix-claude-history-reliability/design.md
@@ -1,0 +1,17 @@
+## Context
+
+Independent submission base: upstream `e8f8ecd`. Old PR #158 contains the relevant history attribution evidence; newer upstream already supports rollback and must retain that capability.
+
+## Decisions
+
+An interruption record must have exactly one recognized text block, match the current human promptId, and omit promptSource. Text alone is insufficient. Attribute it to the existing Turn, mark cancellation and retain its UUID as the checkpoint.
+
+Before emitting completion, retain the current Turn's known user UUID and checkpoint UUID. Snapshot reads poll within the existing close timeout until both appear. Return retryable sessionBusy on timeout and retain the expectation for a later read. Track only the most recently completed Turn so later native compaction does not require obsolete IDs. Existing history validation still runs on the resulting messages.
+
+## Risks and limits
+
+This proves observed live messages are present, not that all native background execution stopped. Cold resume has no live completion evidence and retains existing missing-history errors. Native record metadata is version-sensitive; native CLI validation must record actual versions. No pending records or process-fence contract is introduced here.
+
+## Validation
+
+Three old-history regressions fail on unchanged upstream. Cover literal strings, distinct prompt IDs, explicit promptSource, interruption before assistant output, delayed persistence, timeout and later successful retry. Run the owning Adapter tests and TypeScript/lint/format checks. Native CLI validation must record the actual version and environment separately.

--- a/openspec/changes/fix-claude-history-reliability/proposal.md
+++ b/openspec/changes/fix-claude-history-reliability/proposal.md
@@ -1,0 +1,23 @@
+## Why
+
+Native interruption messages are currently projected as extra human Turns. A completed native result can also precede its transcript write, allowing immediate edits to read stale history.
+
+## What Changes
+
+- Attribute native interruption records by prompt identity and message metadata while preserving literal user input.
+- Preserve the cancellation checkpoint, including interruptions before any assistant message.
+- Wait for the latest completed Turn's known user and checkpoint IDs before returning history; timeout remains retryable.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `claude-code-text-session`: cancellation history attribution and persistence-aware snapshot reads.
+
+## Impact
+
+Claude Adapter history projection and live Session reads only. No capability, public API or stored schema changes. Native shutdown and durable empty rollback are separate changes.

--- a/openspec/changes/fix-claude-history-reliability/specs/claude-code-text-session/spec.md
+++ b/openspec/changes/fix-claude-history-reliability/specs/claude-code-text-session/spec.md
@@ -1,0 +1,25 @@
+## ADDED Requirements
+
+### Requirement: Native interruptions retain their human Turn
+
+The Adapter SHALL attribute a native interruption marker to its matching human prompt using native identity and metadata rather than text alone.
+
+#### Scenario: Cancellation precedes assistant output
+- **WHEN** a recognized interruption shares the human promptId and has no promptSource
+- **THEN** history contains one cancelled Turn and its checkpoint is the interruption UUID
+
+#### Scenario: A user quotes interruption text
+- **WHEN** interruption text arrives with a different promptId, an explicit promptSource, or without matching prompt evidence
+- **THEN** the user input remains a separate visible Turn
+
+### Requirement: Live completion history waits for known messages
+
+The Adapter SHALL wait for the latest completed Turn's known user and checkpoint UUIDs before returning its history snapshot.
+
+#### Scenario: The native transcript write lags completion
+- **WHEN** a completed message is initially absent and appears within the bounded wait
+- **THEN** the read returns the updated snapshot
+
+#### Scenario: The transcript remains stale
+- **WHEN** the bounded wait expires before the known messages appear
+- **THEN** the read returns retryable sessionBusy and a later read can retry the same expectation

--- a/openspec/changes/fix-claude-history-reliability/tasks.md
+++ b/openspec/changes/fix-claude-history-reliability/tasks.md
@@ -1,0 +1,6 @@
+## Implementation
+
+- [x] 1. Reproduce interruption grouping failures and migrate attribution tests.
+- [x] 2. Implement interruption metadata checks and checkpoints.
+- [x] 3. Add persistence wait and timeout/retry regressions.
+- [x] 4. Run targeted tests, typecheck, static checks and strict spec validation; record results.

--- a/openspec/changes/fix-claude-history-reliability/validation.md
+++ b/openspec/changes/fix-claude-history-reliability/validation.md
@@ -1,0 +1,9 @@
+# 验证记录
+
+独立分支基于上游 `e8f8ecd`。
+
+- `npm run typecheck`：通过。
+- Claude Code Adapter 与 Harness Broker 回归测试：14 个文件通过，258 个用例通过；真实 CLI 测试 1 个文件、3 个用例因未启用环境而跳过。
+- 变更文件 ESLint、Prettier 与 `git diff --check`：通过。
+
+上述结果不覆盖未启用的真实 CLI、Windows 或第三方客户端并发行为。

--- a/packages/adapters/claude-code/src/claude-code-adapter.ts
+++ b/packages/adapters/claude-code/src/claude-code-adapter.ts
@@ -71,6 +71,7 @@ import {
 
 import { ClaudeBackgroundOccupancy } from "./background-occupancy.js";
 import { ClaudeCodeExecutableError, resolveClaudeCodeExecutable } from "./command.js";
+import { ClaudePendingSessions, isPendingClaudeSession } from "./pending-session.js";
 import { forkClaudeSession } from "./claude-fork.js";
 import { mapClaudeSnapshot, mapClaudeSubagentSnapshot } from "./claude-history.js";
 import { claudeTranscriptItemId } from "./item-identity.js";
@@ -504,6 +505,10 @@ class ClaudeHarnessSession implements HarnessSession {
   readonly #onClosed: () => void;
   readonly #onPlanLimitObserved: (planLimit: ClaudePlanLimitEvent) => ClaudePlanLimitEvent | null;
   #openMode: "create" | "resume";
+  readonly #pendingSessions: ClaudePendingSessions;
+  #pendingClaimed = false;
+  #submittedInput = false;
+  #startupTask: Promise<ClaudeTurnTransport> | null = null;
   readonly #randomUUID: () => string;
   #requestedModel: HarnessModelRef | undefined;
   #requestedPermissionModeId: HarnessPermissionModeId;
@@ -521,7 +526,9 @@ class ClaudeHarnessSession implements HarnessSession {
   #readingHistory = false;
   #state: HarnessSessionState;
   #statePublished = false;
+  #unpersistedMessageIds: string[] = [];
   #transport: ClaudeTurnTransport | null = null;
+  #hardCancelTask: Promise<void> | null = null;
   #usageGeneration = 0;
   #latestUsage: HostUsage | null = null;
   #minimumContextUsedTokens: number | null = null;
@@ -549,6 +556,9 @@ class ClaudeHarnessSession implements HarnessSession {
       environment?: NodeJS.ProcessEnv;
       openMode: "create" | "resume";
       sessionId: string;
+      nativeRef?: NativeSessionRef;
+      pendingSessions: ClaudePendingSessions;
+      knownConfiguration?: boolean;
       requestedModel?: HarnessModelRef;
       requestedPermissionModeId: HarnessPermissionModeId;
       requestedThinkingOptionId: HarnessThinkingOptionId;
@@ -558,6 +568,7 @@ class ClaudeHarnessSession implements HarnessSession {
     },
   ) {
     this.#cwd = cwd;
+    this.#pendingSessions = options.pendingSessions;
     const environment = options.environment;
     this.#createTransport = environment
       ? (input) => dependencies.createTransport({ ...input, environment })
@@ -575,18 +586,32 @@ class ClaudeHarnessSession implements HarnessSession {
     this.#sessionId = options.sessionId;
     this.#toolOutputLimit = options.toolOutputLimit;
     this.#continuationQuiescenceMs = options.continuationQuiescenceMs;
-    this.#nativeRef = nativeSessionRefSchema.parse({
-      harnessId: this.harnessId,
-      nativeSessionId: this.#sessionId,
-      formatVersion: 1,
-    });
+    this.#nativeRef =
+      options.nativeRef ??
+      nativeSessionRefSchema.parse({
+        harnessId: this.harnessId,
+        nativeSessionId: this.#sessionId,
+        formatVersion: 1,
+      });
     this.commands = {
       list: async () => ({ ok: true, value: claudeCommandCatalog }),
       execute: (command) => this.#executeHarnessCommand(command),
     };
-    this.initialState = this.#openMode === "resume" ? { nativeRef: this.#nativeRef } : {};
+    const durable = this.#openMode === "resume" || options.nativeRef !== undefined;
+    this.initialState = durable
+      ? {
+          nativeRef: this.#nativeRef,
+          ...(options.knownConfiguration
+            ? {
+                ...(options.requestedModel ? { effectiveModel: options.requestedModel } : {}),
+                effectiveThinkingOptionId: this.#requestedThinkingOptionId,
+                effectivePermissionModeId: this.#requestedPermissionModeId,
+              }
+            : {}),
+        }
+      : {};
     this.#state = this.initialState;
-    this.#statePublished = this.#openMode === "resume";
+    this.#statePublished = durable;
     this.outputs = this.#channel.outputs;
   }
 
@@ -610,7 +635,34 @@ class ClaudeHarnessSession implements HarnessSession {
     try {
       let messages: unknown[];
       try {
-        messages = await this.#readSessionMessages({ cwd: this.#cwd, sessionId: this.#sessionId });
+        // Native result frames can arrive before the transcript batch is written.
+        const deadline = Date.now() + this.#closeTimeoutMs;
+        for (;;) {
+          messages = await this.#readSessionMessages({
+            cwd: this.#cwd,
+            sessionId: this.#sessionId,
+          });
+          const ids = new Set(
+            messages.flatMap((message) =>
+              isRecord(message) && typeof message.uuid === "string" ? [message.uuid] : [],
+            ),
+          );
+          if (this.#unpersistedMessageIds.every((id) => ids.has(id))) {
+            this.#unpersistedMessageIds = [];
+            break;
+          }
+          if (Date.now() >= deadline || this.#phase !== "open") {
+            return {
+              ok: false,
+              error: {
+                code: "sessionBusy",
+                message: "Claude Code history is still being persisted",
+                retryable: true,
+              },
+            };
+          }
+          await delay(25);
+        }
       } catch {
         return {
           ok: false,
@@ -620,6 +672,21 @@ class ClaudeHarnessSession implements HarnessSession {
             retryable: true,
           },
         };
+      }
+      if (messages.length === 0 && isPendingClaudeSession(this.#nativeRef)) {
+        try {
+          const pending = await this.#pendingSessions.read(this.#nativeRef, this.#cwd);
+          if (!pending.started) return { ok: true, value: { turns: [], state: this.#state } };
+        } catch {
+          return {
+            ok: false,
+            error: {
+              code: "sessionNotFound",
+              message: "Claude Code pending Session is unavailable",
+              retryable: false,
+            },
+          };
+        }
       }
       if (messages.length === 0) {
         return {
@@ -766,6 +833,7 @@ class ClaudeHarnessSession implements HarnessSession {
       resolveCompletion,
     };
     this.#active = active;
+    this.#submittedInput = true;
     this.#event({ type: "turn.started", turnId: command.turnId });
     this.#event({ type: "item.started", turnId: command.turnId, item });
     try {
@@ -877,6 +945,7 @@ class ClaudeHarnessSession implements HarnessSession {
       resolveCompletion,
     };
     this.#active = active;
+    this.#submittedInput = true;
     this.#event({ type: "turn.started", turnId: command.turnId });
     if (item) this.#event({ type: "item.started", turnId: command.turnId, item });
     const running =
@@ -910,6 +979,21 @@ class ClaudeHarnessSession implements HarnessSession {
       CONTEXT_USAGE_RETRY_DELAYS_MS,
     );
     return this.#contextRefreshInFlight ?? Promise.resolve();
+  }
+
+  blocksRollback(sessionId: string): boolean {
+    return (
+      this.#sessionId === sessionId &&
+      (this.#phase !== "open" ||
+        this.#active !== null ||
+        this.#acceptingTurn ||
+        this.#configurationTask !== null ||
+        this.#readingHistory)
+    );
+  }
+
+  async prepareRollback(sessionId: string): Promise<HarnessResult<unknown>> {
+    return this.#sessionId === sessionId ? this.readSnapshot() : { ok: true, value: null };
   }
 
   close(): Promise<void> {
@@ -965,6 +1049,8 @@ class ClaudeHarnessSession implements HarnessSession {
         }
       }
       this.#requestedModel = command.model;
+      const persistenceError = await this.#savePendingConfiguration();
+      if (persistenceError) return { ok: false, error: persistenceError };
       this.#publishState(this.#configuredState());
       return { ok: true, value: { completed: true } };
     } finally {
@@ -1023,6 +1109,8 @@ class ClaudeHarnessSession implements HarnessSession {
         }
       }
       this.#requestedThinkingOptionId = thinkingOptionId;
+      const persistenceError = await this.#savePendingConfiguration();
+      if (persistenceError) return { ok: false, error: persistenceError };
       this.#publishState(this.#configuredState());
       return { ok: true, value: { completed: true } };
     } finally {
@@ -1087,6 +1175,8 @@ class ClaudeHarnessSession implements HarnessSession {
       this.#requestedPermissionModeId = transport
         ? encodeClaudePermissionModeId(transport.getPermissionMode())
         : command.permissionModeId;
+      const persistenceError = await this.#savePendingConfiguration();
+      if (persistenceError) return { ok: false, error: persistenceError };
       this.#publishState(this.#configuredState());
       return { ok: true, value: { completed: true } };
     } finally {
@@ -1224,6 +1314,7 @@ class ClaudeHarnessSession implements HarnessSession {
 
   async #close(): Promise<void> {
     if (this.#phase === "closed") return;
+    this.#phase = "closing";
     this.#usageGeneration += 1;
     this.#contextUsageFreshUntilMs = 0;
     this.#contextUsageCooldownUntilMs = 0;
@@ -1233,74 +1324,135 @@ class ClaudeHarnessSession implements HarnessSession {
     this.#contextRefreshWake = null;
     this.#clearCancelEscalation();
     this.#clearContinuationQuiescence();
-    if (this.#phase !== "faulted") this.#phase = "closing";
-    const configurationTask = this.#configurationTask;
-    if (configurationTask) {
-      await Promise.race([configurationTask, delay(this.#closeTimeoutMs)]);
-    }
-    let transportClosed = false;
-    const active = this.#active;
-    if (active) {
-      active.cancellationRequested = true;
-      if (active.held) {
-        this.#finishFailed(active, invalidState("Claude Code Session closed during active Turn"));
-      } else {
-        await this.#transport?.abort().catch(() => undefined);
-        await Promise.race([active.completion, delay(this.#closeTimeoutMs)]);
-        if (this.#active === active) {
-          await this.#transport?.close().catch(() => undefined);
-          transportClosed = true;
-          this.#finishFailed(active, invalidState("Claude Code Session closed during active Turn"));
-        }
+    const failures: unknown[] = [];
+    const settle = async (task: Promise<unknown> | undefined): Promise<void> => {
+      if (!task) return;
+      const timeout = rejectAfter(this.#closeTimeoutMs * 4, "Claude Code Session close timed out");
+      try {
+        await Promise.race([task, timeout.promise]);
+      } catch (error) {
+        failures.push(error);
+      } finally {
+        timeout.cancel();
       }
-    }
-    if (!transportClosed) await this.#transport?.close().catch(() => undefined);
+    };
+    // Closing the transport also releases in-flight configuration/initialization RPCs.
+    const closingTransport = this.#transport;
+    await settle(closingTransport?.close());
+    await settle(this.#configurationTask ?? undefined);
+    await settle(
+      this.#startupTask?.then(
+        () => undefined,
+        () => undefined,
+      ),
+    );
+    if (this.#transport !== closingTransport) await settle(this.#transport?.close());
+    if (failures.length === 0) await settle(this.#releaseUnusedClaim());
+    const active = this.#active;
+    if (active)
+      this.#finishFailed(active, invalidState("Claude Code Session closed during active Turn"));
     this.#phase = "closed";
     this.#channel.end();
     this.#onClosed();
+    if (failures.length > 0)
+      throw new AggregateError(failures, "Claude Code Session could not stop safely");
   }
 
-  async #ensureTransport(): Promise<ClaudeTurnTransport> {
-    if (this.#transport) return this.#transport;
+  #ensureTransport(): Promise<ClaudeTurnTransport> {
+    if (this.#startupTask) return this.#startupTask;
+    if (this.#transport) return Promise.resolve(this.#transport);
+    const task = this.#startTransport();
+    this.#startupTask = task;
+    void task
+      .finally(() => {
+        if (this.#startupTask === task) this.#startupTask = null;
+      })
+      .catch(() => undefined);
+    return task;
+  }
+
+  async #startTransport(): Promise<ClaudeTurnTransport> {
+    if (this.#openMode === "create" && isPendingClaudeSession(this.#nativeRef)) {
+      await this.#pendingSessions.claim(this.#nativeRef, this.#cwd);
+      this.#pendingClaimed = true;
+    }
+    if (this.#phase !== "open") {
+      await this.#releaseUnusedClaim();
+      throw new Error("Claude Code Session closed during startup");
+    }
     const selectedModel =
       this.#requestedModel ?? (this.#openMode === "create" ? CLAUDE_DEFAULT_MODEL_REF : undefined);
     const model = selectedModel ? decodeClaudeModelRef(selectedModel) : undefined;
     const permissionMode = decodeClaudePermissionModeId(this.#requestedPermissionModeId);
-    const transport = this.#createTransport({
-      cwd: this.#cwd,
-      sessionId: this.#sessionId,
-      openMode: this.#openMode,
-      ...(model ? { model } : {}),
-      thinkingOptionId: this.#requestedThinkingOptionId,
-      permissionMode,
-      onPermissionModeChanged: (mode) => this.#handlePermissionModeChanged(mode),
-      onFault: () => this.#fault(faultError()),
-      onPlanLimit: (planLimit) => this.#handlePlanLimit(planLimit),
-    });
-    transport.setAutonomousTurnHandler((turn) => this.#handleAutonomousTurn(turn));
-    transport.setIdleTurnHandler({
-      onEvent: (event) => {
-        const active = this.#active;
-        if (active) this.#handleTurnEvent(active, event);
-      },
-      onTerminal: (result) => {
-        const active = this.#active;
-        if (active) this.#finishResult(active, result);
-      },
-    });
+    let transport: ClaudeTurnTransport;
     try {
+      transport = this.#createTransport({
+        cwd: this.#cwd,
+        sessionId: this.#sessionId,
+        openMode: this.#openMode,
+        ...(model ? { model } : {}),
+        thinkingOptionId: this.#requestedThinkingOptionId,
+        permissionMode,
+        onPermissionModeChanged: (mode) => this.#handlePermissionModeChanged(mode),
+        onFault: () => this.#fault(faultError()),
+        onPlanLimit: (planLimit) => this.#handlePlanLimit(planLimit),
+      });
+      this.#transport = transport;
+      transport.setAutonomousTurnHandler((turn) => this.#handleAutonomousTurn(turn));
+      transport.setIdleTurnHandler({
+        onEvent: (event) => {
+          const active = this.#active;
+          if (active) this.#handleTurnEvent(active, event);
+        },
+        onTerminal: (result) => {
+          const active = this.#active;
+          if (active) this.#finishResult(active, result);
+        },
+      });
       await transport.start();
       this.#state = {
         ...this.#configuredState(true),
         effectivePermissionModeId: encodeClaudePermissionModeId(transport.getPermissionMode()),
       };
     } catch (error) {
-      await transport.close().catch(() => undefined);
+      try {
+        await this.#transport?.close();
+      } catch (closeError) {
+        this.#fault(faultError());
+        throw closeError;
+      }
+      this.#transport = null;
+      await this.#releaseUnusedClaim();
       throw error;
     }
     this.#openMode = "resume";
     this.#transport = transport;
     return transport;
+  }
+
+  async #releaseUnusedClaim(): Promise<void> {
+    if (!this.#pendingClaimed || this.#submittedInput) return;
+    await this.#pendingSessions.release(this.#nativeRef, this.#cwd);
+    this.#pendingClaimed = false;
+    this.#openMode = "create";
+  }
+
+  async #savePendingConfiguration(): Promise<HarnessError | null> {
+    if (!isPendingClaudeSession(this.#nativeRef)) return null;
+    const configuration = { ...this.#configuredState() };
+    delete configuration.nativeRef;
+    try {
+      await this.#pendingSessions.saveConfiguration(this.#nativeRef, this.#cwd, configuration);
+      return null;
+    } catch {
+      const error: HarnessError = {
+        code: "nativeFailure",
+        message: "Claude Code pending configuration could not be persisted",
+        retryable: false,
+      };
+      this.#fault(error);
+      return error;
+    }
   }
 
   #configuredState(nativeReady = this.#state.nativeRef !== undefined): HarnessSessionState {
@@ -1790,7 +1942,8 @@ class ClaudeHarnessSession implements HarnessSession {
   }
 
   #finishResult(active: ActiveTurn, result: ClaudeTransportTurnResult): void {
-    if (this.#active !== active) return;
+    // A late native terminal cannot substitute for the process shutdown already in progress.
+    if (this.#active !== active || this.#hardCancelTask) return;
     if (result.status === "succeeded" && (active.tools.size > 0 || active.subagents.size > 0)) {
       this.#finishFailed(active, transportFailure("protocol"));
     } else if (result.status === "succeeded") {
@@ -2136,6 +2289,12 @@ class ClaudeHarnessSession implements HarnessSession {
           formatVersion: 1,
         })
       : null;
+    this.#unpersistedMessageIds = [
+      ...new Set([
+        ...(active.nativeTurnRef ? [active.nativeTurnRef.nativeTurnKey] : []),
+        ...(active.checkpointId ? [active.checkpointId] : []),
+      ]),
+    ];
     this.#event({
       type: "turn.completed",
       turnId: active.command.turnId,
@@ -2175,13 +2334,25 @@ class ClaudeHarnessSession implements HarnessSession {
   }
 
   #hardCancel(active: ActiveTurn): void {
-    if (this.#active !== active) return;
+    if (this.#active !== active || this.#hardCancelTask) return;
     this.#clearCancelEscalation();
     const transport = this.#transport;
-    this.#transport = null;
-    this.#openMode = "resume";
-    this.#finish(active, { status: "cancelled", reason: "Cancelled by user" });
-    void transport?.close().catch(() => undefined);
+    // Retain both the active Turn and its Transport until shutdown is confirmed. Session close
+    // must still own this resource, and no new Turn may resume the same native history yet.
+    this.#hardCancelTask = Promise.resolve()
+      .then(() => transport?.close())
+      .then(
+        () => {
+          if (this.#phase !== "open" || this.#active !== active) return;
+          this.#transport = null;
+          this.#openMode = "resume";
+          this.#finish(active, { status: "cancelled", reason: "Cancelled by user" });
+        },
+        () => this.#fault(faultError()),
+      )
+      .finally(() => {
+        this.#hardCancelTask = null;
+      });
   }
 
   #fault(error: HarnessError): void {
@@ -2199,8 +2370,8 @@ class ClaudeHarnessSession implements HarnessSession {
     this.#phase = "faulted";
     this.#event({ type: "session.faulted", error });
     this.#channel.end();
-    void this.#transport?.close();
-    this.#onClosed();
+    void this.#transport?.close().catch(() => undefined);
+    // Keep faulted resources owned until explicit close confirms resource shutdown.
   }
 
   #event(event: HostEvent): void {
@@ -2263,6 +2434,7 @@ export class ClaudeCodeAdapter implements HarnessAdapter {
   readonly #cancelTimeoutMs: number;
   readonly #closeTimeoutMs: number;
   readonly #dependencies: ClaudeAdapterDependencies;
+  readonly #pendingSessions: ClaudePendingSessions;
   readonly #toolOutputLimit: number;
   readonly #continuationQuiescenceMs: number;
   readonly #inspectionCache = new Map<string, HarnessInspection>();
@@ -2274,6 +2446,7 @@ export class ClaudeCodeAdapter implements HarnessAdapter {
   #accountInspection: Promise<HarnessAccountSnapshot | null> | null = null;
 
   constructor(options: ClaudeCodeAdapterOptions = {}, dependencies?: ClaudeAdapterDependencies) {
+    this.#pendingSessions = new ClaudePendingSessions(options.environment ?? process.env);
     this.#closeTimeoutMs = options.closeTimeoutMs ?? DEFAULT_CLOSE_TIMEOUT_MS;
     this.#cancelTimeoutMs = options.cancelTimeoutMs ?? DEFAULT_CANCEL_TIMEOUT_MS;
     if (!Number.isSafeInteger(this.#cancelTimeoutMs) || this.#cancelTimeoutMs <= 0) {
@@ -2475,83 +2648,24 @@ export class ClaudeCodeAdapter implements HarnessAdapter {
         },
       };
     }
-    let rollback:
-      | {
-          openMode: "create" | "resume";
-          sessionId?: string;
-        }
-      | undefined;
-    if (input.kind === "rollbackLastTurn") {
-      const sourceRef = nativeSessionRefSchema.safeParse(input.sourceRef);
-      if (!sourceRef.success || sourceRef.data.harnessId !== this.harnessId) {
-        return {
-          ok: false,
-          error: {
-            code: "invalidRequest",
-            message: "Claude Code cannot roll back another Harness's Native Session",
-            retryable: false,
-          },
-        };
-      }
-      let sourceSnapshot: HostThreadSnapshot;
-      try {
-        const messages = await this.#dependencies.readSessionMessages({
-          cwd: path.resolve(input.cwd),
-          sessionId: sourceRef.data.nativeSessionId,
-        });
-        sourceSnapshot = mapClaudeSnapshot(messages, sourceRef.data.nativeSessionId);
-      } catch {
-        return {
-          ok: false,
-          error: {
-            code: "nativeFailure",
-            message: "Claude Code history could not be read",
-            retryable: true,
-          },
-        };
-      }
-      if (sourceSnapshot.turns.length === 0) {
-        return {
-          ok: false,
-          error: {
-            code: "invalidState",
-            message: "Claude Code Native Session has no Turn to roll back",
-            retryable: false,
-          },
-        };
-      }
-      const retained = sourceSnapshot.turns.at(-2);
-      if (!retained) {
-        rollback = {
-          openMode: "create",
-          sessionId: this.#dependencies.randomUUID(),
-        };
-      } else if (!retained.checkpoint?.checkpointId) {
-        return {
-          ok: false,
-          error: {
-            code: "checkpointNotFound",
-            message: "Claude Code last-Turn rollback boundary is unavailable",
-            retryable: false,
-          },
-        };
-      } else {
-        const forked = await forkClaudeSession({
-          checkpoint: retained.checkpoint,
-          cwd: path.resolve(input.cwd),
-          dependencies: this.#dependencies,
-          harnessId: this.harnessId,
-          sourceRef: sourceRef.data,
-        });
-        if (!forked.ok) return forked;
-        rollback = {
-          openMode: "resume",
-          sessionId: forked.value.sessionId,
-        };
-      }
+    if (
+      input.kind === "rollbackLastTurn" &&
+      [...this.#sessions].some((session) => session.blocksRollback(input.sourceRef.nativeSessionId))
+    ) {
+      return {
+        ok: false,
+        error: {
+          code: "sessionBusy",
+          message: "Claude Code Session is busy during rollback",
+          retryable: true,
+        },
+      };
     }
     let requestedThinkingOptionId = CLAUDE_DEFAULT_THINKING_OPTION_ID;
-    if (input.kind === "create" && input.thinkingOptionId) {
+    if (
+      (input.kind === "create" || input.kind === "rollbackLastTurn" || input.kind === "resume") &&
+      input.thinkingOptionId
+    ) {
       try {
         requestedThinkingOptionId = parseClaudeThinkingOptionId(input.thinkingOptionId);
       } catch {
@@ -2565,7 +2679,10 @@ export class ClaudeCodeAdapter implements HarnessAdapter {
         };
       }
     }
-    if (input.kind === "create" && input.model) {
+    if (
+      (input.kind === "create" || input.kind === "rollbackLastTurn" || input.kind === "resume") &&
+      input.model
+    ) {
       try {
         decodeClaudeModelRef(input.model);
       } catch {
@@ -2579,13 +2696,15 @@ export class ClaudeCodeAdapter implements HarnessAdapter {
         };
       }
     }
-    const requestedPermissionModeId =
+    let requestedPermissionModeId =
       input.kind === "create"
         ? (input.permissionModeId ??
           (input.executionPolicy === "unattended-full-access"
             ? encodeClaudePermissionModeId("auto")
             : CLAUDE_DEFAULT_PERMISSION_MODE_ID))
-        : CLAUDE_DEFAULT_PERMISSION_MODE_ID;
+        : input.kind === "rollbackLastTurn" || input.kind === "resume"
+          ? (input.permissionModeId ?? CLAUDE_DEFAULT_PERMISSION_MODE_ID)
+          : CLAUDE_DEFAULT_PERMISSION_MODE_ID;
     try {
       decodeClaudePermissionModeId(requestedPermissionModeId);
     } catch {
@@ -2599,6 +2718,12 @@ export class ClaudeCodeAdapter implements HarnessAdapter {
       };
     }
     const cwd = path.resolve(input.cwd);
+    if (input.kind === "rollbackLastTurn") {
+      for (const source of this.#sessions) {
+        const ready = await source.prepareRollback(input.sourceRef.nativeSessionId);
+        if (!ready.ok) return ready;
+      }
+    }
     const nativeRef =
       input.kind === "resume" ? nativeSessionRefSchema.safeParse(input.nativeRef) : null;
     if (nativeRef && (!nativeRef.success || nativeRef.data.harnessId !== this.harnessId)) {
@@ -2612,9 +2737,19 @@ export class ClaudeCodeAdapter implements HarnessAdapter {
       };
     }
     const forked =
-      input.kind === "fork"
+      input.kind === "fork" || input.kind === "rollbackLastTurn"
         ? await forkClaudeSession({
-            checkpoint: input.checkpoint,
+            ...(input.kind === "fork"
+              ? { kind: "fork" as const, checkpoint: input.checkpoint }
+              : {
+                  kind: "rollbackLastTurn" as const,
+                  pendingSessions: this.#pendingSessions,
+                  configuration: {
+                    ...(input.model ? { effectiveModel: input.model } : {}),
+                    effectiveThinkingOptionId: requestedThinkingOptionId,
+                    effectivePermissionModeId: requestedPermissionModeId,
+                  },
+                }),
             cwd,
             dependencies: this.#dependencies,
             harnessId: this.harnessId,
@@ -2622,6 +2757,52 @@ export class ClaudeCodeAdapter implements HarnessAdapter {
           })
         : null;
     if (forked && !forked.ok) return forked;
+    const durableRef = forked?.ok
+      ? forked.value.nativeRef
+      : nativeRef?.success
+        ? nativeRef.data
+        : undefined;
+    let openMode: "create" | "resume" =
+      (forked?.ok && forked.value.openMode === "create") || input.kind === "create"
+        ? "create"
+        : "resume";
+    let requestedModel = input.kind !== "fork" ? input.model : undefined;
+    if (durableRef && isPendingClaudeSession(durableRef)) {
+      try {
+        const pending = await this.#pendingSessions.read(durableRef, cwd);
+        if (!pending.started) {
+          const messages = await this.#dependencies.readSessionMessages({
+            cwd,
+            sessionId: durableRef.nativeSessionId,
+          });
+          if (messages.length > 0 || (input.kind === "resume" && input.knownTurnRefs?.length))
+            throw new Error("Pending Session unexpectedly contains history");
+          openMode = "create";
+        }
+        if (pending.configuration.effectiveModel)
+          decodeClaudeModelRef(pending.configuration.effectiveModel);
+        if (pending.configuration.effectiveThinkingOptionId)
+          parseClaudeThinkingOptionId(pending.configuration.effectiveThinkingOptionId);
+        if (pending.configuration.effectivePermissionModeId)
+          decodeClaudePermissionModeId(pending.configuration.effectivePermissionModeId);
+        requestedModel = pending.configuration.effectiveModel ?? requestedModel;
+        requestedThinkingOptionId =
+          pending.configuration.effectiveThinkingOptionId ?? requestedThinkingOptionId;
+        requestedPermissionModeId =
+          input.kind === "resume" && input.permissionModeId
+            ? input.permissionModeId
+            : (pending.configuration.effectivePermissionModeId ?? requestedPermissionModeId);
+      } catch {
+        return {
+          ok: false,
+          error: {
+            code: "sessionNotFound",
+            message: "Claude Code pending Session cannot be recovered",
+            retryable: false,
+          },
+        };
+      }
+    }
     const session: ClaudeHarnessSession = new ClaudeHarnessSession(
       cwd,
       this.#dependencies,
@@ -2630,15 +2811,19 @@ export class ClaudeCodeAdapter implements HarnessAdapter {
       (planLimit) => this.#recordPlanLimit(session, planLimit),
       {
         ...(input.environment ? { environment: input.environment } : {}),
-        openMode: rollback?.openMode ?? (input.kind === "create" ? "create" : "resume"),
-        sessionId:
-          rollback?.sessionId ??
-          (forked?.ok
-            ? forked.value.sessionId
-            : nativeRef?.success
-              ? nativeRef.data.nativeSessionId
-              : this.#dependencies.randomUUID()),
-        ...(input.kind === "create" && input.model ? { requestedModel: input.model } : {}),
+        openMode,
+        pendingSessions: this.#pendingSessions,
+        knownConfiguration:
+          input.kind === "rollbackLastTurn" ||
+          (input.kind === "resume" && Boolean(input.model || input.thinkingOptionId)) ||
+          Boolean(durableRef && isPendingClaudeSession(durableRef)),
+        ...(durableRef ? { nativeRef: durableRef } : {}),
+        sessionId: forked?.ok
+          ? forked.value.sessionId
+          : nativeRef?.success
+            ? nativeRef.data.nativeSessionId
+            : this.#dependencies.randomUUID(),
+        ...(requestedModel ? { requestedModel } : {}),
         requestedPermissionModeId,
         requestedThinkingOptionId,
         toolOutputLimit: this.#toolOutputLimit,

--- a/packages/adapters/claude-code/src/claude-fork.ts
+++ b/packages/adapters/claude-code/src/claude-fork.ts
@@ -11,15 +11,16 @@ import {
   nativeCheckpointRefSchema,
   nativeSessionRefSchema,
   type HarnessId,
+  type HarnessConfigurationState,
   type NativeCheckpointRef,
   type NativeSessionRef,
 } from "@codexhost/shared-contracts";
 
 import { mapClaudeSnapshot } from "./claude-history.js";
+import type { ClaudePendingSessions } from "./pending-session.js";
 import type { ClaudeAdapterDependencies } from "./transport.js";
 
-interface ClaudeForkInput {
-  checkpoint: NativeCheckpointRef;
+interface ClaudeForkBase {
   cwd: string;
   dependencies: Pick<
     ClaudeAdapterDependencies,
@@ -28,6 +29,16 @@ interface ClaudeForkInput {
   harnessId: HarnessId;
   sourceRef: NativeSessionRef;
 }
+
+type ClaudeForkInput = ClaudeForkBase &
+  (
+    | { kind: "fork"; checkpoint: NativeCheckpointRef }
+    | {
+        kind: "rollbackLastTurn";
+        pendingSessions: ClaudePendingSessions;
+        configuration: HarnessConfigurationState;
+      }
+  );
 
 function error(code: HarnessError["code"], message: string, retryable: boolean): HarnessError {
   return { code, message, retryable };
@@ -41,6 +52,7 @@ function comparableTurn(turn: HostTurnSnapshot): unknown {
       outcome,
     })),
     outcome: turn.outcome,
+    hasCheckpoint: turn.checkpoint !== undefined,
     ...(turn.model ? { model: turn.model } : {}),
   };
 }
@@ -86,15 +98,19 @@ async function readSnapshot(
 
 export async function forkClaudeSession(
   input: ClaudeForkInput,
-): Promise<HarnessResult<{ sessionId: string }>> {
+): Promise<
+  HarnessResult<{ sessionId: string; nativeRef?: NativeSessionRef; openMode?: "create" }>
+> {
   const sourceRef = nativeSessionRefSchema.safeParse(input.sourceRef);
-  const checkpoint = nativeCheckpointRefSchema.safeParse(input.checkpoint);
+  const checkpoint =
+    input.kind === "fork" ? nativeCheckpointRefSchema.safeParse(input.checkpoint) : null;
   if (
     !sourceRef.success ||
-    !checkpoint.success ||
     sourceRef.data.harnessId !== input.harnessId ||
-    checkpoint.data.harnessId !== input.harnessId ||
-    checkpoint.data.nativeSessionId !== sourceRef.data.nativeSessionId
+    (checkpoint &&
+      (!checkpoint.success ||
+        checkpoint.data.harnessId !== input.harnessId ||
+        checkpoint.data.nativeSessionId !== sourceRef.data.nativeSessionId))
   ) {
     return {
       ok: false,
@@ -138,10 +154,51 @@ export async function forkClaudeSession(
 
   const source = await readSnapshot(input.dependencies, input.cwd, sourceRef.data.nativeSessionId);
   if (!source.ok) return source;
-  const boundaryIndex = source.value.turns.findIndex(
-    (turn) => turn.checkpoint?.checkpointId === checkpoint.data.checkpointId,
-  );
-  if (boundaryIndex < 0) {
+  if (input.kind === "rollbackLastTurn" && source.value.turns.length === 0) {
+    return {
+      ok: false,
+      error: error("invalidRequest", "Claude Code Session has no Turn to roll back", false),
+    };
+  }
+  if (input.kind === "rollbackLastTurn" && source.value.turns.length === 1) {
+    let nativeRef: NativeSessionRef;
+    try {
+      nativeRef = await input.pendingSessions.create(input.cwd, input.configuration);
+    } catch {
+      return {
+        ok: false,
+        error: error("nativeFailure", "Claude Code empty rollback could not be persisted", true),
+      };
+    }
+    const sourceAfter = await readSnapshot(
+      input.dependencies,
+      input.cwd,
+      sourceRef.data.nativeSessionId,
+    );
+    if (!sourceAfter.ok || !isDeepStrictEqual(sourceAfter.value, source.value)) {
+      await input.pendingSessions.discard(nativeRef, input.cwd).catch(() => undefined);
+      return {
+        ok: false,
+        error: error("protocolError", "Claude Code source history changed during rollback", false),
+      };
+    }
+    return {
+      ok: true,
+      value: { sessionId: nativeRef.nativeSessionId, nativeRef, openMode: "create" },
+    };
+  }
+  const boundaryIndex =
+    input.kind === "rollbackLastTurn"
+      ? source.value.turns.length - 2
+      : source.value.turns.findIndex(
+          (turn) =>
+            checkpoint?.success && turn.checkpoint?.checkpointId === checkpoint.data.checkpointId,
+        );
+  const retained = source.value.turns[boundaryIndex];
+  const boundaryId =
+    retained?.checkpoint?.checkpointId ??
+    (input.kind === "rollbackLastTurn" ? retained?.nativeTurnRef.nativeTurnKey : undefined);
+  if (boundaryIndex < 0 || !boundaryId) {
     return {
       ok: false,
       error: error("checkpointNotFound", "Claude Code Fork Checkpoint is unavailable", false),
@@ -151,7 +208,7 @@ export async function forkClaudeSession(
   let derivedSessionId: string;
   try {
     const forked = await input.dependencies.forkSession({
-      checkpointId: checkpoint.data.checkpointId,
+      checkpointId: boundaryId,
       cwd: input.cwd,
       sourceSessionId: sourceRef.data.nativeSessionId,
     });
@@ -195,7 +252,13 @@ export async function forkClaudeSession(
   const sourceIds = nativeIds(source.value);
   const derivedIds = nativeIds(derived.value);
   if (
-    !isDeepStrictEqual(sourceAfter.value.turns.slice(0, boundaryIndex + 1), sourcePrefix) ||
+    (input.kind === "rollbackLastTurn" &&
+      sourceAfter.value.turns.length !== source.value.turns.length) ||
+    sourceAfter.value.turns.length < source.value.turns.length ||
+    !isDeepStrictEqual(
+      sourceAfter.value.turns.slice(0, source.value.turns.length),
+      source.value.turns,
+    ) ||
     !isDeepStrictEqual(derivedContent, expectedPrefix) ||
     derivedIds.size === 0 ||
     [...derivedIds].some((id) => sourceIds.has(id))

--- a/packages/adapters/claude-code/src/claude-history.ts
+++ b/packages/adapters/claude-code/src/claude-history.ts
@@ -19,6 +19,7 @@ interface ClaudeHistoryMessage {
   uuid: string;
   message: Record<string, unknown>;
   syntheticUser: boolean;
+  interrupted: boolean;
 }
 
 const claudeCodeHarnessId: HarnessId = harnessIdSchema.parse("claude-code");
@@ -92,9 +93,30 @@ function visibleUserTextParts(message: ClaudeHistoryMessage): string[] {
   return parts.filter((part) => !isLocalCommandRecord(part) && !isTaskNotificationRecord(part));
 }
 
+function isInterruptionRecord(value: Record<string, unknown>, promptId: string | null): boolean {
+  if (
+    value.type !== "user" ||
+    promptId === null ||
+    value.promptId !== promptId ||
+    value.promptSource !== undefined ||
+    !isRecord(value.message)
+  )
+    return false;
+  const content = value.message.content;
+  if (!Array.isArray(content) || content.length !== 1) return false;
+  const part: unknown = content[0];
+  return (
+    isRecord(part) &&
+    part.type === "text" &&
+    (part.text === "[Request interrupted by user]" ||
+      part.text === "[Request interrupted by user for tool use]")
+  );
+}
+
 function conversationMessages(values: unknown[], sessionId: string): ClaudeHistoryMessage[] {
   const messages: ClaudeHistoryMessage[] = [];
   const ids = new Set<string>();
+  let promptId: string | null = null;
   for (const value of values) {
     if (!isRecord(value)) throw new Error("Claude history contains a malformed message");
     if (value.type === "system") continue;
@@ -110,17 +132,27 @@ function conversationMessages(values: unknown[], sessionId: string): ClaudeHisto
     }
     if (ids.has(value.uuid)) throw new Error("Claude history contains duplicate message IDs");
     ids.add(value.uuid);
-    messages.push({
+    // Native interruption records reuse the human promptId and omit promptSource. Their role is
+    // user, but they terminate that prompt rather than starting another Host Turn.
+    const interrupted = isInterruptionRecord(value, promptId);
+    const message: ClaudeHistoryMessage = {
       type: value.type,
       uuid: value.uuid,
       message: value.message,
+      interrupted,
       syntheticUser:
         value.type === "user" &&
-        (value.isSynthetic === true ||
+        (interrupted ||
+          value.isSynthetic === true ||
           value.isMeta === true ||
           isTaskNotificationOrigin(value) ||
           (value.toolUseResult !== undefined && value.toolUseResult !== null)),
-    });
+    };
+    messages.push(message);
+    if (isHumanUser(message)) {
+      promptId =
+        typeof value.promptId === "string" && value.promptId.length > 0 ? value.promptId : null;
+    }
   }
   return messages;
 }
@@ -130,6 +162,8 @@ function isHumanUser(message: ClaudeHistoryMessage): boolean {
 }
 
 function turnOutcome(messages: ClaudeHistoryMessage[]): HistoricalTurnOutcome {
+  if (messages.some(({ interrupted }) => interrupted))
+    return { status: "cancelled", reason: "Cancelled by user" };
   const assistants = messages.filter(({ type }) => type === "assistant");
   const failed = assistants.some(({ message }) => typeof message.error === "string");
   if (failed) {
@@ -175,7 +209,9 @@ export function mapClaudeSnapshot(values: unknown[], sessionId: string): HostThr
     const turnMessages = messages.slice(index, end);
     const outcome = turnOutcome(turnMessages);
     const results = toolResultBlocks(turnMessages);
-    const checkpointMessage = turnMessages.findLast(({ type }) => type === "assistant");
+    const checkpointMessage = turnMessages.findLast(
+      ({ type, interrupted }) => type === "assistant" || interrupted,
+    );
     let agentMessageOrdinal = 0;
     let reasoningOrdinal = 0;
     turns.push({

--- a/packages/adapters/claude-code/src/pending-session.ts
+++ b/packages/adapters/claude-code/src/pending-session.ts
@@ -1,0 +1,170 @@
+import { randomUUID } from "node:crypto";
+import { mkdir, open, readFile, rename, rm, stat, unlink } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { z } from "zod";
+
+import {
+  harnessConfigurationStateSchema,
+  nativeSessionRefSchema,
+  type HarnessConfigurationState,
+  type NativeSessionRef,
+} from "@codexhost/shared-contracts";
+
+const reservationSchema = z.strictObject({
+  version: z.literal(1),
+  sessionId: z.uuid(),
+  cwd: z.string().min(1),
+  configuration: harnessConfigurationStateSchema,
+});
+
+export function isPendingClaudeSession(ref: NativeSessionRef): boolean {
+  return ref.locator !== undefined;
+}
+
+/** Durable empty history. The separate, exclusive claim is never inferred from a missing transcript. */
+export class ClaudePendingSessions {
+  readonly #directory: string;
+
+  constructor(environment: NodeJS.ProcessEnv) {
+    this.#directory = path.join(
+      path.resolve(environment.CLAUDE_CONFIG_DIR ?? path.join(os.homedir(), ".claude")),
+      "codexhost",
+      "pending-sessions",
+    );
+  }
+
+  #path(ref: NativeSessionRef, cwd: string): string {
+    if (
+      ref.harnessId !== "claude-code" ||
+      !z.uuid().safeParse(ref.nativeSessionId).success ||
+      !z.strictObject({ pendingSession: z.literal(1) }).safeParse(ref.locator).success ||
+      !path.isAbsolute(cwd)
+    ) {
+      throw new Error("Claude Code pending Session identity is invalid");
+    }
+    return path.join(this.#directory, ref.nativeSessionId);
+  }
+
+  async create(cwd: string, configuration: HarnessConfigurationState): Promise<NativeSessionRef> {
+    const ref = nativeSessionRefSchema.parse({
+      harnessId: "claude-code",
+      nativeSessionId: randomUUID(),
+      locator: { pendingSession: 1 },
+      formatVersion: 1,
+    });
+    const directory = this.#path(ref, cwd);
+    const reservation = reservationSchema.parse({
+      version: 1,
+      sessionId: ref.nativeSessionId,
+      cwd,
+      configuration,
+    });
+    await mkdir(this.#directory, { recursive: true, mode: 0o700 });
+    await mkdir(directory, { mode: 0o700 });
+    try {
+      const file = await open(path.join(directory, "session.json"), "wx", 0o600);
+      try {
+        await file.writeFile(JSON.stringify(reservation));
+        await file.sync();
+      } finally {
+        await file.close();
+      }
+    } catch (error) {
+      await rm(directory, { recursive: true, force: true });
+      throw error;
+    }
+    await this.#sync(directory);
+    await this.#sync(this.#directory);
+    return ref;
+  }
+
+  async read(
+    ref: NativeSessionRef,
+    cwd: string,
+  ): Promise<{
+    started: boolean;
+    configuration: HarnessConfigurationState;
+  }> {
+    const directory = this.#path(ref, cwd);
+    const reservation = reservationSchema.parse(
+      JSON.parse(await readFile(path.join(directory, "session.json"), "utf8")),
+    );
+    if (reservation.sessionId !== ref.nativeSessionId || reservation.cwd !== cwd) {
+      throw new Error("Claude Code pending Session does not belong to this working directory");
+    }
+    let started = false;
+    try {
+      const claim = await stat(path.join(directory, "started"));
+      if (!claim.isFile()) throw new Error("Claude Code pending Session claim is invalid");
+      started = true;
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+    }
+    return { started, configuration: reservation.configuration };
+  }
+
+  async saveConfiguration(
+    ref: NativeSessionRef,
+    cwd: string,
+    configuration: HarnessConfigurationState,
+  ): Promise<void> {
+    await this.read(ref, cwd);
+    const directory = this.#path(ref, cwd);
+    const temporary = path.join(directory, `${randomUUID()}.tmp`);
+    try {
+      const file = await open(temporary, "wx", 0o600);
+      try {
+        await file.writeFile(
+          JSON.stringify(
+            reservationSchema.parse({
+              version: 1,
+              sessionId: ref.nativeSessionId,
+              cwd,
+              configuration,
+            }),
+          ),
+        );
+        await file.sync();
+      } finally {
+        await file.close();
+      }
+      await rename(temporary, path.join(directory, "session.json"));
+      await this.#sync(directory);
+    } finally {
+      await rm(temporary, { force: true });
+    }
+  }
+
+  async #sync(directory: string): Promise<void> {
+    if (process.platform === "win32") return;
+    const handle = await open(directory, "r");
+    try {
+      await handle.sync();
+    } finally {
+      await handle.close();
+    }
+  }
+
+  async claim(ref: NativeSessionRef, cwd: string): Promise<void> {
+    await this.read(ref, cwd);
+    // wx arbitrates competing wrappers/processes before either can start the native CLI.
+    const claim = await open(path.join(this.#path(ref, cwd), "started"), "wx", 0o600);
+    try {
+      await claim.sync();
+    } finally {
+      await claim.close();
+    }
+    await this.#sync(this.#path(ref, cwd));
+  }
+
+  /** Only the claim owner may release, after proven close and before submitting any native input. */
+  async release(ref: NativeSessionRef, cwd: string): Promise<void> {
+    await unlink(path.join(this.#path(ref, cwd), "started"));
+    await this.#sync(this.#path(ref, cwd));
+  }
+
+  async discard(ref: NativeSessionRef, cwd: string): Promise<void> {
+    await rm(this.#path(ref, cwd), { recursive: true, force: true });
+  }
+}

--- a/packages/adapters/claude-code/src/process-fence.ts
+++ b/packages/adapters/claude-code/src/process-fence.ts
@@ -1,0 +1,57 @@
+import { execFile, type ChildProcess } from "node:child_process";
+import path from "node:path";
+import { setTimeout } from "node:timers/promises";
+import { promisify } from "node:util";
+
+const executeFile = promisify(execFile);
+
+function signalGroup(pid: number, signal: NodeJS.Signals | 0): boolean {
+  try {
+    process.kill(-pid, signal);
+    return true;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ESRCH") return false;
+    // EPERM from the existence probe means the group still exists (macOS can report it while
+    // exiting). Keep waiting; only ESRCH proves absence. Actual signal failures still reject.
+    if (signal === 0 && (error as NodeJS.ErrnoException).code === "EPERM") return true;
+    throw error;
+  }
+}
+
+/** The SDK spawn hook creates an owned process group on Unix, including wrapper children. */
+export async function closeClaudeProcessGroup(
+  child: ChildProcess,
+  timeoutMs: number,
+): Promise<void> {
+  const pid = child.pid;
+  if (!pid) return;
+  if (process.platform === "win32") {
+    if (child.exitCode !== null || child.signalCode !== null)
+      throw new Error("Claude process tree cannot be confirmed after its Windows root exited");
+    const root = process.env.SystemRoot ?? process.env.SYSTEMROOT;
+    if (!root || !path.win32.isAbsolute(root)) throw new Error("Windows SystemRoot is unavailable");
+    await executeFile(
+      path.win32.join(root, "System32", "taskkill.exe"),
+      ["/PID", String(pid), "/T", "/F"],
+      {
+        timeout: timeoutMs,
+        windowsHide: true,
+      },
+    );
+    return;
+  }
+  // Signal even after the wrapper exits: its group can still contain the native CLI or MCP child.
+  if (!signalGroup(pid, "SIGTERM")) return;
+  const gracefulDeadline = Date.now() + timeoutMs;
+  while (Date.now() < gracefulDeadline) {
+    if (!signalGroup(pid, 0)) return;
+    await setTimeout(10);
+  }
+  if (!signalGroup(pid, "SIGKILL")) return;
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (!signalGroup(pid, 0)) return;
+    await setTimeout(10);
+  }
+  throw new Error("Claude SDK process group did not exit");
+}

--- a/packages/adapters/claude-code/src/sdk-transport.ts
+++ b/packages/adapters/claude-code/src/sdk-transport.ts
@@ -17,6 +17,7 @@ import { resolveClaudeCodeExecutable, withNodeRuntimeOnPath } from "./command.js
 import type { ClaudeModelInspectionSnapshot } from "./model-catalog.js";
 import { ClaudeNativeTurnAccumulator, parseClaudePlanLimitEvent } from "./native-message.js";
 import { isClaudePermissionMode, type ClaudePermissionMode } from "./permission-modes.js";
+import { closeClaudeProcessGroup } from "./process-fence.js";
 import { claudeThinkingConfiguration, parseClaudeThinkingOptionId } from "./thinking-options.js";
 import type {
   ClaudeApprovalRequest,
@@ -370,6 +371,7 @@ export class ClaudeSdkTransport implements ClaudeTurnTransport {
   #provider: string | undefined;
   #query: Query | null = null;
   #started = false;
+  #backgroundTasks = new Set<string>();
 
   constructor(options: ClaudeSdkTransportOptions) {
     this.sessionId = options.sessionId;
@@ -521,7 +523,7 @@ export class ClaudeSdkTransport implements ClaudeTurnTransport {
     userMessageId: string,
     onEvent: (event: ClaudeTurnEvent) => void,
   ): Promise<ClaudeTransportTurnResult> {
-    if (!this.#started || !this.#query) {
+    if (this.#closePromise || !this.#started || !this.#query) {
       return Promise.reject(new Error("Claude SDK transport is not started"));
     }
     if (this.#active) return Promise.reject(new Error("Claude SDK transport is busy"));
@@ -751,22 +753,55 @@ export class ClaudeSdkTransport implements ClaudeTurnTransport {
   }
 
   async #close(): Promise<void> {
+    const failures: unknown[] = [];
     if (this.#active) this.#closeInteractions(this.#active, "cancelled");
-    this.#input.end();
-    this.#query?.close();
-    await Promise.race([
-      this.#consumeTask?.catch(() => undefined) ?? Promise.resolve(),
-      delay(this.#closeTimeoutMs),
-    ]);
-    for (const child of this.#children) {
-      if (!processExited(child)) child.kill("SIGTERM");
+    try {
+      const timeout = rejectAfter(this.#closeTimeoutMs, "Claude background tasks did not stop");
+      try {
+        await Promise.race([this.#stopBackgroundTasks(), timeout.promise]);
+      } finally {
+        timeout.cancel();
+      }
+    } catch (error) {
+      failures.push(error);
     }
-    await Promise.race([
-      Promise.all(this.#children.map((child) => this.#waitForExit(child))),
-      delay(this.#closeTimeoutMs),
-    ]);
-    for (const child of this.#children) {
-      if (!processExited(child)) child.kill("SIGKILL");
+    const stopOwnedProcesses = async (): Promise<void> => {
+      const stopped = await Promise.allSettled(
+        this.#children.map((child) => closeClaudeProcessGroup(child, this.#closeTimeoutMs)),
+      );
+      for (const result of stopped) if (result.status === "rejected") failures.push(result.reason);
+    };
+    // taskkill needs a living root to enumerate the Windows tree. Unix groups remain addressable
+    // after their root exits, so let the SDK initiate its native cleanup first there.
+    if (process.platform === "win32") await stopOwnedProcesses();
+    this.#input.end();
+    try {
+      this.#query?.close();
+    } catch (error) {
+      failures.push(error);
+    }
+    if (process.platform !== "win32") await stopOwnedProcesses();
+    const exitTimeout = rejectAfter(this.#closeTimeoutMs, "Claude SDK process did not exit");
+    try {
+      await Promise.race([
+        Promise.all(this.#children.map((child) => this.#waitForExit(child))),
+        exitTimeout.promise,
+      ]);
+    } catch (error) {
+      failures.push(error);
+    } finally {
+      exitTimeout.cancel();
+    }
+    const drainTimeout = rejectAfter(this.#closeTimeoutMs, "Claude SDK output did not drain");
+    try {
+      await Promise.race([
+        this.#consumeTask?.catch(() => undefined) ?? Promise.resolve(),
+        drainTimeout.promise,
+      ]);
+    } catch (error) {
+      failures.push(error);
+    } finally {
+      drainTimeout.cancel();
     }
     this.#query = null;
     const active = this.#active;
@@ -775,11 +810,49 @@ export class ClaudeSdkTransport implements ClaudeTurnTransport {
     this.#idleAccumulator = null;
     this.#idleLive = false;
     active?.reject(new Error("Claude SDK transport closed"));
+    if (failures.length > 0)
+      throw new AggregateError(failures, "Claude SDK shutdown could not be confirmed");
+  }
+
+  async #stopBackgroundTasks(): Promise<void> {
+    const requested = new Set<string>();
+    const deadline = Date.now() + this.#closeTimeoutMs;
+    while (this.#backgroundTasks.size > 0) {
+      if (Date.now() >= deadline || !this.#query)
+        throw new Error("Claude background tasks remain active");
+      for (const id of this.#backgroundTasks) {
+        if (requested.has(id)) continue;
+        requested.add(id);
+        await this.#query.stopTask(id);
+      }
+      // A control receipt alone is not a task terminal; consume its native stopped notification.
+      if (this.#backgroundTasks.size > 0) await delay(10);
+    }
+  }
+
+  #observeBackgroundTasks(message: unknown): void {
+    if (!isRecord(message) || message.type !== "system") return;
+    if (message.subtype === "background_tasks_changed" && Array.isArray(message.tasks)) {
+      this.#backgroundTasks = new Set(
+        message.tasks.flatMap((task) =>
+          isRecord(task) && typeof task.task_id === "string" ? [task.task_id] : [],
+        ),
+      );
+    } else if (message.subtype === "task_started" && typeof message.task_id === "string") {
+      this.#backgroundTasks.add(message.task_id);
+    } else if (
+      message.subtype === "task_notification" &&
+      typeof message.task_id === "string" &&
+      ["completed", "failed", "stopped"].includes(String(message.status))
+    ) {
+      this.#backgroundTasks.delete(message.task_id);
+    }
   }
 
   async #consume(activeQuery: Query): Promise<void> {
     try {
       for await (const message of activeQuery) {
+        this.#observeBackgroundTasks(message);
         const permissionMode = permissionModeFromMessage(message);
         if (permissionMode && permissionMode !== this.#permissionMode) {
           this.#permissionMode = permissionMode;
@@ -861,6 +934,7 @@ export class ClaudeSdkTransport implements ClaudeTurnTransport {
       signal: options.signal,
       stdio: ["pipe", "pipe", "pipe"],
       windowsHide: true,
+      detached: process.platform !== "win32",
     });
     child.stderr.on("data", (chunk: Buffer | string) => {
       this.#stderrTail = sanitizeDiagnosticTail(`${this.#stderrTail}${chunk.toString()}`);

--- a/packages/adapters/claude-code/test/claude-code-adapter.test.ts
+++ b/packages/adapters/claude-code/test/claude-code-adapter.test.ts
@@ -461,7 +461,7 @@ describe("Claude Code HarnessAdapter", () => {
 
     await expect(
       adapter.open({ kind: "rollbackLastTurn", sourceRef, cwd: "/synthetic" }),
-    ).resolves.toMatchObject({ ok: false, error: { code: "invalidState" } });
+    ).resolves.toMatchObject({ ok: false, error: { code: "sessionNotFound" } });
     expect(dependencies.createTransport).not.toHaveBeenCalled();
     expect(transports).toHaveLength(0);
     await adapter.close();
@@ -1448,6 +1448,60 @@ describe("Claude Code HarnessAdapter", () => {
       liveStarted.item.itemId,
     ]);
     await session.close();
+  });
+
+  it.each([false, true])("waits for transcript persistence (timeout: %s)", async (timeout) => {
+    const { adapter, transports, history, dependencies } = fixture();
+    const session = await openSession(adapter);
+    try {
+      await session.execute(textTurn("delayed-history"));
+      const transport = transports[0];
+      if (!transport) throw new Error("Fake Claude transport was not created");
+      transport.event({ type: "message.completed", messageId: "answer", checkpointId: "answer" });
+      transport.finish({ status: "succeeded" });
+      await Promise.resolve();
+      const sent = transport.turns[0];
+      if (!sent) throw new Error("Fake Claude Turn was not submitted");
+      const persisted = [
+        {
+          type: "user",
+          uuid: sent.userMessageId,
+          session_id: transport.sessionId,
+          message: { role: "user", content: "delayed-history" },
+        },
+        {
+          type: "assistant",
+          uuid: "answer",
+          session_id: transport.sessionId,
+          message: { role: "assistant", content: "done" },
+        },
+      ];
+      vi.mocked(dependencies.readSessionMessages).mockClear();
+      if (!timeout)
+        vi.mocked(dependencies.readSessionMessages)
+          .mockResolvedValueOnce([])
+          .mockResolvedValue(persisted);
+      const result = await session.readSnapshot();
+      if (timeout) {
+        expect(result).toMatchObject({
+          ok: false,
+          error: { code: "sessionBusy", retryable: true },
+        });
+        history.push(...persisted);
+        await expect(session.readSnapshot()).resolves.toMatchObject({
+          ok: true,
+          value: { turns: [{ input: [{ text: "delayed-history" }] }] },
+        });
+      } else {
+        expect(result).toMatchObject({
+          ok: true,
+          value: { turns: [{ input: [{ text: "delayed-history" }] }] },
+        });
+        expect(dependencies.readSessionMessages).toHaveBeenCalledTimes(2);
+      }
+    } finally {
+      await adapter.close();
+    }
   });
 
   it("projects automatic Compaction and defers Usage refresh until Turn completion", async () => {
@@ -4563,6 +4617,91 @@ describe("Claude Code HarnessAdapter", () => {
     expect((await nextEvent(iterator)).type).toBe("item.completed");
     expect((await nextEvent(iterator)).type).toBe("turn.completed");
     await session.close();
+  });
+
+  it("keeps an escalated cancellation busy until the old Transport closes", async () => {
+    const { adapter, transports } = fixture({ cancelTimeoutMs: 10 });
+    const session = await openSession(adapter);
+    const events: HarnessOutput[] = [];
+    const consuming = (async () => {
+      for await (const output of session.outputs) events.push(output);
+    })();
+    await session.execute(textTurn("retiring"));
+    const transport = transports[0];
+    if (!transport) throw new Error("Expected an active Transport");
+    const stopped = Promise.withResolvers<undefined>();
+    transport.close.mockImplementation(() => stopped.promise);
+    await session.execute({ type: "turn.cancel", turnId: hostTurnIdSchema.parse("retiring") });
+    await vi.waitFor(() => expect(transport.close).toHaveBeenCalled());
+    // A late cancelled frame also does not prove that owned processes have exited.
+    transport.finish({ status: "cancelled", reason: "aborted_streaming" });
+    await Promise.resolve();
+    try {
+      await expect(session.readSnapshot()).resolves.toMatchObject({
+        ok: false,
+        error: { code: "sessionBusy" },
+      });
+      expect(
+        events.some((output) => output.kind === "event" && output.event.type === "turn.completed"),
+      ).toBe(false);
+      await expect(session.execute(textTurn("too-early"))).resolves.toMatchObject({
+        ok: false,
+        error: { code: "sessionBusy" },
+      });
+      expect(transports).toHaveLength(1);
+    } finally {
+      stopped.resolve(undefined);
+      await session.close();
+      await consuming;
+    }
+  });
+
+  it("does not confirm Session close while a hard-cancelled Transport is still stopping", async () => {
+    const { adapter, transports } = fixture({ cancelTimeoutMs: 10 });
+    const session = await openSession(adapter);
+    await session.execute(textTurn("retiring-close"));
+    const transport = transports[0];
+    if (!transport) throw new Error("Expected an active Transport");
+    const stopped = Promise.withResolvers<undefined>();
+    transport.close.mockImplementation(() => stopped.promise);
+    await session.execute({
+      type: "turn.cancel",
+      turnId: hostTurnIdSchema.parse("retiring-close"),
+    });
+    await vi.waitFor(() => expect(transport.close).toHaveBeenCalled());
+    let closed = false;
+    const closing = session.close().then(() => {
+      closed = true;
+    });
+    try {
+      await new Promise((resolve) => setTimeout(resolve, 20));
+      expect(closed).toBe(false);
+    } finally {
+      stopped.resolve(undefined);
+      await closing;
+    }
+  });
+
+  it("retains a failed hard-cancel Transport and rejects reuse and confirmed close", async () => {
+    const { adapter, transports } = fixture({ cancelTimeoutMs: 10 });
+    const session = await openSession(adapter);
+    const events: HarnessOutput[] = [];
+    const consuming = (async () => {
+      for await (const output of session.outputs) events.push(output);
+    })();
+    await session.execute(textTurn("failed-close"));
+    const transport = transports[0];
+    if (!transport) throw new Error("Expected an active Transport");
+    transport.close.mockRejectedValue(new Error("native process remains alive"));
+    await session.execute({ type: "turn.cancel", turnId: hostTurnIdSchema.parse("failed-close") });
+    await vi.waitFor(() => expect(transport.close).toHaveBeenCalled());
+    await expect(session.execute(textTurn("unsafe-retry"))).resolves.toMatchObject({ ok: false });
+    expect(transports).toHaveLength(1);
+    await expect(session.close()).rejects.toThrow("could not stop safely");
+    await consuming;
+    expect(
+      events.some((output) => output.kind === "event" && output.event.type === "session.faulted"),
+    ).toBe(true);
   });
 
   it("maps failed native results without faulting a reusable Session", async () => {

--- a/packages/adapters/claude-code/test/claude-history.test.ts
+++ b/packages/adapters/claude-code/test/claude-history.test.ts
@@ -20,6 +20,70 @@ function message(type: "user" | "assistant", uuid: string, content: unknown, sto
 }
 
 describe("Claude history mapping", () => {
+  it("keeps native interruption records in the cancelled Turn rather than inventing another user Turn", () => {
+    const snapshot = mapClaudeSnapshot(
+      [
+        { ...message("user", "user-1", "first"), promptId: "prompt-1", promptSource: "sdk" },
+        message("assistant", "partial", [{ type: "text", text: "partial answer" }]),
+        {
+          ...message("user", "interruption", [
+            { type: "text", text: "[Request interrupted by user]" },
+          ]),
+          promptId: "prompt-1",
+        },
+      ],
+      sessionId,
+    );
+    expect(snapshot.turns).toHaveLength(1);
+    expect(snapshot.turns[0]).toMatchObject({
+      nativeTurnRef: { nativeTurnKey: "user-1" },
+      input: [{ text: "first" }],
+      outcome: { status: "cancelled" },
+      checkpoint: { checkpointId: "interruption" },
+    });
+  });
+
+  it("retains genuine user inputs that quote the native interruption text", () => {
+    const text = "[Request interrupted by user]";
+    const snapshot = mapClaudeSnapshot(
+      [
+        { ...message("user", "first", "start"), promptId: "first" },
+        { ...message("user", "literal", [{ type: "text", text }]), promptId: "literal" },
+        {
+          ...message("user", "sdk-input", [{ type: "text", text }]),
+          promptId: "literal",
+          promptSource: "sdk",
+        },
+        message("user", "unattributed", [{ type: "text", text }]),
+      ],
+      sessionId,
+    );
+    expect(snapshot.turns.map((turn) => turn.nativeTurnRef.nativeTurnKey)).toEqual([
+      "first",
+      "literal",
+      "sdk-input",
+      "unattributed",
+    ]);
+  });
+
+  it.each(["[Request interrupted by user]", "[Request interrupted by user for tool use]"])(
+    "recognizes %s without an assistant checkpoint",
+    (text) => {
+      const snapshot = mapClaudeSnapshot(
+        [
+          { ...message("user", "first", "start"), promptId: "first", promptSource: "sdk" },
+          { ...message("user", "interruption", [{ type: "text", text }]), promptId: "first" },
+        ],
+        sessionId,
+      );
+      expect(snapshot.turns).toHaveLength(1);
+      expect(snapshot.turns[0]).toMatchObject({
+        checkpoint: { checkpointId: "interruption" },
+        outcome: { status: "cancelled" },
+      });
+    },
+  );
+
   it("groups human Turns around native Tool messages with stable identities", () => {
     const history = [
       message("user", "user-1", "first"),

--- a/packages/adapters/claude-code/test/claude-rollback.test.ts
+++ b/packages/adapters/claude-code/test/claude-rollback.test.ts
@@ -1,0 +1,428 @@
+import assert from "node:assert/strict";
+import { randomUUID } from "node:crypto";
+import { mkdtemp, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { hostTurnIdSchema, nativeSessionRefSchema } from "@codexhost/shared-contracts";
+import type { HarnessSession } from "@codexhost/harness-adapter";
+
+import { ClaudeCodeAdapter } from "../src/claude-code-adapter.js";
+import { encodeClaudeModelRef } from "../src/model-catalog.js";
+import { CLAUDE_DEFAULT_THINKING_OPTION_ID } from "../src/thinking-options.js";
+import { CLAUDE_DEFAULT_PERMISSION_MODE_ID } from "../src/permission-modes.js";
+import { ClaudePendingSessions } from "../src/pending-session.js";
+import type {
+  ClaudeAdapterDependencies,
+  ClaudeTransportFactoryInput,
+  ClaudeTurnTransport,
+} from "../src/transport.js";
+
+const cleanups: Array<() => Promise<unknown>> = [];
+afterEach(async () => {
+  for (const cleanup of cleanups.splice(0).reverse()) await cleanup();
+});
+
+function messages(sessionId: string, text: string) {
+  return [
+    {
+      type: "user",
+      uuid: randomUUID() as string,
+      session_id: sessionId,
+      message: { role: "user", content: text },
+    },
+    {
+      type: "assistant",
+      uuid: randomUUID() as string,
+      session_id: sessionId,
+      message: { role: "assistant", content: [{ type: "text", text: `${text} response` }] },
+    },
+  ];
+}
+
+async function fixture(turns = 1) {
+  const directory = await mkdtemp(path.join(os.tmpdir(), "claude-rollback-"));
+  cleanups.push(() => rm(directory, { force: true, recursive: true }));
+  const environment = { CLAUDE_CONFIG_DIR: directory };
+  const sourceRef = nativeSessionRefSchema.parse({
+    harnessId: "claude-code",
+    nativeSessionId: randomUUID(),
+    formatVersion: 1,
+  });
+  const histories = new Map([
+    [
+      sourceRef.nativeSessionId,
+      Array.from({ length: turns }, (_, i) =>
+        messages(sourceRef.nativeSessionId, `prompt ${i + 1}`),
+      ).flat(),
+    ],
+  ]);
+  const transports: Array<ClaudeTurnTransport & { input: ClaudeTransportFactoryInput }> = [];
+  const dependencies: ClaudeAdapterDependencies = {
+    randomUUID,
+    inspectInstallation: () => undefined,
+    createInspector: () => ({
+      inspect: async () => ({
+        models: [{ value: "default", displayName: "Default", description: "Default" }],
+        canSelectModel: true,
+        canSelectPermissionMode: true,
+      }),
+      close: async () => undefined,
+    }),
+    deleteSession: vi.fn(async ({ sessionId }) => {
+      histories.delete(sessionId);
+    }),
+    forkSession: vi.fn(async ({ sourceSessionId, checkpointId }) => {
+      const id = randomUUID();
+      const source = histories.get(sourceSessionId) ?? [];
+      const prefix = source.slice(0, source.findIndex((m) => m.uuid === checkpointId) + 1);
+      histories.set(
+        id,
+        prefix.map((m) => ({
+          ...structuredClone(m),
+          uuid: randomUUID() as string,
+          session_id: id,
+        })),
+      );
+      return { sessionId: id };
+    }),
+    getSessionInfo: async ({ sessionId }) =>
+      histories.has(sessionId) ? { cwd: directory } : undefined,
+    readSessionMessages: vi.fn(async ({ sessionId }) =>
+      structuredClone(histories.get(sessionId) ?? []),
+    ),
+    readSubagentMessages: async () => [],
+    createTransport: vi.fn((input) => {
+      let permissionMode = input.permissionMode;
+      const transport = {
+        input,
+        sessionId: input.sessionId,
+        start: vi.fn(async () => undefined),
+        close: vi.fn(async () => undefined),
+        abort: vi.fn(async () => undefined),
+        setAutonomousTurnHandler: () => undefined,
+        setIdleTurnHandler: () => undefined,
+        setIdleLive: () => undefined,
+        getContextUsage: async () => null,
+        getPermissionMode: () => permissionMode,
+        setPermissionMode: async (mode) => {
+          permissionMode = mode;
+        },
+        setModel: async () => undefined,
+        setThinkingOption: async () => undefined,
+        respondToInteraction: async () => undefined,
+        compact: async () => ({ status: "succeeded" as const }),
+        init: async () => ({ status: "succeeded" as const }),
+        recap: async () => ({ status: "succeeded" as const }),
+        runTurn: async (text, userMessageId, onEvent) => {
+          const next = messages(input.sessionId, text);
+          assert.ok(next[0]);
+          assert.ok(next[1]);
+          next[0].uuid = userMessageId;
+          histories.set(input.sessionId, [...(histories.get(input.sessionId) ?? []), ...next]);
+          onEvent({ type: "text.delta", messageId: next[1].uuid, delta: `${text} response` });
+          onEvent({
+            type: "message.completed",
+            messageId: next[1].uuid,
+            checkpointId: next[1].uuid,
+          });
+          return { status: "succeeded" };
+        },
+      } satisfies ClaudeTurnTransport & { input: ClaudeTransportFactoryInput };
+      transports.push(transport);
+      return transport;
+    }),
+  };
+  const adapter = () => {
+    const value = new ClaudeCodeAdapter({ environment, closeTimeoutMs: 50 }, dependencies);
+    cleanups.push(() => value.close().catch(() => undefined));
+    return value;
+  };
+  return { adapter, directory, environment, sourceRef, histories, dependencies, transports };
+}
+
+async function unwrap(result: ReturnType<ClaudeCodeAdapter["open"]>): Promise<HarnessSession> {
+  const opened = await result;
+  if (!opened.ok) throw new Error(opened.error.message);
+  return opened.value;
+}
+
+const model = encodeClaudeModelRef("sonnet");
+
+describe("Claude last-Turn rollback", () => {
+  it("restores lazy native configuration before selecting permission mode", async () => {
+    const f = await fixture();
+    const session = await unwrap(
+      f.adapter().open({
+        kind: "resume",
+        cwd: f.directory,
+        nativeRef: f.sourceRef,
+        model,
+        thinkingOptionId: CLAUDE_DEFAULT_THINKING_OPTION_ID,
+      }),
+    );
+    await session.execute({
+      type: "permissionMode.select",
+      permissionModeId: CLAUDE_DEFAULT_PERMISSION_MODE_ID,
+    });
+    expect(await session.readSnapshot()).toMatchObject({
+      ok: true,
+      value: { state: { effectiveModel: model } },
+    });
+    expect(f.transports).toHaveLength(0);
+  });
+
+  it("keeps durable pending configuration authoritative over stale resume hints", async () => {
+    const f = await fixture();
+    const ref = await new ClaudePendingSessions(f.environment).create(f.directory, {
+      effectiveModel: model,
+    });
+    const session = await unwrap(
+      f.adapter().open({
+        kind: "resume",
+        cwd: f.directory,
+        nativeRef: ref,
+        model: encodeClaudeModelRef("default"),
+      }),
+    );
+    expect(session.initialState.effectiveModel).toEqual(model);
+  });
+
+  it("reserves empty history, restores it in another Adapter and uses the same ID for edited input", async () => {
+    const f = await fixture();
+    const source = structuredClone(f.histories.get(f.sourceRef.nativeSessionId));
+    const first = f.adapter();
+    const replacement = await unwrap(
+      first.open({ kind: "rollbackLastTurn", cwd: f.directory, sourceRef: f.sourceRef, model }),
+    );
+    expect(replacement.capabilities.history).toMatchObject({
+      rollbackLastTurn: true,
+    });
+    const ref = nativeSessionRefSchema.parse(replacement.initialState.nativeRef);
+    expect(ref.nativeSessionId).not.toBe(f.sourceRef.nativeSessionId);
+    expect(await replacement.readSnapshot()).toMatchObject({
+      ok: true,
+      value: { turns: [], state: { nativeRef: ref, effectiveModel: model } },
+    });
+    await first.close();
+    const second = f.adapter();
+    const resumed = await unwrap(
+      second.open({ kind: "resume", cwd: f.directory, nativeRef: ref, knownTurnRefs: [] }),
+    );
+    expect(await resumed.readSnapshot()).toMatchObject({ ok: true, value: { turns: [] } });
+    expect(f.transports).toHaveLength(0);
+    expect(
+      await resumed.execute({
+        type: "turn.start",
+        turnId: hostTurnIdSchema.parse(randomUUID()),
+        input: [{ type: "text", text: "edited" }],
+      }),
+    ).toMatchObject({ ok: true });
+    await vi.waitFor(async () =>
+      expect(await resumed.readSnapshot()).toMatchObject({
+        ok: true,
+        value: { turns: [{ input: [{ text: "edited" }] }] },
+      }),
+    );
+    expect(f.transports[0]?.input).toMatchObject({
+      openMode: "create",
+      sessionId: ref.nativeSessionId,
+      model: "sonnet",
+    });
+    await second.close();
+    const third = f.adapter();
+    const cold = await unwrap(third.open({ kind: "resume", cwd: f.directory, nativeRef: ref }));
+    expect(await cold.readSnapshot()).toMatchObject({
+      ok: true,
+      value: { turns: [{ input: [{ text: "edited" }] }] },
+    });
+    expect(f.histories.get(f.sourceRef.nativeSessionId)).toEqual(source);
+    f.histories.delete(ref.nativeSessionId);
+    expect(await cold.readSnapshot()).toMatchObject({
+      ok: false,
+      error: { code: "sessionNotFound" },
+    });
+  });
+
+  it("keeps the full prior Turn through native Fork and preserves source history", async () => {
+    const f = await fixture(2);
+    const before = structuredClone(f.histories.get(f.sourceRef.nativeSessionId));
+    const replacement = await unwrap(
+      f
+        .adapter()
+        .open({ kind: "rollbackLastTurn", cwd: f.directory, sourceRef: f.sourceRef, model }),
+    );
+    expect(await replacement.readSnapshot()).toMatchObject({
+      ok: true,
+      value: {
+        turns: [
+          { input: [{ text: "prompt 1" }], items: [{ item: { text: "prompt 1 response" } }] },
+        ],
+      },
+    });
+    expect(f.histories.get(f.sourceRef.nativeSessionId)).toEqual(before);
+    expect(f.dependencies.forkSession).toHaveBeenCalledOnce();
+  });
+
+  it("persists configuration changes made before the first resend", async () => {
+    const f = await fixture();
+    const first = f.adapter();
+    const session = await unwrap(
+      first.open({ kind: "rollbackLastTurn", cwd: f.directory, sourceRef: f.sourceRef }),
+    );
+    await session.execute({ type: "model.select", model });
+    await session.close();
+    const resumed = await unwrap(
+      f.adapter().open({
+        kind: "resume",
+        cwd: f.directory,
+        nativeRef: nativeSessionRefSchema.parse(session.initialState.nativeRef),
+      }),
+    );
+    expect(await resumed.readSnapshot()).toMatchObject({
+      ok: true,
+      value: {
+        state: {
+          effectiveModel: model,
+          effectiveThinkingOptionId: CLAUDE_DEFAULT_THINKING_OPTION_ID,
+          effectivePermissionModeId: CLAUDE_DEFAULT_PERMISSION_MODE_ID,
+        },
+      },
+    });
+  });
+
+  it("does not pretend a claimed but missing transcript is an empty Session", async () => {
+    const f = await fixture();
+    const store = new ClaudePendingSessions(f.environment);
+    const ref = await store.create(f.directory, {});
+    await store.claim(ref, f.directory);
+    const session = await unwrap(
+      f.adapter().open({ kind: "resume", cwd: f.directory, nativeRef: ref }),
+    );
+    expect(await session.readSnapshot()).toMatchObject({
+      ok: false,
+      error: { code: "sessionNotFound" },
+    });
+    await expect(store.claim(ref, f.directory)).rejects.toMatchObject({ code: "EEXIST" });
+    await expect(store.read(ref, path.join(f.directory, "other"))).rejects.toThrow();
+  });
+
+  it("propagates a failed Transport close to the history replacement caller", async () => {
+    const f = await fixture(2);
+    const session = await unwrap(
+      f.adapter().open({ kind: "resume", cwd: f.directory, nativeRef: f.sourceRef }),
+    );
+    await session.execute({
+      type: "turn.start",
+      turnId: hostTurnIdSchema.parse(randomUUID()),
+      input: [{ type: "text", text: "next" }],
+    });
+    assert.ok(f.transports[0]);
+    vi.mocked(f.transports[0].close).mockRejectedValue(new Error("process still alive"));
+    await expect(session.close()).rejects.toThrow("could not stop safely");
+    await expect(session.close()).rejects.toThrow();
+  });
+
+  it("waits for the completed native message before deriving an immediate edit", async () => {
+    const f = await fixture();
+    const adapter = f.adapter();
+    const session = await unwrap(
+      adapter.open({ kind: "resume", cwd: f.directory, nativeRef: f.sourceRef }),
+    );
+    await session.execute({
+      type: "turn.start",
+      turnId: hostTurnIdSchema.parse(randomUUID()),
+      input: [{ type: "text", text: "not flushed yet" }],
+    });
+    await vi.waitFor(() => expect(f.histories.get(f.sourceRef.nativeSessionId)).toHaveLength(4));
+    const saved = f.histories.get(f.sourceRef.nativeSessionId);
+    assert.ok(saved);
+    f.histories.set(f.sourceRef.nativeSessionId, saved.slice(0, 2));
+    const rollback = adapter.open({
+      kind: "rollbackLastTurn",
+      cwd: f.directory,
+      sourceRef: f.sourceRef,
+    });
+    setTimeout(() => f.histories.set(f.sourceRef.nativeSessionId, saved), 10);
+    const replacement = await unwrap(rollback);
+    expect(await replacement.readSnapshot()).toMatchObject({
+      ok: true,
+      value: { turns: [{ input: [{ text: "prompt 1" }] }] },
+    });
+    expect(f.dependencies.forkSession).toHaveBeenCalledOnce();
+  });
+
+  it("allows only one competing wrapper to create the reserved native Session", async () => {
+    const f = await fixture();
+    const ref = await new ClaudePendingSessions(f.environment).create(f.directory, {});
+    const sessions = await Promise.all(
+      [f.adapter(), f.adapter()].map((adapter) =>
+        unwrap(adapter.open({ kind: "resume", cwd: f.directory, nativeRef: ref })),
+      ),
+    );
+    const results = await Promise.all(
+      sessions.map((session) =>
+        session.execute({
+          type: "turn.start",
+          turnId: hostTurnIdSchema.parse(randomUUID()),
+          input: [{ type: "text", text: "one owner" }],
+        }),
+      ),
+    );
+    expect(results.filter((result) => result.ok)).toHaveLength(1);
+    expect(f.transports).toHaveLength(1);
+  });
+
+  it("releases an unused reservation after startup fails and close succeeds", async () => {
+    const f = await fixture();
+    const store = new ClaudePendingSessions(f.environment);
+    const ref = await store.create(f.directory, {});
+    vi.mocked(f.dependencies.createTransport).mockImplementationOnce(() => {
+      throw new Error("cannot spawn");
+    });
+    const session = await unwrap(
+      f.adapter().open({ kind: "resume", cwd: f.directory, nativeRef: ref }),
+    );
+    expect(
+      await session.execute({
+        type: "turn.start",
+        turnId: hostTurnIdSchema.parse(randomUUID()),
+        input: [{ type: "text", text: "retry" }],
+      }),
+    ).toMatchObject({ ok: false });
+    expect(await store.read(ref, f.directory)).toMatchObject({ started: false });
+    expect(
+      await session.execute({
+        type: "turn.start",
+        turnId: hostTurnIdSchema.parse(randomUUID()),
+        input: [{ type: "text", text: "retry" }],
+      }),
+    ).toMatchObject({ ok: true });
+    expect(f.transports).toHaveLength(1);
+  });
+
+  it("keeps an interrupted preceding Turn without an assistant checkpoint", async () => {
+    const f = await fixture(2);
+    const source = f.histories.get(f.sourceRef.nativeSessionId);
+    assert.ok(source?.[0]);
+    f.histories.set(f.sourceRef.nativeSessionId, [source[0], ...source.slice(2)]);
+    const replacement = await unwrap(
+      f.adapter().open({ kind: "rollbackLastTurn", cwd: f.directory, sourceRef: f.sourceRef }),
+    );
+    expect(await replacement.readSnapshot()).toMatchObject({
+      ok: true,
+      value: { turns: [{ input: [{ text: "prompt 1" }], items: [] }] },
+    });
+  });
+
+  it("rejects missing recovery metadata instead of silently recreating it", async () => {
+    const f = await fixture();
+    const store = new ClaudePendingSessions(f.environment);
+    const ref = await store.create(f.directory, {});
+    await store.discard(ref, f.directory);
+    expect(
+      await f.adapter().open({ kind: "resume", cwd: f.directory, nativeRef: ref }),
+    ).toMatchObject({ ok: false, error: { code: "sessionNotFound" } });
+    expect(f.transports).toHaveLength(0);
+  });
+});

--- a/packages/adapters/claude-code/test/sdk-transport.test.ts
+++ b/packages/adapters/claude-code/test/sdk-transport.test.ts
@@ -1,3 +1,5 @@
+import type { ChildProcessWithoutNullStreams } from "node:child_process";
+import { once } from "node:events";
 import path from "node:path";
 
 import { describe, expect, it, vi } from "vitest";
@@ -29,6 +31,14 @@ class FakeQuery {
     ],
   }));
   readonly interrupt = vi.fn(async () => undefined);
+  readonly stopTask = vi.fn(async (taskId: string) => {
+    this.push({
+      type: "system",
+      subtype: "task_notification",
+      task_id: taskId,
+      status: "stopped",
+    } as unknown as SDKMessage);
+  });
   readonly getContextUsage = vi.fn(
     async (): Promise<{
       totalTokens: number;
@@ -1859,4 +1869,68 @@ describe("ClaudeSdkTransport Tool Approval callbacks", () => {
     ).rejects.toThrow("not pending");
     await value.transport.close();
   });
+});
+
+describe("Claude history replacement fence", () => {
+  it("does not accept a stop-task receipt without a native task terminal", async () => {
+    const value = fixture();
+    await value.transport.start();
+    value.fakeQuery.stopTask.mockImplementation(async () => undefined);
+    value.fakeQuery.push({
+      type: "system",
+      subtype: "task_started",
+      task_id: "still-running",
+    } as unknown as SDKMessage);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    await expect(value.transport.close()).rejects.toThrow("shutdown could not be confirmed");
+    expect(value.fakeQuery.stopTask).toHaveBeenCalledWith("still-running");
+  });
+
+  it("rejects close if native output cannot be drained", async () => {
+    const value = fixture();
+    await value.transport.start();
+    const close = vi.spyOn(value.fakeQuery, "close").mockImplementation(() => undefined);
+    try {
+      await expect(value.transport.close()).rejects.toThrow("shutdown could not be confirmed");
+    } finally {
+      close.mockRestore();
+      value.fakeQuery.close();
+    }
+  });
+
+  it.skipIf(process.platform === "win32")(
+    "stops wrapper children even when the wrapper has exited",
+    async () => {
+      const value = fixture();
+      await value.transport.start();
+      const spawnProcess = options(value).spawnClaudeCodeProcess;
+      if (!spawnProcess) throw new Error("Missing native process ownership hook");
+      const child = spawnProcess({
+        command: process.execPath,
+        args: [
+          "-e",
+          "const c=require('child_process').spawn(process.execPath,['-e','setInterval(()=>{},1000)'],{stdio:'ignore'}); process.stdout.write(String(c.pid)); c.unref();",
+        ],
+        signal: new AbortController().signal,
+        cwd: process.cwd(),
+        env: process.env,
+      }) as ChildProcessWithoutNullStreams;
+      let pid = 0;
+      try {
+        const [chunk] = await once(child.stdout, "data");
+        pid = Number(String(chunk));
+        if (child.exitCode === null) await once(child, "exit");
+        expect(() => process.kill(pid, 0)).not.toThrow();
+        await value.transport.close();
+        expect(() => process.kill(pid, 0)).toThrow();
+      } finally {
+        if (pid) {
+          try {
+            process.kill(pid, "SIGKILL");
+          } catch {}
+        }
+        await value.transport.close().catch(() => undefined);
+      }
+    },
+  );
 });

--- a/packages/harness-adapter/src/text-session.ts
+++ b/packages/harness-adapter/src/text-session.ts
@@ -80,6 +80,9 @@ export interface CreateSessionInput {
 }
 
 export interface ResumeSessionInput {
+  /** Saved selection hints for Harnesses that initialize configuration lazily. */
+  model?: HarnessModelRef;
+  thinkingOptionId?: HarnessThinkingOptionId;
   kind: "resume";
   nativeRef: NativeSessionRef;
   cwd: string;
@@ -98,6 +101,10 @@ export interface ForkSessionInput {
 }
 
 export interface RollbackLastTurnSessionInput {
+  /** Current settings required by a derived Session before it can start native work. */
+  model?: HarnessModelRef;
+  thinkingOptionId?: HarnessThinkingOptionId;
+  permissionModeId?: HarnessPermissionModeId;
   kind: "rollbackLastTurn";
   sourceRef: NativeSessionRef;
   cwd: string;

--- a/packages/harness-broker/src/validation.ts
+++ b/packages/harness-broker/src/validation.ts
@@ -29,6 +29,8 @@ const createSchema = z
 const resumeSchema = z
   .object({
     kind: z.literal("resume"),
+    model: harnessModelRefSchema.optional(),
+    thinkingOptionId: harnessThinkingOptionIdSchema.optional(),
     nativeRef: nativeSessionRefSchema,
     cwd: cwdSchema,
     knownTurnRefs: z.array(nativeTurnRefSchema).max(100_000).optional(),
@@ -45,6 +47,9 @@ const forkSchema = z
 const rollbackSchema = z
   .object({
     kind: z.literal("rollbackLastTurn"),
+    model: harnessModelRefSchema.optional(),
+    thinkingOptionId: harnessThinkingOptionIdSchema.optional(),
+    permissionModeId: harnessPermissionModeIdSchema.optional(),
     sourceRef: nativeSessionRefSchema,
     cwd: cwdSchema,
   })

--- a/packages/harness-broker/test/harness-broker.test.ts
+++ b/packages/harness-broker/test/harness-broker.test.ts
@@ -17,6 +17,9 @@ import {
 import { FakeHarnessAdapter, FakeHarnessSession } from "@codexhost/harness-adapter/testing";
 import {
   harnessIdSchema,
+  harnessModelRefSchema,
+  harnessThinkingOptionIdSchema,
+  harnessPermissionModeIdSchema,
   harnessPermissionModeCatalogSchema,
   hostTurnIdSchema,
 } from "@codexhost/shared-contracts";
@@ -110,6 +113,29 @@ describe("macOS Aqua Harness broker", () => {
     expect(native.sessions).toHaveLength(1);
     expect(native.sessions[0]?.cwd).toBe(root);
     expect(nativeOpen).toHaveBeenCalledWith({ kind: "create", cwd: root });
+    const sourceRef = opened.value.initialState.nativeRef;
+    if (!sourceRef) throw new Error("Fixture Session has no native identity");
+    const rollback = {
+      kind: "rollbackLastTurn" as const,
+      cwd: root,
+      sourceRef: { ...sourceRef, nativeSessionId: "separate-id" },
+      model: harnessModelRefSchema.parse({ id: "custom-model" }),
+      thinkingOptionId: harnessThinkingOptionIdSchema.parse("high"),
+      permissionModeId: harnessPermissionModeIdSchema.parse("default"),
+    };
+    nativeOpen.mockResolvedValueOnce({
+      ok: false,
+      error: {
+        code: "unsupported",
+        message: "Synthetic rollback",
+        retryable: false,
+      },
+    });
+    await expect(adapter.open(rollback)).resolves.toMatchObject({
+      ok: false,
+      error: { code: "unsupported" },
+    });
+    expect(nativeOpen).toHaveBeenLastCalledWith(rollback);
     await opened.value.close();
     await adapter.close();
     await server.close();

--- a/packages/host-runtime/src/external-thread-rollback.ts
+++ b/packages/host-runtime/src/external-thread-rollback.ts
@@ -126,6 +126,7 @@ async function executeCurrentLastTurnRollback(input: {
     };
   }
 
+  const configuration = currentConfiguration(current);
   let opened: Awaited<ReturnType<HarnessAdapter["open"]>>;
   try {
     opened = await adapter.open({
@@ -136,6 +137,13 @@ async function executeCurrentLastTurnRollback(input: {
         [DELEGATION_THREAD_ID_ENV]: current.id,
       },
       sourceRef: currentNativeRef as NativeSessionRef,
+      ...(configuration.effectiveModel ? { model: configuration.effectiveModel } : {}),
+      ...(configuration.effectiveThinkingOptionId
+        ? { thinkingOptionId: configuration.effectiveThinkingOptionId }
+        : {}),
+      ...(configuration.effectivePermissionModeId
+        ? { permissionModeId: configuration.effectivePermissionModeId }
+        : {}),
     });
   } catch {
     return { ok: false, error: { code: -32076, message: "External Thread rollback failed" } };
@@ -153,7 +161,6 @@ async function executeCurrentLastTurnRollback(input: {
       error: { code: -32076, message: "External rollback did not return a valid Session" },
     };
   }
-  const configuration = currentConfiguration(current);
   const configurationError = await restoreCurrentConfiguration(session, configuration);
   if (configurationError) {
     await session.close().catch(() => undefined);

--- a/packages/host-runtime/src/external-thread-runtime.ts
+++ b/packages/host-runtime/src/external-thread-runtime.ts
@@ -470,6 +470,10 @@ export class ExternalThreadRuntime {
       environment: { ...this.#environment, [DELEGATION_THREAD_ID_ENV]: record.hostThreadId },
       nativeRef: record.nativeSessionRef as NativeSessionRef,
       knownTurnRefs: record.turnMappings.map(({ nativeTurnRef }) => nativeTurnRef),
+      ...(restoredSelection?.model ? { model: restoredSelection.model } : {}),
+      ...(restoredSelection?.thinkingOptionId
+        ? { thinkingOptionId: restoredSelection.thinkingOptionId }
+        : {}),
       ...(harnessId === "grok" && restoredSelection?.permissionModeId
         ? { permissionModeId: restoredSelection.permissionModeId }
         : {}),

--- a/tools/gate-claude-code/close.real.test.mjs
+++ b/tools/gate-claude-code/close.real.test.mjs
@@ -1,0 +1,174 @@
+import os from "node:os";
+import fs from "node:fs/promises";
+import path from "node:path";
+import http from "node:http";
+import { randomUUID } from "node:crypto";
+import assert from "node:assert/strict";
+import { describe, it } from "vitest";
+import { ClaudeSdkTransport } from "../../packages/adapters/claude-code/dist/sdk-transport.js";
+const command = process.env.CODEXHOST_CLAUDE_REAL_COMMAND;
+describe.runIf(Boolean(command) && process.env.CODEXHOST_CLAUDE_REAL_LIVE !== "1")(
+  "Claude native background task fence",
+  () => {
+    it("stops a running native Bash task before close resolves", async () => {
+      const root = await fs.mkdtemp(path.join(os.tmpdir(), "claude-history-native-"));
+      const cwd = path.join(root, "workspace");
+      const config = path.join(root, "config");
+      await fs.mkdir(cwd);
+      await fs.mkdir(config);
+
+      const requests = [];
+      const server = http.createServer(async (req, res) => {
+        let data = "";
+        for await (const b of req) data += b;
+        const body = JSON.parse(data || "{}");
+        if (req.url.includes("/count_tokens")) {
+          res.writeHead(200, { "content-type": "application/json" });
+          res.end('{"input_tokens":10}');
+          return;
+        }
+        if (!req.url.includes("/messages")) {
+          res.writeHead(404);
+          res.end("{}");
+          return;
+        }
+        requests.push(body.messages);
+        const msg = {
+          id: "msg_" + randomUUID(),
+          type: "message",
+          role: "assistant",
+          model: body.model,
+          content: [{ type: "text", text: "PROBE_OK" }],
+          stop_reason: "end_turn",
+          stop_sequence: null,
+          usage: { input_tokens: 10, output_tokens: 5 },
+        };
+        if (requests.length === 1) {
+          msg.content = [
+            {
+              type: "tool_use",
+              id: "tool_background_probe",
+              name: "Bash",
+              input: {
+                command: `touch ${cwd}/started; sleep 4; printf 'late' > ${cwd}/late.txt`,
+                run_in_background: true,
+                description: "Temporary close fence probe",
+              },
+            },
+          ];
+          msg.stop_reason = "tool_use";
+        }
+        res.writeHead(200, {
+          "content-type": body.stream ? "text/event-stream" : "application/json",
+        });
+        if (!body.stream) {
+          res.end(JSON.stringify(msg));
+          return;
+        }
+        for (const [event, value] of [
+          [
+            "message_start",
+            { type: "message_start", message: { ...msg, content: [], stop_reason: null } },
+          ],
+          [
+            "content_block_start",
+            {
+              type: "content_block_start",
+              index: 0,
+              content_block:
+                msg.content[0].type === "tool_use"
+                  ? { ...msg.content[0], input: {} }
+                  : { type: "text", text: "" },
+            },
+          ],
+          [
+            "content_block_delta",
+            {
+              type: "content_block_delta",
+              index: 0,
+              delta:
+                msg.content[0].type === "tool_use"
+                  ? { type: "input_json_delta", partial_json: JSON.stringify(msg.content[0].input) }
+                  : { type: "text_delta", text: "PROBE_OK" },
+            },
+          ],
+          ["content_block_stop", { type: "content_block_stop", index: 0 }],
+          [
+            "message_delta",
+            {
+              type: "message_delta",
+              delta: { stop_reason: msg.stop_reason, stop_sequence: null },
+              usage: { output_tokens: 5 },
+            },
+          ],
+          ["message_stop", { type: "message_stop" }],
+        ])
+          res.write(`event: ${event}\ndata: ${JSON.stringify(value)}\n\n`);
+        res.end();
+      });
+      await new Promise((r) => server.listen(0, "127.0.0.1", r));
+      const env = {
+        ...process.env,
+        ANTHROPIC_API_KEY: "local-probe",
+        ANTHROPIC_BASE_URL: `http://127.0.0.1:${server.address().port}`,
+        CLAUDE_CONFIG_DIR: config,
+        CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC: "1",
+      };
+      for (const key of Object.keys(env)) {
+        if (
+          (key.startsWith("ANTHROPIC_") &&
+            !["ANTHROPIC_API_KEY", "ANTHROPIC_BASE_URL"].includes(key)) ||
+          key.startsWith("CLAUDE_CODE_USE_") ||
+          key === "AWS_BEARER_TOKEN_BEDROCK"
+        )
+          delete env[key];
+      }
+
+      const transport = new ClaudeSdkTransport({
+        command,
+        environment: env,
+        cwd,
+        sessionId: randomUUID(),
+        openMode: "create",
+        model: "claude-sonnet-4-6",
+        thinkingOptionId: "off",
+        permissionMode: "bypassPermissions",
+        closeTimeoutMs: 7000,
+        onFault: () => {},
+        onPermissionModeChanged: () => {},
+        onPlanLimit: () => {},
+      });
+      try {
+        await transport.start();
+        assert.equal(
+          (
+            await transport.runTurn(
+              "Run the temporary background close probe, then reply OK.",
+              randomUUID(),
+              () => {},
+            )
+          ).status,
+          "succeeded",
+        );
+        const exists = async (name) =>
+          fs.stat(path.join(cwd, name)).then(
+            () => true,
+            () => false,
+          );
+        const deadline = Date.now() + 10000;
+        while (!(await exists("started")) && Date.now() < deadline)
+          await new Promise((resolve) => setTimeout(resolve, 50));
+        assert.equal(await exists("started"), true);
+        assert.equal(await exists("late.txt"), false);
+        await transport.close();
+        await new Promise((resolve) => setTimeout(resolve, 4500));
+        assert.equal(await exists("late.txt"), false, "native background Bash wrote after close");
+      } finally {
+        await transport.close().catch(() => undefined);
+        server.closeAllConnections();
+        await new Promise((resolve) => server.close(resolve));
+        await fs.rm(root, { force: true, recursive: true });
+      }
+    }, 30000);
+  },
+);

--- a/tools/gate-claude-code/rollback.real.test.mjs
+++ b/tools/gate-claude-code/rollback.real.test.mjs
@@ -1,0 +1,508 @@
+import assert from "node:assert/strict";
+import { randomUUID } from "node:crypto";
+import { EventEmitter } from "node:events";
+import { mkdir, mkdtemp, readFile, realpath, rm } from "node:fs/promises";
+import http from "node:http";
+import os from "node:os";
+import path from "node:path";
+import { PassThrough } from "node:stream";
+import vm from "node:vm";
+import { describe, it, vi } from "vitest";
+import { getSessionMessages } from "@anthropic-ai/claude-agent-sdk";
+import { ClaudeCodeAdapter } from "../../packages/adapters/claude-code/dist/index.js";
+import { encodeClaudeModelRef } from "../../packages/adapters/claude-code/dist/model-catalog.js";
+import { AppServerHost } from "../../packages/host-runtime/dist/index.js";
+import { MappingStore } from "../../packages/mapping-store/dist/index.js";
+import { encodeClaudeTransportModel } from "../../packages/protocol-core/dist/index.js";
+
+const command = process.env.CODEXHOST_CLAUDE_REAL_COMMAND;
+const live = process.env.CODEXHOST_CLAUDE_REAL_LIVE === "1";
+const desktopAsset = process.env.CODEXHOST_CLAUDE_REAL_DESKTOP_ASSET;
+
+class Official extends EventEmitter {
+  stdin = new PassThrough();
+  stdout = new PassThrough();
+  stderr = new PassThrough();
+  constructor() {
+    super();
+    this.stdin.on("finish", () => {
+      this.stdout.end();
+      this.emit("exit", 0, null);
+    });
+  }
+  kill() {
+    return true;
+  }
+}
+async function waitFor(predicate, label) {
+  const deadline = Date.now() + 60000;
+  while (Date.now() < deadline) {
+    const result = await predicate();
+    if (result) return result;
+    await new Promise((resolve) => setTimeout(resolve, 15));
+  }
+  throw new Error(`Timed out: ${label}`);
+}
+function startHost({ root, environment }) {
+  const input = new PassThrough(),
+    output = new PassThrough();
+  const adapter = new ClaudeCodeAdapter({ command, environment, startupTimeoutMs: 30000 });
+  const openSession = adapter.open.bind(adapter);
+  adapter.open = async (input) => {
+    const result = await openSession(input);
+
+    if (result.ok) {
+      const close = result.value.close.bind(result.value);
+      result.value.close = async () => {
+        try {
+          await close();
+        } catch (error) {
+          console.error(
+            JSON.stringify(error, (_key, value) =>
+              value instanceof Error
+                ? { message: value.message, errors: value.errors, code: value.code }
+                : value,
+            ),
+          );
+          throw error;
+        }
+      };
+    }
+    return result;
+  };
+  const store = new MappingStore({ directory: path.join(root, "mapping") });
+  const host = new AppServerHost({
+    stockCodexPath: "/synthetic/codex",
+    arguments: ["app-server"],
+    defaultAgent: "codex",
+    environment,
+    desktopInput: input,
+    desktopOutput: output,
+    diagnosticOutput: new PassThrough(),
+    mappingStore: store,
+    externalAdapters: new Map([["claude-code", adapter]]),
+    spawnOfficial: () => new Official(),
+  });
+  const responses = new Map(),
+    notifications = [];
+  let buffer = "",
+    id = 0;
+  output.setEncoding("utf8");
+  output.on("data", (chunk) => {
+    buffer += chunk;
+    while (buffer.includes("\n")) {
+      const end = buffer.indexOf("\n"),
+        message = JSON.parse(buffer.slice(0, end));
+      buffer = buffer.slice(end + 1);
+      if (message.id !== undefined) responses.set(message.id, message);
+      else notifications.push(message);
+    }
+  });
+  const running = host.run();
+  return {
+    store,
+    notifications,
+    async rpc(method, params) {
+      const requestId = ++id;
+      input.write(JSON.stringify({ id: requestId, method, params }) + "\n");
+      const response = await Promise.race([
+        waitFor(() => responses.get(requestId), method),
+        running.then((code) => {
+          throw new Error(`Host exited before ${method}: ${code}`);
+        }),
+      ]);
+      if (response.error) throw new Error(`${method}: ${response.error.message}`);
+      return response.result;
+    },
+    async close() {
+      input.end();
+      await running;
+      await adapter.close();
+    },
+  };
+}
+
+// Uses a real native CLI and real SDK history, with only the model response controlled locally.
+// LIVE=1 uses the authenticated native CLI and its configured model. Each scenario sends short prompts; interruption
+// scenarios cancel the long-response prompt immediately after its first text delta. Tool tests stay local.
+describe.runIf(Boolean(command))("Claude message editing through Host", () => {
+  const scenarios = [
+    "completed",
+    "first interrupted",
+    "second interrupted",
+    "retained interruption",
+    "first interrupted after restart",
+    ...(!live ? ["first interrupted before output", "first interrupted during tool"] : []),
+  ];
+  it.each(scenarios)("edits and resumes: %s", runScenario, 240000);
+  async function runScenario(scenario) {
+    const root = await realpath(await mkdtemp(path.join(os.tmpdir(), "claude-host-rollback-")));
+    const cwd = path.join(root, "workspace");
+    await mkdir(cwd);
+    const config = live
+      ? process.env.CLAUDE_CONFIG_DIR || path.join(os.homedir(), ".claude")
+      : path.join(root, "config");
+    if (!live) await mkdir(config);
+    vi.stubEnv("CLAUDE_CONFIG_DIR", config);
+    const requests = [];
+    const server = http.createServer(async (req, res) => {
+      let data = "";
+      for await (const chunk of req) data += chunk;
+      const body = JSON.parse(data || "{}");
+      if (req.url.includes("/count_tokens")) {
+        res.end('{"input_tokens":10}');
+        return;
+      }
+      if (!req.url.includes("/messages")) {
+        res.writeHead(404);
+        res.end("{}");
+        return;
+      }
+      requests.push(body.messages);
+      if (
+        scenario === "first interrupted before output" &&
+        JSON.stringify(body.messages?.at(-1)?.content).includes("CANCEL_PENDING")
+      )
+        return;
+      const text = "EDIT_OK";
+      const tool =
+        scenario === "first interrupted during tool" &&
+        JSON.stringify(body.messages?.at(-1)?.content).includes("CANCEL_PENDING");
+      const block = tool
+        ? {
+            type: "tool_use",
+            id: "pause-tool",
+            name: "Bash",
+            input: {
+              command: `touch ${cwd}/started; sleep 30`,
+              description: "Disposable pause regression",
+            },
+          }
+        : { type: "text", text };
+      const message = {
+        id: "msg_" + randomUUID(),
+        type: "message",
+        role: "assistant",
+        model: body.model,
+        content: [block],
+        stop_reason: tool ? "tool_use" : "end_turn",
+        stop_sequence: null,
+        usage: { input_tokens: 10, output_tokens: 5 },
+      };
+      res.writeHead(200, {
+        "content-type": body.stream ? "text/event-stream" : "application/json",
+      });
+      if (!body.stream) {
+        res.end(JSON.stringify(message));
+        return;
+      }
+      for (const value of [
+        { type: "message_start", message: { ...message, content: [], stop_reason: null } },
+        {
+          type: "content_block_start",
+          index: 0,
+          content_block: tool ? { ...block, input: {} } : { type: "text", text: "" },
+        },
+        {
+          type: "content_block_delta",
+          index: 0,
+          delta: tool
+            ? { type: "input_json_delta", partial_json: JSON.stringify(block.input) }
+            : { type: "text_delta", text },
+        },
+        { type: "content_block_stop", index: 0 },
+        {
+          type: "message_delta",
+          delta: { stop_reason: message.stop_reason, stop_sequence: null },
+          usage: { output_tokens: 5 },
+        },
+        { type: "message_stop" },
+      ]) {
+        res.write(`event: ${value.type}\ndata: ${JSON.stringify(value)}\n\n`);
+        if (
+          value.type === "content_block_delta" &&
+          !tool &&
+          JSON.stringify(body.messages?.at(-1)?.content).includes("CANCEL_PENDING")
+        )
+          return;
+      }
+      res.end();
+    });
+    await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+    const environment = {
+      ...process.env,
+      CLAUDE_CONFIG_DIR: config,
+      CODEXHOST_DATA_DIR: path.join(root, "host-data"),
+      CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC: "1",
+    };
+    for (const key of Object.keys(environment))
+      if (
+        key.startsWith("ANTHROPIC_") ||
+        key.startsWith("CLAUDE_CODE_USE_") ||
+        key === "AWS_BEARER_TOKEN_BEDROCK"
+      )
+        delete environment[key];
+    if (!live)
+      Object.assign(environment, {
+        ANTHROPIC_API_KEY: "local-test",
+        ANTHROPIC_BASE_URL: `http://127.0.0.1:${server.address().port}`,
+      });
+    let host = startHost({ root, environment });
+    const nativeIds = new Set();
+    let threadId;
+    const mapping = async () => {
+      const result = await host.store.getThread(threadId);
+      assert.ok(result);
+      nativeIds.add(result.nativeSessionRef.nativeSessionId);
+      return result;
+    };
+    const complete = async (turnId) => {
+      const event = await waitFor(
+        () =>
+          host.notifications.find(
+            (m) => m.method === "turn/completed" && m.params.turn.id === turnId,
+          ),
+        "turn completion",
+      );
+      assert.equal(event.params.turn.status, "completed", JSON.stringify(event.params.turn));
+      return turnId;
+    };
+    const send = async (label, interrupt = false) => {
+      const requestCount = requests.length;
+      const turnId = (
+        await host.rpc("turn/start", {
+          threadId,
+          input: [
+            {
+              type: "text",
+              text: interrupt
+                ? `CANCEL_PENDING ${label}: Write a numbered list of 1000 simple English sentences. Do not use tools.`
+                : `Reply with exactly ${label}. Do not use tools.`,
+            },
+          ],
+        })
+      ).turn.id;
+      if (!interrupt) return complete(turnId);
+      if (scenario === "first interrupted during tool") {
+        await waitFor(
+          () =>
+            readFile(path.join(cwd, "started")).then(
+              () => true,
+              () => false,
+            ),
+          "native tool started",
+        );
+      } else if (scenario === "first interrupted before output") {
+        await waitFor(() => requests.length > requestCount, "model request before any output");
+      } else {
+        await waitFor(
+          () =>
+            host.notifications.some(
+              (m) => m.method === "item/agentMessage/delta" && m.params.turnId === turnId,
+            ),
+          "streaming before manual stop",
+        );
+      }
+      await host.rpc("turn/interrupt", { threadId, turnId });
+      const terminal = await waitFor(
+        () =>
+          host.notifications.find(
+            (m) => m.method === "turn/completed" && m.params.turn.id === turnId,
+          ),
+        "manual stop terminal",
+      );
+      assert.equal(terminal.params.turn.status, "interrupted");
+      return turnId;
+    };
+    const revert = async (turnId) => host.rpc("thread/revert", { threadId, beforeTurnId: turnId });
+    const restart = async () => {
+      await host.close();
+      host = startHost({ root, environment });
+      await host.rpc("thread/resume", { threadId });
+    };
+    const history = async (id) => getSessionMessages(id, { dir: cwd });
+    try {
+      const model = encodeClaudeModelRef(live ? "default" : "claude-sonnet-4-6");
+      threadId = (
+        await host.rpc("thread/start", {
+          cwd,
+          model: encodeClaudeTransportModel(
+            model,
+            scenario === "first interrupted during tool" ? "bypassPermissions" : "default",
+            "off",
+          ),
+          historyMode: "paginated",
+        })
+      ).thread.id;
+      let first = await send(
+        "FIRST_KEPT",
+        scenario.startsWith("first interrupted") || scenario === "retained interruption",
+      );
+      if (scenario.startsWith("first interrupted")) {
+        await mapping();
+        if (scenario === "first interrupted after restart") {
+          // Simulate the extra mapping persisted by the old reader, then let cold recovery repair it.
+          const previous = await mapping();
+          const native = await waitFor(async () => {
+            const h = await history(previous.nativeSessionRef.nativeSessionId);
+            return JSON.stringify(h).includes("[Request interrupted by user]") ? h : null;
+          }, "persisted interruption");
+          const marker = native.findLast((m) => m.type === "user");
+          await host.store.reconcileTurnMappings(threadId, [
+            ...previous.turnMappings,
+            {
+              hostTurnId: randomUUID(),
+              nativeTurnRef: {
+                harnessId: "claude-code",
+                nativeSessionId: previous.nativeSessionRef.nativeSessionId,
+                nativeTurnKey: marker.uuid,
+                formatVersion: 1,
+              },
+            },
+          ]);
+          await restart();
+          assert.equal((await mapping()).turnMappings.length, 1);
+        }
+        await revert(first);
+        assert.equal((await mapping()).turnMappings.length, 0);
+        first = await send("FIRST_KEPT");
+      }
+      const second = await send("SECOND_REMOVED", scenario === "second interrupted");
+      const original = (await mapping()).nativeSessionRef.nativeSessionId;
+      await revert(second);
+      const before = await history(original);
+      assert.equal(
+        before.filter((m) => m.type === "user").length,
+        scenario === "second interrupted" || scenario === "retained interruption" ? 3 : 2,
+      );
+      if (scenario === "retained interruption") {
+        const kept = await history((await mapping()).nativeSessionRef.nativeSessionId);
+        assert.ok(JSON.stringify(kept).includes("[Request interrupted by user]"));
+      }
+      assert.equal((await mapping()).turnMappings.length, 1);
+      assert.notEqual((await mapping()).nativeSessionRef.nativeSessionId, original);
+      const edited = await send("EDITED_SECOND");
+      assert.equal((await mapping()).turnMappings.length, 2);
+      assert.deepEqual(await history(original), before);
+      if (!live) assert.ok(!JSON.stringify(requests.at(-1)).includes("SECOND_REMOVED"));
+      await revert(edited);
+      await revert(first);
+      const pending = (await mapping()).nativeSessionRef;
+      assert.deepEqual(pending.locator, { pendingSession: 1 });
+      assert.equal((await mapping()).turnMappings.length, 0);
+      await restart();
+      assert.deepEqual((await mapping()).nativeSessionRef, pending);
+      assert.equal((await mapping()).turnMappings.length, 0);
+      await send("EDITED_FIRST");
+      assert.equal((await mapping()).nativeSessionRef.nativeSessionId, pending.nativeSessionId);
+      if (!live) assert.ok(!JSON.stringify(requests.at(-1)).includes("FIRST_KEPT"));
+      await restart();
+      assert.equal(
+        (await history(pending.nativeSessionId)).filter((m) => m.type === "user").length,
+        1,
+      );
+      assert.equal((await mapping()).turnMappings.length, 1);
+      await send("AFTER_EDITED_FIRST");
+      assert.equal((await mapping()).turnMappings.length, 2);
+      if (desktopAsset) {
+        // Use the installed Desktop's actual edit implementation, without manually constructing its resend.
+        const desktop = await readFile(desktopAsset, "utf8");
+        const begin = desktop.indexOf("async function lcn("),
+          end = desktop.indexOf("var ucn=", begin);
+        assert.ok(begin >= 0 && end > begin);
+        const edit = vm.runInNewContext("(" + desktop.slice(begin, end) + ")", {
+          TS: (state, id) => state.turns.find((t) => t.turnId === id),
+          wS: (state) => state.turns,
+          C8t: (_old, text) => text,
+          Ig: () => true,
+          scn: () => {
+            throw new Error("Unexpected legacy history");
+          },
+        });
+        const state = {
+          cwd,
+          historyMode: "paginated",
+          turns: (await mapping()).turnMappings.map((m) => ({
+            turnId: m.hostTurnId,
+            status: "completed",
+            params: { input: [{ type: "text", text: "original" }] },
+            items: [],
+          })),
+        };
+        const manager = {
+          getConversation: () => state,
+          updateConversationState: (_id, update) => update(state),
+          getStreamRole: () => ({ role: "owner" }),
+          sendThreadFollowerRequest: async () => false,
+          waitForPendingThreadSettingsUpdate: async () => {},
+          requestClient: { getAppServerVersion: () => "0.0.0" },
+          sendRequest: host.rpc,
+          applyRevertResponseToConversation: ({ revertedTurns }) => {
+            state.turns = state.turns.filter((t) => !revertedTurns.includes(t));
+          },
+        };
+        let resent;
+        await edit({
+          manager,
+          conversationId: threadId,
+          options: {
+            turnId: state.turns.at(-1).turnId,
+            message: "Reply with exactly DESKTOP_EDIT. Do not use tools.",
+            shouldSendPermissionOverrides: false,
+          },
+          startTurn: async (params) => {
+            assert.ok(params.input[0].text.includes("DESKTOP_EDIT"));
+            resent = (await host.rpc("turn/start", params)).turn.id;
+          },
+          turnMergePolicy: undefined,
+          ownerWindowError: "Not owner",
+        });
+        await complete(resent);
+        assert.equal((await mapping()).turnMappings.length, 2);
+      }
+      // Only delete this test's native transcript. A committed Session must not recover as empty.
+      await host.close();
+      host = null;
+      await rm(
+        path.join(
+          config,
+          "projects",
+          cwd.replace(/[^a-zA-Z0-9]/g, "-"),
+          pending.nativeSessionId + ".jsonl",
+        ),
+      );
+      // The Desktop optional edit may have replaced the pending identity; test its recovery directly.
+      const adapter = new ClaudeCodeAdapter({ command, environment });
+      try {
+        const opened = await adapter.open({ kind: "resume", cwd, nativeRef: pending });
+        if (opened.ok) assert.equal((await opened.value.readSnapshot()).ok, false);
+      } finally {
+        await adapter.close();
+      }
+      console.log(
+        JSON.stringify({
+          realClaudeHostRollback: true,
+          liveCompany: live,
+          actualDesktopEditFunction: Boolean(desktopAsset),
+          root,
+        }),
+      );
+    } finally {
+      await host?.close();
+      server.closeAllConnections();
+      await new Promise((resolve) => server.close(resolve));
+      // All native files belong to the disposable test cwd, even in authenticated wrapper mode.
+      await rm(path.join(config, "projects", cwd.replace(/[^a-zA-Z0-9]/g, "-")), {
+        force: true,
+        recursive: true,
+      });
+      for (const id of nativeIds)
+        await rm(path.join(config, "codexhost", "pending-sessions", id), {
+          force: true,
+          recursive: true,
+        });
+      await rm(root, { force: true, recursive: true });
+      vi.unstubAllEnvs();
+    }
+  }
+});


### PR DESCRIPTION
编辑首轮消息后尚未重发便退出时，派生 Session 可能没有原生历史文件，导致重启无法恢复；暂停记录和延迟落盘也可能使可编辑历史判断错误。本 PR 从 #158 的改进方向独立整理，保留上游现有 rollback 能力。

- 按 promptId、来源与原生记录结构识别暂停，等待已观察到的完成记录落盘，超时返回可重试错误。
- 持久化空历史编辑的恢复信息，冷恢复保留 Model、Thinking 与权限配置；失败路径清理候选 Session。
- 明确 SDK 进程关闭与输出读取的归属，关闭未确认时保留重试路径，避免过早替换历史。
- 为 Resume/Rollback 增加最小可选配置提示及 Broker 校验；既有调用方无需提供，也不新增强制 replacementFence。

包含实现、回归测试、OpenSpec 与使用说明。独立基于 e8f8ecd，不依赖其他拆分 PR。

验证：`npm run typecheck` 通过；Claude Code Adapter 与 Harness Broker 的 14 个测试文件、258 个用例通过，真实 CLI 测试 1 个文件、3 个用例因未启用环境而跳过；变更文件 ESLint、Prettier、`git diff --check` 通过。真实 CLI Gate 已提供，未把未执行的原生平台验证视为通过。