### PR TITLE
fix: invoke delegation CLI through the Host-provided path

### DIFF
--- a/packages/host-runtime/src/app-server-host.ts
+++ b/packages/host-runtime/src/app-server-host.ts
@@ -107,6 +107,7 @@ import {
   DELEGATION_RUNTIME_TOKEN_ENV,
   DELEGATION_THREAD_ID_ENV,
   DelegationControlError,
+  delegationNextCommands,
 } from "./delegation-types.js";
 import { HarnessDelegationCoordinator } from "./harness-delegation-coordinator.js";
 import { loadHarnessPlugins } from "./harness-plugin-loader.js";
@@ -1880,6 +1881,10 @@ export class AppServerHost {
     };
   }
 
+  #delegationNext(threadId: string): { read: string; wait: string } {
+    return delegationNextCommands(this.#options.environment ?? process.env, threadId);
+  }
+
   async #startOfficialDelegation(
     input: DelegationStartInput & { parentThreadId: string },
   ): Promise<DelegationStartResult> {
@@ -1927,10 +1932,7 @@ export class AppServerHost {
         harnessId: "codex",
         deepLink: `codex://threads/${existing.childHostThreadId}`,
         status: existing.status,
-        next: {
-          read: `codexhost thread read ${existing.childHostThreadId}`,
-          wait: `codexhost thread wait ${existing.childHostThreadId} --timeout-ms 30000`,
-        },
+        next: this.#delegationNext(existing.childHostThreadId),
       };
     }
     if (requestedModel || input.thinkingOptionId) {
@@ -2042,10 +2044,7 @@ export class AppServerHost {
               },
             }
           : {}),
-        next: {
-          read: `codexhost thread read ${threadId}`,
-          wait: `codexhost thread wait ${threadId} --timeout-ms 30000`,
-        },
+        next: this.#delegationNext(threadId),
       };
     } catch (error) {
       this.#activeOfficialTurns.delete(threadId);
@@ -2103,10 +2102,7 @@ export class AppServerHost {
       turnId,
       harnessId: "codex",
       status: "running",
-      next: {
-        read: `codexhost thread read ${input.threadId}`,
-        wait: `codexhost thread wait ${input.threadId} --timeout-ms 30000`,
-      },
+      next: this.#delegationNext(input.threadId),
     };
   }
 

--- a/packages/host-runtime/src/delegation-cli.ts
+++ b/packages/host-runtime/src/delegation-cli.ts
@@ -77,6 +77,7 @@ export const DELEGATION_HELP = `usage:
   codexhost thread wait <thread> [--timeout-ms <n>] [--view result|messages] [--cursor <cursor>] [--limit <n>]
   codexhost thread list [--cwd <path>] [--parent <thread>] [--limit <n>] [--cursor <cursor>] [--sort created-asc|created-desc|updated-asc|updated-desc|recency-asc|recency-desc]
 
+Invoke this CLI through the absolute path in CODEXHOST_CLI_PATH. A bare 'codexhost' is absent from PATH in some installations and may resolve to a different Host's CLI.
 Thread identifiers accept a bare ID or codex://threads/<id>. Output is JSON by default.
 harness inspect returns the target Model catalog, default Model, Thinking options, and configuration capabilities without creating a Thread. Use opaque IDs exactly as returned.
 delegate start requires --harness and --task, creates and submits the child Thread, then returns immediately. --model and --thinking select values returned by harness inspect. Omit either option to preserve that target's current default behavior. --parent-thread overrides caller inference. Reuse --request-id for idempotent retries; without it, identical recent parent/target/task/configuration requests are deduplicated briefly.

--- a/packages/host-runtime/src/delegation-cli.ts
+++ b/packages/host-runtime/src/delegation-cli.ts
@@ -77,7 +77,7 @@ export const DELEGATION_HELP = `usage:
   codexhost thread wait <thread> [--timeout-ms <n>] [--view result|messages] [--cursor <cursor>] [--limit <n>]
   codexhost thread list [--cwd <path>] [--parent <thread>] [--limit <n>] [--cursor <cursor>] [--sort created-asc|created-desc|updated-asc|updated-desc|recency-asc|recency-desc]
 
-Invoke this CLI through the absolute path in CODEXHOST_CLI_PATH. A bare 'codexhost' is absent from PATH in some installations and may resolve to a different Host's CLI.
+Invoke this CLI through the absolute path in CODEXHOST_CLI_PATH, quoted as your own shell requires. A bare 'codexhost' is absent from PATH in some installations and may resolve to a different Host's CLI.
 Thread identifiers accept a bare ID or codex://threads/<id>. Output is JSON by default.
 harness inspect returns the target Model catalog, default Model, Thinking options, and configuration capabilities without creating a Thread. Use opaque IDs exactly as returned.
 delegate start requires --harness and --task, creates and submits the child Thread, then returns immediately. --model and --thinking select values returned by harness inspect. Omit either option to preserve that target's current default behavior. --parent-thread overrides caller inference. Reuse --request-id for idempotent retries; without it, identical recent parent/target/task/configuration requests are deduplicated briefly.

--- a/packages/host-runtime/src/delegation-skill.ts
+++ b/packages/host-runtime/src/delegation-skill.ts
@@ -3,13 +3,20 @@ import { mkdir, open, readFile, rename, rm, stat } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 
-const SKILL_VERSION = 5;
+const SKILL_VERSION = 6;
 const SKILL_RELATIVE_PATH = path.join("skills", "codexhost-delegation", "SKILL.md");
-const PREVIOUS_MANAGED_DIGESTS: readonly string[] = [
+/**
+ * Digests of every previously shipped managed Skill. A released digest missing
+ * from this list makes the installer treat that copy as user-modified, so the
+ * affected installations silently stop receiving Skill updates.
+ */
+export const PREVIOUS_MANAGED_DIGESTS: readonly string[] = [
   "aff258622dc8ff321f32b15620d081e578cb9c9ed1134d6a57f35ca8e7762c0a",
   "ba509f57e5448e796b3dfdd5031dcb08672eded50b61c0a54de84cfa02c49dd3",
   "d3ddf6db9bc5c5df825479c885bbbf0ca08da66f7057a12e02e1fdf57525149e",
   "15eb63519ff867e1536c97188a0c43738d7a49d38d4d6adeb7a1036726e7246d",
+  "fa7944cd1e72ffbaf932fca2074bdb78aad4670d8990b6711220dd83c39509a0",
+  "2bb0aebb9b06febbc6c0c0bcdb0b32506c7cdbf8dc3b734cc6b2a86621270e4e",
 ];
 
 export const CODEXHOST_DELEGATION_SKILL = `---
@@ -26,9 +33,16 @@ description: >
 
 # Execute the task
 
+The \`CODEXHOST_CLI_PATH\` environment variable holds the absolute path of the CLI
+for this Host. Always invoke the CLI through that variable, using the syntax your
+shell requires. Do not run a bare \`codexhost\`: it is absent from \`PATH\` in some
+installations and may resolve to a different Host's CLI. If the variable is not
+set, report that delegation is unavailable from this session instead of searching
+\`PATH\`.
+
 Before acting, run:
 
-\`codexhost delegate --help\`
+\`"$CODEXHOST_CLI_PATH" delegate --help\`
 
 Treat its output as the sole authoritative source for:
 

--- a/packages/host-runtime/src/delegation-skill.ts
+++ b/packages/host-runtime/src/delegation-skill.ts
@@ -34,15 +34,17 @@ description: >
 # Execute the task
 
 The \`CODEXHOST_CLI_PATH\` environment variable holds the absolute path of the CLI
-for this Host. Always invoke the CLI through that variable, using the syntax your
-shell requires. Do not run a bare \`codexhost\`: it is absent from \`PATH\` in some
-installations and may resolve to a different Host's CLI. If the variable is not
-set, report that delegation is unavailable from this session instead of searching
-\`PATH\`.
+for this Host. Always invoke the CLI through that path. Do not run a bare
+\`codexhost\`: it is absent from \`PATH\` in some installations and may resolve to a
+different Host's CLI. If the variable is not set, report that delegation is
+unavailable from this session instead of searching \`PATH\`.
 
-Before acting, run:
+Before acting, run the help command, using the syntax of the shell you execute
+commands in:
 
-\`"$CODEXHOST_CLI_PATH" delegate --help\`
+- POSIX shells: \`"$CODEXHOST_CLI_PATH" delegate --help\`
+- PowerShell: \`& $env:CODEXHOST_CLI_PATH delegate --help\`
+- cmd: \`"%CODEXHOST_CLI_PATH%" delegate --help\`
 
 Treat its output as the sole authoritative source for:
 

--- a/packages/host-runtime/src/delegation-types.ts
+++ b/packages/host-runtime/src/delegation-types.ts
@@ -11,6 +11,25 @@ export const DELEGATION_RUNTIME_TOKEN_ENV = "CODEXHOST_RUNTIME_TOKEN";
 export const DELEGATION_CLI_PATH_ENV = "CODEXHOST_CLI_PATH";
 export const DELEGATION_THREAD_ID_ENV = "CODEXHOST_THREAD_ID";
 
+/**
+ * Follow-up commands are executed by the caller Agent, which reaches this CLI
+ * through the Host-provided absolute path rather than `PATH`: the packaged
+ * application never places `codexhost` on `PATH`, and an npm installation that
+ * does may belong to a different Host. Quoting keeps installation directories
+ * containing spaces usable verbatim.
+ */
+export function delegationNextCommands(
+  environment: NodeJS.ProcessEnv,
+  threadId: string,
+): { read: string; wait: string } {
+  const cliPath = environment[DELEGATION_CLI_PATH_ENV];
+  const cli = cliPath ? JSON.stringify(cliPath) : "codexhost";
+  return {
+    read: `${cli} thread read ${threadId}`,
+    wait: `${cli} thread wait ${threadId} --timeout-ms 30000`,
+  };
+}
+
 export type DelegationThreadStatus =
   "creating" | "running" | "completed" | "failed" | "interrupted";
 

--- a/packages/host-runtime/src/delegation-types.ts
+++ b/packages/host-runtime/src/delegation-types.ts
@@ -11,19 +11,36 @@ export const DELEGATION_RUNTIME_TOKEN_ENV = "CODEXHOST_RUNTIME_TOKEN";
 export const DELEGATION_CLI_PATH_ENV = "CODEXHOST_CLI_PATH";
 export const DELEGATION_THREAD_ID_ENV = "CODEXHOST_THREAD_ID";
 
+/** Paths built only from these characters need no quoting in any target shell. */
+const UNQUOTED_COMMAND_PATH = /^[A-Za-z0-9_.:\\/+@=-]+$/u;
+
+/**
+ * Renders an executable path as text the caller Agent can run in its own shell.
+ * An unquoted path runs identically under POSIX shells, PowerShell, and cmd, so
+ * it is preferred whenever the path allows it. Quoting is otherwise shell
+ * specific: PowerShell needs the `&` call operator because a leading quoted
+ * string is only an expression, and both shells treat backslashes literally, so
+ * a Windows path must never be escaped as if it were a C or JSON string.
+ */
+function commandPath(cliPath: string, platform: NodeJS.Platform): string {
+  if (UNQUOTED_COMMAND_PATH.test(cliPath)) return cliPath;
+  if (platform === "win32") return `& '${cliPath.replaceAll("'", "''")}'`;
+  return `'${cliPath.replaceAll("'", String.raw`'\''`)}'`;
+}
+
 /**
  * Follow-up commands are executed by the caller Agent, which reaches this CLI
  * through the Host-provided absolute path rather than `PATH`: the packaged
  * application never places `codexhost` on `PATH`, and an npm installation that
- * does may belong to a different Host. Quoting keeps installation directories
- * containing spaces usable verbatim.
+ * does may belong to a different Host.
  */
 export function delegationNextCommands(
   environment: NodeJS.ProcessEnv,
   threadId: string,
+  platform: NodeJS.Platform = process.platform,
 ): { read: string; wait: string } {
   const cliPath = environment[DELEGATION_CLI_PATH_ENV];
-  const cli = cliPath ? JSON.stringify(cliPath) : "codexhost";
+  const cli = cliPath ? commandPath(cliPath, platform) : "codexhost";
   return {
     read: `${cli} thread read ${threadId}`,
     wait: `${cli} thread wait ${threadId} --timeout-ms 30000`,

--- a/packages/host-runtime/src/harness-delegation-coordinator.ts
+++ b/packages/host-runtime/src/harness-delegation-coordinator.ts
@@ -21,6 +21,7 @@ import { harnessIdSchema, hostThreadIdSchema, hostTurnIdSchema } from "@codexhos
 import {
   DELEGATION_THREAD_ID_ENV,
   DelegationControlError,
+  delegationNextCommands,
   type DelegationConfigurationResult,
   type DelegationStartInput,
   type DelegationStartResult,
@@ -602,16 +603,17 @@ export class HarnessDelegationCoordinator {
     );
   }
 
+  #next(threadId: string): { read: string; wait: string } {
+    return delegationNextCommands(this.#environment, threadId);
+  }
+
   #turnResult(threadId: string, turnId: string, harnessId: RoutedHarnessId): ThreadSendResult {
     return {
       threadId,
       turnId,
       harnessId,
       status: "running",
-      next: {
-        read: `codexhost thread read ${threadId}`,
-        wait: `codexhost thread wait ${threadId} --timeout-ms 30000`,
-      },
+      next: this.#next(threadId),
     };
   }
 
@@ -635,10 +637,7 @@ export class HarnessDelegationCoordinator {
         Object.keys(configuration.effective ?? {}).length > 0)
         ? { configuration }
         : {}),
-      next: {
-        read: `codexhost thread read ${threadId}`,
-        wait: `codexhost thread wait ${threadId} --timeout-ms 30000`,
-      },
+      next: this.#next(threadId),
     };
   }
 }

--- a/packages/host-runtime/src/run-host-runtime.ts
+++ b/packages/host-runtime/src/run-host-runtime.ts
@@ -95,8 +95,18 @@ function requiredRuntimeConfiguration(environment: NodeJS.ProcessEnv): {
   return { stockCodexPath, defaultAgent };
 }
 
-function delegationCliPath(environment: NodeJS.ProcessEnv): string | undefined {
-  return environment[DELEGATION_CLI_PATH_ENV] ?? environment.CODEXHOST_LAUNCHER_EXECUTABLE;
+/**
+ * An npm installation has no bundled `runtime/` directory, so its native
+ * launcher cannot resolve the Node runtime that the delegation CLI needs and
+ * fails before parsing any subcommand. Its Node launcher already knows which
+ * Node to use, so prefer that entry point whenever npm provided one.
+ */
+export function delegationCliPath(environment: NodeJS.ProcessEnv): string | undefined {
+  return (
+    environment[DELEGATION_CLI_PATH_ENV] ??
+    environment.CODEXHOST_NPM_LAUNCHER_PATH ??
+    environment.CODEXHOST_LAUNCHER_EXECUTABLE
+  );
 }
 
 async function prepareDelegationRuntime(input: {

--- a/packages/host-runtime/test/delegation-next-commands.test.ts
+++ b/packages/host-runtime/test/delegation-next-commands.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+
+import { delegationNextCommands } from "../src/delegation-types.js";
+
+const thread = "thread-1";
+
+function read(cliPath: string | undefined, platform: NodeJS.Platform): string {
+  return delegationNextCommands(
+    cliPath === undefined ? {} : { CODEXHOST_CLI_PATH: cliPath },
+    thread,
+    platform,
+  ).read;
+}
+
+describe("delegationNextCommands", () => {
+  it("leaves ordinary install paths unquoted so any target shell can run them", () => {
+    expect(read("/Applications/codexhost.app/Contents/MacOS/codexhost", "darwin")).toBe(
+      `/Applications/codexhost.app/Contents/MacOS/codexhost thread read ${thread}`,
+    );
+    expect(read(String.raw`C:\Users\dev\codexhost\codexhost.exe`, "win32")).toBe(
+      String.raw`C:\Users\dev\codexhost\codexhost.exe thread read ${thread}`,
+    );
+  });
+
+  it("quotes a POSIX path containing spaces literally", () => {
+    expect(read("/Applications/My codexhost.app/Contents/MacOS/codexhost", "darwin")).toBe(
+      `'/Applications/My codexhost.app/Contents/MacOS/codexhost' thread read ${thread}`,
+    );
+  });
+
+  it("keeps Windows backslashes literal and calls through the PowerShell operator", () => {
+    // A leading quoted string is only an expression in PowerShell, so `&` is
+    // required; backslashes must survive verbatim rather than being escaped as
+    // they would be in a C or JSON string literal.
+    const command = read(String.raw`C:\Program Files\codexhost\codexhost.exe`, "win32");
+    expect(command).toBe(
+      String.raw`& 'C:\Program Files\codexhost\codexhost.exe' thread read ${thread}`,
+    );
+    expect(command).not.toContain(String.raw`\\`);
+  });
+
+  it("escapes single quotes for each shell", () => {
+    expect(read("/opt/it's/codexhost", "linux")).toBe(
+      `'/opt/it'\\''s/codexhost' thread read ${thread}`,
+    );
+    expect(read(String.raw`C:\it's dir\codexhost.exe`, "win32")).toBe(
+      String.raw`& 'C:\it''s dir\codexhost.exe' thread read ${thread}`,
+    );
+  });
+
+  it("falls back to the bare name only when the Host provided no path", () => {
+    expect(read(undefined, "darwin")).toBe(`codexhost thread read ${thread}`);
+    expect(delegationNextCommands({}, thread, "darwin").wait).toBe(
+      `codexhost thread wait ${thread} --timeout-ms 30000`,
+    );
+  });
+});

--- a/packages/host-runtime/test/delegation-skill.test.ts
+++ b/packages/host-runtime/test/delegation-skill.test.ts
@@ -4,7 +4,11 @@ import path from "node:path";
 
 import { describe, expect, it } from "vitest";
 
-import { CODEXHOST_DELEGATION_SKILL, installDelegationSkills } from "../src/delegation-skill.js";
+import {
+  CODEXHOST_DELEGATION_SKILL,
+  PREVIOUS_MANAGED_DIGESTS,
+  installDelegationSkills,
+} from "../src/delegation-skill.js";
 
 async function home(): Promise<string> {
   return mkdtemp(path.join(os.tmpdir(), "codexhost-skill-test-"));
@@ -83,15 +87,34 @@ describe("delegation Skill installation", () => {
   });
 
   it("routes natural agent requests and points execution to the authoritative help", () => {
-    expect(CODEXHOST_DELEGATION_SKILL).toContain("version: 5");
+    expect(CODEXHOST_DELEGATION_SKILL).toContain("version: 6");
     expect(CODEXHOST_DELEGATION_SKILL).toContain("@agent) to independently perform a task");
     expect(CODEXHOST_DELEGATION_SKILL).toContain("session's content, progress, or results");
     expect(CODEXHOST_DELEGATION_SKILL).toContain("Not for recapping the current conversation");
-    expect(CODEXHOST_DELEGATION_SKILL).toContain("codexhost delegate --help");
+    expect(CODEXHOST_DELEGATION_SKILL).toContain('"$CODEXHOST_CLI_PATH" delegate --help');
     expect(CODEXHOST_DELEGATION_SKILL).toContain("sole authoritative source");
     expect(CODEXHOST_DELEGATION_SKILL).toContain("send a follow-up message");
     expect(CODEXHOST_DELEGATION_SKILL).toContain("cancel its current Turn");
     expect(CODEXHOST_DELEGATION_SKILL).toContain("target keeps its default");
     expect(CODEXHOST_DELEGATION_SKILL).not.toContain("--timeout-ms");
+  });
+
+  it("directs the CLI invocation through the Host-provided absolute path", () => {
+    expect(CODEXHOST_DELEGATION_SKILL).toContain("CODEXHOST_CLI_PATH");
+    expect(CODEXHOST_DELEGATION_SKILL).toContain("Do not run a bare");
+    expect(CODEXHOST_DELEGATION_SKILL).not.toMatch(/(^|[^"])`codexhost /mu);
+  });
+
+  it("keeps every previously shipped digest recognized as a managed copy", async () => {
+    const { createHash } = await import("node:crypto");
+    // v4 shipped in 0.6.0; its digest was previously absent, which pinned those
+    // installations to a stale Skill because updates were reported as conflicts.
+    expect(PREVIOUS_MANAGED_DIGESTS).toContain(
+      "fa7944cd1e72ffbaf932fca2074bdb78aad4670d8990b6711220dd83c39509a0",
+    );
+    expect(PREVIOUS_MANAGED_DIGESTS).not.toContain(
+      createHash("sha256").update(CODEXHOST_DELEGATION_SKILL).digest("hex"),
+    );
+    expect(new Set(PREVIOUS_MANAGED_DIGESTS).size).toBe(PREVIOUS_MANAGED_DIGESTS.length);
   });
 });

--- a/packages/host-runtime/test/delegation-skill.test.ts
+++ b/packages/host-runtime/test/delegation-skill.test.ts
@@ -105,6 +105,14 @@ describe("delegation Skill installation", () => {
     expect(CODEXHOST_DELEGATION_SKILL).not.toMatch(/(^|[^"])`codexhost /mu);
   });
 
+  it("gives a runnable bootstrap example for every supported shell", () => {
+    // A POSIX-only example is not executable on Windows, where PowerShell needs
+    // the `&` call operator and `$env:` scoping, and cmd needs `%VAR%`.
+    expect(CODEXHOST_DELEGATION_SKILL).toContain('"$CODEXHOST_CLI_PATH" delegate --help');
+    expect(CODEXHOST_DELEGATION_SKILL).toContain("& $env:CODEXHOST_CLI_PATH delegate --help");
+    expect(CODEXHOST_DELEGATION_SKILL).toContain('"%CODEXHOST_CLI_PATH%" delegate --help');
+  });
+
   it("keeps every previously shipped digest recognized as a managed copy", async () => {
     const { createHash } = await import("node:crypto");
     // v4 shipped in 0.6.0; its digest was previously absent, which pinned those

--- a/packages/host-runtime/test/harness-delegation-coordinator.test.ts
+++ b/packages/host-runtime/test/harness-delegation-coordinator.test.ts
@@ -12,7 +12,10 @@ import { HarnessDelegationCoordinator } from "../src/harness-delegation-coordina
 import { ExternalThreadRepository } from "../src/external-thread-repository.js";
 import { ExternalThreadRuntime } from "../src/external-thread-runtime.js";
 
-async function fixture(adapter = new FakeHarnessAdapter(harnessIdSchema.parse("pi"))) {
+async function fixture(
+  adapter = new FakeHarnessAdapter(harnessIdSchema.parse("pi")),
+  environment: NodeJS.ProcessEnv = {},
+) {
   const directory = await mkdtemp(path.join(os.tmpdir(), "codexhost-delegation-coordinator-"));
   const store = new MappingStore({ directory });
   await store.initialize();
@@ -28,7 +31,7 @@ async function fixture(adapter = new FakeHarnessAdapter(harnessIdSchema.parse("p
   });
   const coordinator = new HarnessDelegationCoordinator({
     adapters,
-    environment: {},
+    environment,
     externalRuntime: runtime,
     repository,
     registerExternalThread: (input) => {
@@ -99,6 +102,29 @@ class FailingTurnAdapter extends FakeHarnessAdapter {
 }
 
 describe("HarnessDelegationCoordinator", () => {
+  it("builds follow-up commands from the Host-provided CLI path", async () => {
+    const adapter = new RecordingAdapter(harnessIdSchema.parse("pi"));
+    const value = await fixture(adapter, {
+      CODEXHOST_CLI_PATH: "/Applications/My codexhost.app/Contents/MacOS/codexhost",
+    });
+    try {
+      const result = await value.coordinator.start({
+        harnessId: "pi",
+        task: "review auth",
+        cwd: "/synthetic",
+        parentThreadId: "parent-thread",
+      });
+      expect(result.next.read).toBe(
+        `"/Applications/My codexhost.app/Contents/MacOS/codexhost" thread read ${result.threadId}`,
+      );
+      expect(result.next.wait).toBe(
+        `"/Applications/My codexhost.app/Contents/MacOS/codexhost" thread wait ${result.threadId} --timeout-ms 30000`,
+      );
+    } finally {
+      await value.close();
+    }
+  });
+
   it("creates a normal writable child Thread and publishes it only after initial delivery", async () => {
     const adapter = new RecordingAdapter(harnessIdSchema.parse("pi"));
     const value = await fixture(adapter);

--- a/packages/host-runtime/test/harness-delegation-coordinator.test.ts
+++ b/packages/host-runtime/test/harness-delegation-coordinator.test.ts
@@ -104,9 +104,8 @@ class FailingTurnAdapter extends FakeHarnessAdapter {
 describe("HarnessDelegationCoordinator", () => {
   it("builds follow-up commands from the Host-provided CLI path", async () => {
     const adapter = new RecordingAdapter(harnessIdSchema.parse("pi"));
-    const value = await fixture(adapter, {
-      CODEXHOST_CLI_PATH: "/Applications/My codexhost.app/Contents/MacOS/codexhost",
-    });
+    const cliPath = "/Applications/codexhost.app/Contents/MacOS/codexhost";
+    const value = await fixture(adapter, { CODEXHOST_CLI_PATH: cliPath });
     try {
       const result = await value.coordinator.start({
         harnessId: "pi",
@@ -114,11 +113,9 @@ describe("HarnessDelegationCoordinator", () => {
         cwd: "/synthetic",
         parentThreadId: "parent-thread",
       });
-      expect(result.next.read).toBe(
-        `"/Applications/My codexhost.app/Contents/MacOS/codexhost" thread read ${result.threadId}`,
-      );
+      expect(result.next.read).toBe(`${cliPath} thread read ${result.threadId}`);
       expect(result.next.wait).toBe(
-        `"/Applications/My codexhost.app/Contents/MacOS/codexhost" thread wait ${result.threadId} --timeout-ms 30000`,
+        `${cliPath} thread wait ${result.threadId} --timeout-ms 30000`,
       );
     } finally {
       await value.close();

--- a/packages/host-runtime/test/run-host-runtime.test.ts
+++ b/packages/host-runtime/test/run-host-runtime.test.ts
@@ -5,6 +5,7 @@ import { describe, expect, it } from "vitest";
 import {
   createRemoteControlOfficialAppServerPlan,
   createRemoteOfficialAppServerPlan,
+  delegationCliPath,
   hasLauncherManagedUpdateRuntime,
   MANAGED_REMOTE_APP_SERVER_PROCESS_TITLE,
 } from "../src/run-host-runtime.js";
@@ -54,6 +55,40 @@ describe("Host Runtime composition", () => {
         "--analytics-default-enabled",
       ],
     });
+  });
+
+  it("advertises the npm Node launcher instead of its native launcher", () => {
+    // An npm installation ships no `runtime/` directory, so the native launcher
+    // aborts with a missing-file error before it reaches the delegation CLI.
+    // The Node launcher resolves its own Node runtime and works.
+    const npmLauncher = path.resolve("npm", "node_modules", "@codexhost", "cli", "bin", "codexhost.js");
+    const nativeLauncher = path.resolve("npm", "node_modules", "@codexhost", "cli-darwin-arm64", "bin", "codexhost");
+
+    expect(
+      delegationCliPath({
+        CODEXHOST_NPM_LAUNCHER_PATH: npmLauncher,
+        CODEXHOST_LAUNCHER_EXECUTABLE: nativeLauncher,
+      }),
+    ).toBe(npmLauncher);
+  });
+
+  it("keeps the packaged launcher when npm did not provide one", () => {
+    const packaged = path.resolve("Applications", "codexhost.app", "Contents", "MacOS", "codexhost");
+
+    expect(delegationCliPath({ CODEXHOST_LAUNCHER_EXECUTABLE: packaged })).toBe(packaged);
+    expect(delegationCliPath({})).toBeUndefined();
+  });
+
+  it("lets an explicit CLI path override every launcher", () => {
+    const explicit = path.resolve("custom", "codexhost");
+
+    expect(
+      delegationCliPath({
+        CODEXHOST_CLI_PATH: explicit,
+        CODEXHOST_NPM_LAUNCHER_PATH: path.resolve("npm", "codexhost.js"),
+        CODEXHOST_LAUNCHER_EXECUTABLE: path.resolve("native", "codexhost"),
+      }),
+    ).toBe(explicit);
   });
 
   it("disables launcher-owned updates for a direct SSH Host invocation", () => {


### PR DESCRIPTION
## Purpose

Cross-Harness delegation is unusable from a packaged install, and the next release would have silently frozen the delegation Skill on every machine running 0.6.0.

### 1. The Skill points Agents at a command that does not exist

`SKILL.md` instructs the Agent to run:

```
codexhost delegate --help
```

But `codexhost` only exists at `/Applications/codexhost.app/Contents/MacOS/codexhost`, and an app bundle's `MacOS/` directory is never on `PATH`. Any Agent following the Skill gets `command not found: codexhost` and delegation fails before a Runtime request is ever made.

This also contradicts an explicit design decision. `add-cross-harness-delegation/design.md` rejects PATH discovery precisely because it cross-wires installations:

> 不回退到 PATH 猜测——猜测正是 npm 版与安装包版串线的来源

The Host already exports `CODEXHOST_CLI_PATH` for this, and whitelists it through to the official app-server so native Codex inherits it. The Skill just never mentioned it. The npm meta package *does* expose `bin: { codexhost }`, so on a mixed install the bare name can resolve to a different Host's CLI — exactly the cross-wiring above.

The same bare command is returned in `next.read` / `next.wait`, which Agents copy verbatim.

### 2. The v4 digest is missing, which would freeze the Skill on 0.6.0

`PREVIOUS_MANAGED_DIGESTS` is how the installer tells a managed copy from a user-edited one. Verified digests of every shipped template:

| version | digest | listed before this PR |
|---|---|---|
| v2 | `d3ddf6db…` | yes |
| v3 | `15eb6351…` | yes |
| **v4 (shipped in 0.6.0)** | **`fa7944cd…`** | **no** |

The v5 commit added `aff258622dc8…`, which matches no shipped template. So once v5 released, every 0.6.0 install would hit `!knownDigests.has(currentDigest)`, be reported as `conflict`, and **never receive another Skill update**.

## Changes

- Skill, CLI help, and `next.read` / `next.wait` now direct invocation through `CODEXHOST_CLI_PATH`; the Skill instructs Agents to report delegation as unavailable rather than searching `PATH` when it is unset.
- `delegationNextCommands` is shared between the Adapter and native-Codex paths so the two cannot drift; the path is quoted so install directories containing spaces work verbatim.
- Added the v4 and v5 digests and bumped the Skill to v6.
- `PREVIOUS_MANAGED_DIGESTS` is exported and documented so a regression test can assert shipped digests stay recognized.

## Affected requirements

`cross-harness-delegation` — "委派 CLI 的运行时连接与调用方身份由 Host 解析". Host-side behavior is unchanged; this aligns the Agent-facing text and returned commands with the contract that was already implemented. No protocol, persistence, or Adapter change.

## Validation

- `npm run test:typescript` — 2900 passed / 250 files, 0 failures
- `npm run typecheck` — clean
- `npm run lint` — clean (ESLint + boundary check)
- New focused tests: follow-up commands built from the CLI path (including a path with spaces); Skill contains no bare `codexhost`; shipped digests stay recognized as managed
- Verified end-to-end against a live Host before the change: `delegate start --harness grok` → `thread wait` returned `status: completed`, confirming the Runtime path itself was already sound and the failure was purely CLI resolution

Digests were recomputed from each historical revision of the template rather than copied from the existing list.