### PR TITLE
fix: 通过派生 Session 保留 OpenCode 编辑前的原生历史

### DIFF
--- a/docs/opencode-edit-recovery.md
+++ b/docs/opencode-edit-recovery.md
@@ -1,0 +1,11 @@
+# OpenCode 消息编辑恢复
+
+消息编辑只替换当前 Thread 关联的会话历史。OpenCode Adapter 使用原生 Fork 在指定消息之前派生独立 Session；保留源 Session 和当前工作区文件。移除聊天记录不会撤销已经发生的文件修改。
+
+- 派生候选必须具有不同 Native Session ID，精确保留输入、输出、结果及文件修改记录。Model、Thinking 和 Permission Mode 随候选持久化，包括编辑第一条消息后暂不重发便退出的情况。
+- 源会话忙、文件历史尚不完整、内容被并发修改、配置或身份不一致时，编辑失败。原始记录仍是恢复依据；不伪造空历史或继续使用不可信候选。
+- 取消确认表示原生执行收到请求。Adapter 等到 native idle 后才发出 Turn 终态，使后续输入沿上游的取消→终态→新 Turn 路径执行。若取消时原生没有写入 Assistant 终态，当前取消可结束，但冷读仍如实显示原生历史的 unknown 状态，不制造持久检查点。
+
+真实 CLI 验证通过显式命令运行隔离 Gate；不同原生版本、Windows、远端共享服务或第三方客户端的并发行为需分别验证。
+
+运行定向原生验证：先 `npm run build:typescript`，再设置 `CODEXHOST_OPENCODE_REAL_COMMAND` 为待测 CLI 路径，运行 `packages/adapters/opencode/test/opencode-adapter.rollback.real.test.ts` 和 `tools/gate-opencode/cancel.real.test.mjs` 对应的 Vitest 用例。它们不接入真实模型账号。

--- a/docs/opencode-harness-integration-analysis.md
+++ b/docs/opencode-harness-integration-analysis.md
@@ -53,7 +53,7 @@ OpenCodeAdapter
 - Renderer 的 Agent picker、Model/Thinking 草稿状态、Thread ownership 恢复和 OpenCode 图标；
 - Text/Reasoning streaming、Tool lifecycle、Question、Approval once/deny、Cancel、Usage、完整 Diff、Native command、Compact、Model 与 variant；
 - transcript Snapshot、精确 Checkpoint Fork、SSE 重连后的 status/messages/pending interaction 对账；
-- Revert/unrevert、失败补偿和 `rollbackLastTurn` capability；已用 loopback 假模型驱动 OpenCode `1.18.4` 的真实 `edit` Tool，验证 Git-backed Diff、精确 Fork 和工作树恢复。
+- `rollbackLastTurn` 使用源保留的原生 Fork；编辑消息保留当前工作树文件，验证精确保留历史、配置与源未变。原生 Revert API 仍存在，但不用于消息编辑。
 
 当前明确不对外声明：
 
@@ -77,7 +77,7 @@ OpenCodeAdapter
 | ESLint + package boundary audit | 通过 |
 | Release Host Bundle 审计与真实 build | 通过 |
 | 隔离 OpenCode `1.18.25` real smoke | inspect、create、read、command list、close、resume 通过；没有调用付费/外部 Model |
-| Git-backed real Gate | loopback 假模型驱动原生 `edit` Tool；stream、Tool、Diff、精确 Fork、rollback 文件恢复通过 |
+| Git-backed real Gate | loopback 假模型驱动原生 `edit` Tool；stream、Tool、Diff、精确 Fork、源保留 rollback 和冷恢复；当前验证见下文编辑恢复说明 |
 | 进程清理 | real smoke 结束后没有残留受管 `opencode serve` 进程 |
 
 真实 smoke 还发现并修正了 macOS `/var` 与 `/private/var` realpath 别名导致的 Resume/Fork cwd 误拒绝。尚未执行 Desktop 启动，也没有覆盖本机 OpenCode `1.18.4`。
@@ -313,7 +313,7 @@ OpenCode `Session.fork({ messageID })` 会复制 **目标 message 之前**的消
 
 `forkAcrossCwd` 第一版应声明 `false`。OpenCode request 可以带另一个 directory，但复制的旧 assistant message 仍保存原 path，而且 transcript Fork 不复制文件系统；只有跨 cwd 的历史、工具路径和文件安全 Gate 全部通过后才能开启。
 
-`rollbackLastTurn` 在最后一个 User Message 边界调用 `session.revert()`：它在原 Native Session 上设置持久 revert boundary，并在 Git-backed workspace 通过 Snapshot 恢复该 Turn 的文件修改。Adapter 的 Snapshot 会立即隐藏被回滚 Turn；下一次 prompt/compact 时 OpenCode cleanup 会删除被放弃的 Message/Part。若 Session attach 或后续校验失败，Adapter 调用 `unrevert()` 恢复来源 Session 和工作树。
+`rollbackLastTurn` 在最后一个 User Message 的排他边界调用原生 `session.fork()`，创建独立 Native Session。当前文件不回滚，源历史不修改。派生前后校验源历史及配置，校验候选的完整保留内容和文件 Diff；空历史候选保存 Model/Thinking/Permission Mode，可在退出后恢复。失败只清理已确认独立创建的候选，不调用 `unrevert()`。详见 [OpenCode 消息编辑恢复](opencode-edit-recovery.md)。
 
 ### Diff、Usage 与 Subagent
 
@@ -528,7 +528,7 @@ OpenCode Console 还存在多 account/org 的隐藏实验功能，如 `opencode 
 | Fork | 支持但标明语义 | exact transcript checkpoint fork；不是文件系统 Fork |
 | Fork across cwd | 首版不支持 | 新旧 message path 和文件系统不随 transcript 一起 Fork |
 | Compact | 支持 | `session.summarize()` |
-| Revert/unrevert | 支持 | 原 Session 原生回滚 + Git-backed Snapshot/Diff/恢复 Gate |
+| 消息编辑 rollback | 支持 | 原生 Fork 派生独立历史；保留源会话与当前文件 |
 | Model selection | 支持 | provider/model API；凭据留在 OpenCode |
 | Permission Mode | 支持 | `default` / `ask` / `allow`；Session 原生 PermissionRuleset |
 | Thinking/effort | 按 Model 探测 | 只映射已验证的 variant |

--- a/openspec/changes/fix-opencode-source-preserving-edits/.openspec.yaml
+++ b/openspec/changes/fix-opencode-source-preserving-edits/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-09-08

--- a/openspec/changes/fix-opencode-source-preserving-edits/design.md
+++ b/openspec/changes/fix-opencode-source-preserving-edits/design.md
@@ -1,0 +1,11 @@
+## Decisions
+
+Keep history projection and strict file verification inside the Adapter. Native Fork creates an exclusive prefix; verify a distinct identity before accepting cleanup ownership. Compare ordered semantic history (ignoring regenerated Item IDs and native references), source identity/history/configuration before and after, and derived Model/Thinking/Permission Mode. Empty derived Sessions persist selection metadata. Failure deletes only an independently created candidate. Source and candidate must be idle. Native clients outside this Host remain outside local transaction guarantees.
+
+Strict verification requires successful native path and diff reads, reliable diff entries and coverage of all native patch paths. It never invents file changes or silently replaces unreadable history with an empty result. Extract this cohesive projection responsibility from the already oversized Adapter module.
+
+Cancelled session.error triggers the existing status/transcript reconciliation. Only idle can complete cancellation. Follow-up Turn semantics remain upstream cancel/terminal/new-Turn.
+
+## Validation
+
+Unit failures: same-count corruption, source mutation, reused identity, incomplete diff, incompatible configuration, attachment failure, busy Session and early abort error. Real CLI: Edit file, Fork exact prefix, rollback first Turn without file rewind, cold resume and repeated edit. Record actual native versions and configuration isolation.

--- a/openspec/changes/fix-opencode-source-preserving-edits/proposal.md
+++ b/openspec/changes/fix-opencode-source-preserving-edits/proposal.md
@@ -1,0 +1,21 @@
+## Why
+
+OpenCode native revert also rewinds workspace files and mutates the source Session. Message editing needs an independent, durable history prefix while retaining current files. Cancellation errors can arrive before native idle and must not admit a follow-up Turn prematurely.
+
+## What Changes
+
+Use native exclusive-boundary Fork for rollback. Validate exact retained content, complete file-change projection, configuration and unchanged source. Preserve configuration on empty derived Sessions. Await native idle before cancellation completion.
+
+## Capabilities
+
+### New Capabilities
+
+- `opencode-edit-recovery`: source-preserving native edits and idle-confirmed cancellation.
+
+### Modified Capabilities
+
+None.
+
+## Impact
+
+OpenCode Adapter, transport path inspection, focused regressions and real CLI gate. Uses current public interfaces; no Host-specific dispatch or mandatory fence. Company command and environment changes remain a later internal integration change.

--- a/openspec/changes/fix-opencode-source-preserving-edits/specs/opencode-edit-recovery/spec.md
+++ b/openspec/changes/fix-opencode-source-preserving-edits/specs/opencode-edit-recovery/spec.md
@@ -1,0 +1,24 @@
+## ADDED Requirements
+
+### Requirement: Source-preserving message edit
+
+The Adapter SHALL derive rollback history into a distinct durable Session without reverting workspace files or mutating source history, and SHALL verify retained history and settings before returning it.
+
+#### Scenario: Editing the first Turn
+
+- **WHEN** the only Turn is rolled back
+- **THEN** the candidate has empty history and current settings, remains resumable after restart, and the source and current files remain intact
+
+#### Scenario: Invalid native derivation
+
+- **WHEN** native Fork returns a reused identity, changed source or mismatching retained history
+- **THEN** opening fails and an owned source Session is never deleted as cleanup
+
+### Requirement: Idle-confirmed cancellation
+
+The Adapter SHALL wait for native idle before projecting cancellation completion.
+
+#### Scenario: Abort error arrives while busy
+
+- **WHEN** the native Session emits an abort error while still busy
+- **THEN** the current Turn remains active until native idle is confirmed and another Turn cannot start

--- a/openspec/changes/fix-opencode-source-preserving-edits/tasks.md
+++ b/openspec/changes/fix-opencode-source-preserving-edits/tasks.md
@@ -1,0 +1,6 @@
+## Implementation
+
+- [x] 1. Implement strict projection and source-preserving derivation.
+- [x] 2. Reconcile cancellation errors against native idle.
+- [x] 3. Add regression tests and update the real CLI gate.
+- [x] 4. Run targeted/static/native validation and document results.

--- a/openspec/changes/fix-opencode-source-preserving-edits/validation.md
+++ b/openspec/changes/fix-opencode-source-preserving-edits/validation.md
@@ -1,0 +1,9 @@
+# 验证记录
+
+独立基于上游 `e8f8ecd`。
+
+- `npm run typecheck`：通过。
+- Adapter 回归测试：7 个文件、72 个用例通过；2 个真实 CLI 文件、2 个用例未启用而跳过。
+- 变更文件 ESLint、Prettier 和 `git diff --check`：通过。
+
+未将集成分支或未执行的真实 CLI、其他平台测试视为本分支验证。

--- a/packages/adapters/opencode/src/file-change-verification.ts
+++ b/packages/adapters/opencode/src/file-change-verification.ts
@@ -1,0 +1,98 @@
+import fs from "node:fs";
+import path from "node:path";
+
+function missingPath(error: unknown): boolean {
+  if (!error || typeof error !== "object") return false;
+  const code = Reflect.get(error, "code");
+  return code === "ENOENT" || code === "ENOTDIR";
+}
+
+function hasDotPathSegment(value: string): boolean {
+  const segments = process.platform === "win32" ? value.split(/[\\/]+/) : value.split("/");
+  return segments.some((segment) => segment === "." || segment === "..");
+}
+
+function canonicalDirectoryPath(value: string): string | undefined {
+  let candidate = path.resolve(value);
+  const missingSegments: string[] = [];
+  for (;;) {
+    try {
+      return path.join(fs.realpathSync.native(candidate), ...missingSegments);
+    } catch (error) {
+      if (!missingPath(error)) return undefined;
+      const parent = path.dirname(candidate);
+      if (parent === candidate) return undefined;
+      missingSegments.unshift(path.basename(candidate));
+      candidate = parent;
+    }
+  }
+}
+
+function canonicalFilePath(value: string): string | undefined {
+  const absolute = path.resolve(value);
+  const parent = canonicalDirectoryPath(path.dirname(absolute));
+  return parent ? path.join(parent, path.basename(absolute)) : undefined;
+}
+
+function pathIsWithin(root: string, candidate: string, allowRoot: boolean): boolean {
+  const relative = path.relative(root, candidate);
+  return (
+    (allowRoot && relative === "") ||
+    (relative !== "" &&
+      relative !== ".." &&
+      !relative.startsWith(`..${path.sep}`) &&
+      !path.isAbsolute(relative))
+  );
+}
+
+export function verifiedOpenCodeWorktree(
+  sessionDirectory: string,
+  paths: { directory: string; worktree: string },
+): string | undefined {
+  if (
+    !paths ||
+    typeof paths !== "object" ||
+    typeof sessionDirectory !== "string" ||
+    typeof paths.directory !== "string" ||
+    typeof paths.worktree !== "string" ||
+    hasDotPathSegment(sessionDirectory) ||
+    hasDotPathSegment(paths.directory) ||
+    hasDotPathSegment(paths.worktree) ||
+    !path.isAbsolute(sessionDirectory) ||
+    !path.isAbsolute(paths.directory) ||
+    !path.isAbsolute(paths.worktree)
+  ) {
+    return undefined;
+  }
+  const session = canonicalDirectoryPath(sessionDirectory);
+  const directory = canonicalDirectoryPath(paths.directory);
+  const worktree = canonicalDirectoryPath(paths.worktree);
+  if (
+    !session ||
+    !directory ||
+    !worktree ||
+    session !== directory ||
+    !pathIsWithin(worktree, directory, true)
+  ) {
+    return undefined;
+  }
+  return worktree;
+}
+
+export function openCodeFileIdentity(file: string, worktree: string): string | undefined {
+  if (
+    typeof file !== "string" ||
+    typeof worktree !== "string" ||
+    hasDotPathSegment(file) ||
+    hasDotPathSegment(worktree) ||
+    !path.isAbsolute(worktree) ||
+    !file ||
+    file.includes("\0") ||
+    file.includes("\n") ||
+    file.includes("\r")
+  ) {
+    return undefined;
+  }
+  const candidate = canonicalFilePath(path.isAbsolute(file) ? file : path.resolve(worktree, file));
+  return candidate && pathIsWithin(worktree, candidate, false) ? candidate : undefined;
+}

--- a/packages/adapters/opencode/src/history-derivation.ts
+++ b/packages/adapters/opencode/src/history-derivation.ts
@@ -1,0 +1,129 @@
+import { isDeepStrictEqual } from "node:util";
+
+import type { Session } from "@opencode-ai/sdk/v2";
+import type { HostThreadSnapshot, OpenSessionInput } from "@codexhost/harness-adapter";
+
+import { resolveOpenCodeForkBoundary, resolveOpenCodeLastTurnBoundary } from "./history.js";
+import {
+  readProjection,
+  selectionMetadata,
+  type OpenCodeSnapshotProjection,
+} from "./history-projection.js";
+import type { OpenCodeProviderCatalog } from "./model-catalog.js";
+import { OpenCodeTransportError, type OpenCodeTransport } from "./protocol.js";
+
+function semanticHistory(snapshot: HostThreadSnapshot) {
+  return snapshot.turns.map((turn) => ({
+    input: turn.input,
+    items: turn.items.map(({ item, outcome }) => {
+      const { itemId: _itemId, ...content } = item;
+      void _itemId;
+      return { item: content, outcome };
+    }),
+    outcome: turn.outcome,
+    model: turn.model,
+    checkpoint: Boolean(turn.checkpoint),
+  }));
+}
+
+function sourceState(projection: OpenCodeSnapshotProjection) {
+  return {
+    id: projection.session.id,
+    directory: projection.session.directory,
+    revert: projection.session.revert,
+    metadata: projection.session.metadata,
+    permission: projection.session.permission,
+    model: projection.model,
+    variant: projection.variant,
+    snapshot: projection.snapshot,
+  };
+}
+
+export async function deriveOpenCodeHistory(options: {
+  transport: OpenCodeTransport;
+  source: Session;
+  input: Extract<OpenSessionInput, { kind: "fork" | "rollbackLastTurn" }>;
+  providers: OpenCodeProviderCatalog;
+  toolOutputLimit: number;
+  onCreated(session: Session): void;
+}): Promise<Session> {
+  const { transport, source, input, providers, toolOutputLimit } = options;
+  const read = (id: string) =>
+    readProjection(transport, id, providers, toolOutputLimit, { strictFileChanges: true });
+  if ((await transport.getStatus(source.id)).type !== "idle") {
+    throw new Error("OpenCode source Session is busy");
+  }
+  const before = await read(source.id);
+  // Freeze evidence: a native client or a test transport may mutate returned objects.
+  const expectedSource = structuredClone(sourceState(before));
+  let messageID: string | undefined;
+  let retainedCount: number;
+  if (input.kind === "fork") {
+    const boundary = resolveOpenCodeForkBoundary(before.session, before.messages, input.checkpoint);
+    if (!boundary)
+      throw new OpenCodeTransportError(
+        "checkpointNotFound",
+        "OpenCode Checkpoint is not on the source Session transcript",
+      );
+    messageID = boundary.messageID;
+    retainedCount = boundary.sourceTurnCount;
+  } else {
+    const boundary = resolveOpenCodeLastTurnBoundary(before.session, before.messages);
+    if (!boundary)
+      throw new OpenCodeTransportError(
+        "invalidState",
+        "OpenCode Native Session has no Turn to roll back",
+      );
+    messageID = boundary.lastUserMessageID;
+    retainedCount = boundary.sourceTurnCount - 1;
+  }
+  const expectedHistory = structuredClone(semanticHistory(before.snapshot).slice(0, retainedCount));
+  let candidate = await transport.forkSession(source.id, messageID);
+  if (candidate.id === source.id) {
+    throw new OpenCodeTransportError(
+      "protocolError",
+      "OpenCode Fork did not create a distinct Native Session",
+    );
+  }
+  const candidateID = candidate.id;
+  options.onCreated(candidate);
+  if (candidate.directory !== expectedSource.directory) {
+    throw new OpenCodeTransportError("protocolError", "OpenCode Fork changed working directory");
+  }
+  if (expectedSource.model) {
+    candidate = await transport.updateSessionMetadata(
+      candidateID,
+      selectionMetadata(candidate, expectedSource.model, expectedSource.variant),
+    );
+  }
+  if (!isDeepStrictEqual(candidate.permission ?? [], expectedSource.permission ?? [])) {
+    candidate = await transport.updateSessionPermission(
+      candidateID,
+      expectedSource.permission ?? [],
+    );
+  }
+  const [derived, after, candidateStatus, sourceStatus] = await Promise.all([
+    read(candidateID),
+    read(source.id),
+    transport.getStatus(candidateID),
+    transport.getStatus(source.id),
+  ]);
+  if (
+    derived.session.id !== candidateID ||
+    candidate.id !== candidateID ||
+    derived.session.directory !== before.session.directory ||
+    candidateStatus.type !== "idle" ||
+    sourceStatus.type !== "idle" ||
+    !isDeepStrictEqual(semanticHistory(derived.snapshot), expectedHistory) ||
+    !isDeepStrictEqual(sourceState(after), expectedSource) ||
+    !isDeepStrictEqual(derived.model, expectedSource.model) ||
+    derived.variant !== expectedSource.variant ||
+    !isDeepStrictEqual(derived.session.permission ?? [], expectedSource.permission ?? [])
+  ) {
+    throw new OpenCodeTransportError(
+      "protocolError",
+      "OpenCode derived history, source or configuration changed during Fork",
+    );
+  }
+  return derived.session;
+}

--- a/packages/adapters/opencode/src/history-projection.ts
+++ b/packages/adapters/opencode/src/history-projection.ts
@@ -1,0 +1,244 @@
+import type { Session, SnapshotFileDiff } from "@opencode-ai/sdk/v2";
+import type { HostThreadSnapshot, HostUsage } from "@codexhost/harness-adapter";
+import {
+  openCodeAssistantMessages,
+  projectOpenCodeHistory,
+  reliableOpenCodeFileChanges,
+  type OpenCodeMessageWithParts,
+} from "./history.js";
+import {
+  openCodeContextWindow,
+  type OpenCodeNativeModelRef,
+  type OpenCodeProviderCatalog,
+} from "./model-catalog.js";
+import { openCodeFileIdentity, verifiedOpenCodeWorktree } from "./file-change-verification.js";
+import { OpenCodeTransportError, type OpenCodeTransport } from "./protocol.js";
+import { projectOpenCodeUsage } from "./usage.js";
+
+export interface OpenCodeSnapshotProjection {
+  session: Session;
+  messages: OpenCodeMessageWithParts[];
+  snapshot: HostThreadSnapshot;
+  usage: HostUsage | null;
+  model?: OpenCodeNativeModelRef;
+  variant?: string;
+}
+
+const SELECTION_METADATA_KEY = "codexhost.selection.v1";
+// Native summary persistence can lag the terminal Patch Part.
+const DIFF_RECONCILIATION_DELAYS_MS = [25, 50, 100, 200, 400, 800] as const;
+
+function storedSelection(
+  session: Session,
+): (OpenCodeNativeModelRef & { variant?: string }) | undefined {
+  const value = session.metadata?.[SELECTION_METADATA_KEY];
+  if (!value || typeof value !== "object" || Array.isArray(value)) return undefined;
+  const providerID = Reflect.get(value, "providerID");
+  const modelID = Reflect.get(value, "modelID");
+  const variant = Reflect.get(value, "variant");
+  if (
+    typeof providerID !== "string" ||
+    !providerID ||
+    typeof modelID !== "string" ||
+    !modelID ||
+    (variant !== undefined && (typeof variant !== "string" || !variant))
+  ) {
+    return undefined;
+  }
+  return { providerID, modelID, ...(typeof variant === "string" ? { variant } : {}) };
+}
+
+export function selectionMetadata(
+  session: Session,
+  model: OpenCodeNativeModelRef,
+  variant: string | undefined,
+): Record<string, unknown> {
+  return {
+    ...session.metadata,
+    [SELECTION_METADATA_KEY]: {
+      providerID: model.providerID,
+      modelID: model.modelID,
+      ...(variant ? { variant } : {}),
+    },
+  };
+}
+
+function nativeModelFromSession(
+  session: Session,
+  messages: readonly OpenCodeMessageWithParts[],
+): OpenCodeNativeModelRef | undefined {
+  const stored = storedSelection(session);
+  if (stored) return { providerID: stored.providerID, modelID: stored.modelID };
+  if (session.model) {
+    return { providerID: session.model.providerID, modelID: session.model.id };
+  }
+  for (let index = messages.length - 1; index >= 0; index -= 1) {
+    const info = messages[index]?.info;
+    if (info?.role === "user") return info.model;
+  }
+  return undefined;
+}
+
+function nativeVariantFromSession(
+  session: Session,
+  messages: readonly OpenCodeMessageWithParts[],
+): string | undefined {
+  const stored = storedSelection(session);
+  if (stored) return stored.variant;
+  if (session.model?.variant) return session.model.variant;
+  for (let index = messages.length - 1; index >= 0; index -= 1) {
+    const info = messages[index]?.info;
+    if (info?.role === "user") return info.model.variant;
+  }
+  return undefined;
+}
+
+export function turnNativePatchFiles(
+  messages: readonly OpenCodeMessageWithParts[],
+  userMessageID: string,
+): string[] {
+  const start = messages.findIndex(({ info }) => info.id === userMessageID);
+  if (start < 0) return [];
+  let end = start + 1;
+  while (end < messages.length && messages[end]?.info.role !== "user") end += 1;
+  return [
+    ...new Set(
+      messages
+        .slice(start + 1, end)
+        .flatMap(({ parts }) => parts.flatMap((part) => (part.type === "patch" ? part.files : []))),
+    ),
+  ];
+}
+
+export async function readTurnDiff(
+  transport: OpenCodeTransport,
+  sessionID: string,
+  userMessageID: string,
+  nativePatchFiles: readonly string[],
+  options: { strict?: boolean; worktree?: string } = {},
+): Promise<SnapshotFileDiff[]> {
+  const strict = options.strict === true;
+  for (let attempt = 0; ; attempt += 1) {
+    let diffs: SnapshotFileDiff[];
+    try {
+      diffs = await transport.getDiff(sessionID, userMessageID);
+    } catch (error) {
+      if (strict) {
+        throw new OpenCodeTransportError(
+          "protocolError",
+          "OpenCode could not verify FileChange history",
+          { cause: error },
+        );
+      }
+      diffs = [];
+    }
+    const reliableChanges = reliableOpenCodeFileChanges(diffs);
+    const worktree = options.worktree;
+    const reliablePaths = worktree
+      ? reliableChanges.map(({ path: file }) => openCodeFileIdentity(file, worktree))
+      : [];
+    const nativePatchPaths = worktree
+      ? nativePatchFiles.map((file) => openCodeFileIdentity(file, worktree))
+      : [];
+    const completeStrictProjection =
+      Boolean(worktree) &&
+      reliableChanges.length === diffs.length &&
+      reliablePaths.every((file): file is string => file !== undefined) &&
+      nativePatchPaths.every((file) => file !== undefined && reliablePaths.includes(file));
+    if (
+      strict
+        ? completeStrictProjection
+        : reliableChanges.length > 0 || nativePatchFiles.length === 0
+    ) {
+      return diffs;
+    }
+    if (attempt >= DIFF_RECONCILIATION_DELAYS_MS.length) {
+      if (strict) {
+        throw new OpenCodeTransportError(
+          "protocolError",
+          "OpenCode did not expose complete reliable FileChange history",
+        );
+      }
+      return diffs;
+    }
+    await new Promise<void>((resolve) =>
+      setTimeout(resolve, DIFF_RECONCILIATION_DELAYS_MS[attempt]),
+    );
+  }
+}
+
+export async function readProjection(
+  transport: OpenCodeTransport,
+  sessionID: string,
+  providerCatalog: OpenCodeProviderCatalog,
+  toolOutputLimit: number,
+  options: { strictFileChanges?: boolean } = {},
+): Promise<OpenCodeSnapshotProjection> {
+  const strictFileChanges = options.strictFileChanges === true;
+  const [session, messages, paths] = await Promise.all([
+    transport.getSession(sessionID),
+    transport.getMessages(sessionID),
+    strictFileChanges
+      ? transport.getPaths().catch((error: unknown) => {
+          throw new OpenCodeTransportError(
+            "protocolError",
+            "OpenCode could not verify worktree paths",
+            { cause: error },
+          );
+        })
+      : undefined,
+  ]);
+  const worktree = paths ? verifiedOpenCodeWorktree(session.directory, paths) : undefined;
+  if (strictFileChanges && !worktree) {
+    throw new OpenCodeTransportError(
+      "protocolError",
+      "OpenCode returned inconsistent Session and worktree paths",
+    );
+  }
+  const userMessageIds = messages
+    .filter(({ info }) => info.role === "user")
+    .map(({ info }) => info.id);
+  const diffEntries = await Promise.all(
+    userMessageIds.map(async (messageID) => {
+      const diffs = await readTurnDiff(
+        transport,
+        sessionID,
+        messageID,
+        turnNativePatchFiles(messages, messageID),
+        { strict: strictFileChanges, ...(worktree ? { worktree } : {}) },
+      );
+      return [messageID, diffs] as const;
+    }),
+  );
+  const snapshot = projectOpenCodeHistory({
+    session,
+    messages,
+    diffsByUserMessageId: new Map(diffEntries),
+    toolOutputLimit,
+  });
+  const model = nativeModelFromSession(session, messages);
+  const nativeVariant = nativeVariantFromSession(session, messages);
+  const nativeModel = model
+    ? providerCatalog.all.find(({ id }) => id === model.providerID)?.models[model.modelID]
+    : undefined;
+  // Codewiz can persist the default selection as the literal "default".
+  // Keep a real named variant when the Model advertises one with that name.
+  const variant =
+    nativeVariant === "default" &&
+    nativeModel &&
+    !Object.hasOwn(nativeModel.variants ?? {}, "default")
+      ? undefined
+      : nativeVariant;
+  const usage = projectOpenCodeUsage(
+    openCodeAssistantMessages(session, messages),
+    model ? openCodeContextWindow(providerCatalog, model) : undefined,
+  );
+  return {
+    session,
+    messages,
+    snapshot,
+    usage,
+    ...(model ? { model } : {}),
+    ...(variant ? { variant } : {}),
+  };
+}

--- a/packages/adapters/opencode/src/opencode-adapter.ts
+++ b/packages/adapters/opencode/src/opencode-adapter.ts
@@ -9,7 +9,6 @@ import type {
   PermissionRequest,
   QuestionRequest,
   Session,
-  SnapshotFileDiff,
   ToolPart,
 } from "@opencode-ai/sdk/v2";
 
@@ -74,13 +73,9 @@ import {
 } from "@codexhost/shared-contracts";
 
 import {
-  openCodeAssistantMessages,
   openCodeNativeSessionRef,
   parseOpenCodeSessionRef,
-  projectOpenCodeHistory,
   reliableOpenCodeFileChanges,
-  resolveOpenCodeForkBoundary,
-  resolveOpenCodeLastTurnBoundary,
   type OpenCodeExecutionPolicy,
   type OpenCodeMessageWithParts,
 } from "./history.js";
@@ -90,7 +85,6 @@ import {
   encodeOpenCodeModelRef,
   encodeOpenCodeVariant,
   normalizeOpenCodeModelCatalog,
-  openCodeContextWindow,
   type OpenCodeNativeModelRef,
   type OpenCodeProviderCatalog,
 } from "./model-catalog.js";
@@ -114,7 +108,14 @@ import {
   type OpenCodeServerConnectionLike,
   type OpenCodeServerOptions,
 } from "./sdk-transport.js";
-import { projectOpenCodeUsage } from "./usage.js";
+import {
+  readProjection,
+  readTurnDiff,
+  selectionMetadata,
+  turnNativePatchFiles,
+  type OpenCodeSnapshotProjection,
+} from "./history-projection.js";
+import { deriveOpenCodeHistory } from "./history-derivation.js";
 
 export interface OpenCodeAdapterOptions extends OpenCodeServerOptions {
   toolOutputLimit?: number;
@@ -183,23 +184,10 @@ interface ActiveTurn {
   admissionSequence: number;
 }
 
-interface OpenCodeSnapshotProjection {
-  session: Session;
-  messages: OpenCodeMessageWithParts[];
-  snapshot: HostThreadSnapshot;
-  usage: HostUsage | null;
-  model?: OpenCodeNativeModelRef;
-  variant?: string;
-}
-
 const openCodeHarnessId = harnessIdSchema.parse("opencode");
 const DEFAULT_TOOL_OUTPUT_LIMIT = 64_000;
 const DEFAULT_CLOSE_TIMEOUT_MS = 3_000;
-// OpenCode persists session.diff in a background summary after emitting the
-// terminal Patch Part. Reconcile briefly so FileChange precedes Turn completion.
-const DIFF_RECONCILIATION_DELAYS_MS = [25, 50, 100, 200, 400, 800] as const;
 const COMPACT_COMMAND_ID = "opencode.compact";
-const SELECTION_METADATA_KEY = "codexhost.selection.v1";
 
 function invalidState(message: string): HarnessError {
   return { code: "invalidState", message, retryable: false };
@@ -244,151 +232,6 @@ function sameCwd(left: string, right: string): boolean {
     }
   };
   return canonical(left) === canonical(right);
-}
-
-function storedSelection(
-  session: Session,
-): (OpenCodeNativeModelRef & { variant?: string }) | undefined {
-  const value = session.metadata?.[SELECTION_METADATA_KEY];
-  if (!value || typeof value !== "object" || Array.isArray(value)) return undefined;
-  const providerID = Reflect.get(value, "providerID");
-  const modelID = Reflect.get(value, "modelID");
-  const variant = Reflect.get(value, "variant");
-  if (
-    typeof providerID !== "string" ||
-    !providerID ||
-    typeof modelID !== "string" ||
-    !modelID ||
-    (variant !== undefined && (typeof variant !== "string" || !variant))
-  ) {
-    return undefined;
-  }
-  return { providerID, modelID, ...(typeof variant === "string" ? { variant } : {}) };
-}
-
-function selectionMetadata(
-  session: Session,
-  model: OpenCodeNativeModelRef,
-  variant: string | undefined,
-): Record<string, unknown> {
-  return {
-    ...session.metadata,
-    [SELECTION_METADATA_KEY]: {
-      providerID: model.providerID,
-      modelID: model.modelID,
-      ...(variant ? { variant } : {}),
-    },
-  };
-}
-
-function nativeModelFromSession(
-  session: Session,
-  messages: readonly OpenCodeMessageWithParts[],
-): OpenCodeNativeModelRef | undefined {
-  const stored = storedSelection(session);
-  if (stored) return { providerID: stored.providerID, modelID: stored.modelID };
-  if (session.model) {
-    return { providerID: session.model.providerID, modelID: session.model.id };
-  }
-  for (let index = messages.length - 1; index >= 0; index -= 1) {
-    const info = messages[index]?.info;
-    if (info?.role === "user") return info.model;
-  }
-  return undefined;
-}
-
-function nativeVariantFromSession(
-  session: Session,
-  messages: readonly OpenCodeMessageWithParts[],
-): string | undefined {
-  const stored = storedSelection(session);
-  if (stored) return stored.variant;
-  if (session.model?.variant) return session.model.variant;
-  for (let index = messages.length - 1; index >= 0; index -= 1) {
-    const info = messages[index]?.info;
-    if (info?.role === "user") return info.model.variant;
-  }
-  return undefined;
-}
-
-function turnHasNativePatch(
-  messages: readonly OpenCodeMessageWithParts[],
-  userMessageID: string,
-): boolean {
-  const start = messages.findIndex(({ info }) => info.id === userMessageID);
-  if (start < 0) return false;
-  let end = start + 1;
-  while (end < messages.length && messages[end]?.info.role !== "user") end += 1;
-  return messages
-    .slice(start + 1, end)
-    .some(({ parts }) => parts.some((part) => part.type === "patch" && part.files.length > 0));
-}
-
-async function readTurnDiff(
-  transport: OpenCodeTransport,
-  sessionID: string,
-  userMessageID: string,
-  nativePatchObserved: boolean,
-): Promise<SnapshotFileDiff[]> {
-  for (let attempt = 0; ; attempt += 1) {
-    const diffs = await transport.getDiff(sessionID, userMessageID).catch(() => []);
-    if (
-      reliableOpenCodeFileChanges(diffs).length > 0 ||
-      !nativePatchObserved ||
-      attempt >= DIFF_RECONCILIATION_DELAYS_MS.length
-    ) {
-      return diffs;
-    }
-    await new Promise<void>((resolve) =>
-      setTimeout(resolve, DIFF_RECONCILIATION_DELAYS_MS[attempt]),
-    );
-  }
-}
-
-async function readProjection(
-  transport: OpenCodeTransport,
-  sessionID: string,
-  providerCatalog: OpenCodeProviderCatalog,
-  toolOutputLimit: number,
-): Promise<OpenCodeSnapshotProjection> {
-  const [session, messages] = await Promise.all([
-    transport.getSession(sessionID),
-    transport.getMessages(sessionID),
-  ]);
-  const userMessageIds = messages
-    .filter(({ info }) => info.role === "user")
-    .map(({ info }) => info.id);
-  const diffEntries = await Promise.all(
-    userMessageIds.map(async (messageID) => {
-      const diffs = await readTurnDiff(
-        transport,
-        sessionID,
-        messageID,
-        turnHasNativePatch(messages, messageID),
-      );
-      return [messageID, diffs] as const;
-    }),
-  );
-  const snapshot = projectOpenCodeHistory({
-    session,
-    messages,
-    diffsByUserMessageId: new Map(diffEntries),
-    toolOutputLimit,
-  });
-  const model = nativeModelFromSession(session, messages);
-  const variant = nativeVariantFromSession(session, messages);
-  const usage = projectOpenCodeUsage(
-    openCodeAssistantMessages(session, messages),
-    model ? openCodeContextWindow(providerCatalog, model) : undefined,
-  );
-  return {
-    session,
-    messages,
-    snapshot,
-    usage,
-    ...(model ? { model } : {}),
-    ...(variant ? { variant } : {}),
-  };
 }
 
 function sessionState(
@@ -1049,6 +892,11 @@ class OpenCodeHarnessSession implements HarnessSession, OpenCodeTransportListene
       active
     ) {
       const error = event.properties.error;
+      if (active.cancellationRequested || error?.name === "MessageAbortedError") {
+        active.cancellationRequested = true;
+        void this.#reconcileAndFinish(active);
+        return;
+      }
       this.#completeTurn(active, {
         status: active.cancellationRequested ? "cancelled" : "failed",
         ...(active.cancellationRequested
@@ -1334,6 +1182,22 @@ class OpenCodeHarnessSession implements HarnessSession, OpenCodeTransportListene
           !terminal.error &&
           !active.nativeCompleted)
       ) {
+        if (active.cancellationRequested) {
+          for (const entry of assistants) {
+            for (const part of entry.parts) this.#projectPart(active, part);
+          }
+          this.#completeTurn(
+            active,
+            { status: "cancelled", reason: "Cancelled by user" },
+            {
+              harnessId: this.harnessId,
+              nativeSessionId: this.#session.id,
+              nativeTurnKey: active.userMessageID as string,
+              formatVersion: 1,
+            },
+          );
+          void this.#refreshProjection(active.turnId);
+        }
         return;
       }
       for (const entry of assistants) {
@@ -1346,7 +1210,7 @@ class OpenCodeHarnessSession implements HarnessSession, OpenCodeTransportListene
           this.#transport,
           this.#session.id,
           userMessageID,
-          turnHasNativePatch(messages, userMessageID),
+          turnNativePatchFiles(messages, userMessageID),
         ),
       );
       if (changes.length > 0) {
@@ -1786,7 +1650,6 @@ export class OpenCodeAdapter implements HarnessAdapter {
     let connection: OpenCodeServerConnectionLike | undefined;
     let transport: OpenCodeTransport | undefined;
     let createdForCleanup: Session | undefined;
-    let revertedForCleanup: string | undefined;
     try {
       const sourceRef =
         input.kind === "create"
@@ -1886,73 +1749,17 @@ export class OpenCodeAdapter implements HarnessAdapter {
         }
         if (input.kind === "resume") {
           session = source;
-        } else if (input.kind === "fork") {
-          const checkpoint = nativeCheckpointRefSchema.parse(input.checkpoint);
-          if (checkpoint.harnessId !== this.harnessId || checkpoint.nativeSessionId !== source.id) {
-            throw new OpenCodeTransportError(
-              "protocolError",
-              "OpenCode Checkpoint does not belong to the source Session",
-            );
-          }
-          const sourceMessages = await transport.getMessages(source.id);
-          const boundary = resolveOpenCodeForkBoundary(source, sourceMessages, checkpoint);
-          if (!boundary) {
-            await transport.close().catch(() => undefined);
-            await connection.close().catch(() => undefined);
-            return {
-              ok: false,
-              error: {
-                code: "checkpointNotFound",
-                message: "OpenCode Checkpoint is not on the source Session transcript",
-                retryable: false,
-              },
-            };
-          }
-          session = await transport.forkSession(source.id, boundary.messageID);
-          createdForCleanup = session;
-          if (session.id === source.id) {
-            throw new OpenCodeTransportError(
-              "protocolError",
-              "OpenCode Fork did not create a distinct Native Session",
-            );
-          }
-          const derivedMessages = await transport.getMessages(session.id);
-          const derived = projectOpenCodeHistory({
-            session,
-            messages: derivedMessages,
-            toolOutputLimit: this.#toolOutputLimit,
-          });
-          if (derived.turns.length !== boundary.sourceTurnCount) {
-            throw new OpenCodeTransportError(
-              "protocolError",
-              "OpenCode Fork derived history does not match the requested Checkpoint",
-            );
-          }
         } else {
-          const sourceMessages = await transport.getMessages(source.id);
-          const boundary = resolveOpenCodeLastTurnBoundary(source, sourceMessages);
-          if (!boundary) {
-            await transport.close().catch(() => undefined);
-            await connection.close().catch(() => undefined);
-            return {
-              ok: false,
-              error: invalidState("OpenCode Native Session has no Turn to roll back"),
-            };
-          }
-          session = await transport.revertSession(source.id, boundary.lastUserMessageID);
-          revertedForCleanup = source.id;
-          const afterMessages = await transport.getMessages(session.id);
-          const after = projectOpenCodeHistory({
-            session,
-            messages: afterMessages,
+          session = await deriveOpenCodeHistory({
+            transport,
+            source,
+            input,
+            providers,
             toolOutputLimit: this.#toolOutputLimit,
+            onCreated: (candidate) => {
+              createdForCleanup = candidate;
+            },
           });
-          if (after.turns.length !== boundary.sourceTurnCount - 1) {
-            throw new OpenCodeTransportError(
-              "protocolError",
-              "OpenCode rollback did not remove exactly the last Turn",
-            );
-          }
         }
       }
       const projection = await readProjection(
@@ -1977,12 +1784,8 @@ export class OpenCodeAdapter implements HarnessAdapter {
       await harnessSession.start();
       this.#sessions.add(harnessSession);
       createdForCleanup = undefined;
-      revertedForCleanup = undefined;
       return { ok: true, value: harnessSession };
     } catch (error) {
-      if (revertedForCleanup && transport) {
-        await transport.unrevertSession(revertedForCleanup).catch(() => undefined);
-      }
       if (createdForCleanup && transport) {
         await transport.deleteSession(createdForCleanup.id).catch(() => undefined);
       }

--- a/packages/adapters/opencode/src/protocol.ts
+++ b/packages/adapters/opencode/src/protocol.ts
@@ -44,6 +44,7 @@ export interface OpenCodeTransport {
   }): Promise<Session>;
   deleteSession(sessionID: string): Promise<void>;
   getSession(sessionID: string): Promise<Session>;
+  getPaths(): Promise<{ directory: string; worktree: string }>;
   updateSessionMetadata(sessionID: string, metadata: Record<string, unknown>): Promise<Session>;
   updateSessionPermission(sessionID: string, permission: PermissionRuleset): Promise<Session>;
   getMessages(sessionID: string): Promise<OpenCodeMessageWithParts[]>;
@@ -65,7 +66,13 @@ export interface OpenCodeTransport {
 }
 
 export type OpenCodeTransportErrorCode =
-  "notInstalled" | "authenticationRequired" | "unavailable" | "protocolError" | "processExited";
+  | "notInstalled"
+  | "authenticationRequired"
+  | "unavailable"
+  | "protocolError"
+  | "processExited"
+  | "checkpointNotFound"
+  | "invalidState";
 
 export class OpenCodeTransportError extends Error {
   constructor(

--- a/packages/adapters/opencode/src/sdk-transport.ts
+++ b/packages/adapters/opencode/src/sdk-transport.ts
@@ -170,6 +170,14 @@ export class SdkOpenCodeTransport implements OpenCodeTransport {
     );
   }
 
+  async getPaths() {
+    const client = await this.#getClient();
+    return responseData(
+      await withTimeout(client.path.get(), this.#commandTimeoutMs, "OpenCode Path read"),
+      "Path read",
+    );
+  }
+
   async updateSessionMetadata(sessionID: string, metadata: Record<string, unknown>) {
     const client = await this.#getClient();
     return responseData(

--- a/packages/adapters/opencode/test/file-change-verification.test.ts
+++ b/packages/adapters/opencode/test/file-change-verification.test.ts
@@ -1,0 +1,104 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import { openCodeFileIdentity, verifiedOpenCodeWorktree } from "../src/file-change-verification.js";
+
+const volumeRoot = path.parse(process.cwd()).root;
+const worktree = path.join(volumeRoot, "codexhost-synthetic-worktree");
+const directory = path.join(worktree, "packages", "app");
+
+describe("OpenCode strict FileChange path verification", () => {
+  it("uses authoritative worktree identity across absolute and relative paths", () => {
+    const verified = verifiedOpenCodeWorktree(directory, { directory, worktree });
+    expect(verified).toBe(worktree);
+    if (!verified) throw new Error("Synthetic worktree was not verified");
+
+    expect(openCodeFileIdentity(path.join(worktree, "src", "fixture.ts"), verified)).toBe(
+      openCodeFileIdentity(path.join("src", "fixture.ts"), verified),
+    );
+  });
+
+  it("keeps equal basenames in different worktree directories distinct", () => {
+    expect(openCodeFileIdentity(path.join("src", "fixture.ts"), worktree)).not.toBe(
+      openCodeFileIdentity(path.join("other", "fixture.ts"), worktree),
+    );
+  });
+
+  it.skipIf(process.platform === "win32")(
+    "canonicalizes directory aliases without collapsing a file symlink into its target",
+    async () => {
+      const root = await fs.mkdtemp(path.join(os.tmpdir(), "codexhost-opencode-paths-"));
+      const realWorktree = path.join(root, "real-worktree");
+      const aliasWorktree = path.join(root, "alias-worktree");
+      const outside = path.join(root, "outside");
+      try {
+        await fs.mkdir(realWorktree);
+        await fs.mkdir(path.join(outside, "nested"), { recursive: true });
+        await fs.writeFile(path.join(realWorktree, "target.ts"), "target\n", "utf8");
+        await fs.writeFile(path.join(outside, "escape.ts"), "outside\n", "utf8");
+        await fs.symlink(realWorktree, aliasWorktree);
+        await fs.symlink("target.ts", path.join(realWorktree, "link.ts"));
+        await fs.symlink(path.join(outside, "nested"), path.join(realWorktree, "outside-link"));
+
+        const verified = verifiedOpenCodeWorktree(aliasWorktree, {
+          directory: realWorktree,
+          worktree: aliasWorktree,
+        });
+        const canonicalWorktree = await fs.realpath(realWorktree);
+        expect(verified).toBe(canonicalWorktree);
+        if (!verified) throw new Error("Aliased worktree was not verified");
+        expect(openCodeFileIdentity(path.join(aliasWorktree, "link.ts"), verified)).toBe(
+          path.join(canonicalWorktree, "link.ts"),
+        );
+        expect(openCodeFileIdentity(path.join(aliasWorktree, "target.ts"), verified)).toBe(
+          path.join(canonicalWorktree, "target.ts"),
+        );
+        expect(
+          openCodeFileIdentity(
+            `${aliasWorktree}${path.sep}outside-link${path.sep}..${path.sep}escape.ts`,
+            verified,
+          ),
+        ).toBeUndefined();
+      } finally {
+        await fs.rm(root, { recursive: true, force: true });
+      }
+    },
+  );
+
+  it.each([
+    "../outside/fixture.ts",
+    "src/../fixture.ts",
+    path.join(path.dirname(worktree), "outside", "fixture.ts"),
+    "bad\0path.ts",
+    "bad\npath.ts",
+  ])("rejects an invalid or out-of-worktree file path: %s", (file) => {
+    expect(openCodeFileIdentity(file, worktree)).toBeUndefined();
+  });
+
+  it("rejects relative, mismatched, or out-of-worktree path metadata", () => {
+    expect(
+      verifiedOpenCodeWorktree("relative", { directory: "relative", worktree: "also-relative" }),
+    ).toBeUndefined();
+    expect(
+      verifiedOpenCodeWorktree(directory, {
+        directory: path.join(worktree, "different"),
+        worktree,
+      }),
+    ).toBeUndefined();
+    expect(
+      verifiedOpenCodeWorktree(`${worktree}${path.sep}packages${path.sep}..${path.sep}app`, {
+        directory,
+        worktree,
+      }),
+    ).toBeUndefined();
+    expect(
+      verifiedOpenCodeWorktree(directory, {
+        directory,
+        worktree: path.join(worktree, "nested-root"),
+      }),
+    ).toBeUndefined();
+  });
+});

--- a/packages/adapters/opencode/test/opencode-adapter.rollback.real.test.ts
+++ b/packages/adapters/opencode/test/opencode-adapter.rollback.real.test.ts
@@ -97,7 +97,10 @@ async function startModelServer(filePath: string): Promise<TestModelServer> {
       }
       const input = await readJson(request);
       const editTool = input.tools?.find(({ function: candidate }) => candidate?.name === "edit");
-      const shouldEdit = Boolean(editTool) && !input.messages?.some(({ role }) => role === "tool");
+      const shouldEdit =
+        Boolean(editTool) &&
+        !input.messages?.some(({ role }) => role === "tool") &&
+        (await fs.readFile(filePath, "utf8")) === "before\n";
       const toolArguments = JSON.stringify({
         filePath,
         oldString: "before\n",
@@ -239,7 +242,7 @@ async function waitForTurn(session: HarnessSession, turnId: string): Promise<Har
 }
 
 describe.runIf(Boolean(command))("OpenCode Adapter real rollback", () => {
-  it("restores a real Edit Tool change and preserves exact Fork history", async () => {
+  it("preserves current files and source history across rollback and restart", async () => {
     if (!command) throw new Error("CODEXHOST_OPENCODE_REAL_COMMAND is required");
     const root = await fs.mkdtemp(path.join(os.tmpdir(), "codexhost-opencode-rollback-"));
     const workspace = path.join(root, "workspace");
@@ -294,6 +297,8 @@ describe.runIf(Boolean(command))("OpenCode Adapter real rollback", () => {
         OPENCODE_CONFIG_DIR: path.join(root, "config"),
         OPENCODE_DISABLE_PROJECT_CONFIG: "true",
         OPENCODE_TEST_HOME: path.join(root, "home"),
+        XDG_CONFIG_HOME: path.join(root, "xdg-config"),
+        CODEWIZ_AUTO_UPDATE: "0",
         XDG_DATA_HOME: path.join(root, "data"),
         XDG_CACHE_HOME: path.join(root, "cache"),
         XDG_STATE_HOME: path.join(root, "state"),
@@ -352,10 +357,10 @@ describe.runIf(Boolean(command))("OpenCode Adapter real rollback", () => {
         cwd: workspace,
       });
       if (!rolledBack.ok) throw new Error(rolledBack.error.message);
-      expect(rolledBack.value.initialState.nativeRef?.nativeSessionId).toBe(
-        sourceRef.nativeSessionId,
-      );
-      expect(await fs.readFile(fixture, "utf8")).toBe("before\n");
+      const candidateRef = rolledBack.value.initialState.nativeRef;
+      if (!candidateRef) throw new Error("Rollback returned no Native Ref");
+      expect(candidateRef.nativeSessionId).not.toBe(sourceRef.nativeSessionId);
+      expect(await fs.readFile(fixture, "utf8")).toBe("after\n");
       await expect(rolledBack.value.readSnapshot()).resolves.toMatchObject({
         ok: true,
         value: { turns: [] },
@@ -364,7 +369,16 @@ describe.runIf(Boolean(command))("OpenCode Adapter real rollback", () => {
 
       await adapter.close();
       adapter = new OpenCodeAdapter(adapterOptions);
-      const resumed = await adapter.open({ kind: "resume", nativeRef: sourceRef, cwd: workspace });
+      const original = await adapter.open({ kind: "resume", nativeRef: sourceRef, cwd: workspace });
+      if (!original.ok) throw new Error(original.error.message);
+      const originalSnapshot = await original.value.readSnapshot();
+      expect(originalSnapshot).toEqual(snapshot);
+      await original.value.close();
+      const resumed = await adapter.open({
+        kind: "resume",
+        nativeRef: candidateRef,
+        cwd: workspace,
+      });
       if (!resumed.ok) throw new Error(resumed.error.message);
       expect(resumed.value.initialState.nativeRef?.locator).toMatchObject({
         executionPolicy: "unattended-full-access",
@@ -383,14 +397,14 @@ describe.runIf(Boolean(command))("OpenCode Adapter real rollback", () => {
 
       const rolledBackAgain = await adapter.open({
         kind: "rollbackLastTurn",
-        sourceRef,
+        sourceRef: candidateRef,
         cwd: workspace,
       });
       if (!rolledBackAgain.ok) throw new Error(rolledBackAgain.error.message);
-      expect(rolledBackAgain.value.initialState.nativeRef?.nativeSessionId).toBe(
-        sourceRef.nativeSessionId,
+      expect(rolledBackAgain.value.initialState.nativeRef?.nativeSessionId).not.toBe(
+        candidateRef.nativeSessionId,
       );
-      expect(await fs.readFile(fixture, "utf8")).toBe("before\n");
+      expect(await fs.readFile(fixture, "utf8")).toBe("after\n");
       await expect(rolledBackAgain.value.readSnapshot()).resolves.toMatchObject({
         ok: true,
         value: { turns: [] },

--- a/packages/adapters/opencode/test/opencode-adapter.test.ts
+++ b/packages/adapters/opencode/test/opencode-adapter.test.ts
@@ -226,6 +226,10 @@ class FakeOpenCodeTransport implements OpenCodeTransport {
     return session;
   }
 
+  async getPaths() {
+    return { directory: cwd, worktree: cwd };
+  }
+
   async getMessages(sessionID: string) {
     return [...(this.messages.get(sessionID) ?? [])];
   }
@@ -1523,23 +1527,20 @@ describe("OpenCode HarnessAdapter", () => {
       sourceRef,
       cwd,
     });
-    expect(rollbackTransport.forkCalls).toEqual([]);
-    expect(rollbackTransport.revertCalls).toEqual([
-      { sessionID: "session-1", messageID: "user-2" },
-    ]);
-    expect(rollbackFixture.session.initialState.nativeRef?.nativeSessionId).toBe("session-1");
+    expect(rollbackTransport.revertCalls).toEqual([]);
+    expect(rollbackTransport.forkCalls).toEqual([{ sessionID: "session-1", messageID: "user-2" }]);
+    expect(rollbackFixture.session.initialState.nativeRef?.nativeSessionId).toBe("session-fork");
     await expect(rollbackFixture.session.readSnapshot()).resolves.toMatchObject({
       ok: true,
       value: { turns: [{ input: [{ text: "one" }] }] },
     });
-    expect(rollbackTransport.sessions.get("session-1")?.revert).toMatchObject({
-      messageID: "user-2",
-    });
+    expect(rollbackTransport.sessions.get("session-1")?.revert).toBeUndefined();
+    expect(rollbackTransport.messages.get("session-1")).toEqual(sourceMessages);
     await rollbackFixture.session.close();
     await rollbackFixture.adapter.close();
   });
 
-  it("restores a reverted source Session when attachment fails", async () => {
+  it("preserves the source and deletes only the candidate when attachment fails", async () => {
     const transport = new FakeOpenCodeTransport();
     transport.messages.set("session-1", [
       userMessage("user-1", "one"),
@@ -1559,13 +1560,207 @@ describe("OpenCode HarnessAdapter", () => {
         ok: false,
       },
     );
-    expect(transport.forkCalls).toEqual([]);
-    expect(transport.revertCalls).toEqual([{ sessionID: "session-1", messageID: "user-1" }]);
-    expect(transport.unrevertCalls).toEqual(["session-1"]);
+    expect(transport.forkCalls).toEqual([{ sessionID: "session-1", messageID: "user-1" }]);
+    expect(transport.revertCalls).toEqual([]);
+    expect(transport.unrevertCalls).toEqual([]);
+    expect(transport.sessions.has("session-fork")).toBe(false);
     expect(transport.sessions.get("session-1")?.revert).toBeUndefined();
     expect(transport.sessions.get("session-1")).not.toHaveProperty("revert");
     await adapter.close();
   });
+  for (const kind of ["fork", "rollbackLastTurn"] as const) {
+    for (const failure of [
+      "source-id",
+      "changed-source",
+      "wrong-prefix",
+      "diff-read",
+      "permission",
+      "busy",
+    ] as const) {
+      it(`rejects ${failure} during ${kind} without deleting the source`, async () => {
+        const transport = new FakeOpenCodeTransport();
+        const originalMessages = [
+          userMessage("user-1", "one"),
+          assistantMessage("assistant-1", "user-1"),
+          userMessage("user-2", "two"),
+          assistantMessage("assistant-2", "user-2"),
+        ];
+        transport.messages.set("session-1", structuredClone(originalMessages));
+        const sourceRef = nativeSessionRefSchema.parse({
+          harnessId: "opencode",
+          nativeSessionId: "session-1",
+          locator: { directory: cwd },
+          formatVersion: 1,
+        });
+        const checkpoint = nativeCheckpointRefSchema.parse({
+          harnessId: "opencode",
+          nativeSessionId: "session-1",
+          formatVersion: 1,
+          checkpointId: "assistant-1",
+        });
+        const fork = transport.forkSession.bind(transport);
+        vi.spyOn(transport, "forkSession").mockImplementation(async (...args) => {
+          if (failure === "source-id") return transport.getSession("session-1");
+          const candidate = await fork(...args);
+          if (failure === "changed-source")
+            transport.messages.get("session-1")?.push(userMessage("user-3", "external write"));
+          if (failure === "wrong-prefix")
+            transport.messages.set(candidate.id, [
+              userMessage("wrong-user", "corrupted"),
+              assistantMessage("wrong-assistant", "wrong-user"),
+            ]);
+          return candidate;
+        });
+        if (failure === "diff-read")
+          vi.spyOn(transport, "getDiff").mockRejectedValue(new Error("unreadable diff"));
+        if (failure === "permission") {
+          (await transport.getSession("session-1")).permission = [
+            { permission: "*", pattern: "*", action: "deny" },
+          ];
+          vi.spyOn(transport, "updateSessionPermission").mockImplementation(async (id) =>
+            transport.getSession(id),
+          );
+        }
+        if (failure === "busy") transport.status = { type: "busy" };
+        const adapter = adapterFor(transport);
+        const result = await adapter.open(
+          kind === "fork" ? { kind, sourceRef, checkpoint, cwd } : { kind, sourceRef, cwd },
+        );
+        expect(result.ok).toBe(false);
+        expect(transport.sessions.has("session-1")).toBe(true);
+        expect(transport.sessions.has("session-fork")).toBe(false);
+        expect(transport.revertCalls).toEqual([]);
+        if (failure !== "changed-source")
+          expect(transport.messages.get("session-1")).toEqual(originalMessages);
+        await adapter.close();
+      });
+    }
+  }
+
+  it("persists empty rollback selection and permissions across Adapter restart", async () => {
+    const transport = new FakeOpenCodeTransport();
+    transport.messages.set("session-1", [
+      userMessage("user-1", "one"),
+      assistantMessage("assistant-1", "user-1"),
+    ]);
+    const source = await transport.getSession("session-1");
+    source.model = { providerID: "provider-1", id: "model-1", variant: "high" };
+    source.permission = [{ permission: "*", pattern: "*", action: "allow" }];
+    const sourceRef = nativeSessionRefSchema.parse({
+      harnessId: "opencode",
+      nativeSessionId: "session-1",
+      locator: { directory: cwd },
+      formatVersion: 1,
+    });
+    let adapter = adapterFor(transport);
+    const result = await adapter.open({ kind: "rollbackLastTurn", sourceRef, cwd });
+    if (!result.ok || !result.value.initialState.nativeRef) throw new Error("rollback failed");
+    const nativeRef = result.value.initialState.nativeRef;
+    const expected = {
+      effectiveModel: encodeOpenCodeModelRef({ providerID: "provider-1", modelID: "model-1" }),
+      effectiveThinkingOptionId: encodeOpenCodeVariant("high"),
+      effectivePermissionModeId: "allow",
+    };
+    expect(result.value.initialState).toMatchObject(expected);
+    await adapter.close();
+    adapter = adapterFor(transport);
+    const resumed = await adapter.open({ kind: "resume", nativeRef, cwd });
+    if (!resumed.ok) throw new Error(resumed.error.message);
+    expect(resumed.value.initialState).toMatchObject(expected);
+    await expect(resumed.value.readSnapshot()).resolves.toMatchObject({
+      ok: true,
+      value: { turns: [] },
+    });
+    await adapter.close();
+  });
+
+  it("waits for native idle after an abort error before admitting another Turn", async () => {
+    const { adapter, session, transport } = await openFixture();
+    const iterator = session.outputs[Symbol.asyncIterator]();
+    const active = turn("cancel-busy");
+    await session.execute(active);
+    await nextEvent(iterator);
+    transport.status = { type: "busy" };
+    await session.execute({ type: "turn.cancel", turnId: active.turnId });
+    transport.emit({
+      id: "early-abort",
+      type: "session.error",
+      properties: {
+        sessionID: "session-1",
+        error: { name: "MessageAbortedError", data: { message: "aborted" } },
+      },
+    });
+    await flush();
+    await expect(session.execute(turn("too-early"))).resolves.toMatchObject({
+      ok: false,
+      error: { code: "sessionBusy" },
+    });
+    appendTerminal(transport, [], { name: "MessageAbortedError", data: { message: "aborted" } });
+    transport.status = { type: "idle" };
+    transport.emit({ id: "settled", type: "session.idle", properties: { sessionID: "session-1" } });
+    expect(await nextEvent(iterator)).toMatchObject({
+      type: "turn.completed",
+      outcome: { status: "cancelled" },
+    });
+    await expect(session.execute(turn("follow-up"))).resolves.toMatchObject({ ok: true });
+    appendTerminal(transport);
+    await completeAfterBusy(transport);
+    await session.close();
+    await adapter.close();
+  });
+  it("settles idle cancellation even before an Assistant message is persisted", async () => {
+    const { adapter, session, transport } = await openFixture();
+    const iterator = session.outputs[Symbol.asyncIterator]();
+    const active = turn("cancel-before-assistant");
+    await session.execute(active);
+    await nextEvent(iterator);
+    await session.execute({ type: "turn.cancel", turnId: active.turnId });
+    transport.emit({ id: "idle", type: "session.idle", properties: { sessionID: "session-1" } });
+    expect(await nextEvent(iterator)).toMatchObject({
+      type: "turn.completed",
+      outcome: { status: "cancelled" },
+    });
+    await adapter.close();
+  });
+
+  for (const failure of ["missing-patch", "partial-diff", "wrong-worktree"] as const) {
+    it(`rejects ${failure} without manufacturing complete FileChange history`, async () => {
+      const transport = new FakeOpenCodeTransport();
+      transport.messages.set("session-1", [
+        userMessage("user-1", "one"),
+        assistantMessage("assistant-1", "user-1", [
+          {
+            id: "patch-1",
+            sessionID: "session-1",
+            messageID: "assistant-1",
+            type: "patch",
+            hash: "hash",
+            files: ["file.txt"],
+          },
+        ]),
+      ]);
+      if (failure === "partial-diff")
+        transport.diffs.set("user-1", [{ file: "file.txt", additions: 1, deletions: 1 }]);
+      if (failure === "wrong-worktree")
+        vi.spyOn(transport, "getPaths").mockResolvedValue({
+          directory: "/other",
+          worktree: "/other",
+        });
+      const adapter = adapterFor(transport);
+      const sourceRef = nativeSessionRefSchema.parse({
+        harnessId: "opencode",
+        nativeSessionId: "session-1",
+        locator: { directory: cwd },
+        formatVersion: 1,
+      });
+      await expect(
+        adapter.open({ kind: "rollbackLastTurn", sourceRef, cwd }),
+      ).resolves.toMatchObject({ ok: false, error: { code: "protocolError" } });
+      expect(transport.forkCalls).toEqual([]);
+      expect(transport.sessions.has("session-1")).toBe(true);
+      await adapter.close();
+    });
+  }
 });
 
 function adapterFor(transport: FakeOpenCodeTransport): OpenCodeAdapter {

--- a/tools/gate-opencode/cancel.real.test.mjs
+++ b/tools/gate-opencode/cancel.real.test.mjs
@@ -1,0 +1,157 @@
+import assert from "node:assert/strict";
+import http from "node:http";
+import { mkdtemp, rm } from "node:fs/promises";
+import path from "node:path";
+import { OpenCodeAdapter } from "../../packages/adapters/opencode/dist/index.js";
+import { describe, it } from "vitest";
+const command = process.env.CODEXHOST_OPENCODE_REAL_COMMAND;
+describe.runIf(Boolean(command))("OpenCode cancellation with a local model", () => {
+  it("closes the old request before continuation and preserves warm and cold history", async () => {
+    const root = await mkdtemp("/private/tmp/opencode-controlled-");
+    const model = "adjust-model",
+      provider = "codexhost-adjust-test";
+    let firstClosed = false,
+      agentRequests = 0,
+      overlappingRequests = false,
+      activeResponses = new Set();
+    const requests = [];
+    const server = http.createServer((req, res) => {
+      void (async () => {
+        let text = "";
+        for await (const c of req) text += c;
+        const body = JSON.parse(text);
+        requests.push(body.messages);
+        const isTitle = body.messages?.some(
+          (m) =>
+            m.role === "system" &&
+            typeof m.content === "string" &&
+            m.content.includes("You are a title generator"),
+        );
+        const index = isTitle ? 0 : ++agentRequests;
+        if (index > 1 && !firstClosed) overlappingRequests = true;
+
+        res.writeHead(200, { "content-type": "text/event-stream", "cache-control": "no-cache" });
+        activeResponses.add(res);
+        res.on("close", () => {
+          activeResponses.delete(res);
+          if (index === 1) firstClosed = true;
+        });
+        const chunk = (content, finish_reason = null) =>
+          res.write(
+            "data: " +
+              JSON.stringify({
+                id: "chatcmpl-adjust",
+                object: "chat.completion.chunk",
+                created: 0,
+                model,
+                choices: [{ index: 0, delta: { role: "assistant", content }, finish_reason }],
+              }) +
+              "\n\n",
+          );
+        chunk(index === 1 ? "FIRST_BEGIN" : isTitle ? "Adjustment test" : "OPENCODE_CANCEL_OK");
+        if (index !== 1) {
+          chunk("", "stop");
+          res.end("data: [DONE]\n\n");
+        }
+      })().catch(() => {
+        res.writeHead(500);
+        res.end();
+      });
+    });
+    await new Promise((r) => server.listen(0, "127.0.0.1", r));
+    const config = {
+      enabled_providers: [provider],
+      model: provider + "/" + model,
+      small_model: provider + "/" + model,
+      provider: {
+        [provider]: {
+          npm: "@ai-sdk/openai-compatible",
+          name: "Local adjustment test",
+          options: {
+            apiKey: "test-only",
+            baseURL: "http://127.0.0.1:" + server.address().port + "/v1",
+          },
+          models: {
+            [model]: { name: model, tool_call: true, limit: { context: 32000, output: 4000 } },
+          },
+        },
+      },
+    };
+    const environment = {
+      ...process.env,
+      CODEWIZ_AUTO_UPDATE: "0",
+      OPENCODE_CONFIG_CONTENT: JSON.stringify(config),
+      OPENCODE_CONFIG_DIR: path.join(root, "config"),
+      OPENCODE_DISABLE_PROJECT_CONFIG: "true",
+      OPENCODE_TEST_HOME: path.join(root, "home"),
+      XDG_CONFIG_HOME: path.join(root, "xdg-config"),
+      XDG_DATA_HOME: path.join(root, "data"),
+      XDG_CACHE_HOME: path.join(root, "cache"),
+      XDG_STATE_HOME: path.join(root, "state"),
+    };
+    const adapter = new OpenCodeAdapter({ command, environment, startupTimeoutMs: 30000 });
+    const events = [];
+    let session, consumed;
+    const waitFor = async (predicate, label) => {
+      const deadline = Date.now() + 40000;
+      while (Date.now() < deadline) {
+        const value = predicate();
+        if (value) return value;
+        await new Promise((r) => setTimeout(r, 20));
+      }
+      throw Error("Timed out " + label);
+    };
+    const start = (turnId, text) =>
+      session.execute({ type: "turn.start", turnId, input: [{ type: "text", text }] });
+    try {
+      const opened = await adapter.open({ kind: "create", cwd: root, executionPolicy: "default" });
+      if (!opened.ok) throw Error("Open " + opened.error.code + ": " + opened.error.message);
+      session = opened.value;
+      consumed = (async () => {
+        for await (const o of session.outputs) {
+          if (o.kind === "event") {
+            events.push(o.event);
+          }
+        }
+      })();
+      assert.equal((await start("before", "FIRST_INPUT")).ok, true);
+      await waitFor(() => agentRequests === 1, "first request");
+      const ack = await session.execute({ type: "turn.cancel", turnId: "before" });
+      assert.equal(ack.ok, true);
+      const before = await waitFor(
+        () => events.find((e) => e.type === "turn.completed" && e.turnId === "before"),
+        "cancel terminal",
+      );
+      assert.equal(before.outcome.status, "cancelled");
+      assert.equal((await start("after", "SECOND_INPUT")).ok, true);
+      const after = await waitFor(
+        () => events.find((e) => e.type === "turn.completed" && e.turnId === "after"),
+        "next terminal",
+      );
+      assert.equal(after.outcome.status, "succeeded");
+      const snap = await session.readSnapshot();
+      assert.equal(snap.ok, true);
+      assert.equal(snap.value.turns.length, 2);
+      assert.ok(JSON.stringify(snap.value.turns.at(-1)).includes("OPENCODE_CANCEL_OK"));
+      assert.equal(agentRequests, 2);
+      assert.equal(overlappingRequests, false);
+      assert.equal(firstClosed, true);
+      const nativeRef = session.initialState.nativeRef;
+      await session.close();
+      await consumed;
+      const resumed = await adapter.open({ kind: "resume", nativeRef, cwd: root });
+      assert.equal(resumed.ok, true);
+      const cold = await resumed.value.readSnapshot();
+      assert.equal(cold.ok, true);
+      assert.equal(cold.value.turns.length, 2);
+      assert.ok(JSON.stringify(cold.value.turns.at(-1)).includes("OPENCODE_CANCEL_OK"));
+    } finally {
+      await adapter.close();
+      if (consumed) await consumed;
+      for (const r of activeResponses) r.destroy();
+      server.closeAllConnections();
+      await new Promise((r) => server.close(r));
+      await rm(root, { recursive: true, force: true });
+    }
+  }, 90000);
+});


### PR DESCRIPTION
消息编辑应先生成可验证的候选历史，再由 Host 替换映射。直接修改 OpenCode 源 Session 会让失败或并发路径影响编辑前的历史，本 PR 将编辑改为保留源 Session 的派生流程。

- 派生空历史或保留前缀的候选 Session，校验历史与配置后返回；失败时清理候选资源。
- 恢复历史投影及文件变更验证使用一致的原生记录边界。
- 明确取消和传输关闭的处理，保留可重试错误及源历史。
- 补充回归测试、原生 CLI Gate、OpenSpec 与适配文档。

从 #158 的编辑可靠性方向独立整理，基于 e8f8ecd。与流式增量修复 #212 分开，两者均可独立审查；本 PR 不包含 #212 的空 Part 修复。

验证：`npm run typecheck` 通过；OpenCode Adapter 7 个文件、72 个用例通过；2 个真实 CLI 文件、2 个用例因未启用环境而跳过；变更文件 ESLint、Prettier、`git diff --check` 和 OpenSpec 严格校验通过。未将未执行的真实 CLI、Windows 或远端共享服务并发验证视为通过。