### PR TITLE
feat: add slash picker and native prompts for Claude Code and OMP

### DIFF
--- a/docs/harness-command-integration.md
+++ b/docs/harness-command-integration.md
@@ -19,7 +19,7 @@ Use `none` when the command has no argument and `text` when it accepts trailing 
 
 ## 2. Register it in the owning Adapter
 
-Declare a static `HarnessAdapter.commandCatalog`. Reading this metadata must not call `inspect()`, connect to a native service, or open a Session. Keep `session.commands.list()` consistent with this catalog for existing execution clients. Implement execution in the owning Adapter and validate:
+Declare a static `HarnessAdapter.commandCatalog`. Reading this metadata must not call `inspect()`, connect to a native service, or open a Session. The static catalog remains available before a Native Session exists. An already-started Session may extend `session.commands.list()` with commands discovered through its native interface; listing must never start or resume a Native Session. Implement execution in the owning Adapter and validate:
 
 - command ID;
 - argument shape;
@@ -41,9 +41,11 @@ For commands with visible progress, decide explicitly whether they need:
 
 ## 4. Reuse Host and Renderer routing
 
-The Renderer reads static metadata via `codexhost/harness/commands/inspect { harnessId }`, through the target Host and public Adapter contract. No Thread or Native Session is needed, and there is no native-discovery fallback. The legacy Thread catalog RPC also reads Adapter metadata without opening or resuming a Session. The independent Composer popover has no Harness-specific catalog branches. Selecting `/compact` always executes directly with no text arguments, leaving the current draft and attachments untouched, even when the Harness supports optional compaction instructions. Other text commands prefix their invocation in the current editor, including before the first Turn, preserving the draft and attachments for ordinary submission. Direct commands (`/compact` and argument-free commands) execute only when a Thread exists; otherwise their menu items are disabled with an explanation, while the menu and other text commands remain available. Manually submitted `/compact` text retains the Adapter's existing argument support.
+The Renderer reads static metadata via `codexhost/harness/commands/inspect { harnessId }`, through the target Host and public Adapter contract. No Thread or Native Session is needed, and there is no native-discovery fallback. The Thread catalog RPC reads `commands.list()` from an already-open Session, falling back to static Adapter metadata only when no Session is loaded. It never opens or resumes a Session to populate the menu. The independent Composer popover has no Harness-specific catalog branches. Selecting `/compact` always executes directly with no text arguments, leaving the current draft and attachments untouched, even when the Harness supports optional compaction instructions. Other text commands prefix their invocation in the current editor, including before the first Turn, preserving the draft and attachments for ordinary submission. Direct commands (`/compact` and argument-free commands) execute only when a Thread exists; otherwise their menu items are disabled with an explanation, while the menu and other text commands remain available. Manually submitted `/compact` text retains the Adapter's existing argument support.
 
 The command button belongs to the active external Harness controls, near the Composer's left-side actions. It remains visible before a Thread exists and while the command catalog is empty or unavailable; in those states it is disabled with a localized availability hint. Only command execution requires a Thread; catalog inspection does not. Switching to Codex hides the external Harness command button and closes its popover. It MUST remain outside the Codex React-managed Slash command list; the independent popover owns its own focus, keyboard navigation, positioning, and scrolling.
+
+The independent popover includes a search field. Typing `/` into an empty external Composer opens this search field before Codex handles the keystroke; composing text, slashes inside ordinary drafts, and native Codex input remain untouched. Opening the picker refreshes its catalog through the target Host.
 
 For typed submission, the Host first checks for a leading slash-command token (ignoring leading whitespace). Only command candidates have trailing whitespace removed before catalog matching; ordinary prompts retain their original text and skip command catalog inspection. Unknown slash commands are rejected.
 
@@ -118,3 +120,17 @@ The public `/dsh-goal` invocation avoids Codex Desktop's built-in `/goal` comman
 - Shared contracts remain Harness-neutral.
 - Renderer code must not parse or execute Harness `SKILL.md` files.
 - UI DOM selectors are compatibility details, not command contract requirements.
+
+## Claude Code and OMP native prompt commands
+
+Descriptors may declare `executionMode: "prompt"`. These commands insert a draft on selection and execute through an ordinary `turn/start` after explicit submission. They do not use ephemeral `command/execute`; direct command execution rejects them. This preserves native prompt expansion and normal conversation history.
+
+- Claude Code reads SDK `supportedCommands()` from the existing query. Eligible SDK prompts and skills appear as `/claude:<name>` (including plugin-qualified names such as `/claude:plugin:review`). The Adapter validates the name against the current SDK catalog immediately before translating it to the native `/<name>` invocation. Model, permission, identity-replacement and known local control commands remain on existing controls or are excluded. Existing `/compact`, `/init`, and `/recap` keep their original execution paths.
+- OMP reads RPC `get_available_commands` from the existing transport. File prompt templates (`source: "file"`) and skills (`source: "skill"`) appear as `/omp:<name>`, for example `/omp:skill:review`. Unknown/missing native discovery on older OMP releases leaves the static catalog intact. Terminal-only builtins, extensions and custom imperative handlers are not assumed to be ordinary prompt turns; they remain excluded in this slice. Existing `/compact` is unchanged.
+- Namespaces prevent same-named native Codex commands from consuming these invocations before Harness routing. Only the owning Adapter removes its prefix; arbitrary unknown slash input is still rejected.
+- Native entries become available once that Thread's native transport has started (normally after the first message). Draft and cold, unopened Session inspection remains static and side-effect-free. The picker explains this limitation; it refreshes when opened.
+- Discovery uses each Harness's existing configuration sources. In particular, Claude currently uses `settingSources: ["user"]`; this change does not enable project/local settings, add plugin roots, read command files in the Renderer, or invent terminal-only capabilities. Installed user/plugin prompts exposed by that query are supported. OMP retains its existing file/skill discovery behavior.
+
+### Validation
+
+Use a harmless native file/plugin command that expands its arguments into an exact response. Verify native catalog discovery, namespaced invocation translation, a successful command Turn, and a subsequent normal Turn. OMP RPC and Claude SDK shapes must come from those real interfaces; unit fixtures may anonymize names and descriptions. Browser tests should verify that `/` opens only the active Harness menu, search filters its entries, selection preserves drafts, and Codex's own slash handling remains unchanged.

--- a/packages/adapters/claude-code/src/claude-code-adapter.ts
+++ b/packages/adapters/claude-code/src/claude-code-adapter.ts
@@ -1,3 +1,4 @@
+import { claudeNativeCommandCatalog, claudeNativePrompt } from "./claude-commands.js";
 import { randomUUID } from "node:crypto";
 import path from "node:path";
 
@@ -594,7 +595,7 @@ class ClaudeHarnessSession implements HarnessSession {
         formatVersion: 1,
       });
     this.commands = {
-      list: async () => ({ ok: true, value: claudeCommandCatalog }),
+      list: () => this.#listCommands(),
       execute: (command) => this.#executeHarnessCommand(command),
     };
     const durable = this.#openMode === "resume" || options.nativeRef !== undefined;
@@ -613,6 +614,22 @@ class ClaudeHarnessSession implements HarnessSession {
     this.#state = this.initialState;
     this.#statePublished = durable;
     this.outputs = this.#channel.outputs;
+  }
+
+  async #listCommands() {
+    try {
+      const native = (await this.#transport?.getAvailableCommands?.()) ?? [];
+      return { ok: true as const, value: claudeNativeCommandCatalog(claudeCommandCatalog, native) };
+    } catch {
+      return {
+        ok: false as const,
+        error: {
+          code: "unavailable" as const,
+          message: "Claude Code command catalog is unavailable",
+          retryable: true,
+        },
+      };
+    }
   }
 
   async readSnapshot(): Promise<HarnessResult<HostThreadSnapshot>> {
@@ -756,7 +773,7 @@ class ClaudeHarnessSession implements HarnessSession {
         },
       };
     }
-    const text = command.input.map((input) => input.text).join("\n");
+    let text = command.input.map((input) => input.text).join("\n");
     if (text.length === 0) {
       return {
         ok: false,
@@ -773,6 +790,11 @@ class ClaudeHarnessSession implements HarnessSession {
     let transport: ClaudeTurnTransport;
     try {
       transport = await this.#ensureTransport();
+      if (text.trimStart().startsWith("/claude:")) {
+        const catalog = await this.#listCommands();
+        if (!catalog.ok) throw new Error(catalog.error.message);
+        text = claudeNativePrompt(text, catalog.value);
+      }
     } catch (error) {
       this.#acceptingTurn = false;
       return { ok: false, error: startupFailure(error) };

--- a/packages/adapters/claude-code/src/claude-commands.ts
+++ b/packages/adapters/claude-code/src/claude-commands.ts
@@ -1,0 +1,92 @@
+import {
+  harnessCommandCatalogSchema,
+  harnessCommandDescriptorSchema,
+  type HarnessCommandCatalog,
+} from "@codexhost/shared-contracts";
+
+export interface ClaudeNativeCommand {
+  name: string;
+  description: string;
+  argumentHint: string;
+}
+
+// These controls replace identity, require terminal UI, or bypass the Host's model/account controls.
+const reserved = new Set([
+  "compact",
+  "init",
+  "recap",
+  "clear",
+  "new",
+  "resume",
+  "fork",
+  "exit",
+  "quit",
+  "import",
+  "model",
+  "effort",
+  "fast",
+  "config",
+  "permissions",
+  "permission",
+  "login",
+  "logout",
+  "color",
+  "rename",
+  "heapdump",
+  "__remote-workflow",
+  "workflow-launch-exec",
+  "context",
+  "usage",
+  "usage-credits",
+  "extra-usage",
+  "mcp",
+  "reload-skills",
+  "doctor",
+  "agents",
+  "design-consent",
+  "design-revoke",
+  "design",
+  "goal",
+  "auto-mode-setup",
+  "team-onboarding",
+  "run",
+]);
+
+export function claudeNativeCommandCatalog(
+  base: HarnessCommandCatalog,
+  native: readonly ClaudeNativeCommand[],
+): HarnessCommandCatalog {
+  const commands = [...base.commands];
+  const names = new Set<string>();
+  for (const command of native) {
+    const name = command.name;
+    if (!/^[A-Za-z0-9][A-Za-z0-9._:-]{0,99}$/u.test(name) || reserved.has(name) || names.has(name))
+      continue;
+    names.add(name);
+    commands.push(
+      harnessCommandDescriptorSchema.parse({
+        id: `claude.native.${name}`,
+        invocation: `/claude:${name}`,
+        label: name,
+        description: command.description?.trim().slice(0, 512) || name,
+        argumentMode: "text",
+        executionMode: "prompt",
+      }),
+    );
+  }
+  return harnessCommandCatalogSchema.parse({ commands });
+}
+
+export function claudeNativePrompt(text: string, catalog: HarnessCommandCatalog): string {
+  if (!text.trimStart().startsWith("/claude:")) return text;
+  const candidate = text.trimStart();
+  const token = candidate.match(/^\S+/u)?.[0];
+  if (
+    !catalog.commands.some(
+      (command) => command.executionMode === "prompt" && command.invocation === token,
+    )
+  ) {
+    throw new Error("Claude Code command is no longer available in the Native Session");
+  }
+  return `/${candidate.slice("/claude:".length)}`;
+}

--- a/packages/adapters/claude-code/src/sdk-transport.ts
+++ b/packages/adapters/claude-code/src/sdk-transport.ts
@@ -1,3 +1,4 @@
+import type { ClaudeNativeCommand } from "./claude-commands.js";
 import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
 
 import {
@@ -453,6 +454,11 @@ export class ClaudeSdkTransport implements ClaudeTurnTransport {
     }
     this.#started = true;
     this.#consumeTask = this.#consume(activeQuery);
+  }
+
+  async getAvailableCommands(): Promise<ClaudeNativeCommand[]> {
+    if (!this.#started || !this.#query) return [];
+    return this.#query.supportedCommands();
   }
 
   async getContextUsage(): Promise<ClaudeTransportContextUsage | null> {

--- a/packages/adapters/claude-code/src/transport.ts
+++ b/packages/adapters/claude-code/src/transport.ts
@@ -1,3 +1,4 @@
+import type { ClaudeNativeCommand } from "./claude-commands.js";
 import type {
   HarnessAccountSnapshot,
   HarnessThinkingOptionId,
@@ -178,6 +179,7 @@ export interface ClaudeIdleTurnHandler {
 }
 
 export interface ClaudeTurnTransport {
+  getAvailableCommands?(): Promise<ClaudeNativeCommand[]>;
   readonly sessionId: string;
   setAutonomousTurnHandler(handler: (turn: ClaudeAutonomousTurn) => void): void;
   setIdleTurnHandler(handler: ClaudeIdleTurnHandler | null): void;

--- a/packages/adapters/claude-code/test/claude-code-adapter.test.ts
+++ b/packages/adapters/claude-code/test/claude-code-adapter.test.ts
@@ -64,6 +64,10 @@ class FakeClaudeTransport implements ClaudeTurnTransport {
       reason: "cancelled" in response ? "cancelled" : "responded",
     });
   });
+  nativeCommands: Array<{ name: string; description: string; argumentHint: string }> = [];
+  async getAvailableCommands() {
+    return this.nativeCommands;
+  }
   readonly start = vi.fn(async () => undefined);
   readonly compactCalls: Array<{ userMessageId: string; customInstructions: string | undefined }> =
     [];
@@ -1129,6 +1133,56 @@ describe("Claude Code HarnessAdapter", () => {
         },
       },
     });
+    await session.close();
+  });
+
+  it("discovers SDK prompt commands without creating a transport just to inspect metadata", async () => {
+    const { adapter, transports } = fixture();
+    const session = await openSession(adapter);
+    const iterator = session.outputs[Symbol.asyncIterator]();
+    await session.commands?.list();
+    expect(transports).toHaveLength(0);
+    await session.execute({
+      type: "turn.start",
+      turnId: hostTurnIdSchema.parse("warm"),
+      input: [{ type: "text", text: "warm" }],
+    });
+    const transport = transports[0];
+    if (!transport) throw new Error("No transport");
+    transport.nativeCommands = [{ name: "probe", description: "Probe", argumentHint: "<message>" }];
+    transport.delta("READY");
+    transport.finish({ status: "succeeded" });
+    while ((await nextEvent(iterator)).type !== "turn.completed") {
+      /* drain warmup */
+    }
+    await expect(session.commands?.list()).resolves.toMatchObject({
+      ok: true,
+      value: {
+        commands: expect.arrayContaining([
+          expect.objectContaining({ invocation: "/claude:probe", executionMode: "prompt" }),
+        ]),
+      },
+    });
+    await session.execute({
+      type: "turn.start",
+      turnId: hostTurnIdSchema.parse("probe"),
+      input: [{ type: "text", text: "/claude:probe ARG42" }],
+    });
+    expect(transport.turns.at(-1)?.text).toBe("/probe ARG42");
+    transport.delta("SLASH_OK ARG42");
+    transport.finish({ status: "succeeded" });
+    while ((await nextEvent(iterator)).type !== "turn.completed") {
+      /* drain command */
+    }
+    transport.nativeCommands = [];
+    await expect(
+      session.execute({
+        type: "turn.start",
+        turnId: hostTurnIdSchema.parse("removed"),
+        input: [{ type: "text", text: "/claude:probe ARG42" }],
+      }),
+    ).resolves.toMatchObject({ ok: false });
+    expect(transport.turns).toHaveLength(2);
     await session.close();
   });
 

--- a/packages/adapters/claude-code/test/claude-commands.test.ts
+++ b/packages/adapters/claude-code/test/claude-commands.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { claudeNativeCommandCatalog, claudeNativePrompt } from "../src/claude-commands.js";
+
+describe("Claude SDK prompt commands", () => {
+  it("routes SDK commands through a namespace without leaking identity/config controls", () => {
+    // Shape observed from SDK supportedCommands(), with synthetic prompt names.
+    const catalog = claudeNativeCommandCatalog({ commands: [] }, [
+      { name: "probe", description: "Test prompt", argumentHint: "<message>" },
+      { name: "review:probe", description: "Review", argumentHint: "" },
+      { name: "clear", description: "Clear", argumentHint: "" },
+      { name: "model", description: "Change model", argumentHint: "" },
+      { name: "probe", description: "Duplicate", argumentHint: "" },
+      { name: "bad name", description: "Invalid", argumentHint: "" },
+    ]);
+    expect(catalog.commands.map((c) => c.invocation)).toEqual([
+      "/claude:probe",
+      "/claude:review:probe",
+    ]);
+    expect(claudeNativePrompt("/claude:probe alpha  beta\ngamma", catalog)).toBe(
+      "/probe alpha  beta\ngamma",
+    );
+    expect(claudeNativePrompt("hello /probe", catalog)).toBe("hello /probe");
+    expect(() => claudeNativePrompt("/claude:clear", catalog)).toThrow("no longer available");
+  });
+});

--- a/packages/adapters/omp/src/omp-adapter.ts
+++ b/packages/adapters/omp/src/omp-adapter.ts
@@ -1,3 +1,4 @@
+import { ompNativeCommandCatalog, ompNativePrompt, type OmpNativeCommand } from "./omp-commands.js";
 import { createTwoFilesPatch, parsePatch } from "diff";
 import { randomUUID } from "node:crypto";
 import path from "node:path";
@@ -123,6 +124,7 @@ export interface OmpTurnTransport {
   readonly stderrTail?: string;
   start(): Promise<unknown>;
   getAvailableModels(): Promise<OmpNativeModel[]>;
+  getAvailableCommands?(): Promise<OmpNativeCommand[]>;
   getAvailableThinkingLevels(): Promise<HarnessThinkingOptionId[] | null>;
   getEntries(): Promise<OmpSessionHistory>;
   getSubagentMessages(input: {
@@ -629,7 +631,7 @@ class OmpHarnessSession implements HarnessSession {
       subagents: { observe: true, readTranscript: true },
     };
     this.commands = {
-      list: async () => ({ ok: true, value: ompCommandCatalog }),
+      list: () => this.#listCommands(),
       execute: (command) => this.#executeHarnessCommand(command),
     };
     this.#transport = options.startedTransport ?? null;
@@ -644,6 +646,22 @@ class OmpHarnessSession implements HarnessSession {
     this.#usage = this.initialUsage;
     this.#state = this.initialState;
     this.outputs = this.#channel.outputs;
+  }
+
+  async #listCommands() {
+    try {
+      const native = (await this.#transport?.getAvailableCommands?.()) ?? [];
+      return { ok: true as const, value: ompNativeCommandCatalog(ompCommandCatalog, native) };
+    } catch {
+      return {
+        ok: false as const,
+        error: {
+          code: "unavailable" as const,
+          message: "OMP command catalog is unavailable",
+          retryable: true,
+        },
+      };
+    }
   }
 
   handleTransportFault(error: OmpRpcFaultError): void {
@@ -894,7 +912,7 @@ class OmpHarnessSession implements HarnessSession {
         },
       };
     }
-    const text = command.input.map((input) => input.text).join("\n");
+    let text = command.input.map((input) => input.text).join("\n");
     if (text.length === 0) {
       return {
         ok: false,
@@ -917,6 +935,11 @@ class OmpHarnessSession implements HarnessSession {
       let transport: OmpTurnTransport;
       try {
         transport = await this.#ensureTransport();
+        if (text.trimStart().startsWith("/omp:")) {
+          const catalog = await this.#listCommands();
+          if (!catalog.ok) throw new Error(catalog.error.message);
+          text = ompNativePrompt(text, catalog.value);
+        }
       } catch (error) {
         return { ok: false, error: normalizedError(error, "unavailable") };
       }

--- a/packages/adapters/omp/src/omp-commands.ts
+++ b/packages/adapters/omp/src/omp-commands.ts
@@ -1,0 +1,68 @@
+import {
+  harnessCommandCatalogSchema,
+  harnessCommandDescriptorSchema,
+  type HarnessCommandCatalog,
+} from "@codexhost/shared-contracts";
+
+export interface OmpNativeCommand {
+  name: string;
+  description?: string;
+  source: string;
+}
+
+// Native Session replacement and terminal-only controls cannot be projected as Turns.
+const promptSources = new Set(["file", "skill"]);
+const reserved = new Set([
+  "compact",
+  "clear",
+  "new",
+  "resume",
+  "branch",
+  "fork",
+  "quit",
+  "exit",
+  "model",
+  "switch",
+  "login",
+  "logout",
+]);
+
+export function ompNativeCommandCatalog(
+  base: HarnessCommandCatalog,
+  native: readonly OmpNativeCommand[],
+): HarnessCommandCatalog {
+  const commands = [...base.commands];
+  const names = new Set<string>();
+  for (const command of native) {
+    const name = command.name;
+    if (!/^[A-Za-z0-9][A-Za-z0-9._:-]{0,99}$/u.test(name) || reserved.has(name) || names.has(name))
+      continue;
+    if (!promptSources.has(command.source)) continue;
+    names.add(name);
+    commands.push(
+      harnessCommandDescriptorSchema.parse({
+        id: `omp.native.${name}`,
+        invocation: `/omp:${name}`,
+        label: name,
+        description: command.description?.trim().slice(0, 512) || name,
+        argumentMode: "text",
+        executionMode: "prompt",
+      }),
+    );
+  }
+  return harnessCommandCatalogSchema.parse({ commands });
+}
+
+export function ompNativePrompt(text: string, catalog: HarnessCommandCatalog): string {
+  if (!text.trimStart().startsWith("/omp:")) return text;
+  const candidate = text.trimStart();
+  const token = candidate.match(/^\S+/u)?.[0];
+  if (
+    !catalog.commands.some(
+      (command) => command.executionMode === "prompt" && command.invocation === token,
+    )
+  ) {
+    throw new Error("OMP command is no longer available in the Native Session");
+  }
+  return `/${candidate.slice("/omp:".length)}`;
+}

--- a/packages/adapters/omp/src/omp-rpc-session.ts
+++ b/packages/adapters/omp/src/omp-rpc-session.ts
@@ -1,3 +1,4 @@
+import type { OmpNativeCommand } from "./omp-commands.js";
 import { spawn, spawnSync, type ChildProcessWithoutNullStreams } from "node:child_process";
 import { randomUUID } from "node:crypto";
 import path from "node:path";
@@ -791,6 +792,33 @@ export class OmpRpcSession {
       sessionFile: this.state.sessionFile,
       sessionId: this.state.sessionId,
       expectedCwd,
+    });
+  }
+
+  async getAvailableCommands(): Promise<OmpNativeCommand[]> {
+    let response: Record<string, unknown>;
+    try {
+      response = await this.#send("get_available_commands", {});
+    } catch (error) {
+      if (error instanceof OmpRpcUnsupportedCommandError) return [];
+      throw error;
+    }
+    const data = isRecord(response.data) ? response.data : null;
+    if (!data || !Array.isArray(data.commands)) throw new Error("OMP command catalog is invalid");
+    return data.commands.flatMap((command) => {
+      if (
+        !isRecord(command) ||
+        typeof command.name !== "string" ||
+        typeof command.source !== "string"
+      )
+        return [];
+      return [
+        {
+          name: command.name,
+          source: command.source,
+          ...(typeof command.description === "string" ? { description: command.description } : {}),
+        },
+      ];
     });
   }
 

--- a/packages/adapters/omp/test/omp-adapter.test.ts
+++ b/packages/adapters/omp/test/omp-adapter.test.ts
@@ -53,6 +53,11 @@ class FakeOmpTransport implements OmpTurnTransport {
 
   async start(): Promise<void> {}
 
+  nativeCommands: Array<{ name: string; description?: string; source: string }> = [];
+  async getAvailableCommands() {
+    return this.nativeCommands;
+  }
+
   async getAvailableModels(): Promise<OmpNativeModel[]> {
     return [{ provider: "synthetic", id: "model", reasoning: true }];
   }
@@ -626,6 +631,35 @@ describe("OMP Adapter Subagents", () => {
       nativeSubagentId: "subagent-1",
     });
     await opened.value.close();
+    await adapter.close();
+  });
+
+  it("uses the live OMP catalog and revalidates native prompt names before execution", async () => {
+    const transport = new FakeOmpTransport();
+    transport.nativeCommands = [{ name: "probe", description: "Test", source: "file" }];
+    const createTransport = vi.fn(() => transport);
+    const adapter = new OmpAdapter({}, { createTransport });
+    const opened = await adapter.open({ kind: "create", cwd: "/synthetic" });
+    if (!opened.ok) throw new Error(opened.error.message);
+    const session = opened.value;
+    await session.commands?.list();
+    expect(createTransport).not.toHaveBeenCalled();
+    await session.readSnapshot();
+    await expect(session.commands?.list()).resolves.toMatchObject({
+      ok: true,
+      value: {
+        commands: expect.arrayContaining([
+          expect.objectContaining({ invocation: "/omp:probe", executionMode: "prompt" }),
+        ]),
+      },
+    });
+    const run = vi.spyOn(transport, "runTurn");
+    await session.execute({
+      type: "turn.start",
+      turnId: "native-probe" as HostTurnId,
+      input: [{ type: "text", text: "/omp:probe ARG42" }],
+    });
+    expect(run).toHaveBeenCalledWith("/probe ARG42", expect.any(Function));
     await adapter.close();
   });
 

--- a/packages/adapters/omp/test/omp-commands.test.ts
+++ b/packages/adapters/omp/test/omp-commands.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import { ompNativeCommandCatalog, ompNativePrompt } from "../src/omp-commands.js";
+
+describe("OMP native prompt commands", () => {
+  it("discovers native file and skill prompts, excluding terminal and unclassified handlers", () => {
+    // Shapes observed from OMP get_available_commands; only fixture names/content are synthetic.
+    const catalog = ompNativeCommandCatalog({ commands: [] }, [
+      { name: "probe", description: "Test $@ arguments", source: "file" },
+      { name: "skill:probe", source: "skill" },
+      { name: "model", source: "builtin" },
+      { name: "local-handler", source: "extension" },
+      { name: "probe", source: "file" },
+      { name: "../unsafe", source: "file" },
+    ]);
+    expect(catalog.commands.map((c) => c.invocation)).toEqual(["/omp:probe", "/omp:skill:probe"]);
+    expect(catalog.commands.every((c) => c.executionMode === "prompt")).toBe(true);
+    expect(ompNativePrompt("/omp:probe one  two\nthree", catalog)).toBe("/probe one  two\nthree");
+    expect(ompNativePrompt("  ordinary prompt  ", catalog)).toBe("  ordinary prompt  ");
+    expect(() => ompNativePrompt("/omp:gone", catalog)).toThrow("no longer available");
+    expect(() => ompNativePrompt("/omp:probe-more", catalog)).toThrow("no longer available");
+  });
+});

--- a/packages/host-runtime/src/app-server-host.ts
+++ b/packages/host-runtime/src/app-server-host.ts
@@ -2642,6 +2642,24 @@ export class AppServerHost {
       await this.#writer.json(rpcEnvelope(request, { result: { commands: [] } }));
       return;
     }
+    // Only query an already-open Native Session; metadata reads never resume one.
+    const commands = location.thread?.session.commands;
+    if (commands) {
+      try {
+        const result = await commands.list();
+        if (!result.ok) {
+          await this.#writer.json(rpcError(request, -32078, result.error.message));
+          return;
+        }
+        const catalog = harnessCommandCatalogSchema.parse(result.value);
+        await this.#writer.json(rpcEnvelope(request, { result: jsonValueSchema.parse(catalog) }));
+      } catch {
+        await this.#writer.json(
+          rpcError(request, -32078, "Harness command catalog is unavailable"),
+        );
+      }
+      return;
+    }
     await this.#writeHarnessCommandCatalog(request, location.record.harnessId);
   }
 
@@ -2697,6 +2715,12 @@ export class AppServerHost {
         return;
       }
       const descriptor = catalog.value.commands.find(({ id }) => id === params.data.commandId);
+      if (descriptor?.executionMode === "prompt") {
+        await this.#writer.json(
+          rpcError(request, -32602, "Prompt commands must be submitted as ordinary Turns"),
+        );
+        return;
+      }
       if (!descriptor) {
         await this.#writer.json(
           rpcError(
@@ -3677,6 +3701,27 @@ export class AppServerHost {
               command.argumentMode === "text" && commandText.startsWith(`${command.invocation} `)
             );
           });
+        if (matched?.executionMode === "prompt") {
+          // Hand the admission reservation to the ordinary Turn synchronously.
+          this.#pendingExternalCommandRequests.delete(thread.id);
+          try {
+            const started = await this.#beginExternalTurn(thread, commandText);
+            try {
+              await this.#writer.json(rpcEnvelope(request, { result: { turn: started.turn } }));
+            } finally {
+              started.gate.resolve();
+            }
+          } catch (error) {
+            await this.#writer.json(
+              rpcError(
+                request,
+                error instanceof ExternalSteerError ? error.code : -32073,
+                errorMessage(error),
+              ),
+            );
+          }
+          return;
+        }
         if (matched) {
           const argumentText = commandText.slice(matched.invocation.length).trimStart();
           try {

--- a/packages/host-runtime/test/app-server-host.test.ts
+++ b/packages/host-runtime/test/app-server-host.test.ts
@@ -4311,6 +4311,54 @@ describe("AppServerHost HarnessAdapter projection", () => {
     await stopFixture(fixture);
   });
 
+  it("discovers live prompt commands and persists typed invocations as ordinary Turns", async () => {
+    const fixture = createFixture();
+    const threadId = await startPiThread(fixture);
+    const session = fixture.adapter.sessions[0];
+    if (!session) throw new Error("Missing session");
+    const execute = vi.fn();
+    const catalog = {
+      commands: [
+        harnessCommandDescriptorSchema.parse({
+          id: "fake.probe",
+          invocation: "/fake:probe",
+          label: "Probe",
+          argumentMode: "text",
+          executionMode: "prompt",
+        }),
+      ],
+    };
+    session.commands = { list: async () => ({ ok: true, value: catalog }), execute };
+    writeRequest(fixture.desktopInput, {
+      id: 2,
+      method: "codexhost/thread/commands/inspect",
+      params: { threadId },
+    });
+    await expect(fixture.collector.waitFor((m) => requestId(m, 2))).resolves.toMatchObject({
+      result: catalog,
+    });
+    writeRequest(fixture.desktopInput, {
+      id: 3,
+      method: "turn/start",
+      params: { threadId, input: [{ type: "text", text: "/fake:probe alpha  beta" }] },
+    });
+    await fixture.collector.waitFor((m) => requestId(m, 3));
+    session.appendText("PROMPT_OK");
+    session.succeedTurn();
+    await fixture.collector.waitFor((m) => method(m, "turn/completed"));
+    expect(execute).not.toHaveBeenCalled();
+    expect(session.persistedSnapshot().turns).toHaveLength(1);
+    writeRequest(fixture.desktopInput, {
+      id: 4,
+      method: "codexhost/thread/command/execute",
+      params: { threadId, commandId: "fake.probe" },
+    });
+    await expect(fixture.collector.waitFor((m) => requestId(m, 4))).resolves.toMatchObject({
+      error: { code: -32602 },
+    });
+    await stopFixture(fixture);
+  });
+
   it("reads static Harness command catalogs without inspection or opening a Session", async () => {
     const fixture = createFixture();
     const catalog = {

--- a/packages/renderer-extension/src/renderer-binding-probe.ts
+++ b/packages/renderer-extension/src/renderer-binding-probe.ts
@@ -817,6 +817,9 @@ export function installRendererBindingProbe(
       })),
       mounted.ownershipStatus === "error",
     );
+    mounted.control.harnessCommands.onOpen = () => {
+      void refreshCommands(mounted);
+    };
     if (mounted.control.usage) {
       mounted.control.usage.onOpen = () => {
         void refreshThreadUsage(
@@ -838,11 +841,15 @@ export function installRendererBindingProbe(
     mounted.control.harnessCommands.setCommands([]);
     if (agent === "codex" || !client) return;
     try {
-      const catalog = await client.inspectHarnessCommands({ harnessId: externalHarnessIds[agent] });
+      const threadId = threadIdFromComposerModelTarget(mounted.modelTarget);
+      const catalog = threadId
+        ? await client.inspectThreadCommands({ threadId })
+        : await client.inspectHarnessCommands({ harnessId: externalHarnessIds[agent] });
       if (
         disposed ||
         mountedByComposer.get(mounted.composer) !== mounted ||
         mounted.commandRequestGeneration !== generation ||
+        threadId !== threadIdFromComposerModelTarget(mounted.modelTarget) ||
         requestControl !== modelControl ||
         (threadIdFromComposerModelTarget(mounted.modelTarget)
           ? mounted.hostId
@@ -2583,7 +2590,28 @@ export function installRendererBindingProbe(
     const composer = editor ? composerForEditor(editor) : null;
     return composer && isMountedComposer(composer) ? composer : null;
   };
+  const openSlashMenu = (event: InputEvent | KeyboardEvent): boolean => {
+    if (event.isComposing) return false;
+    const slash =
+      event instanceof window.InputEvent
+        ? event.inputType === "insertText" && event.data === "/"
+        : event.key === "/" && !event.ctrlKey && !event.metaKey && !event.altKey;
+    if (!slash) return false;
+    const composer = composerForTarget(event.target);
+    if (!composer || controller.isSwitching(composer) || controller.get(composer).agent === "codex")
+      return false;
+    const mounted = mountedByComposer.get(composer);
+    if (!mounted || isOwnershipSubmissionBlocked(mounted.ownershipStatus)) return false;
+    const editor = composer.querySelector<HTMLElement>(EDITOR_SELECTOR);
+    const text = editor instanceof window.HTMLTextAreaElement ? editor.value : editor?.textContent;
+    if (text?.trim()) return false;
+    if (!mounted.control.harnessCommands.openSearch()) return false;
+    blockEvent(event);
+    return true;
+  };
+
   const onBeforeInput = (event: InputEvent): void => {
+    if (openSlashMenu(event)) return;
     const composer = composerForTarget(event.target);
     if (!composer) return;
     controller.clearPendingSubmission(composer);
@@ -2605,6 +2633,7 @@ export function installRendererBindingProbe(
     notifySubmission(composer, "submit");
   };
   const onKeyDown = (event: KeyboardEvent): void => {
+    if (openSlashMenu(event)) return;
     const composer = isComposerInputIntent(event) ? composerForTarget(event.target) : null;
     const mounted = composer ? mountedByComposer.get(composer) : undefined;
     if (

--- a/packages/renderer-extension/src/renderer-harness-command-claim.ts
+++ b/packages/renderer-extension/src/renderer-harness-command-claim.ts
@@ -48,7 +48,10 @@ function prependEditor(editor: HTMLElement, prefix: string): boolean {
 
 // Clicking compact always uses the native default; typed instructions remain supported.
 export function rendererHarnessCommandExecutesDirectly(command: HarnessCommandDescriptor): boolean {
-  return command.invocation === "/compact" || command.argumentMode === "none";
+  return (
+    command.executionMode !== "prompt" &&
+    (command.invocation === "/compact" || command.argumentMode === "none")
+  );
 }
 
 export function routeRendererHarnessCommandSelection(

--- a/packages/renderer-extension/src/renderer-harness-command-control.ts
+++ b/packages/renderer-extension/src/renderer-harness-command-control.ts
@@ -39,6 +39,8 @@ export interface RendererHarnessCommandControl {
   root: HTMLElement;
   trigger: HTMLButtonElement;
   menu: HTMLElement;
+  onOpen?: () => void;
+  openSearch(): boolean;
   setCommands(commands: readonly HarnessCommandDescriptor[], hasSession?: boolean): void;
   setExecuting(commandId: string | null): void;
   setLocale(locale: RendererSettingsLocale): void;
@@ -181,6 +183,17 @@ export function mountRendererHarnessCommandControl(
   menu.style.background = "Canvas";
   menu.style.color = "CanvasText";
   menu.style.boxShadow = "0 12px 32px rgba(0, 0, 0, 0.22)";
+  const search = ownerDocument.createElement("input");
+  search.type = "search";
+  search.placeholder = messages.searchCommands;
+  search.setAttribute("aria-label", messages.searchCommands);
+  search.style.cssText =
+    "box-sizing:border-box;width:100%;padding:8px;border:0;border-bottom:1px solid rgba(127,127,127,.2);background:transparent;color:inherit;font:13px system-ui;outline-offset:-2px";
+  const list = ownerDocument.createElement("div");
+  const footer = ownerDocument.createElement("div");
+  footer.style.cssText = "padding:6px 8px;color:GrayText;font:11px/16px system-ui";
+  footer.textContent = messages.nativeCommandsHint;
+  menu.append(search, list, footer);
   ownerDocument.body.append(menu);
 
   if (insertBefore?.parentElement === parent) parent.insertBefore(root, insertBefore);
@@ -193,11 +206,15 @@ export function mountRendererHarnessCommandControl(
   let hasSession = true;
   let triggerHovered = false;
   let disposed = false;
+  let searchMode = false;
 
   const positionMenu = (): void => {
     const rect = trigger.getBoundingClientRect();
+    const above = rect.top - MENU_GAP - VIEWPORT_MARGIN;
+    const below = window.innerHeight - rect.bottom - MENU_GAP - VIEWPORT_MARGIN;
+    const opensAbove = above >= below;
+    menu.style.maxHeight = `${Math.max(40, Math.min(360, opensAbove ? above : below))}px`;
     const menuHeight = menu.getBoundingClientRect().height;
-    const opensAbove = rect.top >= menuHeight + MENU_GAP + VIEWPORT_MARGIN;
     const left = clamp(
       rect.left,
       VIEWPORT_MARGIN,
@@ -241,7 +258,8 @@ export function mountRendererHarnessCommandControl(
   };
 
   const open = (shouldFocus = true): void => {
-    if (commands.length === 0 || executingCommandId !== null) return;
+    if (executingCommandId !== null) return;
+    control.onOpen?.();
     menu.hidden = false;
     positionMenu();
     trigger.setAttribute("aria-expanded", "true");
@@ -259,7 +277,12 @@ export function mountRendererHarnessCommandControl(
     cancelClose();
     closeTimer = window.setTimeout(() => {
       closeTimer = null;
-      if (!trigger.matches(":hover") && !menu.matches(":hover")) close();
+      if (
+        !trigger.matches(":hover") &&
+        !menu.matches(":hover") &&
+        !menu.contains(ownerDocument.activeElement)
+      )
+        close();
     }, 140);
   };
 
@@ -269,14 +292,20 @@ export function mountRendererHarnessCommandControl(
   };
 
   const renderItems = (): void => {
-    menu.replaceChildren();
+    list.replaceChildren();
     const header = ownerDocument.createElement("div");
     header.textContent = messages.commands;
     header.style.padding = "5px 8px 4px";
     header.style.color = "rgba(127, 127, 127, 0.75)";
     header.style.font = "600 11px/16px system-ui, sans-serif";
-    menu.append(header);
-    items = commands.map((command) =>
+    list.append(header);
+    const query = search.value.trim().toLocaleLowerCase().replace(/^\//u, "");
+    const filtered = commands.filter((command) =>
+      `${command.invocation} ${command.label} ${command.description ?? ""}`
+        .toLocaleLowerCase()
+        .includes(query),
+    );
+    items = filtered.map((command) =>
       menuItem(
         ownerDocument,
         command,
@@ -288,7 +317,14 @@ export function mountRendererHarnessCommandControl(
           : undefined,
       ),
     );
-    menu.append(...items);
+    list.append(...items);
+    if (items.length === 0) {
+      const empty = ownerDocument.createElement("div");
+      empty.textContent =
+        commands.length === 0 ? messages.commandsUnavailable : messages.noMatchingCommands;
+      empty.style.cssText = "padding:8px;color:GrayText;font:12px system-ui";
+      list.append(empty);
+    }
     activeIndex = Math.min(activeIndex, Math.max(0, items.length - 1));
     if (executingCommandId !== null) {
       for (const item of items) {
@@ -307,6 +343,7 @@ export function mountRendererHarnessCommandControl(
     }
   };
   const onMenuKeyDown = (event: KeyboardEvent): void => {
+    if (event.isComposing) return;
     if (event.key === "Escape") {
       event.preventDefault();
       close();
@@ -315,6 +352,7 @@ export function mountRendererHarnessCommandControl(
     }
     if (event.key === "ArrowDown" || event.key === "ArrowUp") {
       event.preventDefault();
+      if (items.length === 0) return;
       const delta = event.key === "ArrowDown" ? 1 : -1;
       activeIndex = (activeIndex + delta + items.length) % items.length;
       focusActive(delta);
@@ -338,8 +376,15 @@ export function mountRendererHarnessCommandControl(
     if (!menu.hidden) positionMenu();
   };
 
+  search.addEventListener("input", () => {
+    activeIndex = 0;
+    renderItems();
+    positionMenu();
+  });
+
   trigger.addEventListener("click", () => {
     cancelClose();
+    searchMode = false;
     open(true);
   });
   trigger.addEventListener("pointerenter", () => {
@@ -365,6 +410,17 @@ export function mountRendererHarnessCommandControl(
     root,
     trigger,
     menu,
+    openSearch() {
+      if (disposed || root.hidden || executingCommandId !== null) return false;
+      searchMode = true;
+      search.value = "";
+      activeIndex = 0;
+      renderItems();
+      cancelClose();
+      open(false);
+      search.focus({ preventScroll: true });
+      return true;
+    },
     placeBefore(reference) {
       if (!reference?.parentElement) return false;
       if (root.parentElement === reference.parentElement && root.nextElementSibling === reference) {
@@ -376,8 +432,9 @@ export function mountRendererHarnessCommandControl(
     setCommands(nextCommands, nextHasSession = true) {
       commands = [...nextCommands];
       hasSession = nextHasSession;
-      if (commands.length === 0) close();
+      if (commands.length === 0 && !searchMode) close();
       renderItems();
+      if (!menu.hidden) positionMenu();
       syncTriggerState();
     },
     setExecuting(commandId) {
@@ -389,6 +446,9 @@ export function mountRendererHarnessCommandControl(
       if (locale === nextLocale) return;
       locale = nextLocale;
       messages = rendererHarnessMessages(locale);
+      search.placeholder = messages.searchCommands;
+      search.setAttribute("aria-label", messages.searchCommands);
+      footer.textContent = messages.nativeCommandsHint;
       trigger.setAttribute("aria-label", messages.harnessCommands);
       menu.setAttribute("aria-label", messages.harnessCommands);
       renderItems();

--- a/packages/renderer-extension/src/renderer-harness-localization.ts
+++ b/packages/renderer-extension/src/renderer-harness-localization.ts
@@ -4,6 +4,9 @@ import type { RendererSettingsLocale } from "./settings/localization.js";
 
 export interface RendererHarnessMessages {
   readonly commands: string;
+  readonly searchCommands: string;
+  readonly noMatchingCommands: string;
+  readonly nativeCommandsHint: string;
   readonly harnessCommands: string;
   readonly commandsUnavailable: string;
   readonly commandRequiresConversation: string;
@@ -18,6 +21,10 @@ export interface RendererHarnessMessages {
 
 const ENGLISH_HARNESS_MESSAGES: RendererHarnessMessages = Object.freeze({
   commands: "Commands",
+  searchCommands: "Search Harness commands",
+  noMatchingCommands: "No matching commands",
+  nativeCommandsHint:
+    "Native prompts appear after the first message. Terminal-only controls are not included.",
   harnessCommands: "Harness commands",
   commandsUnavailable: "No Harness commands available yet",
   commandRequiresConversation: "Start a conversation before running this command",
@@ -33,6 +40,9 @@ const ENGLISH_HARNESS_MESSAGES: RendererHarnessMessages = Object.freeze({
 
 const CHINESE_HARNESS_MESSAGES: RendererHarnessMessages = Object.freeze({
   commands: "命令",
+  searchCommands: "搜索当前 Harness 的命令",
+  noMatchingCommands: "没有匹配的命令",
+  nativeCommandsHint: "首条消息后显示原生提示词命令；不包含终端专用控件。",
   harnessCommands: "Harness 命令",
   commandsUnavailable: "暂无可用的 Harness 命令",
   commandRequiresConversation: "请先开始对话，再执行此命令",

--- a/packages/renderer-extension/test/renderer-harness-command-claim.test.ts
+++ b/packages/renderer-extension/test/renderer-harness-command-claim.test.ts
@@ -56,6 +56,23 @@ class FakeTextarea {
 }
 
 describe("Renderer Harness command Composer claims", () => {
+  it("inserts prompt-mode commands even without arguments instead of executing them", () => {
+    const editor = new FakeTextarea();
+    const execute = vi.fn();
+    const command = harnessCommandDescriptorSchema.parse({
+      id: "claude.native.probe",
+      invocation: "/claude:probe",
+      label: "Probe",
+      argumentMode: "none",
+      executionMode: "prompt",
+    });
+    expect(
+      routeRendererHarnessCommandSelection(editor as unknown as HTMLElement, command, execute),
+    ).toBe(true);
+    expect(editor.value).toBe("/claude:probe keep this draft");
+    expect(execute).not.toHaveBeenCalled();
+  });
+
   it("prefixes a textarea draft and leaves execution to the normal submit path", () => {
     const editor = new FakeTextarea();
     const execute = vi.fn();

--- a/packages/shared-contracts/src/harness-commands.ts
+++ b/packages/shared-contracts/src/harness-commands.ts
@@ -22,6 +22,7 @@ export const harnessCommandDescriptorSchema = z
     label: commandLabelSchema,
     description: commandDescriptionSchema.optional(),
     argumentMode: z.enum(["none", "text"]),
+    executionMode: z.literal("prompt").optional(),
   })
   .strict();
 

--- a/tests/e2e/renderer-binding-startup.spec.ts
+++ b/tests/e2e/renderer-binding-startup.spec.ts
@@ -289,3 +289,68 @@ test("Kiro selects Thinking inside the Model picker before a Thread exists", asy
   await expect(page.locator('[data-command-id="kiro.effort"]')).toHaveCount(0);
   await expect(page.locator('[data-command-id="kiro.context"]')).toBeVisible();
 });
+
+for (const agent of ["claude-code", "omp"]) {
+  test(`${agent} slash opens a searchable Harness menu without invoking Codex slash handling`, async ({
+    page,
+  }, testInfo) => {
+    await page.setContent("<!doctype html><body></body>");
+    await page.evaluate((agent) => {
+      Reflect.set(globalThis, "startupAgent", agent);
+      const prefix = agent === "omp" ? "omp" : "claude";
+      Reflect.set(globalThis, "startupCommands", [
+        {
+          id: `${prefix}.native.probe`,
+          invocation: `/${prefix}:probe`,
+          label: "Probe",
+          description: "Test arguments",
+          argumentMode: "text",
+          executionMode: "prompt",
+        },
+        { id: `${prefix}.compact`, invocation: "/compact", label: "Compact", argumentMode: "none" },
+      ]);
+    }, agent);
+    await page.addScriptTag({ content: browserBundle });
+    const editor = page.locator("[data-codex-composer]");
+    await expect(page.locator("[data-codexhost-harness-command-control] > button")).toBeEnabled();
+    await editor.evaluate((element) => {
+      Reflect.set(globalThis, "nativeSlashCount", 0);
+      element.addEventListener("keydown", (event) => {
+        if ((event as KeyboardEvent).key === "/") Reflect.set(globalThis, "nativeSlashCount", 1);
+      });
+    });
+    await editor.focus();
+    await page.keyboard.type("/");
+    const menu = page.locator("[data-codexhost-harness-command-menu]");
+    await expect(menu).toBeVisible();
+    await expect(editor).toBeEmpty();
+    expect(await page.evaluate(() => Reflect.get(globalThis, "nativeSlashCount"))).toBe(0);
+    const search = menu.getByRole("searchbox");
+    await expect(search).toBeFocused();
+    await search.fill("arguments");
+    await expect(menu.getByRole("menuitem")).toHaveCount(1);
+    await page.screenshot({ path: testInfo.outputPath("slash-menu.png") });
+    await search.press("Enter");
+    await expect(menu).toBeHidden();
+    const prefix = agent === "omp" ? "omp" : "claude";
+    await expect(editor).toHaveText(`/${prefix}:probe `);
+    expect(await page.evaluate(() => Reflect.get(globalThis, "threadCommandRequests"))).toEqual([]);
+  });
+}
+
+test("Codex slash and slashes inside ordinary external prompts remain native text input", async ({
+  page,
+}) => {
+  await page.setContent("<!doctype html><body></body>");
+  await page.evaluate(() => Reflect.set(globalThis, "startupAgent", "codex"));
+  await page.addScriptTag({ content: browserBundle });
+  const editor = page.locator("[data-codex-composer]");
+  await editor.fill("path");
+  await editor.press("End");
+  await page.keyboard.type("/file");
+  await expect(editor).toHaveText("path/file");
+  await expect(page.locator("[data-codexhost-harness-command-menu]")).toBeHidden();
+  await editor.fill("");
+  await page.keyboard.type("/");
+  await expect(editor).toHaveText("/");
+});


### PR DESCRIPTION
Typing `/` in an external Composer currently reaches Codex's own command UI, while Claude Code and OMP expose only a small static Host command catalog. This change opens the independent Harness command picker from an empty external Composer and adds searchable native prompt commands for already-started Claude Code and OMP Sessions.

Related to #188, #189, and #191. This is a focused slice, not complete terminal-command parity.

- Discover Claude commands through the existing SDK query's `supportedCommands()` and OMP file/skill prompts through `get_available_commands`. Metadata reads never open or resume a Native Session.
- Use `/claude:<name>` and `/omp:<name>` invocations to avoid collisions with Codex builtins. The owning Adapter revalidates the live catalog and translates the namespace before native execution.
- Add optional `executionMode: "prompt"` to preserve ordinary Turn history for prompt invocations; direct ephemeral command execution rejects those descriptors. Existing compact/init/recap paths are unchanged.
- Add search and keyboard selection to the independent picker; preserve IME composition and native Codex slash behavior, guard stale catalog responses, and constrain long menus to available viewport space.

Limits: dynamic entries appear after the native transport starts, normally after the first message. Cold/draft catalogs remain static. Claude retains its existing `settingSources: ["user"]`; project/local settings are not enabled by this PR. OMP exposes file/skill prompts, not arbitrary extension/custom imperative handlers or terminal-only controls. Model, permission, identity replacement, and known local controls are excluded from native prompt discovery. This PR does not include the unrelated OMP late-tool-frame patch from #182.

Validation on macOS ARM64:
- `npm run build:typescript`, `npm run typecheck`, `npm run lint` (including boundaries), changed-file Prettier and `git diff --check` passed.
- Focused Adapter, Host, Renderer and command-contract tests: **788 passed, 3 skipped**.
- Real Chrome: **12 browser tests passed**, including `/` capture for both Harnesses, searchable keyboard selection, ordinary slash text, unchanged Codex behavior and menu layout regressions. This exercises the Renderer with a fixture Composer, not a complete live Desktop session.
- Real OMP RPC with a temporary file command: discovered `/omp:codexhost-probe`, expanded ARG42 to `SLASH_OK ARG42`, then returned `FOLLOWUP_OK` in the next Turn through the Adapter.
- Real Claude SDK transport with an isolated local plugin: discovered `/claude:codexhost-probe:probe`, translated and expanded ARG42 to `SLASH_OK ARG42`, then returned `FOLLOWUP_OK`. The plugin was injected only into the test query; no user command files were changed.
- Rust was unchanged and not tested. No changes were installed into the running Desktop.
