### PR TITLE
fix(claude-code): re-arm Thinking mid-session and scope Thinking options per Model

### DIFF
--- a/packages/adapters/claude-code/src/claude-code-adapter.ts
+++ b/packages/adapters/claude-code/src/claude-code-adapter.ts
@@ -63,6 +63,8 @@ import {
   type AccountCreditsSnapshot,
   type HarnessAccountSnapshot,
   type HarnessId,
+  type HarnessModelCatalog,
+  type HarnessThinkingOption,
   type HarnessThinkingOptionId,
   type HostInteractionId,
   type NativeSessionRef,
@@ -78,6 +80,7 @@ import { claudeTranscriptItemId } from "./item-identity.js";
 import { readClaudeTranscript } from "./claude-transcript.js";
 import {
   CLAUDE_DEFAULT_MODEL_REF,
+  claudeThinkingOptionsForModel,
   decodeClaudeModelRef,
   normalizeClaudeModelCatalog,
 } from "./model-catalog.js";
@@ -502,6 +505,7 @@ class ClaudeHarnessSession implements HarnessSession {
   readonly #createTransport: ClaudeAdapterDependencies["createTransport"];
   readonly #cwd: string;
   readonly #nativeRef: NativeSessionRef;
+  readonly #modelCatalog: HarnessModelCatalog | undefined;
   readonly #onClosed: () => void;
   readonly #onPlanLimitObserved: (planLimit: ClaudePlanLimitEvent) => ClaudePlanLimitEvent | null;
   #openMode: "create" | "resume";
@@ -559,6 +563,7 @@ class ClaudeHarnessSession implements HarnessSession {
       nativeRef?: NativeSessionRef;
       pendingSessions: ClaudePendingSessions;
       knownConfiguration?: boolean;
+      modelCatalog?: HarnessModelCatalog;
       requestedModel?: HarnessModelRef;
       requestedPermissionModeId: HarnessPermissionModeId;
       requestedThinkingOptionId: HarnessThinkingOptionId;
@@ -580,9 +585,16 @@ class ClaudeHarnessSession implements HarnessSession {
     this.#onClosed = onClosed;
     this.#onPlanLimitObserved = onPlanLimitObserved;
     this.#openMode = options.openMode;
+    this.#modelCatalog = options.modelCatalog;
     this.#requestedModel = options.requestedModel;
     this.#requestedPermissionModeId = options.requestedPermissionModeId;
-    this.#requestedThinkingOptionId = options.requestedThinkingOptionId;
+    // A configuration persisted before the selected Model's Thinking support was
+    // known may name an option that Model cannot honour.
+    this.#requestedThinkingOptionId = this.#clampThinkingOptionId(
+      options.requestedModel ??
+        (options.openMode === "create" ? CLAUDE_DEFAULT_MODEL_REF : undefined),
+      options.requestedThinkingOptionId,
+    );
     this.#sessionId = options.sessionId;
     this.#toolOutputLimit = options.toolOutputLimit;
     this.#continuationQuiescenceMs = options.continuationQuiescenceMs;
@@ -1048,7 +1060,27 @@ class ClaudeHarnessSession implements HarnessSession {
           };
         }
       }
+      // The new Model may not honour the Thinking option the previous one did.
+      const thinkingOptionId = this.#clampThinkingOptionId(
+        command.model,
+        this.#requestedThinkingOptionId,
+      );
+      if (transport && thinkingOptionId !== this.#requestedThinkingOptionId) {
+        try {
+          await transport.setThinkingOption(thinkingOptionId);
+        } catch {
+          return {
+            ok: false,
+            error: {
+              code: "nativeFailure",
+              message: "Claude Code rejected the Thinking selection",
+              retryable: true,
+            },
+          };
+        }
+      }
       this.#requestedModel = command.model;
+      this.#requestedThinkingOptionId = thinkingOptionId;
       const persistenceError = await this.#savePendingConfiguration();
       if (persistenceError) return { ok: false, error: persistenceError };
       this.#publishState(this.#configuredState());
@@ -1081,6 +1113,20 @@ class ClaudeHarnessSession implements HarnessSession {
         error: {
           code: "invalidRequest",
           message: "Claude Code Thinking option is invalid",
+          retryable: false,
+        },
+      };
+    }
+    if (
+      !this.#availableThinkingOptions(this.#effectiveModel()).some(
+        ({ id }) => id === thinkingOptionId,
+      )
+    ) {
+      return {
+        ok: false,
+        error: {
+          code: "invalidRequest",
+          message: "Claude Code Thinking option is unavailable for the selected Model",
           retryable: false,
         },
       };
@@ -1455,15 +1501,39 @@ class ClaudeHarnessSession implements HarnessSession {
     }
   }
 
-  #configuredState(nativeReady = this.#state.nativeRef !== undefined): HarnessSessionState {
-    const effectiveModel =
+  #effectiveModel(): HarnessModelRef | undefined {
+    return (
       this.#requestedModel ??
-      (this.#openMode === "create" ? CLAUDE_DEFAULT_MODEL_REF : this.#state.effectiveModel);
+      (this.#openMode === "create" ? CLAUDE_DEFAULT_MODEL_REF : this.#state.effectiveModel)
+    );
+  }
+
+  /**
+   * Claude Code silently downgrades an effort level the selected Model cannot
+   * honour, so a Session only offers the levels that Model reports.
+   */
+  #availableThinkingOptions(model: HarnessModelRef | undefined): HarnessThinkingOption[] {
+    return this.#modelCatalog
+      ? claudeThinkingOptionsForModel(this.#modelCatalog, model)
+      : [...CLAUDE_THINKING_OPTIONS];
+  }
+
+  #clampThinkingOptionId(
+    model: HarnessModelRef | undefined,
+    requested: HarnessThinkingOptionId,
+  ): HarnessThinkingOptionId {
+    return this.#availableThinkingOptions(model).some(({ id }) => id === requested)
+      ? requested
+      : CLAUDE_DEFAULT_THINKING_OPTION_ID;
+  }
+
+  #configuredState(nativeReady = this.#state.nativeRef !== undefined): HarnessSessionState {
+    const effectiveModel = this.#effectiveModel();
     return {
       ...(nativeReady ? { nativeRef: this.#nativeRef } : {}),
       ...(effectiveModel ? { effectiveModel } : {}),
       effectiveThinkingOptionId: this.#requestedThinkingOptionId,
-      availableThinkingOptions: [...CLAUDE_THINKING_OPTIONS],
+      availableThinkingOptions: this.#availableThinkingOptions(effectiveModel),
       effectivePermissionModeId: this.#requestedPermissionModeId,
     };
   }
@@ -2803,6 +2873,8 @@ export class ClaudeCodeAdapter implements HarnessAdapter {
         };
       }
     }
+    const inspection = this.#inspectionCache.get(cwd);
+    const modelCatalog = inspection?.status === "ready" ? inspection.catalog : undefined;
     const session: ClaudeHarnessSession = new ClaudeHarnessSession(
       cwd,
       this.#dependencies,
@@ -2812,6 +2884,7 @@ export class ClaudeCodeAdapter implements HarnessAdapter {
       {
         ...(input.environment ? { environment: input.environment } : {}),
         openMode,
+        ...(modelCatalog ? { modelCatalog } : {}),
         pendingSessions: this.#pendingSessions,
         knownConfiguration:
           input.kind === "rollbackLastTurn" ||

--- a/packages/adapters/claude-code/src/model-catalog.ts
+++ b/packages/adapters/claude-code/src/model-catalog.ts
@@ -9,6 +9,8 @@ import {
   type HarnessModel,
   type HarnessModelCatalog,
   type HarnessModelRef,
+  type HarnessThinkingOption,
+  type HarnessThinkingOptionId,
 } from "@codexhost/shared-contracts";
 import { z } from "zod";
 
@@ -25,6 +27,11 @@ const modelInfoSchema = z.object({
   value: z.string().trim().min(1).max(CLAUDE_MODEL_VALUE_MAX_LENGTH),
   displayName: z.string().trim().min(1).max(HARNESS_MODEL_LABEL_MAX_LENGTH),
   resolvedModel: harnessResolvedModelLabelSchema.optional(),
+  // Capability rows are advisory: an unreadable shape from a future runtime is
+  // dropped rather than failing the whole catalog.
+  supportsEffort: z.boolean().optional().catch(undefined),
+  supportedEffortLevels: z.array(z.string()).optional().catch(undefined),
+  supportsAdaptiveThinking: z.boolean().optional().catch(undefined),
 });
 
 export interface ClaudeModelInspectionSnapshot {
@@ -97,7 +104,10 @@ function uniqueDisplayLabels(rows: Array<z.infer<typeof modelInfoSchema>>): Map<
   return labels;
 }
 
-function normalizeRows(value: unknown): Array<z.infer<typeof modelInfoSchema>> {
+function normalizeRows(value: unknown): {
+  rows: Array<z.infer<typeof modelInfoSchema>>;
+  syntheticDefault: boolean;
+} {
   if (!Array.isArray(value)) throw new Error("Claude Code Model catalog is not an array");
   const byValue = new Map<string, z.infer<typeof modelInfoSchema>>();
   for (const nativeRow of value) {
@@ -109,24 +119,56 @@ function normalizeRows(value: unknown): Array<z.infer<typeof modelInfoSchema>> {
     if (!existing) byValue.set(row.value, row);
   }
   if (byValue.size === 0) throw new Error("Claude Code Model catalog is empty");
-  if (!byValue.has("default")) {
+  const syntheticDefault = !byValue.has("default");
+  if (syntheticDefault) {
     byValue.set("default", { value: "default", displayName: "Default" });
   }
-  return [...byValue.values()];
+  return { rows: [...byValue.values()], syntheticDefault };
+}
+
+/**
+ * Thinking options a single Model can actually honour. `off` and `auto` always
+ * apply — every Model can run without extended Thinking, and `auto` just leaves
+ * the depth to Claude Code. Explicit effort levels only apply to Models that
+ * report effort support: Claude Code silently downgrades an unsupported level,
+ * so offering one would misreport how hard the Model is about to think.
+ *
+ * Installations that report no capabilities at all (older Claude Code builds)
+ * keep the full list rather than losing levels that do work there.
+ */
+function thinkingOptionIdsForModel(
+  row: z.infer<typeof modelInfoSchema>,
+  capabilitiesReported: boolean,
+): HarnessThinkingOptionId[] {
+  if (!capabilitiesReported) return [...CLAUDE_THINKING_OPTION_IDS];
+  const levels = new Set(row.supportsEffort === false ? [] : (row.supportedEffortLevels ?? []));
+  return CLAUDE_THINKING_OPTION_IDS.filter(
+    (id) => id === "off" || id === CLAUDE_DEFAULT_THINKING_OPTION_ID || levels.has(id),
+  );
 }
 
 export function normalizeClaudeModelCatalog(
   snapshot: ClaudeModelInspectionSnapshot,
 ): NormalizedClaudeModelCatalog {
   if (!snapshot.canSelectModel) throw new Error("Claude Code Model selection is unavailable");
-  const rows = normalizeRows(snapshot.models);
+  const { rows, syntheticDefault } = normalizeRows(snapshot.models);
   const labels = uniqueDisplayLabels(rows);
+  const capabilitiesReported = rows.some(
+    (row) =>
+      row.supportsEffort !== undefined ||
+      row.supportedEffortLevels !== undefined ||
+      row.supportsAdaptiveThinking !== undefined,
+  );
   const models: HarnessModel[] = rows.map((row) => {
+    // A `default` row this Adapter synthesized carries no capabilities of its
+    // own, so it keeps the full list instead of being read as "supports nothing".
+    const rowCapabilitiesReported =
+      capabilitiesReported && !(syntheticDefault && row.value === "default");
     return {
       ref: encodeClaudeModelRef(row.value),
       label: labels.get(row.value) ?? row.displayName,
       ...(row.resolvedModel ? { resolvedModelLabel: row.resolvedModel } : {}),
-      supportedThinkingOptionIds: [...CLAUDE_THINKING_OPTION_IDS],
+      supportedThinkingOptionIds: thinkingOptionIdsForModel(row, rowCapabilitiesReported),
     };
   });
   models.sort((left, right) => {
@@ -141,4 +183,20 @@ export function normalizeClaudeModelCatalog(
     defaultThinkingOptionId: CLAUDE_DEFAULT_THINKING_OPTION_ID,
   });
   return { catalog, defaultModel: CLAUDE_DEFAULT_MODEL_REF };
+}
+
+/**
+ * Thinking options a Session may offer while the given Model is selected. Falls
+ * back to the full list for a Model the catalog doesn't cover, which keeps a
+ * Session opened before the first inspection behaving as it did before.
+ */
+export function claudeThinkingOptionsForModel(
+  catalog: HarnessModelCatalog,
+  model: HarnessModelRef | undefined,
+): HarnessThinkingOption[] {
+  const supported = model
+    ? catalog.models.find(({ ref }) => ref.id === model.id)?.supportedThinkingOptionIds
+    : undefined;
+  if (!supported) return [...CLAUDE_THINKING_OPTIONS];
+  return CLAUDE_THINKING_OPTIONS.filter(({ id }) => supported.includes(id));
 }

--- a/packages/adapters/claude-code/src/sdk-transport.ts
+++ b/packages/adapters/claude-code/src/sdk-transport.ts
@@ -18,7 +18,11 @@ import type { ClaudeModelInspectionSnapshot } from "./model-catalog.js";
 import { ClaudeNativeTurnAccumulator, parseClaudePlanLimitEvent } from "./native-message.js";
 import { isClaudePermissionMode, type ClaudePermissionMode } from "./permission-modes.js";
 import { closeClaudeProcessGroup } from "./process-fence.js";
-import { claudeThinkingConfiguration, parseClaudeThinkingOptionId } from "./thinking-options.js";
+import {
+  CLAUDE_THINKING_BUDGET_TOKENS,
+  claudeThinkingConfiguration,
+  parseClaudeThinkingOptionId,
+} from "./thinking-options.js";
 import type {
   ClaudeApprovalRequest,
   ClaudeApprovalSuggestionScope,
@@ -477,11 +481,24 @@ export class ClaudeSdkTransport implements ClaudeTurnTransport {
     if (!this.#started || !activeQuery) throw new Error("Claude SDK transport is not started");
     const id = parseClaudeThinkingOptionId(thinkingOptionId);
     const thinking = claudeThinkingConfiguration(id);
-    await activeQuery.applyFlagSettings(
-      thinking.enabled
-        ? { alwaysThinkingEnabled: true, effortLevel: thinking.effort ?? null }
-        : { alwaysThinkingEnabled: false },
-    );
+    // The Settings switch alone cannot re-arm Thinking: a Session started with
+    // `--thinking disabled` keeps that startup decision, so switching from Off to
+    // any level used to change the effort level while the Session stayed unable to
+    // think for the rest of its life. Setting a Thinking budget is what lifts it,
+    // and adaptive Models read a non-zero budget as "adaptive" — they keep
+    // choosing depth themselves under the effort level. The display mode rides
+    // along because a Session that started with Thinking off carries none, and
+    // the API's default (redacted) display streams Thinking frames that never
+    // carry text for the Renderer to open a Reasoning Item with.
+    if (thinking.enabled) {
+      await activeQuery.setMaxThinkingTokens(CLAUDE_THINKING_BUDGET_TOKENS, "summarized");
+    } else {
+      await activeQuery.setMaxThinkingTokens(0);
+    }
+    await activeQuery.applyFlagSettings({
+      alwaysThinkingEnabled: thinking.enabled,
+      effortLevel: thinking.effort ?? null,
+    });
     this.#thinkingOptionId = id;
   }
 

--- a/packages/adapters/claude-code/src/thinking-options.ts
+++ b/packages/adapters/claude-code/src/thinking-options.ts
@@ -22,6 +22,14 @@ export const CLAUDE_THINKING_OPTIONS = [
 export const CLAUDE_THINKING_OPTION_IDS = CLAUDE_THINKING_OPTIONS.map(({ id }) => id);
 export const CLAUDE_DEFAULT_THINKING_OPTION_ID = harnessThinkingOptionIdSchema.parse("auto");
 
+/**
+ * Thinking budget used when Thinking is re-armed mid-session. Adaptive Models
+ * read any non-zero budget as "adaptive" (so they keep deciding depth for
+ * themselves, guided by the effort level); older Models get a concrete ceiling.
+ * Matches the budget Claude Code's own maximum Thinking keyword uses.
+ */
+export const CLAUDE_THINKING_BUDGET_TOKENS = 31999;
+
 export type ClaudeEffortLevel = "low" | "medium" | "high" | "xhigh" | "max";
 
 export interface ClaudeThinkingConfiguration {

--- a/packages/adapters/claude-code/test/claude-code-adapter.test.ts
+++ b/packages/adapters/claude-code/test/claude-code-adapter.test.ts
@@ -225,6 +225,9 @@ function fixture(options: ClaudeCodeAdapterOptions = {}) {
               description: "ignored",
               resolvedModel: "runtime-default",
               supportsAutoMode: true,
+              supportsEffort: true,
+              supportedEffortLevels: ["low", "medium", "high", "xhigh", "max"],
+              supportsAdaptiveThinking: true,
             },
             {
               value: "sonnet",

--- a/packages/adapters/claude-code/test/model-catalog.test.ts
+++ b/packages/adapters/claude-code/test/model-catalog.test.ts
@@ -72,8 +72,85 @@ describe("Claude Code runtime Model catalog", () => {
     expect(
       normalized.catalog.models.find(({ label }) => label.startsWith("Family (sonnet"))
         ?.supportedThinkingOptionIds,
-    ).toEqual(["off", "auto", "low", "medium", "high", "xhigh", "max"]);
+    ).toEqual(["off", "auto", "low", "high"]);
+    expect(
+      normalized.catalog.models.find(({ label }) => label.startsWith("Family (custom-model"))
+        ?.supportedThinkingOptionIds,
+    ).toEqual(["off", "auto"]);
     expect(JSON.stringify(normalized.catalog)).not.toMatch(/private|apiKey|price|supportsEffort/u);
+  });
+
+  it("offers effort levels only to Models that report effort support", () => {
+    const normalized = normalizeClaudeModelCatalog(
+      snapshot([
+        {
+          value: "default",
+          displayName: "Default (recommended)",
+          description: "ignored",
+          resolvedModel: "claude-opus-5[1m]",
+          supportsEffort: true,
+          supportedEffortLevels: ["low", "medium", "high", "xhigh", "max"],
+          supportsAdaptiveThinking: true,
+        },
+        // Runtime shape for a Model without effort support: the capability keys
+        // are absent rather than false.
+        { value: "haiku", displayName: "Haiku", description: "ignored" },
+      ]),
+    );
+
+    expect(
+      normalized.catalog.models.map(({ label, supportedThinkingOptionIds }) => [
+        label,
+        supportedThinkingOptionIds,
+      ]),
+    ).toEqual([
+      ["Default (recommended)", ["off", "auto", "low", "medium", "high", "xhigh", "max"]],
+      ["Haiku", ["off", "auto"]],
+    ]);
+  });
+
+  it("keeps every Thinking option when the runtime reports no capabilities at all", () => {
+    const normalized = normalizeClaudeModelCatalog(
+      snapshot([
+        { value: "default", displayName: "Default", description: "ignored" },
+        { value: "sonnet", displayName: "Sonnet", description: "ignored" },
+      ]),
+    );
+
+    for (const model of normalized.catalog.models) {
+      expect(model.supportedThinkingOptionIds).toEqual([
+        "off",
+        "auto",
+        "low",
+        "medium",
+        "high",
+        "xhigh",
+        "max",
+      ]);
+    }
+  });
+
+  it("leaves a synthesized default row unnarrowed while other rows report capabilities", () => {
+    const normalized = normalizeClaudeModelCatalog(
+      snapshot([
+        { value: "haiku", displayName: "Haiku", description: "ignored" },
+        {
+          value: "sonnet",
+          displayName: "Sonnet",
+          description: "ignored",
+          supportsEffort: true,
+          supportedEffortLevels: ["high"],
+        },
+      ]),
+    );
+
+    expect(normalized.catalog.models[0]).toMatchObject({
+      label: "Default",
+      supportedThinkingOptionIds: ["off", "auto", "low", "medium", "high", "xhigh", "max"],
+    });
+    expect(
+      normalized.catalog.models.find(({ label }) => label === "Haiku")?.supportedThinkingOptionIds,
+    ).toEqual(["off", "auto"]);
   });
 
   it("uses deterministic bounded labels for long duplicate display names", () => {

--- a/packages/adapters/claude-code/test/sdk-transport.test.ts
+++ b/packages/adapters/claude-code/test/sdk-transport.test.ts
@@ -12,6 +12,7 @@ import {
   ClaudeSdkTransport,
   type ClaudeSdkTransportOptions,
 } from "../src/sdk-transport.js";
+import { CLAUDE_THINKING_BUDGET_TOKENS } from "../src/thinking-options.js";
 import type {
   ClaudeAutonomousTurn,
   ClaudeTransportTurnResult,
@@ -51,7 +52,15 @@ class FakeQuery {
     }),
   );
   readonly setModel = vi.fn(async () => undefined);
-  readonly applyFlagSettings = vi.fn(async () => undefined);
+  readonly applyFlagSettings = vi.fn(async (settings: Record<string, unknown>) => {
+    void settings;
+  });
+  readonly setMaxThinkingTokens = vi.fn(
+    async (maxThinkingTokens: number | null, thinkingDisplay?: string | null) => {
+      void maxThinkingTokens;
+      void thinkingDisplay;
+    },
+  );
   readonly setPermissionMode = vi.fn(async () => undefined);
   #closed = false;
   #messages: SDKMessage[] = [];
@@ -907,7 +916,7 @@ describe("ClaudeSdkTransport Permission Mode control", () => {
 });
 
 describe("ClaudeSdkTransport Thinking control", () => {
-  it("maps Auto, explicit effort, and Off through structured SDK settings", async () => {
+  it("maps Auto, explicit effort, and Off through the budget and the Settings switch", async () => {
     const value = fixture();
 
     await value.transport.start();
@@ -917,17 +926,34 @@ describe("ClaudeSdkTransport Thinking control", () => {
     await value.transport.setThinkingOption(harnessThinkingOptionIdSchema.parse("high"));
     await value.transport.setThinkingOption(harnessThinkingOptionIdSchema.parse("off"));
     await value.transport.setThinkingOption(harnessThinkingOptionIdSchema.parse("auto"));
-    expect(value.fakeQuery.applyFlagSettings).toHaveBeenNthCalledWith(1, {
-      alwaysThinkingEnabled: true,
-      effortLevel: "high",
-    });
-    expect(value.fakeQuery.applyFlagSettings).toHaveBeenNthCalledWith(2, {
-      alwaysThinkingEnabled: false,
-    });
-    expect(value.fakeQuery.applyFlagSettings).toHaveBeenNthCalledWith(3, {
-      alwaysThinkingEnabled: true,
-      effortLevel: null,
-    });
+    expect(value.fakeQuery.setMaxThinkingTokens.mock.calls).toEqual([
+      [CLAUDE_THINKING_BUDGET_TOKENS, "summarized"],
+      [0],
+      [CLAUDE_THINKING_BUDGET_TOKENS, "summarized"],
+    ]);
+    expect(value.fakeQuery.applyFlagSettings.mock.calls).toEqual([
+      [{ alwaysThinkingEnabled: true, effortLevel: "high" }],
+      [{ alwaysThinkingEnabled: false, effortLevel: null }],
+      [{ alwaysThinkingEnabled: true, effortLevel: null }],
+    ]);
+    await value.transport.close();
+  });
+
+  it("re-arms Thinking with a display mode on a Session that started with Thinking off", async () => {
+    const value = fixture("create", "default", harnessThinkingOptionIdSchema.parse("off"));
+
+    await value.transport.start();
+    expect(options(value).thinking).toEqual({ type: "disabled" });
+
+    await value.transport.setThinkingOption(harnessThinkingOptionIdSchema.parse("max"));
+    // Without the budget the Session would keep its startup `--thinking disabled`
+    // decision and never think again, whatever effort level it reported.
+    expect(value.fakeQuery.setMaxThinkingTokens.mock.calls).toEqual([
+      [CLAUDE_THINKING_BUDGET_TOKENS, "summarized"],
+    ]);
+    expect(value.fakeQuery.applyFlagSettings.mock.calls).toEqual([
+      [{ alwaysThinkingEnabled: true, effortLevel: "max" }],
+    ]);
     await value.transport.close();
   });
 


### PR DESCRIPTION
## Purpose

Two defects in the Claude Code Adapter made a selected Thinking level disagree with what Claude Code actually did.

**1. A Session created with Thinking = Off could never think again.** Query creation passes `--thinking disabled`, and `setThinkingOption` only moved the flag Settings layer (`alwaysThinkingEnabled` / `effortLevel`). The effort level changed, but the Session kept its startup decision, so the Renderer reported High/Max on a Session that produced no Reasoning at all.

**2. Every Model advertised all seven Thinking options.** `normalizeClaudeModelCatalog` dropped the `supportsEffort`, `supportedEffortLevels`, and `supportsAdaptiveThinking` rows the runtime reports, so a level Claude Code silently downgrades still looked selectable — Haiku offered Max.

## Changes

- `sdk-transport.ts`: `setThinkingOption` now sets a Thinking budget through `set_max_thinking_tokens` (with summarized display) alongside the Settings switch. The budget is what lifts the startup `--thinking disabled` decision; adaptive Models read a non-zero budget as adaptive, so they keep choosing depth under the effort level. The display mode has to ride along because a Session started with Thinking off carries none, and the API default display streams redacted frames that never open a Reasoning Item.
- `model-catalog.ts`: Thinking options are scoped per Model from the reported capabilities — `off` and `auto` always apply, explicit levels only where the runtime reports them. Capability rows are advisory (an unreadable shape from a future runtime is dropped, not fatal), and an installation that reports no capabilities at all keeps every option rather than losing levels that do work there. A synthesized `default` row is not narrowed.
- `claude-code-adapter.ts`: Session state publishes the current Model's Thinking options instead of the full list, a Model selection clamps an option the new Model cannot honour (pushing the clamp to the live transport), and `thinking.select` rejects an option the selected Model cannot honour.

## Validation

Against Claude Code `2.1.263` with `@anthropic-ai/claude-agent-sdk` `0.3.220`, driving `ClaudeSdkTransport` itself (same script, same prompt, only the code version changed):

| Session | before | after |
|---|---|---|
| turn 1, Thinking = Off at start | 0 Reasoning chars | 0 Reasoning chars |
| turn 2, switched Off → Max | **0 Reasoning chars** | **697 Reasoning chars** |

Real runtime catalog after the change:

```
Default (recommended) -> off, auto, low, medium, high, xhigh, max
Haiku                 -> off, auto
Opus (1M context)     -> off, auto, low, medium, high, xhigh, max
Sonnet                -> off, auto, low, medium, high, xhigh, max
```

Commands run: `npm run build:typescript`, `npx eslint packages/adapters/claude-code`, `node tools/check-boundaries.mjs`, `npx prettier --check` on the diff, and `npx vitest run --config tests/vitest.config.js packages/adapters/claude-code` — 249 passed. `command.test.ts > fails without substituting the SDK bundled binary` fails identically on unmodified `main` in this environment (the SDK bundled binary is resolvable here), so it is unrelated to this change. The full TypeScript suite was also run: its other failures (`tests/release/release-version`, `packages/adapters/opencode/test/command`, `tools/gate-claude-code/run`) reproduce on unmodified `main` too.

Tests added: the re-arm call sequence for a Session that started with Thinking off, per-Model option scoping, the no-capabilities fallback, and the synthesized `default` row.

## Note on documentation

`openspec/specs/claude-code-text-session/spec.md` still carries **Requirement: Claude Thinking selection remains unsupported** (`selectThinkingOption=false`, reject `thinking.select`), which `main` already contradicts — the Adapter ships Thinking selection today. That drift predates this change, so I left it alone rather than rewrite a requirement out of scope here. Happy to follow up with a spec update if you want it in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
