### PR TITLE
fix: 在 DSH 关闭与故障路径中确认原生执行停止

### DIFF
--- a/docs/dsh-edit-recovery.md
+++ b/docs/dsh-edit-recovery.md
@@ -1,0 +1,7 @@
+# DSH Modern 原生停止确认
+
+活动 Session 关闭先请求取消，再等待对应原生 turn/end。未关联请求不能被另一个自主 Turn 的终态遮蔽；故障先于关闭时，本地清理不能证明原生停止；关闭期间晚到的接受回执仍获得终态。无法确认停止时明确拒绝 close，保留上游 Modern rollback 支持和 Legacy 声明。
+
+提供基于本地 SSE 模型、隔离临时数据和真实 CLI 的生命周期 Gate：`tools/gate-dsh/lifecycle.real.test.mjs`。通过对应的 `CODEXHOST_DSH_REAL_COMMAND` 指定原生命令，缺少命令时明确跳过。
+
+Gate 覆盖流式输出、取消、空/保留历史编辑、冷恢复、默认配置保持、源历史不变和活动关闭。不把默认配置验证推广为任意非默认配置，也不证明 Windows、独立第三方客户端或任意后台工具进程的退出。

--- a/packages/adapters/deepseek-harness/src/modern/session.ts
+++ b/packages/adapters/deepseek-harness/src/modern/session.ts
@@ -110,6 +110,8 @@ import {
 } from "./wire.js";
 
 const DEEPSEEK_HARNESS_ID = harnessIdSchema.parse("deepseek-harness");
+const NATIVE_CLOSE_TIMEOUT_MS = 5_000;
+
 export const MODERN_PROMPT_CORRELATION_GRACE_MS = 5_000;
 export const MODERN_ACCEPTED_CORRELATION_TIMEOUT_MS = 300_000;
 const MAX_TIMER_DELAY_MS = 2_147_483_647;
@@ -312,8 +314,11 @@ export class ModernHarnessSession implements HarnessSession, ModernEventSink {
   #usage: HostUsage | null;
   #historyBytes: number;
   #closed = false;
+  #closing = false;
+  #nativeCloseTerminal: (() => void) | undefined;
   #closedNotified = false;
   #faulted?: HarnessError;
+  #faultMayHaveNativeWork = false;
   #closePromise?: Promise<void>;
   readonly #pumpPromise: Promise<void>;
 
@@ -433,7 +438,7 @@ export class ModernHarnessSession implements HarnessSession, ModernEventSink {
     this.#pumpPromise = this.#pump();
     if (resumedAutonomousBuffer) {
       queueMicrotask(() => {
-        if (!this.#closed && this.#buffer === resumedAutonomousBuffer) {
+        if (!this.#closed && !this.#closing && this.#buffer === resumedAutonomousBuffer) {
           this.#activateBufferedAutonomous(true);
         }
       });
@@ -441,7 +446,7 @@ export class ModernHarnessSession implements HarnessSession, ModernEventSink {
   }
 
   readSnapshot(): Promise<HarnessResult<HostThreadSnapshot>> {
-    if (this.#closed) return Promise.resolve({ ok: false, error: closedError() });
+    if (this.#closed || this.#closing) return Promise.resolve({ ok: false, error: closedError() });
     if (this.#reading) return Promise.resolve({ ok: false, error: busyError("read history") });
     this.#reading = true;
     try {
@@ -484,7 +489,7 @@ export class ModernHarnessSession implements HarnessSession, ModernEventSink {
       | PermissionModeSelectCompleted
     >
   > {
-    if (this.#closed) return Promise.resolve({ ok: false, error: closedError() });
+    if (this.#closed || this.#closing) return Promise.resolve({ ok: false, error: closedError() });
     switch (command.type) {
       case "turn.start":
         return this.#start(command);
@@ -502,6 +507,16 @@ export class ModernHarnessSession implements HarnessSession, ModernEventSink {
   }
 
   close(): Promise<void> {
+    const faultCleanup = this.#closePromise;
+    if (this.#faultMayHaveNativeWork && !this.#closing && faultCleanup) {
+      this.#closing = true;
+      // Fault cleanup retires local projection, but cannot certify native execution stopped.
+      this.#closePromise = faultCleanup.then(() => {
+        throw new Error(
+          "DeepSeek Harness native execution stop was not confirmed before the Session fault",
+        );
+      });
+    }
     this.#closePromise ??= this.#performClose();
     return this.#closePromise;
   }
@@ -527,7 +542,7 @@ export class ModernHarnessSession implements HarnessSession, ModernEventSink {
         "DeepSeek Harness event delivery was duplicated",
       );
     }
-    if (this.#closed) {
+    if (this.#closed || this.#closing) {
       this.#queuedDeliveries.set(delivery.eventId, delivery);
       return;
     }
@@ -860,12 +875,12 @@ export class ModernHarnessSession implements HarnessSession, ModernEventSink {
     this.#operationControllers.add(abort);
     try {
       const result = await operation(abort.signal);
-      if (this.#closed) return { ok: false, error: closedError() };
+      if (this.#closed || this.#closing) return { ok: false, error: closedError() };
       this.#publishConfiguration(true);
       return { ok: true, value: result.value };
     } catch (error) {
       if (this.#faulted) return { ok: false, error: this.#faulted };
-      if (this.#closed) return { ok: false, error: closedError() };
+      if (this.#closed || this.#closing) return { ok: false, error: closedError() };
       const failure = configurationOrProtocolError(error, "DeepSeek Harness configuration failed");
       if (configurationFailureRequiresSessionFault(error)) this.#fault(failure);
       return { ok: false, error: failure };
@@ -999,7 +1014,7 @@ export class ModernHarnessSession implements HarnessSession, ModernEventSink {
       return this.#acceptPrompt(pending);
     } catch (error) {
       if (this.#faulted) return { ok: false, error: this.#faulted };
-      if (this.#closed) return { ok: false, error: closedError() };
+      if (this.#closed || this.#closing) return { ok: false, error: closedError() };
       if (pending.admissionObserved) return this.#acceptPrompt(pending);
 
       // The Modern protocol has no requestId idempotency guarantee. Do not resend an uncertain prompt:
@@ -1014,7 +1029,7 @@ export class ModernHarnessSession implements HarnessSession, ModernEventSink {
       );
       if (resolution.kind === "accepted") {
         if (this.#faulted) return { ok: false, error: this.#faulted };
-        if (this.#closed) return { ok: false, error: closedError() };
+        if (this.#closed || this.#closing) return { ok: false, error: closedError() };
         return this.#acceptPrompt(pending);
       }
       if (resolution.kind === "closed") return { ok: false, error: closedError() };
@@ -1091,14 +1106,14 @@ export class ModernHarnessSession implements HarnessSession, ModernEventSink {
   async #listHarnessCommands(): Promise<
     HarnessResult<ReturnType<typeof deepSeekHarnessCommandCatalog>>
   > {
-    if (this.#closed) return { ok: false, error: closedError() };
+    if (this.#closed || this.#closing) return { ok: false, error: closedError() };
     return { ok: true, value: deepSeekHarnessCommandCatalog() };
   }
 
   async #executeHarnessCommand(
     command: HarnessCommandInvocation,
   ): Promise<HarnessResult<HarnessCommandAccepted>> {
-    if (this.#closed) return { ok: false, error: closedError() };
+    if (this.#closed || this.#closing) return { ok: false, error: closedError() };
     const parsed = parseDeepSeekHarnessCommand(command);
     if (!parsed.ok) return parsed;
     if (this.#hasCommandConflict() || this.#acceptedTurnIds.has(command.turnId)) {
@@ -1116,7 +1131,7 @@ export class ModernHarnessSession implements HarnessSession, ModernEventSink {
     try {
       const catalog = await this.#listHarnessCommands();
       if (!catalog.ok) return catalog;
-      if (this.#closed) return { ok: false, error: closedError() };
+      if (this.#closed || this.#closing) return { ok: false, error: closedError() };
       if (admission.cancellationRequested) {
         return { ok: false, error: invalidState("DeepSeek Harness command was cancelled") };
       }
@@ -1556,7 +1571,14 @@ export class ModernHarnessSession implements HarnessSession, ModernEventSink {
 
   #scheduleBoundTurn(pending: PendingPrompt): void {
     const buffer = pending.buffer;
-    if (!buffer || !pending.admitted || pending.publishScheduled || buffer.active || this.#closed) {
+    if (
+      !buffer ||
+      !pending.admitted ||
+      pending.publishScheduled ||
+      buffer.active ||
+      this.#closed ||
+      this.#closing
+    ) {
       return;
     }
     pending.publishScheduled = true;
@@ -1567,6 +1589,7 @@ export class ModernHarnessSession implements HarnessSession, ModernEventSink {
         pending.publishScheduled = false;
         if (
           !this.#closed &&
+          !this.#closing &&
           pending.admitted &&
           pending.buffer === buffer &&
           this.#buffer === buffer &&
@@ -1589,7 +1612,13 @@ export class ModernHarnessSession implements HarnessSession, ModernEventSink {
       delete pending.buffer;
       if (buffer.reachedCorrelationBoundary || buffer.events.at(-1)?.type === "turn/end") {
         queueMicrotask(() => {
-          if (!this.#closed && this.#buffer === buffer && !buffer.active && !buffer.pending) {
+          if (
+            !this.#closed &&
+            !this.#closing &&
+            this.#buffer === buffer &&
+            !buffer.active &&
+            !buffer.pending
+          ) {
             this.#materializeAutonomous(buffer, false);
           }
         });
@@ -1615,6 +1644,7 @@ export class ModernHarnessSession implements HarnessSession, ModernEventSink {
     const buffer = this.#buffer;
     if (
       this.#closed ||
+      this.#closing ||
       !buffer ||
       buffer.active ||
       buffer.pending ||
@@ -1629,6 +1659,7 @@ export class ModernHarnessSession implements HarnessSession, ModernEventSink {
   }
 
   #materializeAutonomous(buffer: NativeTurnBuffer, initialReplay: boolean): void {
+    if (this.#closed || this.#closing) return;
     const turnId = hostTurnIdSchema.parse(this.#randomUUID());
     this.#emit({
       type: "turn.autonomous.started",
@@ -1886,6 +1917,7 @@ export class ModernHarnessSession implements HarnessSession, ModernEventSink {
     this.#completeOpenItems(active, itemOutcome);
     active.terminal = true;
     if (buffer.pending) buffer.pending.terminal = true;
+    this.#nativeCloseTerminal?.();
     const checkpoint = modernCheckpointRef(this.harnessId, this.#sessionId, seq);
     this.#emit({
       type: "turn.completed",
@@ -1950,6 +1982,13 @@ export class ModernHarnessSession implements HarnessSession, ModernEventSink {
     if (this.#closed) return;
     const failure = sanitizedHarnessError(error);
     const acceptedPending = this.#acceptedPending();
+    this.#faultMayHaveNativeWork = Boolean(
+      (this.#active && !this.#active.terminal) ||
+      this.#pendingByRequestId.size > 0 ||
+      this.#buffer ||
+      this.#commandAdmission ||
+      this.#activeCommand,
+    );
     this.#faulted = failure;
     this.#closed = true;
     this.#journalLifetime.abort(new Error("DeepSeek Harness Session faulted"));
@@ -2028,6 +2067,60 @@ export class ModernHarnessSession implements HarnessSession, ModernEventSink {
   }
 
   async #performClose(): Promise<void> {
+    this.#closing = true;
+    let stopFailure: unknown;
+    const activeAtClose = this.#active;
+    const pendingAtClose = new Set(this.#pendingByRequestId.values());
+    if (this.#buffer?.pending) pendingAtClose.add(this.#buffer.pending);
+    const correlatedPending =
+      activeAtClose && this.#buffer?.active === activeAtClose ? this.#buffer.pending : undefined;
+    const uncorrelatedExecution =
+      [...pendingAtClose].some((pending) => !pending.terminal && pending !== correlatedPending) ||
+      (!activeAtClose && this.#buffer !== undefined) ||
+      this.#commandAdmission !== undefined ||
+      this.#activeCommand !== undefined;
+    if (!this.#closed && ((activeAtClose && !activeAtClose.terminal) || uncorrelatedExecution)) {
+      let timer: ReturnType<typeof setTimeout> | undefined;
+      const terminal = new Promise<void>((resolve) => {
+        this.#nativeCloseTerminal = () => {
+          if (activeAtClose?.terminal) resolve();
+        };
+      });
+      try {
+        await Promise.race([
+          (async () => {
+            const result = await (activeAtClose?.cancelPromise ??
+              this.#requestNativeCancel(activeAtClose));
+            if (!result.ok) throw new Error(result.error.message);
+            if (uncorrelatedExecution) {
+              throw new Error(
+                "DeepSeek Harness cannot confirm stop before the native Turn is correlated",
+              );
+            }
+            // A cancel receipt only confirms admission. Keep consuming native history until
+            // turn/end establishes that execution stopped before detaching the Session.
+            await terminal;
+          })(),
+          new Promise<never>((_, reject) => {
+            timer = setTimeout(
+              () =>
+                reject(new Error("DeepSeek Harness did not confirm native Turn stop before close")),
+              NATIVE_CLOSE_TIMEOUT_MS,
+            );
+          }),
+        ]);
+      } catch (error) {
+        stopFailure = error;
+      } finally {
+        if (timer) clearTimeout(timer);
+        this.#nativeCloseTerminal = undefined;
+      }
+    }
+    if (this.#faulted) {
+      // A fault can close admission while this Promise already owns cleanup.
+      await this.#performFault(this.#faulted, this.#acceptedPending(pendingAtClose));
+      throw stopFailure ?? new Error(this.#faulted.message);
+    }
     if (!this.#closed) {
       const acceptedPending = this.#acceptedPending();
       this.#closed = true;
@@ -2082,6 +2175,7 @@ export class ModernHarnessSession implements HarnessSession, ModernEventSink {
     }
     await Promise.allSettled([this.#journal.close(), this.#pumpPromise]);
     this.#notifyClosed();
+    if (stopFailure) throw stopFailure;
   }
 
   #abortOperations(): void {
@@ -2096,8 +2190,7 @@ export class ModernHarnessSession implements HarnessSession, ModernEventSink {
     for (const unsubscribe of this.#removeControlSubscriptions.splice(0)) unsubscribe();
   }
 
-  #acceptedPending(): PendingPrompt[] {
-    const values = new Set(this.#pendingByRequestId.values());
+  #acceptedPending(values = new Set(this.#pendingByRequestId.values())): PendingPrompt[] {
     if (this.#buffer?.pending) values.add(this.#buffer.pending);
     return [...values].filter(
       (pending) =>

--- a/packages/adapters/deepseek-harness/test/modern/deepseek-harness-adapter.test.ts
+++ b/packages/adapters/deepseek-harness/test/modern/deepseek-harness-adapter.test.ts
@@ -19,11 +19,13 @@ class Feed implements AsyncIterable<unknown>, AsyncIterator<unknown> {
   #done = false;
   #returned = false;
   returnCalls = 0;
+  readonly seen: unknown[] = [];
 
   constructor(readonly onReturn: () => void = () => undefined) {}
 
   push(value: unknown): void {
     if (this.#done) return;
+    this.seen.push(value);
     this.#deliver({ done: false, value });
   }
 
@@ -213,6 +215,32 @@ class FakeConnection implements ModernConnectionLike {
     }
     if (endpoint === "session/cancel" && this.cancelResponse) {
       return this.cancelResponse as Promise<ModernRemoteResult<T>>;
+    }
+    if (endpoint === "session/cancel") {
+      const request = args.request as { sessionId: string };
+      const feed = this.follows.get(request.sessionId);
+      const entries = (feed?.seen ?? [])
+        .map(
+          (value) =>
+            (value as { event: { seq: number; type: string; data: Record<string, unknown> } })
+              .event,
+        )
+        .filter(Boolean);
+      const turn = entries.findLast((entry) => entry.type === "turn/start");
+      const ended = entries.findLast((entry) => entry.type === "turn/end");
+      if (feed && turn && (!ended || turn.seq > ended.seq)) {
+        let seq = (entries.at(-1)?.seq ?? 0) + 1;
+        const step = entries.findLast((entry) => entry.type === "step/start");
+        const stepEnd = entries.findLast((entry) => entry.type === "step/end");
+        if (step && (!stepEnd || step.seq > stepEnd.seq))
+          feed.push(liveEvent(seq++, "step/end", { turn: turn.data.turn, step: step.data.step }));
+        feed.push(
+          liveEvent(seq, "turn/end", {
+            turn: turn.data.turn,
+            reason: { kind: "aborted", reason: { kind: "user" } },
+          }),
+        );
+      }
     }
     if (endpoint === "session/prompt" || endpoint === "session/cancel") {
       return Promise.resolve({ ok: true, value: { accepted: true } } as ModernRemoteResult<T>);
@@ -762,7 +790,7 @@ describe("Modern DeepSeek Harness Adapter", () => {
     await adapter.close();
   });
 
-  it("sends next before Session close retires a pending interaction and Turn", async () => {
+  it("cancels native execution before Session close retires a pending interaction and Turn", async () => {
     const { adapter, connection } = setup(["created", "request-close", "interaction-close"]);
     const cwd = path.resolve("fixture-interaction-close");
     connection.expectedCwds.set("session-created", cwd);
@@ -812,7 +840,7 @@ describe("Modern DeepSeek Harness Adapter", () => {
       args: {
         clientId: "client-1",
         eventId: "approval-close",
-        outcome: { kind: "next" },
+        outcome: { kind: "result", value: "cancelled" },
       },
     });
     await expect(outputs.next()).resolves.toMatchObject({

--- a/packages/adapters/deepseek-harness/test/modern/session.test.ts
+++ b/packages/adapters/deepseek-harness/test/modern/session.test.ts
@@ -152,9 +152,11 @@ class EventFeed implements AsyncIterable<ModernJournalEvent>, AsyncIterator<Mode
   readonly #items: IteratorResult<ModernJournalEvent>[] = [];
   #pending: ((item: IteratorResult<ModernJournalEvent>) => void) | undefined;
   #done = false;
+  readonly seen: ModernJournalEvent[] = [];
 
   push(value: ModernJournalEvent): void {
     if (this.#done) return;
+    this.seen.push(value);
     this.#deliver({ done: false, value });
   }
 
@@ -205,6 +207,7 @@ class FakeRemote implements ModernJournalRemote {
     options: ModernRemoteCallOptions | undefined;
   }> = [];
   streamCalls = 0;
+  onUnscriptedCancel?: () => void;
 
   constructor(
     readonly handlers: CallHandler[],
@@ -219,6 +222,10 @@ class FakeRemote implements ModernJournalRemote {
   ): Promise<ModernRemoteResult<T>> {
     this.calls.push({ endpoint, args, signal, options });
     const handler = this.handlers.shift();
+    if (!handler && endpoint === "session/cancel" && this.onUnscriptedCancel) {
+      this.onUnscriptedCancel();
+      return Promise.resolve(accepted()) as Promise<ModernRemoteResult<T>>;
+    }
     if (!handler) return Promise.reject(new Error(`unexpected call: ${endpoint}`));
     return Promise.resolve(handler(endpoint, args, signal, options)) as Promise<
       ModernRemoteResult<T>
@@ -440,6 +447,23 @@ function setup(
       feed.finish();
       return Promise.resolve();
     },
+  };
+  // Native cancellation completes the journal before the transport detaches.
+  remote.onUnscriptedCancel = () => {
+    const entries = [...history, ...feed.seen];
+    let seq = (entries.at(-1)?.seq ?? -1) + 1;
+    const start = entries.findLast((entry) => entry.type === "turn/start");
+    const turn = (start?.data as { turn?: number } | undefined)?.turn;
+    const step = entries.findLast((entry) => entry.type === "step/start");
+    const stepEnd = entries.findLast((entry) => entry.type === "step/end");
+    const turnEnd = entries.findLast((entry) => entry.type === "turn/end");
+    if (turn !== undefined && start && (!turnEnd || start.seq > turnEnd.seq)) {
+      if (step && (!stepEnd || step.seq > stepEnd.seq))
+        feed.push(event(seq++, "step/end", { turn, step: (step.data as { step: number }).step }));
+      feed.push(
+        event(seq, "turn/end", { turn, reason: { kind: "aborted", reason: { kind: "user" } } }),
+      );
+    }
   };
   let uuidIndex = 0;
   const session = new ModernHarnessSession({
@@ -922,7 +946,9 @@ describe("DeepSeek Harness Modern Session", () => {
           (item.type === "item.completed" && item.snapshot.item.type === "reasoning"),
       ),
     ).toBe(false);
-    await test.session.close();
+    await expect(test.session.close()).rejects.toThrow(
+      "native execution stop was not confirmed before the Session fault",
+    );
   });
 
   it("ignores live surface replacement copies for correlation and visible output", async () => {
@@ -1273,7 +1299,9 @@ describe("DeepSeek Harness Modern Session", () => {
       ok: true,
       value: { turns: [{ input: [{ type: "text", text: "visible history" }] }] },
     });
-    await test.session.close();
+    await expect(test.session.close()).rejects.toThrow(
+      "cannot confirm stop before the native Turn is correlated",
+    );
     await expect(outputs.next()).resolves.toEqual({ done: true, value: undefined });
   });
 
@@ -1488,7 +1516,9 @@ describe("DeepSeek Harness Modern Session", () => {
     ).resolves.toMatchObject({ ok: true });
     expect(vi.getTimerCount()).toBe(1);
 
-    await test.session.close();
+    await expect(test.session.close()).rejects.toThrow(
+      "cannot confirm stop before the native Turn is correlated",
+    );
     expect(vi.getTimerCount()).toBe(0);
     expect(await nextEvent(outputs)).toMatchObject({
       type: "turn.completed",
@@ -1550,9 +1580,14 @@ describe("DeepSeek Harness Modern Session", () => {
       input: [{ type: "text", text: "close" }],
     });
     await waitForGraceTimer();
-    await test.session.close();
+    await expect(test.session.close()).rejects.toThrow(
+      "cannot confirm stop before the native Turn is correlated",
+    );
     await expect(execution).resolves.toMatchObject({ ok: false, error: { code: "invalidState" } });
-    expect(test.remote.calls).toHaveLength(1);
+    expect(test.remote.calls.map(({ endpoint }) => endpoint)).toEqual([
+      "session/prompt",
+      "session/cancel",
+    ]);
     expect(vi.getTimerCount()).toBe(0);
     await expect(outputs.next()).resolves.toEqual({ done: true, value: undefined });
   });
@@ -1715,7 +1750,9 @@ describe("DeepSeek Harness Modern Session", () => {
       turnId: turnId("host-turn-1"),
       input: [{ type: "text", text: "queued" }],
     });
-    await test.session.close();
+    await expect(test.session.close()).rejects.toThrow(
+      "cannot confirm stop before the native Turn is correlated",
+    );
     expect(await nextEvent(outputs)).toMatchObject({
       type: "turn.completed",
       turnId: "host-turn-1",
@@ -1737,7 +1774,9 @@ describe("DeepSeek Harness Modern Session", () => {
     test.feed.push(event(1, "step/start", { turn: 1, step: 1 }));
     test.feed.push(userMessage(2, "mine", "request-1"));
     await new Promise<void>((resolve) => setImmediate(resolve));
-    await test.session.close();
+    await expect(test.session.close()).rejects.toThrow(
+      "cannot confirm stop before the native Turn is correlated",
+    );
     await expect(execution).resolves.toMatchObject({ ok: false, error: { code: "invalidState" } });
     expect(await nextEvent(outputs)).toMatchObject({
       type: "turn.completed",
@@ -1763,6 +1802,161 @@ describe("DeepSeek Harness Modern Session", () => {
       turnId: "host-turn-1",
       outcome: { status: "failed" },
     });
+  });
+
+  it("rejects uncorrelated accepted closure instead of claiming native stop", async () => {
+    const test = setup([() => accepted()]);
+    await test.session.execute({
+      type: "turn.start",
+      turnId: turnId("uncorrelated-close"),
+      input: [{ type: "text", text: "go" }],
+    });
+    await expect(test.session.close()).rejects.toThrow(
+      "cannot confirm stop before the native Turn is correlated",
+    );
+    expect(test.remote.calls.filter(({ endpoint }) => endpoint === "session/cancel")).toHaveLength(
+      1,
+    );
+  });
+
+  it("ends outputs when a native cancel fault races close", async () => {
+    const test = setup([() => ({ ok: true, value: { accepted: false } })]);
+    const outputs = test.session.outputs[Symbol.asyncIterator]();
+    beginAutonomousTurn(test);
+    await nextEvent(outputs);
+    await expect(test.session.close()).rejects.toThrow("invalid receipt");
+    const remaining: HarnessOutput[] = [];
+    for (;;) {
+      const next = await outputs.next();
+      if (next.done) break;
+      remaining.push(next.value);
+    }
+    expect(remaining).toContainEqual(
+      expect.objectContaining({
+        kind: "event",
+        event: expect.objectContaining({ type: "session.faulted" }),
+      }),
+    );
+    expect(test.journal.closeCalls).toBe(1);
+  });
+
+  it("rejects stop confirmation when an active Session faults before close", async () => {
+    const test = setup([() => accepted()], [], ["request-1"]);
+    const outputs = test.session.outputs[Symbol.asyncIterator]();
+    await test.session.execute({
+      type: "turn.start",
+      turnId: turnId("fault-first"),
+      input: [{ type: "text", text: "mine" }],
+    });
+    test.feed.push(event(0, "turn/start", { turn: 1 }));
+    test.feed.push(event(1, "step/start", { turn: 1, step: 1 }));
+    test.feed.push(userMessage(2, "mine", "request-1"));
+    await nextEvent(outputs);
+    test.session.fault({ code: "protocolError", message: "broken journal", retryable: false });
+    await eventsThrough(outputs, "session.faulted");
+    await expect(test.session.close()).rejects.toThrow(
+      "native execution stop was not confirmed before the Session fault",
+    );
+    await expect(test.session.close()).rejects.toThrow(
+      "native execution stop was not confirmed before the Session fault",
+    );
+    expect(test.feed.seen.some(({ type }) => type === "turn/end")).toBe(false);
+    await expect(outputs.next()).resolves.toEqual({ done: true, value: undefined });
+  });
+
+  it("does not let an autonomous terminal confirm an unrelated uncertain prompt stopped", async () => {
+    const test = setup(
+      [() => Promise.reject(new Error("lost receipt"))],
+      [],
+      ["request-1", "autonomous-1"],
+      50_000,
+    );
+    const outputs = test.session.outputs[Symbol.asyncIterator]();
+    const execution = test.session.execute({
+      type: "turn.start",
+      turnId: turnId("uncertain"),
+      input: [{ type: "text", text: "mine" }],
+    });
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    test.feed.push(event(0, "turn/start", { turn: 1 }));
+    test.feed.push(event(1, "step/start", { turn: 1, step: 1 }));
+    test.feed.push(sourcedUserMessage(2, "plugin context", { kind: "plugin", plugin: "fixture" }));
+    test.feed.push(requestHeader(3));
+    expect(await nextEvent(outputs)).toMatchObject({ type: "turn.autonomous.started" });
+    expect(await nextEvent(outputs)).toMatchObject({ type: "turn.started" });
+    await expect(test.session.close()).rejects.toThrow(
+      "cannot confirm stop before the native Turn is correlated",
+    );
+    await expect(execution).resolves.toMatchObject({ ok: false });
+    expect(test.remote.calls.map(({ endpoint }) => endpoint)).toEqual([
+      "session/prompt",
+      "session/cancel",
+    ]);
+  });
+
+  it("settles a prompt accepted during close when a subsequent fault owns cleanup", async () => {
+    const receipt = deferred<ModernRemoteResult<unknown>>();
+    const cancel = deferred<ModernRemoteResult<unknown>>();
+    const test = setup([() => receipt.promise, () => cancel.promise], [], ["request-1"]);
+    const outputs = test.session.outputs[Symbol.asyncIterator]();
+    const execution = test.session.execute({
+      type: "turn.start",
+      turnId: turnId("late-accepted"),
+      input: [{ type: "text", text: "mine" }],
+    });
+    const rejected = expect(test.session.close()).rejects.toThrow();
+    receipt.resolve(accepted());
+    await expect(execution).resolves.toMatchObject({ ok: true });
+    test.session.fault({
+      code: "protocolError",
+      message: "fault after late admission",
+      retryable: false,
+    });
+    await rejected;
+    const emitted = await eventsThrough(outputs, "session.faulted");
+    expect(emitted.map(({ type }) => type)).toEqual(["turn.completed", "session.faulted"]);
+    expect(emitted[0]).toMatchObject({ turnId: "late-accepted", outcome: { status: "failed" } });
+    await expect(outputs.next()).resolves.toEqual({ done: true, value: undefined });
+  });
+
+  it("waits for native stop after a cancel receipt and shares close confirmation", async () => {
+    const test = setup([() => accepted()]);
+    const outputs = test.session.outputs[Symbol.asyncIterator]();
+    beginAutonomousTurn(test);
+    await nextEvent(outputs);
+    let closed = false;
+    const first = test.session.close().then(() => {
+      closed = true;
+    });
+    const second = test.session.close();
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(closed).toBe(false);
+    await expect(
+      test.session.execute({
+        type: "turn.start",
+        turnId: turnId("after-close"),
+        input: [{ type: "text", text: "blocked" }],
+      }),
+    ).resolves.toMatchObject({ ok: false, error: { code: "invalidState" } });
+    expect(test.remote.calls.filter(({ endpoint }) => endpoint === "session/cancel")).toHaveLength(
+      1,
+    );
+    finishNativeTurn(test);
+    await Promise.all([first, second]);
+    expect(closed).toBe(true);
+  });
+
+  it("rejects close when a cancel receipt never becomes a native terminal", async () => {
+    vi.useFakeTimers();
+    const test = setup([() => accepted()]);
+    const outputs = test.session.outputs[Symbol.asyncIterator]();
+    beginAutonomousTurn(test);
+    await nextEvent(outputs);
+    const result = expect(test.session.close()).rejects.toThrow("did not confirm native Turn stop");
+    await vi.advanceTimersByTimeAsync(5000);
+    await result;
+    await expect(test.session.close()).rejects.toThrow("did not confirm native Turn stop");
   });
 
   it("closes an active Turn exactly once and ignores late terminal history", async () => {
@@ -2190,7 +2384,9 @@ describe("DeepSeek Harness Modern Session", () => {
     test.feed.push(event(5, "turn/end", { turn: 1, reason: { kind: "completed" } }));
     await new Promise<void>((resolve) => setImmediate(resolve));
 
-    await test.session.close();
+    await expect(test.session.close()).rejects.toThrow(
+      "cannot confirm stop before the native Turn is correlated",
+    );
     expect(test.remote.calls[0]?.signal?.aborted).toBe(true);
     expect(await nextEvent(outputs)).toMatchObject({
       type: "item.completed",
@@ -2231,7 +2427,9 @@ describe("DeepSeek Harness Modern Session", () => {
     expect(test.remote.calls.map(({ endpoint }) => endpoint)).toEqual(["commands/execute"]);
     expect(test.remote.calls[0]).toMatchObject({ options: { timeoutMs: null } });
     await expect(outputs.next()).resolves.toEqual({ done: true, value: undefined });
-    await test.session.close();
+    await expect(test.session.close()).rejects.toThrow(
+      "native execution stop was not confirmed before the Session fault",
+    );
   });
 
   it("publishes an early Host-bound Approval and delivers allow/deny exactly", async () => {
@@ -2738,7 +2936,13 @@ describe("DeepSeek Harness Modern Session", () => {
         turnId: "terminal-order-turn",
         reason: "cancelled",
       });
-      await test.session.close();
+      if (terminal === "Session fault") {
+        await expect(test.session.close()).rejects.toThrow(
+          "native execution stop was not confirmed before the Session fault",
+        );
+      } else {
+        await test.session.close();
+      }
       await expect(outputs.next()).resolves.toEqual({ done: true, value: undefined });
     },
   );

--- a/tools/gate-dsh/lifecycle.real.test.mjs
+++ b/tools/gate-dsh/lifecycle.real.test.mjs
@@ -1,0 +1,259 @@
+import assert from "node:assert/strict";
+import http from "node:http";
+import { mkdir, mkdtemp, realpath, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { describe, it } from "vitest";
+import { encodePiModelRef } from "../../packages/adapters/pi/dist/pi-model-catalog.js";
+import { DeepSeekHarnessAdapter } from "../../packages/adapters/deepseek-harness/dist/index.js";
+
+async function waitFor(predicate, label) {
+  const deadline = Date.now() + 30000;
+  while (Date.now() < deadline) {
+    const result = await predicate();
+    if (result) return result;
+    await new Promise((resolve) => setTimeout(resolve, 20));
+  }
+  throw new Error(`Timed out: ${label}`);
+}
+
+for (const [id, variable, Adapter] of [
+  ["deepseek-harness", "CODEXHOST_DSH_REAL_COMMAND", DeepSeekHarnessAdapter],
+]) {
+  const command = process.env[variable];
+  describe.runIf(Boolean(command))(`${id} native lifecycle`, () => {
+    it("streams, cancels without overlap, edits and resumes empty and retained history", async () => {
+      const root = await realpath(await mkdtemp(path.join(os.tmpdir(), "codexhost-lifecycle-")));
+      const responses = new Set();
+      let overlapping = false;
+      let heldClosed = false;
+      let heldStarted = false;
+      const server = http.createServer((request, response) => {
+        void (async () => {
+          let input = "";
+          for await (const chunk of request) input += chunk;
+          const body = JSON.parse(input);
+          const user = [...(body.messages ?? [])]
+            .reverse()
+            .find((message) => message.role === "user");
+          const text = JSON.stringify(user?.content ?? "");
+          const held = text.includes("HOLD_INPUT");
+          const main = /(?:FIRST|HOLD|THIRD)_INPUT/u.test(text);
+          if (main && responses.size > 0) overlapping = true;
+          if (main) responses.add(response);
+          if (held) heldStarted = true;
+          response.on("close", () => {
+            responses.delete(response);
+            if (held) heldClosed = true;
+          });
+          response.writeHead(200, {
+            "content-type": "text/event-stream",
+            "cache-control": "no-cache",
+          });
+          const chunk = (content, finish_reason = null) =>
+            response.write(
+              `data: ${JSON.stringify({
+                id: "chatcmpl-fixture",
+                object: "chat.completion.chunk",
+                created: 1,
+                model: body.model,
+                choices: [{ index: 0, delta: { role: "assistant", content }, finish_reason }],
+              })}\n\n`,
+            );
+          chunk(held ? "HOLD_BEGIN" : "FIRST_CHUNK");
+          if (!held) {
+            await new Promise((resolve) => setTimeout(resolve, 100));
+            chunk(" SECOND_CHUNK");
+            chunk("", "stop");
+            response.end("data: [DONE]\n\n");
+          }
+        })().catch(() => {
+          response.destroy();
+        });
+      });
+      await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+      const baseURL = `http://127.0.0.1:${server.address().port}/v1`;
+      const agentDirectory = path.join(root, "pi-agent");
+      await mkdir(agentDirectory, { recursive: true });
+      await writeFile(
+        path.join(agentDirectory, "models.json"),
+        JSON.stringify({
+          providers: {
+            "lifecycle-test": {
+              baseUrl: baseURL,
+              api: "openai-completions",
+              apiKey: "test-only",
+              models: [
+                {
+                  id: "test-model",
+                  name: "Lifecycle test",
+                  reasoning: false,
+                  contextWindow: 32000,
+                  maxTokens: 4000,
+                },
+              ],
+            },
+          },
+        }),
+      );
+      const environment = {
+        ...process.env,
+        PI_CODING_AGENT_DIR: agentDirectory,
+        PI_CODING_AGENT_SESSION_DIR: path.join(root, "pi-sessions"),
+        DSH_HOME: path.join(root, "dsh"),
+        DEEPSEEK_API_KEY: "test-only",
+        DEEPSEEK_BASE_URL: baseURL,
+      };
+      const createAdapter = () => new Adapter({ command, environment, startupTimeoutMs: 30000 });
+      let adapter = createAdapter();
+      let session;
+      let events = [];
+      const consumers = [];
+      const attach = (next) => {
+        session = next;
+        events = [];
+        const observed = events;
+        consumers.push(
+          (async () => {
+            for await (const output of next.outputs)
+              if (output.kind === "event") observed.push(output.event);
+          })(),
+        );
+      };
+      const opened = (result) => {
+        assert.equal(result.ok, true, JSON.stringify(result.ok ? {} : result.error));
+        return result.value;
+      };
+      const snapshot = async () => opened(await session.readSnapshot());
+      const start = async (turnId, text) => {
+        opened(
+          await session.execute({ type: "turn.start", turnId, input: [{ type: "text", text }] }),
+        );
+      };
+      const terminal = (turnId) =>
+        waitFor(
+          () => events.find((event) => event.type === "turn.completed" && event.turnId === turnId),
+          `terminal ${turnId}`,
+        );
+      const state = () =>
+        [...events].reverse().find((event) => event.type === "session.state.changed")?.state ??
+        session.initialState;
+      try {
+        const inspection = await adapter.inspect({ cwd: root });
+        assert.equal(inspection.status, "ready", JSON.stringify(inspection));
+        const model =
+          id === "pi"
+            ? inspection.catalog.models.find(
+                (model) =>
+                  model.ref.id ===
+                  encodePiModelRef({ provider: "lifecycle-test", id: "test-model" }).id,
+              )?.ref
+            : inspection.catalog.defaultModel;
+        assert.ok(model, "test Model missing");
+        attach(opened(await adapter.open({ kind: "create", cwd: root, model, environment })));
+        await start("first", "FIRST_INPUT");
+        const first = await terminal("first");
+        assert.equal(first.outcome.status, "succeeded", JSON.stringify(first.outcome));
+        assert.equal((await snapshot()).turns.length, 1);
+        const originalThinking = state().effectiveThinkingOptionId;
+        const originalPermission = state().effectivePermissionModeId;
+        const originalRef = state().nativeRef;
+        assert.ok(originalRef);
+        const replacement = opened(
+          await adapter.open({
+            kind: "rollbackLastTurn",
+            cwd: root,
+            sourceRef: originalRef,
+            environment,
+          }),
+        );
+        assert.equal(opened(await replacement.readSnapshot()).turns.length, 0);
+        assert.deepEqual(
+          replacement.initialState.effectiveModel,
+          model,
+          "empty edit changed Model",
+        );
+        assert.equal(replacement.initialState.effectiveThinkingOptionId, originalThinking);
+        assert.equal(replacement.initialState.effectivePermissionModeId, originalPermission);
+        const emptyRef = replacement.initialState.nativeRef;
+        assert.ok(emptyRef);
+        assert.notEqual(emptyRef.nativeSessionId, originalRef.nativeSessionId);
+        assert.equal((await snapshot()).turns.length, 1, "source history changed");
+        await adapter.close();
+        adapter = createAdapter();
+        attach(
+          opened(
+            await adapter.open({ kind: "resume", cwd: root, nativeRef: emptyRef, environment }),
+          ),
+        );
+        assert.equal((await snapshot()).turns.length, 0);
+        assert.deepEqual(state().effectiveModel, model, "cold empty edit changed Model");
+        assert.equal(state().effectiveThinkingOptionId, originalThinking);
+        assert.equal(state().effectivePermissionModeId, originalPermission);
+        await start("kept", "FIRST_INPUT");
+        const kept = await terminal("kept");
+        assert.equal(kept.outcome.status, "succeeded", JSON.stringify(kept.outcome));
+        await start("held", "HOLD_INPUT");
+        await waitFor(
+          () =>
+            events.some(
+              (event) =>
+                event.type === "item.updated" &&
+                event.update.type === "text.append" &&
+                event.update.text.includes("HOLD_BEGIN"),
+            ),
+          "incremental output before completion",
+        );
+        assert.equal(heldStarted, true);
+        opened(await session.execute({ type: "turn.cancel", turnId: "held" }));
+        assert.equal((await terminal("held")).outcome.status, "cancelled");
+        await waitFor(() => heldClosed, "cancelled HTTP request closed");
+        assert.equal((await snapshot()).turns.length, 2);
+        const retained = opened(
+          await adapter.open({
+            kind: "rollbackLastTurn",
+            cwd: root,
+            sourceRef: state().nativeRef,
+            environment,
+          }),
+        );
+        assert.equal(opened(await retained.readSnapshot()).turns.length, 1);
+        const retainedRef = retained.initialState.nativeRef;
+        await adapter.close();
+        adapter = createAdapter();
+        attach(
+          opened(
+            await adapter.open({ kind: "resume", cwd: root, nativeRef: retainedRef, environment }),
+          ),
+        );
+        assert.equal((await snapshot()).turns.length, 1);
+        await start("continued", "THIRD_INPUT");
+        assert.equal((await terminal("continued")).outcome.status, "succeeded");
+        assert.equal((await snapshot()).turns.length, 2);
+        heldClosed = false;
+        await start("close-active", "HOLD_INPUT");
+        await waitFor(
+          () =>
+            events.some(
+              (event) =>
+                event.type === "item.updated" &&
+                event.turnId === "close-active" &&
+                event.update.type === "text.append" &&
+                event.update.text.includes("HOLD_BEGIN"),
+            ),
+          "output before active close",
+        );
+        await session.close();
+        await waitFor(() => heldClosed, "active Session close stops native request");
+        assert.equal(overlapping, false);
+      } finally {
+        await adapter.close();
+        await Promise.all(consumers);
+        for (const response of responses) response.destroy();
+        server.closeAllConnections();
+        await new Promise((resolve) => server.close(resolve));
+        await rm(root, { recursive: true, force: true });
+      }
+    }, 180000);
+  });
+}


### PR DESCRIPTION
DSH Modern 在活动任务关闭或传输故障时，连接结束不一定表示原生执行已经停止。过早将 close 视为成功，会让后续历史替换建立在不可靠的停止状态上。

- 关闭活动 Session 时等待可归属的原生终态；重复关闭共享清理结果。
- 区分本地待处理请求与自主执行，避免无关事件错误确认停止。
- 在故障先到、终态迟到和清理失败的路径保留停止不确定性，不能确认时返回错误而非假成功。
- 保留 #155 已实现的原生 rollback 声明与修订语义，不关闭该能力，也不要求新增公共 replacementFence。

包含回归测试、适配说明与隔离的真实 CLI 生命周期 Gate。独立基于 e8f8ecd，不依赖其他拆分 PR。

验证：`npm run typecheck` 通过；DSH Adapter 19 个测试文件、602 个用例通过；变更文件 ESLint、Prettier、`git diff --check` 通过。真实 CLI Gate 需显式设置 `CODEXHOST_DSH_REAL_COMMAND`，本次独立分支未执行；不声称证明第三方共享服务、Windows 或任意后台工具进程全部退出。