### PR TITLE
feat: Claude Code skill catalog in Codex Desktop

### DIFF
--- a/docs/harness-command-integration.md
+++ b/docs/harness-command-integration.md
@@ -111,6 +111,25 @@ OpenCode exposes only the fixed `/compact` command, implemented through native S
 
 The public `/dsh-goal` invocation avoids Codex Desktop's built-in `/goal` command and maps only inside the Adapter to native DSH `/goal`. `/dsh-goal` and `/plan` accept text arguments only. DSH remains the owner of goal and plan state and any model-visible follow-up.
 
+## Skill catalog (Claude Code)
+
+Harness Skills are a second, independent catalog: the Adapter enumerates them from the
+Harness's native discovery surface (Claude Code: `reloadSkills()` on the control channel,
+which answers before the first user message; older CLIs fall back to `supportedCommands()`
+filtered by the stream init skill list), never by scanning disk. Skills execute through the same `thread/command/execute`
+Host route; the Host validates against the union of the Thread's Commands and Skills
+catalogs. The Renderer presents them in a separate Composer Skills control — SKILL.md
+files must still never be parsed or executed in the Renderer.
+
+### Claude Code context loading
+
+As of the Skills catalog change, the Claude Code Adapter runs with
+`settingSources: ["user", "project", "local"]` — matching the Claude Code CLI. Project
+`.claude/settings.json`, `.claude/skills/`, and project CLAUDE.md now load for every
+Claude Code Thread, including untrusted repositories. Reviewers of the Desktop
+integration should treat this as a trust-boundary change; the behavior is called out in
+release notes.
+
 ## Boundaries
 
 - The Adapter owns Harness-specific semantics.

--- a/docs/superpowers/plans/2026-09-04-harness-skill-selection.md
+++ b/docs/superpowers/plans/2026-09-04-harness-skill-selection.md
@@ -1,0 +1,828 @@
+# Harness Skill Selection Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let a Claude Code Thread in Codex Desktop discover and execute its natively enumerated skills through a dedicated Composer Skills button (+ `Cmd/Ctrl+Shift+S`), and align Claude context loading with the CLI (`settingSources` user+project+local).
+
+**Architecture:** The Claude Adapter enumerates skills from the Agent SDK (`system/init` message `skills` list + `supportedCommands()` + `system/commands_changed` push), projects them as a second `HarnessCommandCapability` (`session.skills`). The Host adds one read-only inspect RPC and extends the existing `command/execute` boundary to validate against the union of the Thread's two catalogs. The Renderer adds an independent Skills popover beside the existing Harness Commands control. Skills execute by submitting `/<name> [args]` through the existing `runTurn` transport — no raw-RPC passthrough, no SKILL.md parsing outside the CLI.
+
+**Tech Stack:** TypeScript (strict, zod 4 schemas, vitest), Claude Agent SDK 0.3.220 (`node_modules/@anthropic-ai/claude-agent-sdk`), DOM-injected renderer extension (esbuild bundle), no Rust changes.
+
+**Spec:** `openspec/changes/add-harness-skill-selection/` (proposal.md, design.md, specs/harness-skill-catalog/spec.md, specs/harness-command-capabilities/spec.md, tasks.md). Read all four before starting any task.
+
+## Global Constraints
+
+- Brand name always lowercase: `codexhost`. Conventional Commits prefixes (`feat:`/`fix:`/`test:`/`docs:`).
+- Package layering enforced by `tools/check-boundaries.mjs` (runs inside `npm run lint`): Harness-specific protocol details stay inside `packages/adapters/claude-code`; `shared-contracts` and `protocol-core` stay Harness-neutral; `renderer-extension` must not import Node builtins/Electron/Harness SDKs.
+- TypeScript strict mode, ESLint, Prettier (`printWidth 100`, double quotes, trailing commas). Format with `npm run format` before committing.
+- Test runner: `npx vitest run --config tests/vitest.config.js <path>` after `npm run build:typescript`.
+- Skill command IDs use prefix `claude.skill.`; static `claudeCommandCatalog` (compact/init/recap) is never merged into the Skills catalog, and vice versa.
+- Unknown command IDs are rejected at the Host boundary; no arbitrary native string is ever executed.
+- Do NOT run `gate:a`/`gate:c`/`gate:claude` suites; they hit real installs.
+
+## File Map
+
+| File | Change |
+|---|---|
+| `packages/adapters/claude-code/src/sdk-transport.ts` | settingSources ×2, skill snapshot state, `commands_changed` consume branch, `listSkills()` |
+| `packages/adapters/claude-code/src/transport.ts` | `ClaudeSkillCommand` type + `listSkills()` on `ClaudeTurnTransport` |
+| `packages/adapters/claude-code/src/claude-code-adapter.ts` | `projectClaudeSkillCatalog`, `parseClaudeSkillInvocation`, `session.skills` capability, `#beginCommandTurn` refactor, `claude.skill` branch |
+| `packages/adapters/claude-code/test/sdk-transport.test.ts` | FakeQuery gains `supportedCommands`/init fields; settingSources + commands_changed tests |
+| `packages/adapters/claude-code/test/claude-code-adapter.test.ts` | FakeClaudeTransport gains `listSkills`; projection/execution/busy tests |
+| `packages/shared-contracts/src/harness-commands.ts` | (no new schema — reused) |
+| `packages/host-runtime/src/app-server-host.ts` | `codexhost/thread/skills/inspect` route + union validation in `#executeThreadCommand`; `#startExternalCommand` takes capability |
+| `packages/host-runtime/test/app-server-host.test.ts` | skills inspect/execute/isolation tests |
+| `packages/harness-adapter/src/text-session.ts` | `HarnessSession.skills?: HarnessCommandCapability` |
+| `packages/harness-adapter/src/testing.ts` | `FakeHarnessSession.skills` mutable field |
+| `packages/renderer-extension/src/renderer-model-client.ts` | `THREAD_SKILLS_INSPECT_METHOD` + `inspectThreadSkills` |
+| `packages/renderer-extension/src/versioned-renderer-adapter.ts` | pass-through `inspectThreadSkills` |
+| `packages/renderer-extension/src/renderer-harness-skill-control.ts` | **new** — Skills button + popover (filter + argument phase) |
+| `packages/renderer-extension/src/renderer-harness-localization.ts` | `skills`, `back`, `argumentFor` message keys (en/zh-CN) |
+| `packages/renderer-extension/src/renderer-composer-dom.ts` | mount + placement chain + setLocale + dispose |
+| `packages/renderer-extension/src/renderer-binding-probe.ts` | `refreshSkills`, `executeSkill`, `Cmd/Ctrl+Shift+S` in `onKeyDown` |
+| `packages/renderer-extension/test/renderer-harness-skill-control.test.ts` | **new** — control DOM tests |
+| `docs/harness-command-integration.md` | skill integration path + SKILL.md boundary re-affirmation |
+
+---
+
+### Task 1: Transport skill snapshot and CLI-aligned settingSources
+
+**Files:**
+- Modify: `packages/adapters/claude-code/src/sdk-transport.ts` (settingSources at :422 and :891; `start()` :403-447; `#consume()` :756-823; add fields near :369)
+- Modify: `packages/adapters/claude-code/src/transport.ts` (`ClaudeTurnTransport` :168-201)
+- Modify: `packages/adapters/claude-code/test/sdk-transport.test.ts` (FakeQuery :19-117)
+- Modify: `packages/adapters/claude-code/test/claude-code-adapter.test.ts` (FakeClaudeTransport :32 — add `listSkills` in THIS task so the interface addition doesn't break `npm run typecheck` between commits; Task 2's tests reuse it)
+
+**Interfaces:**
+- Consumes: SDK `Query.supportedCommands(): Promise<SlashCommand[]>` where `SlashCommand = { name: string; description: string; argumentHint: string; aliases?: string[] }`; stream messages `system/init` carrying `skills: string[]` and `slash_commands: string[]`, and `system/commands_changed` carrying `commands: SlashCommand[]` (REPLACE semantics).
+- Produces (Task 2 depends on these exact names):
+  ```ts
+  // transport.ts
+  export interface ClaudeSkillCommand {
+    readonly name: string;
+    readonly description: string;
+    readonly argumentHint: string;
+  }
+  // added to ClaudeTurnTransport:
+  listSkills(): Promise<readonly ClaudeSkillCommand[]>; // [] when transport unstarted or enumeration unsupported
+  ```
+
+- [ ] **Step 1: Write the failing tests** in `packages/adapters/claude-code/test/sdk-transport.test.ts`. Verified seams: `FakeQuery` (class at :19) feeds `#consume` via `push(message: SDKMessage)` with a waiter queue; the file's factory is `fixture(openMode?, permissionMode?, thinkingOptionId?, environment?)` returning `{ fakeQuery, onFault, onPermissionModeChanged, onPlanLimit, queryFactory, queryInput, transport }`; the options accessor is `options(value)` (test-local helper) or `value.queryInput().options`. Extend `FakeQuery` with one field:
+
+```ts
+class FakeQuery {
+  // ...existing members unchanged...
+  supportedCommands = vi.fn(async () => [
+    { name: "render-html", description: "Render HTML", argumentHint: "<file>", aliases: [] },
+    { name: "compact", description: "built-in", argumentHint: "", aliases: [] },
+  ]);
+}
+```
+
+(`FakeQuery` is cast `as unknown as Query` in `fixture`, so an added method needs no type gymnastics.)
+
+Add tests (message payloads are cast `as unknown as SDKMessage` following the file's existing push helpers at :120-157; the consume loop is async, so read the snapshot through `vi.waitFor`):
+
+```ts
+it("starts the session with CLI-aligned setting sources", async () => {
+  const value = fixture();
+  await value.transport.start();
+  expect(options(value).settingSources).toEqual(["user", "project", "local"]);
+});
+
+it("listSkills returns only natively reported skill names", async () => {
+  const value = fixture();
+  await value.transport.start();
+  value.fakeQuery.push({
+    type: "system",
+    subtype: "init",
+    skills: ["render-html"],
+    slash_commands: ["/compact"],
+    session_id: "s1",
+    uuid: "u1",
+  } as unknown as SDKMessage);
+  await vi.waitFor(async () => {
+    await expect(value.transport.listSkills()).resolves.toEqual([
+      { name: "render-html", description: "Render HTML", argumentHint: "<file>" },
+    ]);
+  });
+});
+
+it("listSkills includes skills announced by commands_changed pushes", async () => {
+  const value = fixture();
+  await value.transport.start();
+  value.fakeQuery.push({
+    type: "system",
+    subtype: "init",
+    skills: ["render-html"],
+    slash_commands: ["/compact"],
+    session_id: "s1",
+    uuid: "u1",
+  } as unknown as SDKMessage);
+  value.fakeQuery.supportedCommands.mockResolvedValue([
+    { name: "render-html", description: "Render HTML", argumentHint: "<file>" },
+    { name: "pdf-tools:extract", description: "Extract text", argumentHint: "" },
+    { name: "compact", description: "built-in", argumentHint: "" },
+  ]);
+  value.fakeQuery.push({
+    type: "system",
+    subtype: "commands_changed",
+    commands: [
+      { name: "render-html", description: "Render HTML", argumentHint: "<file>" },
+      { name: "pdf-tools:extract", description: "Extract text", argumentHint: "" },
+      { name: "compact", description: "built-in", argumentHint: "" },
+    ],
+    session_id: "s1",
+    uuid: "u2",
+  } as unknown as SDKMessage);
+  await vi.waitFor(async () => {
+    await expect(value.transport.listSkills()).resolves.toEqual([
+      { name: "render-html", description: "Render HTML", argumentHint: "<file>" },
+      { name: "pdf-tools:extract", description: "Extract text", argumentHint: "" },
+    ]);
+  });
+});
+
+it("listSkills degrades to empty when the installed CLI lacks enumeration", async () => {
+  const value = fixture();
+  delete (value.fakeQuery as { supportedCommands?: unknown }).supportedCommands;
+  await value.transport.start();
+  await expect(value.transport.listSkills()).resolves.toEqual([]);
+});
+```
+
+If any existing assertion pins `settingSources` to `["user"]`, update it to the triple in the same edit.
+
+Also add to `FakeClaudeTransport` in `claude-code-adapter.test.ts` (:32) — required because the widened interface would otherwise fail typecheck at this commit:
+
+```ts
+skills: ClaudeSkillCommand[] = [];
+readonly listSkills = vi.fn(async () => this.skills);
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+```bash
+npm run build:typescript
+npx vitest run --config tests/vitest.config.js packages/adapters/claude-code/test/sdk-transport.test.ts
+```
+Expected: FAIL (`settingSources` is `["user"]`; `listSkills` not a function).
+
+- [ ] **Step 3: Implement** in `sdk-transport.ts`:
+
+1. Both `settingSources: ["user"]` literals (:422 in `ClaudeSdkTransport.start`, :891 in `ClaudeSdkModelInspector.inspect`) become `settingSources: ["user", "project", "local"]`. The inspector change is deliberate: project skills/settings must resolve identically for catalog and session paths.
+2. Add private state near the other `#` fields (~:369):
+
+```ts
+#skillNames = new Set<string>();
+#builtInCommandNames = new Set<string>();
+```
+
+3. In `#consume` (the loop at :757), before the `#active` branch, add alongside the existing `permissionModeFromMessage` handling:
+
+```ts
+if (isRecord(message) && message.type === "system") {
+  if (message.subtype === "init" && Array.isArray(message.skills) && Array.isArray(message.slash_commands)) {
+    this.#skillNames = new Set(
+      message.skills.filter((name: unknown): name is string => typeof name === "string"),
+    );
+    this.#builtInCommandNames = new Set(
+      (message.slash_commands as unknown[])
+        .filter((name: unknown): name is string => typeof name === "string")
+        .map((name) => (name.startsWith("/") ? name.slice(1) : name)),
+    );
+  } else if (message.subtype === "commands_changed" && Array.isArray(message.commands)) {
+    for (const command of message.commands as readonly Record<string, unknown>[]) {
+      if (typeof command.name === "string" && !this.#builtInCommandNames.has(command.name)) {
+        this.#skillNames.add(command.name);
+      }
+    }
+  }
+}
+```
+
+4. In `start()`, after `await activeQuery.initializationResult();` (:438), keep no extra call — freshness comes from `listSkills`. Add the public method next to `compact/init/recap` (:486-511):
+
+```ts
+async listSkills(): Promise<readonly ClaudeSkillCommand[]> {
+  const activeQuery = this.#query;
+  if (!this.#started || !activeQuery) return [];
+  const supported = (
+    activeQuery as Partial<Pick<Query, "supportedCommands">>
+  ).supportedCommands;
+  if (typeof supported !== "function") return [];
+  try {
+    const commands = await supported.call(activeQuery);
+    return commands
+      .filter((command) => this.#skillNames.has(command.name))
+      .map(({ name, description, argumentHint }) => ({ name, description, argumentHint }));
+  } catch {
+    return [];
+  }
+}
+```
+
+Export `ClaudeSkillCommand` from `transport.ts` (interface above, plus `listSkills(): Promise<readonly ClaudeSkillCommand[]>;` inside `ClaudeTurnTransport`) and import it in `sdk-transport.ts`. The structural cast above exists because `query()`'s `Query` type may not carry `supportedCommands` on every installed CLI version — keep the `typeof supported !== "function"` guard.
+
+- [ ] **Step 4: Run tests** — same command as Step 2. Expected: PASS (pre-existing `settingSources` assertions, if any, updated to the new triple in the same edit).
+
+- [ ] **Step 5: Commit**
+
+```bash
+npm run format
+git add packages/adapters/claude-code
+git commit -m "feat: enumerate Claude skills from native SDK surface"
+```
+
+---
+
+### Task 2: Adapter skills capability and projection
+
+**Files:**
+- Modify: `packages/adapters/claude-code/src/claude-code-adapter.ts` (catalog :182-206, `parseClaudeHarnessCommand` :208-261, `#executeHarnessCommand` :785-893, session class :478-530)
+- Modify: `packages/harness-adapter/src/text-session.ts` (`HarnessSession` :488-510)
+- Modify: `packages/harness-adapter/src/testing.ts` (`FakeHarnessSession` :153-165)
+- Test: `packages/adapters/claude-code/test/claude-code-adapter.test.ts` (FakeClaudeTransport :32-, helpers :249-)
+
+**Interfaces:**
+- Consumes: Task 1's `transport.listSkills()`.
+- Produces (Tasks 3-4 depend on these exact names):
+  - `HarnessSession.skills?: HarnessCommandCapability` (same `{list, execute}` shape as `commands`).
+  - Skill command IDs: `` `claude.skill.${name.replaceAll(".", "..")}` `` — e.g. skill `render-html` → `claude.skill.render-html`; skill `no-arg.skill` → `claude.skill.no-arg..skill`; plugin-qualified `pdf-tools:extract` → `claude.skill.pdf-tools:extract` (colon already passes the ID regex). Escaping makes IDs injective in the skill name; the display `invocation` carries the raw name, and execution reads the name from the cached descriptor, never by decoding the ID.
+  - Execute argument shape: `{ text: string }` only, mirroring compact (`arguments` absent for `argumentMode: "none"`).
+  - Exported pure helpers for tests: `projectClaudeSkillCatalog(skills: readonly ClaudeSkillCommand[]): HarnessResult<HarnessCommandCatalog>`.
+
+- [ ] **Step 1: Extend the session contract.** In `text-session.ts` `HarnessSession` (:495 area) add after `readonly commands?: HarnessCommandCapability;`:
+
+```ts
+readonly skills?: HarnessCommandCapability;
+```
+
+In `testing.ts` `FakeHarnessSession`, mirror the existing mutable `commands?: HarnessCommandCapability` field (:159) with `skills?: HarnessCommandCapability;` so Host tests can assign it post-construction like they already assign `commands` (app-server-host.test.ts:3088 pattern).
+
+- [ ] **Step 2: Write the failing tests** in `claude-code-adapter.test.ts`. Verified seams: file factory is `fixture(options?) → { adapter, dependencies, history, inspectors, inspectInstallation, transports }` (:205); session via `openSession(adapter)` (:267); the fake transport appears in `transports[]` once any operation triggers `#ensureTransport`; turn-event driving pattern at :1161-1192 (`transport.event(...)`, `transport.finish({ status: "succeeded" })`); `runTurn` already records `transports[].turns.push({ text, userMessageId })` (:137-148). `FakeClaudeTransport` already carries the Task-1 `skills`/`listSkills` members. Then:
+
+```ts
+it("projects native skills into a claude.skill catalog", async () => {
+  const { adapter, transports } = fixture();
+  const session = await openSession(adapter);
+  await session.commands!.execute({
+    turnId: hostTurnIdSchema.parse("prime"),
+    commandId: "claude.recap",
+  }); // force transport creation through any command path
+  const transport = transports[0];
+  if (!transport) throw new Error("Fake transport missing");
+  transport.finish({ status: "succeeded" });
+  transport.skills = [
+    { name: "render-html", description: "Render HTML", argumentHint: "<file>" },
+    { name: "no-arg.skill", description: "Dots escape", argumentHint: "" },
+  ];
+  await expect(session.skills!.list()).resolves.toMatchObject({
+    ok: true,
+    value: {
+      commands: [
+        { id: "claude.skill.render-html", invocation: "/render-html", label: "render-html", description: "Render HTML", argumentMode: "text" },
+        { id: "claude.skill.no-arg..skill", invocation: "/no-arg.skill", label: "no-arg.skill", description: "Dots escape", argumentMode: "none" },
+      ],
+    },
+  });
+});
+
+it("rejects duplicate projected skill IDs instead of dropping entries", async () => {
+  const { adapter, transports } = fixture();
+  const session = await openSession(adapter);
+  await session.skills!.list(); // lazily creates transports[0]
+  const transport = transports[0];
+  if (!transport) throw new Error("Fake transport missing");
+  transport.skills = [
+    { name: "dup", description: "A", argumentHint: "" },
+    { name: "dup", description: "B", argumentHint: "" },
+  ];
+  await expect(session.skills!.list()).resolves.toMatchObject({
+    ok: false,
+    error: { code: "protocolError" },
+  });
+});
+
+it("executes a skill as a native slash turn with optional text argument", async () => {
+  const { adapter, transports } = fixture();
+  const session = await openSession(adapter);
+  await session.skills!.list();
+  const transport = transports[0];
+  transport.skills = [{ name: "render-html", description: "d", argumentHint: "<file>" }];
+  const iterator = session.outputs[Symbol.asyncIterator]();
+  await expect(
+    session.skills!.execute({
+      turnId: hostTurnIdSchema.parse("skill-turn-1"),
+      commandId: "claude.skill.render-html",
+      arguments: { text: "report.html" },
+    }),
+  ).resolves.toEqual({ ok: true, value: { turnId: "skill-turn-1" } });
+  expect(transport.turns.at(-1)?.text).toBe("/render-html report.html");
+  // event sequence mirrors :1160-1192: turn.started, then a real agentMessage item lane
+  // (startAgentItem must be true for skills) — drive transport.event/finish and assert
+  // item.started carries type "agentMessage", turn.completed succeeds.
+});
+
+it("rejects skill execution for unknown id and for arguments on a none skill", async () => {
+  const { adapter, transports } = fixture();
+  const session = await openSession(adapter);
+  await session.skills!.list();
+  transports[0].skills = [{ name: "plain", description: "d", argumentHint: "" }];
+  await expect(
+    session.skills!.execute({ turnId: hostTurnIdSchema.parse("t0"), commandId: "claude.skill.ghost" }),
+  ).resolves.toMatchObject({ ok: false, error: { code: "unsupported" } });
+  await expect(
+    session.skills!.execute({
+      turnId: hostTurnIdSchema.parse("t1"),
+      commandId: "claude.skill.plain",
+      arguments: { text: "nope" },
+    }),
+  ).resolves.toMatchObject({ ok: false, error: { code: "invalidRequest" } });
+});
+
+it("reports sessionBusy when a skill executes during an active Turn", async () => {
+  const { adapter, transports } = fixture();
+  const session = await openSession(adapter);
+  void session.execute(textTurn("busy-turn")); // file helper at :288
+  await session.skills!.list(); // ensure transports exist
+  transports[0].skills = [{ name: "plain", description: "d", argumentHint: "" }];
+  await expect(
+    session.skills!.execute({ turnId: hostTurnIdSchema.parse("t2"), commandId: "claude.skill.plain" }),
+  ).resolves.toMatchObject({ ok: false, error: { code: "sessionBusy" } });
+});
+```
+
+If `session.skills!.list()` during an active turn must not start a second transport, the lazy-bootstrap guard from Step 4's implementation already handles it; assert `transports.length === 1` in the busy test as a bonus.
+
+- [ ] **Step 3: Run to verify failure**
+
+```bash
+npx vitest run --config tests/vitest.config.js packages/adapters/claude-code/test/claude-code-adapter.test.ts
+```
+
+- [ ] **Step 4: Implement.** In `claude-code-adapter.ts`:
+
+```ts
+function claudeSkillCommandId(name: string): string {
+  return `claude.skill.${name.replaceAll(".", "..")}`;
+}
+
+export function projectClaudeSkillCatalog(
+  skills: readonly ClaudeSkillCommand[],
+): HarnessResult<HarnessCommandCatalog> {
+  try {
+    return {
+      ok: true,
+      value: harnessCommandCatalogSchema.parse({
+        commands: skills.map((skill) => ({
+          id: claudeSkillCommandId(skill.name),
+          invocation: `/${skill.name}`,
+          label: skill.name,
+          ...(skill.description ? { description: skill.description } : {}),
+          argumentMode: skill.argumentHint.trim().length > 0 ? "text" : "none",
+        })),
+      }),
+    };
+  } catch (error) {
+    return {
+      ok: false,
+      error: {
+        code: "protocolError",
+        message: `Claude skill catalog is invalid: ${error instanceof Error ? error.message : String(error)}`,
+        retryable: true,
+      },
+    };
+  }
+}
+```
+
+Verified error-code enum (`text-session.ts:35-48`): `notInstalled | unavailable | authenticationRequired | sessionNotFound | sessionBusy | checkpointNotFound | unsupported | invalidRequest | invalidState | protocolError | processExited | nativeFailure | internalError`. Use `code: "protocolError"` for invalid projected catalogs (native returned entries that violate the published contract). Do not add a new code.
+
+In `ClaudeSession`, beside `this.commands = { list…, execute… }` (:520-523) add:
+
+```ts
+this.skills = {
+  list: async () => {
+    if (this.#phase !== "open") return { ok: false, error: invalidState("Claude Code Session is not open") };
+    const transport = this.#transport;
+    if (!transport) {
+      if (this.#acceptingTurn || this.#active || this.#configurationTask || this.#readingHistory) {
+        return { ok: true, value: { commands: [] } };
+      }
+      this.#acceptingTurn = true;
+      try {
+        await this.#ensureTransport();
+      } catch {
+        return { ok: true, value: { commands: [] } };
+      } finally {
+        this.#acceptingTurn = false;
+      }
+    }
+    const active = this.#transport;
+    if (!active) return { ok: true, value: { commands: [] } };
+    return projectClaudeSkillCatalog(await active.listSkills());
+  },
+  execute: (command) => this.#executeSkillCommand(command),
+};
+```
+
+Declare `readonly skills: HarnessCommandCapability;` beside `readonly commands` (:486).
+
+Refactor `#executeHarnessCommand` (:785-893): split its body after the busy/transport bootstrap into `#beginCommandTurn(command: HarnessCommandInvocation, parsed: ClaudeCommandTurn)`, where
+
+```ts
+type ClaudeCommandTurn =
+  | { kind: "native"; native: ClaudeHarnessCommand }
+  | { kind: "skill"; name: string; text: string | undefined };
+```
+
+Inside `#beginCommandTurn`, the running dispatch (:868-876) becomes:
+
+```ts
+const running =
+  parsed.kind === "skill"
+    ? transport.runTurn(
+        parsed.text ? `/${parsed.name} ${parsed.text}` : `/${parsed.name}`,
+        nativeTurnKey,
+        (event) => this.#handleTurnEvent(active, event),
+      )
+    : parsed.native.id === "claude.compact"
+      ? transport.compact(/* unchanged */)
+      : parsed.native.id === "claude.init"
+        ? transport.init(/* unchanged */)
+        : transport.recap(/* unchanged */);
+```
+
+`startAgentItem` (:833) becomes `parsed.kind === "skill" || parsed.native.id !== "claude.compact"` — a skill Turn is a normal visible agent reply, never an ephemeral compaction lane.
+
+Add the skill entry point:
+
+```ts
+async #executeSkillCommand(
+  command: HarnessCommandInvocation,
+): Promise<HarnessResult<HarnessCommandAccepted>> {
+  if (!command.commandId.startsWith("claude.skill.")) {
+    return { ok: false, error: unsupported(`Not a Claude skill command`) }; // reuse the existing error factories in this file
+  }
+  const listed = await this.skills!.list();
+  if (!listed.ok) return listed;
+  const descriptor = listed.value.commands.find(({ id }) => id === command.commandId);
+  if (!descriptor) {
+    return { ok: false, error: { code: "unsupported", message: `Claude Code does not expose skill '${command.commandId}'`, retryable: false } };
+  }
+  const name = descriptor.invocation.slice(1);
+  const args = command.arguments;
+  if (descriptor.argumentMode === "none" && args && Object.keys(args).length > 0) {
+    return { ok: false, error: { code: "invalidRequest", message: `Claude Code skill '${name}' does not accept arguments`, retryable: false } };
+  }
+  if (args && Object.keys(args).some((key) => key !== "text")) {
+    return { ok: false, error: { code: "invalidRequest", message: `Claude Code skill '${name}' has an unknown argument`, retryable: false } };
+  }
+  const text = args?.text;
+  if (text !== undefined && typeof text !== "string") {
+    return { ok: false, error: { code: "invalidRequest", message: `Claude Code skill '${name}' argument 'text' must be a string`, retryable: false } };
+  }
+  // Same pre-flight as #executeHarnessCommand: phase check, then delegate.
+  return this.#beginCommandTurn(command, { kind: "skill", name, text: typeof text === "string" ? text : undefined });
+}
+```
+
+`#beginCommandTurn` carries the existing `#acceptingTurn`/`#phase`/busy checks from :787-834 unchanged; `#executeHarnessCommand` becomes phase-check + `parseClaudeHarnessCommand` + `#beginCommandTurn`.
+
+- [ ] **Step 5: Run tests** — adapter + harness-adapter suites:
+
+```bash
+npm run build:typescript
+npx vitest run --config tests/vitest.config.js packages/adapters/claude-code/test/claude-code-adapter.test.ts packages/harness-adapter
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+npm run format
+git add packages/adapters/claude-code packages/harness-adapter
+git commit -m "feat: expose Claude skill catalog and executor through the Adapter seam"
+```
+
+---
+
+### Task 3: Host skills inspect route and union execution routing
+
+**Files:**
+- Modify: `packages/host-runtime/src/app-server-host.ts` (route table :752-759, `#inspectThreadCommands` :1980-2010, `#executeThreadCommand` :2012-2068, `#startExternalCommand` :2070-2106)
+- Test: `packages/host-runtime/test/app-server-host.test.ts` (fixture pattern :3084-3160)
+
+**Interfaces:**
+- Consumes: Task 2's `session.skills` on `HarnessSession` and FakeHarnessSession.
+- Produces: JSON-RPC method `codexhost/thread/skills/inspect`, params `{ threadId }` (reuse `threadCommandsInspectParamsSchema`), result = `HarnessCommandCatalog` shape (`{ commands: [...] }`). `codexhost/thread/command/execute` now accepts IDs from either catalog. **Discovery (missed in the first draft, verified at app-server-host.ts:2995-3020): the ordinary `turn/start` text path already intercepts text matching the Commands catalog** (`/compact foo` → command execution, longest-invocation-first). Skills must join that interception or typing `/skill-name` into the composer would reach Claude as a plain text Turn and render wrong.
+
+- [ ] **Step 1: Write the failing tests** in `app-server-host.test.ts`, mirroring the "acknowledges an accepted Harness command" test (:3084) and the inspect tests it neighbours:
+
+```ts
+it("returns an empty skills catalog for Harnesses without the capability", async () => {
+  const fixture = createFixture();
+  const threadId = await startPiThread(fixture);
+  writeRequest(fixture.desktopInput, {
+    id: 3,
+    method: "codexhost/thread/skills/inspect",
+    params: { threadId },
+  });
+  await expect(
+    fixture.collector.waitFor((message) => requestId(message, 3)),
+  ).resolves.toMatchObject({ result: { commands: [] } });
+  await stopFixture(fixture);
+});
+
+it("inspects and executes a skill through the unified command route", async () => {
+  const fixture = createFixture();
+  const threadId = await startPiThread(fixture);
+  const session = fixture.adapter.sessions[0];
+  session.commands = { /* one fake.compact entry, as :3088 */ };
+  session.skills = {
+    list: async () => ({
+      ok: true,
+      value: {
+        commands: [harnessCommandDescriptorSchema.parse({
+          id: "fake.skill.render",
+          invocation: "/render",
+          label: "render",
+          argumentMode: "text",
+        })],
+      },
+    }),
+    execute: async ({ turnId, commandId, arguments: arguments_ }) => {
+      expect(commandId).toBe("fake.skill.render");
+      expect(arguments_).toEqual({ text: "a.html" });
+      // Verified FakeHarnessSession API (testing.ts:256): publish an item + complete the turn
+      session.publishEphemeralCommand(turnId, {
+        type: "contextCompaction",
+        itemId: hostItemIdSchema.parse("fake-skill-item"),
+      });
+      return { ok: true, value: { turnId } };
+    },
+  };
+  writeRequest(fixture.desktopInput, {
+    id: 4,
+    method: "codexhost/thread/command/execute",
+    params: { threadId, commandId: "fake.skill.render", arguments: { text: "a.html" } },
+  });
+  await expect(
+    fixture.collector.waitFor((message) => requestId(message, 4)),
+  ).resolves.toMatchObject({ result: { accepted: true } });
+  // and skills/inspect now returns the fake skill
+  await stopFixture(fixture);
+});
+
+it("rejects command execution absent from both catalogs", async () => {
+  // execute with commandId "fake.ghost" against the session above → rpcError -32078,
+  // and assert session.skills.execute was never called.
+});
+```
+
+- [ ] **Step 2: Run to verify failure** — `npx vitest run --config tests/vitest.config.js packages/host-runtime/test/app-server-host.test.ts` → unknown-method error for `skills/inspect`.
+
+- [ ] **Step 3: Implement.** Route table addition after :756:
+
+```ts
+if (request.method === "codexhost/thread/skills/inspect") {
+  await this.#inspectThreadSkills(request);
+  continue;
+}
+```
+
+`#inspectThreadSkills` is `#inspectThreadCommands` with `session.commands` → `session.skills`; when `resolution.kind !== "external" || !resolution.thread.session.skills` respond `{ result: { commands: [] } }` (empty catalog, not error — Harness-neutral contract).
+
+In `#executeThreadCommand`, after the existing `commands.list()` membership check fails, consult skills before rejecting:
+
+```ts
+let capability: HarnessCommandCapability | undefined = commands;
+let listed = await commands.list();
+// ...existing membership check preserved...
+if (!matched) {
+  const skills = thread.session.skills;
+  if (!skills) { /* existing -32078 rejection for unknown command */ }
+  listed = await skills.list();
+  if (!listed.ok) { await this.#writer.json(rpcError(request, -32078, listed.error.message)); return; }
+  if (!listed.value.commands.some(({ id }) => id === params.data.commandId)) {
+    await this.#writer.json(rpcError(request, -32078,
+      `External Harness does not expose command '${params.data.commandId}'`));
+    return;
+  }
+  capability = skills;
+}
+await this.#startExternalCommand(request, thread, capability, params.data.commandId, …);
+```
+
+Concretely: `#startExternalCommand` (:2070) gains a `capability: HarnessCommandCapability` parameter replacing its internal `const commands = thread.session.commands` read (:2079-2085); its null-commands error moves to the caller's existing `!commands && !skills` branch (error text "External Harness does not expose commands" preserved for the no-capability case).
+
+- [ ] **Step 4: Text-turn interception joins both catalogs.** In the `turn/start` handler (:2995-3020), the block that sorts `thread.session.commands.list()` by invocation length and matches `text` — extract the catalog-matching into a local loop over `[commands, skills]` capabilities in that order (static commands win ties), and pass the matched capability's ID plus `catalog` to `#startExternalCommand` exactly as today (`"turn"` responseKind). Command IDs stay globally unique across the two catalogs, so a `matched.id` from skills executes correctly through the Adapter's `claude.skill.` dispatch (Task 2). Test: send `thread/start` + `turn/start` with text `/fake.render a.html` against the Task-3 fixture session (`fake.skill.render`, invocation `/render` — adjust the text to the fixture's invocation) and assert it executes via `session.skills.execute` and never forwards raw text; plus a negative case for a text matching no catalog entry (must still flow to `turn.start` as ordinary input).
+
+- [ ] **Step 5: Run tests** (same as Step 2, plus the new interception tests) → PASS. Then `npm run typecheck`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+npm run format
+git add packages/host-runtime
+git commit -m "feat: route skill inspection and execution through the Host command surface"
+```
+
+---
+
+### Task 4: Renderer Skills control
+
+**Files:**
+- Create: `packages/renderer-extension/src/renderer-harness-skill-control.ts`
+- Modify: `packages/renderer-extension/src/renderer-harness-localization.ts`
+- Modify: `packages/renderer-extension/src/renderer-model-client.ts` (:53 method const, :105-106 interface, :174-181 impl, :229 exports)
+- Modify: `packages/renderer-extension/src/versioned-renderer-adapter.ts` (:1006-1009 pass-through)
+- Modify: `packages/renderer-extension/src/renderer-composer-dom.ts` (:94 control type, :599-660 mount, :503-518 placement, :736 locale, :750 dispose)
+- Modify: `packages/renderer-extension/src/renderer-binding-probe.ts` (:737-778 refresh/execute patterns, :2013 mount args, :962 & :2095 refresh triggers, :2289 onKeyDown)
+- Test: `packages/renderer-extension/test/renderer-harness-skill-control.test.ts` (new), update `renderer-model-client.test.ts` and `renderer-harness-command-control.test.ts`-style localization tests
+
+**Interfaces:**
+- Consumes: Task 3's `codexhost/thread/skills/inspect`; existing `codexhost/thread/command/execute` accepts `{ threadId, commandId, arguments?: { text } }`.
+- Produces:
+
+```ts
+// renderer-harness-skill-control.ts
+export interface RendererHarnessSkillControl {
+  readonly root: HTMLElement;
+  setSkills(skills: readonly HarnessCommandDescriptor[]): void;
+  setExecuting(commandId: string | null): void;
+  setLocale(locale: RendererSettingsLocale): void;
+  placeBefore(reference: Element | null): boolean;
+  open(): void;                       // no-op when empty/executing (same gate as command control :225)
+  hasSkills(): boolean;
+  close(): void;
+  dispose(): void;
+}
+export function mountRendererHarnessSkillControl(
+  parent: Element,
+  anchor: Element | null,
+  onSelectSkill: (skill: HarnessCommandDescriptor, argument: string | undefined) => void,
+): RendererHarnessSkillControl;
+
+// renderer-model-client.ts addition
+export const THREAD_SKILLS_INSPECT_METHOD = "codexhost/thread/skills/inspect";
+inspectThreadSkills(input: ThreadCommandsInspectParams): Promise<HarnessCommandCatalog>;
+```
+
+- [ ] **Step 1: Localization.** In `renderer-harness-localization.ts`, extend `RendererHarnessMessages` with `readonly skills: string; readonly filterSkills: string; readonly back: string;` and values: EN `skills: "Skills"`, `filterSkills: "Filter skills"`, `back: "Back"`; zh-CN `skills: "技能"`, `filterSkills: "过滤技能"`, `back: "返回"` (the message function is a 2-locale ternary, zh-CN vs everything-else-English, :83-85 — no Korean set exists here despite the README's three-doc-language claim). Reuse `rendererHarnessCommandPresentation` unchanged for entries (skills labels/descriptions are native strings; no per-command zh mapping table).
+
+- [ ] **Step 2: Write the failing DOM tests** in the new `renderer-harness-skill-control.test.ts` (jsdom pattern: copy the setup style used by `renderer-fork-control.test.ts` / `renderer-credits-control.test.ts` in the same directory):
+
+```ts
+// Required assertions, one `it` each:
+// - mountRendererHarnessSkillControl hides root when setSkills([]) and hasSkills() is false
+// - setSkills([textSkill, noneSkill]) shows root, trigger aria-expanded toggles on click
+// - open() populates menu items with invocation + description
+// - typing in the filter input narrows items by name OR description (case-insensitive)
+// - clicking an argumentMode:"none" item calls onSelectSkill(item, undefined) and closes
+// - clicking an argumentMode:"text" item switches to the argument phase: header shows the
+//   invocation, an <input> is focused, Enter calls onSelectSkill(item, input.value.trim()),
+//   Escape returns to the list phase without calling onSelectSkill
+// - setExecuting("claude.skill.x") ignores further item clicks
+// - Escape closes the popover; outside pointerdown closes it (mirror the command control's
+//   scheduleClose/close semantics, renderer-harness-command-control.ts:229-247)
+```
+
+- [ ] **Step 3: Run to verify failure** — `npx vitest run --config tests/vitest.config.js packages/renderer-extension/test/renderer-harness-skill-control.test.ts`.
+
+- [ ] **Step 4: Implement `renderer-harness-skill-control.ts`.** Structure follows `renderer-harness-command-control.ts` line-for-line where possible — same attributes pattern (`data-codexhost-harness-skill-control` / `data-codexhost-harness-skill-menu`), same menu width constants, same trigger/menu/schedule-close machinery, `CONTROL_ATTRIBUTE` root hidden by `skills.length === 0` (:348-351 equivalent). Differences only:
+
+- Header row of the list phase contains a filter `<input>` (role `searchbox`, `aria-label` = `messages.filterSkills`, full width, 6px padding, `borderRadius 6`, `background rgba(127,127,127,0.08)`, `color inherit`, `font 13px/18px system-ui`). Filtering predicate: `term === "" || (item.invocation + " " + presentation.label + " " + presentation.description).toLowerCase().includes(term)`.
+- Argument phase for `argumentMode === "text"`: replaces menu children with a back affordance (`← ${messages.back}`), an invocation header (`/${name} ${argumentHintShown ? "" : ""}` — use `command.invocation` as-is), and one argument `<input>` (same style as filter input). `Enter` (no shift) → `onSelectSkill(command, value.trim() || undefined)`; `Escape` → back to list phase (do not close); focus on mount via `queueMicrotask`.
+- `open()` public wrapper calls the internal `open(true)`; `hasSkills()` returns `skills.length > 0`.
+- Trigger icon: reuse `commandIcon()`'s SVG pattern with a distinct glyph (sparkle/book style — any 1024-viewBox path set you copy from the existing file's constants; do not import new icon libraries). Trigger `aria-label`/title = `messages.skills`; add i18n like `harnessCommands` (:18/:32 style keys reuse `messages.skills`).
+- Keyboard nav inside the list: identical `items`/`activeIndex` machinery (focusActive, arrow keys) copied structurally — filter input Escape→blur, second Escape→close.
+
+- [ ] **Step 5: Client + adapter plumbing.** In `renderer-model-client.ts`: add the method const next to :53, add `inspectThreadSkills` to the interface (:105) and an implementation copied from `inspectThreadCommands` (:174-180) swapping schema → same `threadCommandsInspectParamsSchema`/`harnessCommandCatalogSchema` and method → `THREAD_SKILLS_INSPECT_METHOD`; export alongside (:229). Mirror in `versioned-renderer-adapter.ts` (:1006-1007 style). Update `renderer-model-client.test.ts` with one test asserting the request method + schema parse, following existing `inspectThreadCommands` coverage in that file.
+
+- [ ] **Step 6: Composer mount.** `renderer-composer-dom.ts`:
+- `ComposerAgentControl` (:94 area): `harnessSkills: RendererHarnessSkillControl;`.
+- `mountComposerAgentControl` (:599): new final parameter `onSelectSkill: (skill: HarnessCommandDescriptor, argument: string | undefined) => void`; after the `harnessCommands` mount (:630-634):
+
+```ts
+const harnessSkills = mountRendererHarnessSkillControl(
+  toolbar ?? composer,
+  harnessCommands.root,
+  onSelectSkill,
+);
+```
+
+Verified: `mountRendererHarnessCommandControl` is already 4-param `(parent, insertBefore, onCommandSelected, initialLocale = "en")` (control file :134-139); the composer call site passes 3 args and relies on the later `setLocale` render pass — do the same for skills. The command control's mount has an `insertBefore?.parentElement === parent` guard (:176); mirror it in the skill control's mount. Popover menus are body-appended with `position: fixed` (:162-168), so DOM sibling order never affects stacking.
+
+Add `harnessSkills` to the control literal (:657 area, next to `harnessCommands`).
+- Placement (:517): replace the single chain line with:
+
+```ts
+if (usagePositionChanged) {
+  control.harnessSkills.placeBefore(control.usage.root);
+  control.harnessCommands.placeBefore(control.harnessSkills.root);
+}
+```
+
+yielding `[commands][skills][usage]`.
+- Locale (:736): `control.harnessSkills.setLocale(locale);` next to the commands call. Dispose (:750): `control.harnessSkills.dispose();`.
+
+- [ ] **Step 7: Probe wiring** in `renderer-binding-probe.ts`:
+- `MountedComposer` record: add `skillCatalogVersion = 0;` style bookkeeping only if needed for the stale-guard; the stale-guard itself copies `refreshCommands` (:737-758) verbatim with `inspectThreadSkills` → `control.harnessSkills.setSkills(...)`, same disposal/threadId/agent guards, and bump a `refreshSkills(generation)` counter if `MountedComposer` has one for commands (mirror exactly).
+- `executeSkill(mounted, skill, argument)` copies `executeCommand` (:760-778): `setExecuting(skill.id)`, `modelControl.executeThreadCommand({ threadId, commandId: skill.id, ...(argument === undefined ? {} : { arguments: { text: argument } }) })`, finally `setExecuting(null)`.
+- Mount site (:2013-2040): add the extra callback argument after the existing `(command) => { void executeCommand(mounted, command); }`: `(skill, argument) => { const mounted = mountedByComposer.get(composer); if (!composer.isConnected || !mounted) return; void executeSkill(mounted, skill, argument); }`.
+- Refresh triggers (:962 and :2095): where `void refreshCommands(mounted)` appears, add `void refreshSkills(mounted)` on the same guard.
+- Shortcut at the top of `onKeyDown` (:2289, before the first existing branch):
+
+```ts
+if (
+  (event.metaKey || event.ctrlKey) &&
+  event.shiftKey &&
+  event.key.toLowerCase() === "s" &&
+  !event.isComposing
+) {
+  const composer = composerForTarget(event.target);
+  const mounted = composer ? mountedByComposer.get(composer) : undefined;
+  if (mounted && mounted.control.harnessSkills.hasSkills()) {
+    blockEvent(event);
+    mounted.control.harnessSkills.open();
+  }
+  return;
+}
+```
+
+- [ ] **Step 8: Run renderer suites + typecheck**
+
+```bash
+npm run build:typescript
+npx vitest run --config tests/vitest.config.js packages/renderer-extension
+npm run typecheck
+```
+
+- [ ] **Step 9: Commit**
+
+```bash
+npm run format
+git add packages/renderer-extension
+git commit -m "feat: add Composer Skills control with search and shortcut"
+```
+
+---
+
+### Task 5: Docs, full gate, smoke test, real-device checklist
+
+**Files:**
+- Modify: `docs/harness-command-integration.md` (Current examples section :74-95). README.md's 功能状态 table is left to the product owner.
+
+**Interfaces:**
+- Consumes: all tasks above.
+- Produces: nothing downstream.
+
+- [ ] **Step 1: Doc update.** In `docs/harness-command-integration.md` after the "Current examples" block, add:
+
+```markdown
+## Skill catalog (Claude Code)
+
+Harness Skills are a second, independent catalog: the Adapter enumerates them from the
+Harness's native discovery surface (`supportedCommands()` filtered by the session's skill
+list), never by scanning disk. Skills execute through the same `thread/command/execute`
+Host route; the Host validates against the union of the Thread's Commands and Skills
+catalogs. The Renderer presents them in a separate Composer Skills control — SKILL.md
+files must still never be parsed or executed in the Renderer.
+```
+
+- [ ] **Step 2: Full local gate**
+
+```bash
+npm run typecheck
+npm run lint
+npm run test:typescript
+git diff --check
+```
+Expected: all PASS. (`npm run check:rust` unchanged — no Rust touched; skip.)
+
+- [ ] **Step 3: 1-2 trial smoke test before finishing** (per repo rule "Smoke Test First"): run `npm start`, attach Codex Desktop, pick a Claude Code Thread, send one ordinary message so the transport exists, then confirm the Skills button appears (given this machine has `~/.claude/skills`), select an `argumentMode: "none"` skill, and confirm a real Turn streams. If the button never appears, capture `session.skills.list()` failures from host logs before proceeding.
+
+- [ ] **Step 4: Real-device verification checklist** (manual, record results in the PR description; fix inline only what the checklist proves broken):
+1. Project skills: in a repo containing `.claude/skills/<demo>`, confirm `<demo>` appears in Skills (proves `settingSources` change works).
+2. CLAUDE.md: ask "what does your project CLAUDE.md contain?" and confirm it answers (regression check for the settingSources behavior change called out in design.md Risks).
+3. Text-argument skill: execute one with an argument via the popover; confirm the transcript shows `/<name> <arg>` — **if the raw `<command-name>` envelope text is rendered in the user bubble instead**, file the follow-up: extend `displayedUserText` (`packages/adapters/claude-code/src/claude-history.ts:72-76`) with a generic `<command-name>/x</command-name>` → `/x args` mapping fed by the session's known skill-name set, with a focused claude-history test. Do not implement speculatively.
+4. Cancel mid-skill-Turn; approve a tool call the skill requests; confirm both behave like ordinary Turns.
+5. `⌘/Ctrl+Shift+S` opens the popover from composer focus; does nothing on a Pi Thread.
+6. Fork/resume the Thread; confirm skills reappear.
+
+- [ ] **Step 5: Commit + finalize openspec checkboxes**
+
+```bash
+git add docs
+git commit -m "docs: describe Harness skill catalog integration path"
+```
+Then tick the corresponding boxes in `openspec/changes/add-harness-skill-selection/tasks.md` (1.1-1.5 → Tasks 1-2 here; 2.1-2.4 → Tasks 2-3; 3.1-3.4 → Task 4; 4.x → this task; 4.6 doc line included) and commit `docs: record skill selection implementation progress`.
+
+---
+
+## Self-Review Notes (plan vs spec)
+
+- `harness-skill-catalog` requirements: enumeration→Task 1; projection/ID-escape/conflict→Task 2; execution route→Tasks 2+3; `commands_changed` refresh→Task 1 (transport) + passive re-inspect→Task 4 refresh triggers; inspect RPC + non-Claude empty→Task 3; button/filter/shortcut/no-text-injection→Task 4. "MUST NOT scan disk" honored everywhere (transport cache only).
+- `harness-command-capabilities` delta: disjoint catalogs (static parse path never sees skill IDs; skill path never sees static IDs); single execute RPC; union boundary validation; Pi/Codex isolation preserved by the existing per-session capability reads.
+- Known deliberate simplifications: `aliases` ignored (design Open Question); popover refresh is passive (design Open Question); lazy `ensureTransport` inside `skills.list()` means the first inspect on a fresh Thread pays ~1 process spawn — flagged in Task 5 smoke step.

--- a/openspec/changes/add-harness-skill-selection/.openspec.yaml
+++ b/openspec/changes/add-harness-skill-selection/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-09-04

--- a/openspec/changes/add-harness-skill-selection/design.md
+++ b/openspec/changes/add-harness-skill-selection/design.md
@@ -1,0 +1,87 @@
+## Context
+
+Claude Agent SDK（`@anthropic-ai/claude-agent-sdk@0.3.220`）已经把 skill 的完整生命周期暴露为可编程接口：
+
+- `Query.supportedCommands(): Promise<SlashCommand[]>` —— 返回当前 session 可用的 skill/command 列表，`SlashCommand = { name, description, argumentHint, aliases? }`。
+- `Query.initializationResult(): Promise<SDKControlInitializeResponse>` —— 其中 `slash_commands: string[]` 与 `skills: string[]` 分别标识内置命令与 skill，是"哪一项属于 skill"的天然权威分界。
+- `SDKCommandsChangedMessage`（`type: "system", subtype: "commands_changed"`）—— 会话中途变化（例如 agent 进入子目录后动态发现 skill）后的全量 push，文档规定 REPLACE 语义。
+- `Options.skills?: string[] | "all"` —— session 级启用白名单；omitted 时沿用 CLI 自身默认（发现即对模型可用）。
+- `Options.settingSources` —— 文档明确 "Must include `'project'` to load CLAUDE.md files"。当前 `sdk-transport.ts:422` 与 `:891` 传 `["user"]`。
+
+现有 Host 侧管线已经具备执行本能力所需的全部机制：`harnessCommandCatalogSchema`（strict，字段 `id/invocation/label/description/argumentMode`，ID regex `^[A-Za-z0-9._:-]+$`）、`codexhost/thread/commands/inspect` 与 `codexhost/thread/command/execute` RPC、Composer 的独立 Harness Commands popover（`renderer-harness-command-control.ts`，`root.hidden = commands.length === 0`），以及"命令按 ID 执行、不作为 Host text Turn 提交"的既有投影通路。
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- 用户在 Codex Desktop 的 Claude Code Thread 中，通过独立的 Skills 按钮或快捷键发现并显式调用当前 session 的原生 skill。
+- 点击 skill = 显式装载进本轮：作为一次真实 Turn 提交（携带可选参数文本），走完整流式/工具/审批/取消/历史通路。
+- skill 的发现、启用与解析全部由 Claude CLI 进程负责；CodexHost 不读磁盘、不解析 SKILL.md。
+- CodexHost 中的 Claude Code 上下文行为对齐 Claude Code CLI（项目 CLAUDE.md、项目 skills）。
+- 契约保持 Harness 中立：其他 Harness 因无 skill 枚举接口而 catalog 为空、控件隐藏。
+
+**Non-Goals:**
+
+- 不做 skill 启用/禁用白名单管理 UI（`skills` 选项保持 omitted，即 CLI 默认全量可用）。
+- 不做 per-skill 元数据浏览（不展示 SKILL.md 正文、不预览文件）。
+- 不为其他 Harness 发明 skill 支持。
+- 不开放任意字符串命令透传（保持 `harness-command-capabilities` 现有禁令）。
+- 不改 delegation 控制面的 skill 语义。
+
+## Decisions
+
+### 复用 command 通路，不新建 skill 抽象（方案 A）
+
+skill 在 Claude 原生层就是 slash command。`SlashCommand` 的四个字段可无损投影进现有 `HarnessCommandDescriptor`：
+
+```text
+id           = "claude.skill." + name        // 点号与插件限定名的冒号均通过现有 ID regex
+invocation   = "/" + name
+label        = name
+description  = description
+argumentMode = argumentHint 非空 ? "text" : "none"
+```
+
+执行体与 `/compact` `/init` `/recap` 完全同款：`transport.runTurn("/" + name + (args ? " " + args : ""), …)`，即一次真实 user message Turn，由 Claude CLI 自己把 slash 解析为 Skill 工具调用。
+
+曾考虑新开 `HarnessSkillCapability` + `skill/execute` RPC 的独立能力面（方案 B），契约更纯，但需要撑大 5 个包的中立接口只为一个 Claude 专属能力，违反"不为单一调用方造通用抽象"。被否。
+
+### 区分 skill 与内置命令的权威来源
+
+不靠命名启发式。主路径用 `Query.reloadSkills()`：control-channel 的原生 skills 枚举，15ms 级返回、名单里只有 skills（真机验证无 compact/clear 等内置命令），且在首条 user message 之前即可调用。旧版 CLI 无 `reloadSkills` 时回退到 `supportedCommands()` ∩ stream init `skills` 名单（实现期假定的方案；真机验证发现 CLI 直到第一条 user message 入队才 flush init，control 调用也无法提前逼出，故新 Thread 首消息前 inspect 会拿到空目录——因此回退仅作兼容，不作主路径）。`initializationResult().commands` 不可用：真机验证确认它混入 built-in 命令且无判别字段。`/compact` 等内置命令继续留在静态 `claudeCommandCatalog`，两个按钮内容互斥。
+
+### `settingSources` 对齐 CLI
+
+`["user"]` → `["user", "project", "local"]`，`sdk-transport.ts` 两处（主 transport 与子代理/warm transport 的选项构造）同时修改。这是本变更中唯一的非增量行为改动：所有已存在和新建的 Claude Thread 都会开始加载项目 CLAUDE.md 与项目 settings。选择不加开关：可回退性由 git revert 提供，加开关会把配置面分裂成第二真相源。
+
+### Skills 与 Commands 是两个独立控件
+
+按已确认的产品决定：现有 Harness Commands 按钮与其 popover 完全不变；新增 Skills 按钮（同区域、紧邻）拥有自己的 popover，顶部带过滤输入框（skill 数量可达数十条），键盘导航与焦点管理照抄现有 popover 的实现模式。`Cmd/Ctrl+Shift+S` 在 document capture phase 打开该 popover（precedent：`renderer-model-picker.ts:508`），仅当 skills catalog 非空时响应。
+
+### Host 侧只扩"发现"，不扩"执行"
+
+- 新增 `codexhost/thread/skills/inspect`（params 复用 `threadCommandsInspectParamsSchema`，result 复用 `harnessCommandCatalogSchema`）。
+- 执行仍走 `codexhost/thread/command/execute`：command ID 全局路由到 owning Adapter，Adapter 内部按 `claude.skill.` 前缀分派到 skill 执行体。未知 ID 拒绝、参数在命令边界校验、busy session 拒绝——全部沿用现有 requirement。
+- `commands_changed` push 到达后，Renderer 侧的失效策略与现有 catalog 刷新通路一致：Thread 获得新 catalog 即 REPLACE。
+
+### 错误处理
+
+- `supportedCommands()` 失败（旧版 CLI 无此接口）→ skills capability 视为不可用，catalog 为空，不报错、不阻塞 Turn。
+- skill 执行中 Claude CLI 返回未知命令错误 → 作为该 Turn 的正常失败投影（有原生 error 通路），Host 不预校验参数内容。
+- Session resume 路径同样在 open 后拉取 catalog；resume 失败沿用现有 transport 故障处理。
+
+## Risks / Trade-offs
+
+- **`settingSources` 行为跳变**：项目 CLAUDE.md 首次进入 CodexHost 的 Claude Thread 上下文，可能改变模型行为、增加 token 消耗、或让仓库里不可信的 `.claude/settings.json` 生效。接受：这就是"在 Desktop 里用 Claude Code"的默认含义；release notes 需明示。
+- **任意仓库文件驱动 UI**：项目 skills 会出现在按钮列表里。缓解：列表只是枚举结果，点击才执行；执行前走既有工具审批通路（skill 内工具调用同样受 permission mode 约束）。
+- **catalog 新鲜度**：REPLACE push 丢失时列表滞后。缓解：popover 打开时可低频 refresh（实现期决定是否需要）。
+- **ID 命名空间**：skill 名理论上可与静态命令 ID 撞名（都叫 `claude.compact` 之类）。投影统一加 `claude.skill.` 前缀，与静态 `claude.compact` 命名空间天然分离；同名 skill（如两个 plugin 提供同名 skill）由 catalog schema 的 unique-ID superRefine 拒绝投影并在诊断中报告，不静默丢项。
+
+## Migration Plan
+
+单一发布：`0.5.x` 随包生效，无数据迁移。回滚 = revert 本 change；`settingSources` 回到 `["user"]` 即恢复旧上下文行为。Skills catalog 不落盘（mapping-store 无新记录类型），无清理负担。
+
+## Open Questions
+
+- `aliases` 是否需要展示（投影时并入 description 还是忽略）——实现期从简：忽略，CLI 语义由 Claude 侧保留。
+- popover 打开时是否主动 refresh——首版被动（依赖 open 时拉取 + commands_changed），有反馈再加。

--- a/openspec/changes/add-harness-skill-selection/proposal.md
+++ b/openspec/changes/add-harness-skill-selection/proposal.md
@@ -1,0 +1,36 @@
+## Why
+
+Claude Code CLI 的能力面有一大半来自 Skills（`~/.claude/skills`、项目的 `.claude/skills`、plugins、`.claude/commands`），而 CodexHost 目前只静态注册了 `/compact`、`/init`、`/recap` 三条命令。用户在 Codex Desktop 里选中 Claude Code 后，无法发现也无法调用任何 skill。
+
+同时当前 Claude Adapter 传入 SDK 的 `settingSources` 只有 `["user"]`，按 SDK 语义这会跳过项目级 settings，且 **必须包含 `"project"` 才会加载 CLAUDE.md**。也就是说 CodexHost 里的 Claude Code Thread 今天并没有读到项目的 CLAUDE.md，也没有扫描项目 skills。这是一个与 CLI 的行为差距，不只是缺一个按钮。
+
+## What Changes
+
+- Claude Adapter 的 SDK `settingSources` 从 `["user"]` 扩展为 `["user", "project", "local"]`，对齐 Claude Code CLI 默认，使项目 CLAUDE.md、项目 settings 与项目 skills 生效。
+- Claude Adapter 通过官方 SDK 的原生枚举接口 `supportedCommands()` 与初始化响应中的 `skills` 名单发现当前 session 可用的 skill，投影成命令 catalog。
+- 会话中途的 `system/commands_changed` push 事件刷新该 catalog（REPLACE 语义）。
+- `harness-adapter` 的能力接口增加可选 `skills` capability，**复用**既有 `HarnessCommandCapability` 与 `HarnessCommandCatalog` 类型，不新建 skill 专属抽象。
+- Host 新增 `codexhost/thread/skills/inspect`（params/result 复用既有 schema，无新契约类型）；skill 执行**复用**既有 `codexhost/thread/command/execute` 与 command ID 路由，边界校验改为 Commands/Skills 两个 catalog 的并集；`turn/start` 的 slash 文本拦截（现仅匹配 Commands catalog，app-server-host.ts:2995）同步扩到并集，保证用户手敲 `/skill-name args` 与点击走同一条执行路径。不新增第二条执行 RPC，不新增 raw-RPC 透传。
+- Renderer 在 Composer 左侧现有 Harness Commands 按钮旁新增独立 **Skills 按钮 + popover**（顶部带过滤输入框），并绑定 `Cmd/Ctrl+Shift+S` 快捷键。两个按钮彼此独立：Commands 继续只放静态 native 命令，Skills 只放动态枚举项。
+- 未实现该 capability 的 Harness（Pi、Grok、OMP、DeepSeek、OpenCode、Antigravity）catalog 为空，Skills 按钮自动隐藏。
+
+## Capabilities
+
+### New Capabilities
+
+- `harness-skill-catalog`: 从 Harness 原生枚举接口发现 skill，投影为可检查、可执行的 catalog，并在原生侧变化时刷新。
+
+### Modified Capabilities
+
+- `harness-command-capabilities`: 明确"来自 Harness 原生枚举 API 的项属于 native availability"这一例外；允许同一 Thread 存在相互独立的第二个命令 catalog（Skills），且两个 catalog 不得互相混入。
+
+## Impact
+
+- `packages/adapters/claude-code`：`sdk-transport.ts`（settingSources、`supportedCommands()`、`commands_changed` 分支）、`claude-code-adapter.ts`（skill catalog 投影与执行分派）。
+- `packages/harness-adapter`：session capabilities 增加可选 `skills`。
+- `packages/shared-contracts`：无新增 schema（复用 `threadCommandsInspectParamsSchema` 与 `harnessCommandCatalogSchema`）。
+- `packages/host-runtime`：`app-server-host.ts` 增加 skills inspect 路由、`command/execute` 并集校验与 `turn/start` 拦截并集。
+- `packages/renderer-extension`：新 `renderer-harness-skill-control.ts`、composer 挂载、本地化、binding probe。
+- `docs/harness-command-integration.md`：补充 skill 接入路径与"Renderer 仍不得解析 SKILL.md"的边界重申。
+- 行为风险：`settingSources` 变更影响**所有** Claude Code Thread 的上下文（见 design 的 Risks）。
+- 不改动 Rust workspace、不改 delegation 控制面、不引入 skill 白名单管理 UI。

--- a/openspec/changes/add-harness-skill-selection/specs/harness-command-capabilities/spec.md
+++ b/openspec/changes/add-harness-skill-selection/specs/harness-command-capabilities/spec.md
@@ -1,0 +1,71 @@
+## MODIFIED Requirements
+
+### Requirement: Commands are explicitly registered by the owning Adapter
+
+A Harness Adapter MUST publish a command catalog containing stable command IDs, invocations, labels, and argument modes. A command MUST NOT be available merely because a native Harness accepts an arbitrary command string. Entries enumerated from the Harness's own native discovery interface (for Claude Code: `supportedCommands()` filtered by the initialization response's skill list) are a legitimate source of native availability and MUST be admitted through the Adapter's catalog rather than treated as arbitrary strings. Strings that are absent from every published catalog of the current Thread MUST NOT be executed as commands.
+
+#### Scenario: Pi exposes compact
+
+- **WHEN** the Pi Adapter lists commands
+- **THEN** the catalog contains the registered `pi.compact` command
+- **AND** the command declares `/compact` and its supported argument mode
+
+#### Scenario: Natively enumerated skill
+
+- **WHEN** the Claude Code Adapter's native enumeration reports an available skill
+- **THEN** the skill is eligible for the Thread's Skills catalog
+- **AND** this does not count as "available merely because a native Harness accepts a string"
+
+#### Scenario: Unregistered command string is rejected
+
+- **WHEN** an execution request references a `/foo` present in neither catalog of the current Thread
+- **THEN** the Host rejects the request
+- **AND** no native Harness operation is started
+
+### Requirement: Command UI and lifecycle follow Host contracts
+
+A command MAY be discovered by the Renderer through the Host command catalog. The Renderer SHALL present discovered commands through an independent Composer Harness Commands control rather than mutating the Codex-native Slash command list. A Harness that additionally publishes a Skills catalog SHALL present it through a separate independent Composer Skills control; the two controls MUST NOT merge their entries. Each popover SHALL own its layout, scrolling, focus, and keyboard navigation. If execution produces visible lifecycle events, those events MUST use existing Host projection contracts. Temporary command projection Turns MUST NOT be persisted as ordinary conversation history unless the command explicitly requires persistence.
+
+#### Scenario: Manual compaction is projected without a user Turn
+
+- **WHEN** Pi or Claude Code emits native compaction start and end events for their compact command
+- **THEN** codexhost projects the standard context-compaction UI lifecycle
+- **AND** the temporary command Turn is not added to ordinary Thread history
+
+#### Scenario: Skills render in their own control
+
+- **WHEN** a Claude Thread has a non-empty Skills catalog
+- **THEN** its entries render only in the Skills popover
+- **AND** the Harness Commands popover contents are unchanged by the Skills catalog
+
+### Requirement: Commands remain isolated by Harness ownership
+
+The Renderer and Host MUST expose only commands belonging to the current external Harness Thread, including both its Commands catalog and its Skills catalog as two independent collections. Within one Thread the two catalogs MUST NOT contain each other's entries. A command or skill registered by one Harness MUST NOT appear or execute in another Harness Thread.
+
+#### Scenario: Pi command is hidden from Codex Threads
+
+- **WHEN** the current Thread is owned by Codex rather than Pi
+- **THEN** the Pi command catalog is not exposed or rendered
+
+#### Scenario: The two Claude catalogs are disjoint
+
+- **WHEN** the Renderer inspects a Claude Thread's commands and skills
+- **THEN** static native commands appear only in the Commands catalog
+- **AND** natively enumerated skills appear only in the Skills catalog
+
+## ADDED Requirements
+
+### Requirement: Execution route is unified across both catalogs
+
+`codexhost/thread/command/execute` SHALL remain the single execution entry point for both the Commands catalog and the Skills catalog, routing by command ID to the owning Adapter, which dispatches internally. Boundary validation SHALL accept an ID present in either catalog of the current Thread. The Host MUST NOT add a second execution RPC and MUST NOT provide a raw-RPC passthrough for either catalog.
+
+#### Scenario: Skill ID dispatches to the skill executor
+
+- **WHEN** an execution request carries a `claude.skill.`-prefixed ID present in the current Skills catalog
+- **THEN** the Claude Adapter dispatches it to the skill executor
+- **AND** the Host route is the same `command/execute` method used for static commands
+
+#### Scenario: Static command ID dispatches unchanged
+
+- **WHEN** an execution request carries `claude.compact`
+- **THEN** the Claude Adapter dispatches it to the existing dedicated compact transport

--- a/openspec/changes/add-harness-skill-selection/specs/harness-skill-catalog/spec.md
+++ b/openspec/changes/add-harness-skill-selection/specs/harness-skill-catalog/spec.md
@@ -1,0 +1,83 @@
+## ADDED Requirements
+
+### Requirement: Skill catalog 来自 Harness 原生枚举
+支持的 Harness Adapter SHALL 通过其原生枚举接口（Claude Code：`reloadSkills()`；旧版 CLI 无此接口时回退 `supportedCommands()` 与 stream init 消息的 `skills` 名单交集）发现当前 Session 可用的 skill，并投影为与命令 catalog 相同结构（`HarnessCommandCatalog`）的 Skills catalog。Adapter MUST NOT 通过扫描磁盘、读取或解析 SKILL.md 来构造该 catalog。枚举 MUST 在首条 user message 之前即可返回结果（真机 CLI 直到第一条消息入队才向 stream flush init 消息，且任何 control 调用都无法提前触发该 flush）。
+
+#### Scenario: Session 打开后拉取
+- **WHEN** Claude Code Session 完成 open 或 resume
+- **THEN** Adapter SHALL 拉取原生 skill 枚举并缓存为 Skills catalog
+
+#### Scenario: 枚举接口不可用
+- **WHEN** 已安装的 Claude Code 版本不支持 skill 枚举
+- **THEN** Skills catalog SHALL 为空
+- **AND** Session 打开与后续 Turn MUST NOT 因此失败
+
+#### Scenario: 只有 skill 进入 Skills catalog
+- **WHEN** 原生枚举同时返回内置命令与 skill
+- **THEN** 仅出现在 Harness 权威 skills 名单（`reloadSkills()`；回退路径为 stream init 消息 `skills` 字段）中的项 SHALL 进入 Skills catalog
+- **AND** `/compact`、`/init`、`/recap` 等静态 native 命令 MUST NOT 出现在 Skills catalog
+
+### Requirement: Skill 投影保持现有命令契约
+Skills catalog 的每个条目 SHALL 使用 `claude.skill.` 前缀的稳定 ID、以 `/` 开头的 invocation、来自原生 description 的描述，且 `argumentMode` SHALL 由原生 `argumentHint` 是否存在决定（有 → `text`，无 → `none`）。投影 MUST 通过现有 `harnessCommandCatalogSchema` 校验；投影结果 ID 冲突时 MUST 拒绝整批投影并写入诊断，MUST NOT 静默丢弃条目。
+
+#### Scenario: 带参数提示的 skill
+- **WHEN** 原生条目包含非空 `argumentHint`
+- **THEN** 投影条目的 `argumentMode` SHALL 为 `text`
+
+#### Scenario: 无参数 skill
+- **WHEN** 原生条目的 `argumentHint` 为空
+- **THEN** 投影条目的 `argumentMode` SHALL 为 `none`
+- **AND** 执行时携带参数 SHALL 在命令边界被拒绝
+
+### Requirement: Skill 执行复用命令执行通路
+用户执行 Skills catalog 中的条目时，Adapter SHALL 通过该 Harness 的原生 Turn 提交通道以 `/ <name> [arguments]` 形式发起一次真实 Turn，并沿用现有 Item/Turn 投影、审批、取消与历史持久化。Host MUST NOT 为其新增第二条执行 RPC，MUST NOT 提供任意字符串命令透传。
+
+#### Scenario: 显式装载进本轮
+- **WHEN** Renderer 以有效 skill command ID 与合法参数调用 `codexhost/thread/command/execute`
+- **THEN** Adapter SHALL 提交对应的原生 slash Turn 并开始流式投影
+- **AND** 该 Turn SHALL 与普通 Turn 一样可取消、可审批、可持久化
+
+#### Scenario: 未知或已失效的 skill ID
+- **WHEN** 执行请求的 command ID 不在当前 Skills catalog
+- **THEN** Host SHALL 以结构化错误拒绝
+- **AND** MUST NOT 提交任何 Turn
+
+#### Scenario: Session busy
+- **WHEN** 执行请求到达时该 Session 正在运行 Turn
+- **THEN** 执行 SHALL 按现有 busy 拒绝语义失败
+
+### Requirement: Skills catalog 随原生变化刷新
+当 Harness 原生侧推送命令/skill 集合变化（Claude Code：`system/commands_changed`）时，Adapter SHALL 以 REPLACE 语义更新缓存的 Skills catalog，并按现有 catalog 失效通路暴露给 Host 与 Renderer。
+
+#### Scenario: 中途动态发现
+- **WHEN** Session 运行中收到 `commands_changed` push
+- **THEN** 下一次 `skills/inspect` SHALL 返回替换后的 catalog
+- **AND** 已被原生侧移除的 skill MUST NOT 仍可执行
+
+### Requirement: Skills 发现 RPC
+Host SHALL 提供 `codexhost/thread/skills/inspect`，参数与 `codexhost/thread/commands/inspect` 相同（threadId），返回该 Thread 当前 Harness 的 Skills catalog 或空 catalog。该 RPC MUST 保持 Harness 中立：未声明 skills capability 的 Harness 返回空 catalog，而非错误。
+
+#### Scenario: 外部 Thread 查询
+- **WHEN** Renderer 对 Claude Code Thread 调用 `skills/inspect`
+- **THEN** Host SHALL 经 Adapter 返回缓存的 Skills catalog
+
+#### Scenario: 非 Claude Harness 查询
+- **WHEN** Renderer 对 Pi/Grok/OMP/DeepSeek/OpenCode/Antigravity Thread 调用 `skills/inspect`
+- **THEN** 结果 SHALL 为空 catalog
+
+### Requirement: Skills 按钮与快捷键
+Renderer SHALL 在 Composer 的 Harness 控件区提供独立于 Harness Commands 按钮的 Skills 按钮，其 popover 列出当前 Thread Skills catalog（含描述与参数提示）并提供过滤输入框。`Cmd/Ctrl+Shift+S` SHALL 打开该 popover。catalog 为空时按钮与快捷键 SHALL 均不产生可见效果。选中条目 SHALL 经 Host 执行 RPC 触发，而非向 Composer 输入框注入文本。
+
+#### Scenario: catalog 为空
+- **WHEN** 当前 Thread 的 Skills catalog 为空
+- **THEN** Skills 按钮 SHALL 隐藏
+- **AND** 快捷键 SHALL 不打开任何界面
+
+#### Scenario: 过滤大量 skill
+- **WHEN** catalog 条目较多且用户输入过滤词
+- **THEN** popover SHALL 仅展示名称或描述匹配的条目
+
+#### Scenario: 执行反馈
+- **WHEN** 用户选中一个 skill 且执行被接受
+- **THEN** popover SHALL 关闭，该条目 SHALL 呈现 executing 状态
+- **AND** 其输出作为该 Thread 的普通 Turn 出现在 transcript 中

--- a/openspec/changes/add-harness-skill-selection/tasks.md
+++ b/openspec/changes/add-harness-skill-selection/tasks.md
@@ -1,0 +1,30 @@
+## 1. 原生枚举与投影（Claude Adapter）
+
+- [x] 1.1 `sdk-transport.ts` 两处 `settingSources` 从 `["user"]` 扩为 `["user", "project", "local"]`。
+- [x] 1.2 Transport 在 open/resume 后拉取 `initializationResult()` 的 `skills` 名单与 `supportedCommands()` 全量列表，暴露 skill 枚举 seam。
+- [x] 1.3 Consume 循环新增 `system/commands_changed` 分支，REPLACE 缓存并触发 catalog 失效通知。
+- [x] 1.4 Adapter 将 skill 投影为 `HarnessCommandCatalog`（`claude.skill.` 前缀 ID、argumentHint→argumentMode、冲突拒绝并写诊断），与静态 catalog 保持互斥。
+- [x] 1.5 Adapter 增加 skill 执行体：`runTurn("/" + name + (args ? " " + args : ""))`，沿用现有 Turn 投影、busy 拒绝与取消通路。
+
+## 2. 契约与 Host 路由
+
+- [x] 2.1 `harness-adapter` 的 session capabilities 增加可选 `skills`（复用 `HarnessCommandCapability` 类型）。
+- [x] 2.2 `shared-contracts` 增加 `threadSkillsInspect` params/result schema（复用现有 descriptor/catalog schema）(reused existing schemas per ruling — no new schema)。
+- [x] 2.3 `app-server-host.ts` 增加 `codexhost/thread/skills/inspect` 路由；未声明 skills capability 的 Harness 返回空 catalog。
+- [x] 2.4 `commands/execute` 的 Adapter 侧边界按两个 catalog 并集校验（Host 仍只做未知 ID 拒绝），Claude Adapter 内部按 `claude.skill.` 前缀分派到 skill 执行体。
+
+## 3. Renderer
+
+- [x] 3.1 新 `renderer-harness-skill-control.ts`：独立按钮 + popover（顶部过滤输入框），布局/焦点/滚动照抄 command control 模式，空 catalog 隐藏。
+- [x] 3.2 Composer 挂载（紧邻 Harness Commands 按钮）与 catalog 拉取（`skills/inspect`），复用 `renderer-model-client.ts` 的请求通路。
+- [x] 3.3 `Cmd/Ctrl+Shift+S` document capture keydown 打开 popover；catalog 为空时不响应。
+- [x] 3.4 zh/en/ko 本地化条目与按钮图标。
+
+## 4. 测试与验证
+
+- [x] 4.1 Adapter 聚焦测试：枚举过滤（skill vs 内置命令）、投影 schema 校验、ID 冲突诊断、`commands_changed` REPLACE 刷新、执行 payload、busy 拒绝、枚举不可用时静默降级。
+- [x] 4.2 Host 聚焦测试：skills inspect 路由、非 Claude Harness 空 catalog、commands/execute 并集校验与跨 Harness 隔离。
+- [x] 4.3 Renderer binding probe 增加 skill control 挂载、空态隐藏与快捷键行为断言 (coverage delivered via Playwright e2e spec per controller ruling)。
+- [x] 4.4 运行 `npm run build:typescript`、`npm run typecheck`、`npm run lint`（含边界检查）、聚焦 vitest、`git diff --check`。
+- [ ] 4.5 真机验证：在一个含 `.claude/skills` 的项目里确认项目 skill 出现在 Skills popover、点击后正常执行，且 CLAUDE.md 进入上下文。
+- [x] 4.6 更新 `docs/harness-command-integration.md`（skill 接入路径、重申 Renderer 不解析 SKILL.md）与 release 说明（`settingSources` 行为变更）。

--- a/packages/adapters/claude-code/src/claude-code-adapter.ts
+++ b/packages/adapters/claude-code/src/claude-code-adapter.ts
@@ -61,6 +61,7 @@ import {
   nativeSessionRefSchema,
   nativeTurnRefSchema,
   type AccountCreditsSnapshot,
+  type HarnessCommandCatalog,
   type HarnessId,
   type HarnessThinkingOptionId,
   type HostInteractionId,
@@ -108,6 +109,7 @@ import type {
   ClaudePlanApprovalRequest,
   ClaudePlanLimitEvent,
   ClaudeQuestionRequest,
+  ClaudeSkillCommand,
   ClaudeTransportFailureKind,
   ClaudeTransportTurnResult,
   ClaudeTurnEvent,
@@ -267,6 +269,57 @@ function parseClaudeHarnessCommand(
   }
   return { ok: true, value: { id: "claude.compact", text: customInstructions } };
 }
+
+type ClaudeCommandTurn =
+  | { kind: "native"; native: ClaudeHarnessCommand }
+  | { kind: "skill"; name: string; text: string | undefined };
+
+function claudeSkillCommandId(name: string): string {
+  return `claude.skill.${name.replaceAll(".", "..")}`;
+}
+
+// Mirrors the harnessCommandCatalogSchema description limit (shared-contracts
+// keeps it private); real user/project skills routinely exceed it, and one
+// overlong description must not reject the whole catalog.
+const SKILL_DESCRIPTION_LIMIT = 512;
+
+function boundedSkillDescription(description: string): string | undefined {
+  const trimmed = description.trim();
+  if (trimmed.length === 0) return undefined;
+  return trimmed.slice(0, SKILL_DESCRIPTION_LIMIT);
+}
+
+export function projectClaudeSkillCatalog(
+  skills: readonly ClaudeSkillCommand[],
+): HarnessResult<HarnessCommandCatalog> {
+  try {
+    return {
+      ok: true,
+      value: harnessCommandCatalogSchema.parse({
+        commands: skills.map((skill) => {
+          const description = boundedSkillDescription(skill.description);
+          return {
+            id: claudeSkillCommandId(skill.name),
+            invocation: `/${skill.name}`,
+            label: skill.name,
+            ...(description ? { description } : {}),
+            argumentMode: skill.argumentHint.trim().length > 0 ? "text" : "none",
+          };
+        }),
+      }),
+    };
+  } catch (error) {
+    return {
+      ok: false,
+      error: {
+        code: "protocolError",
+        message: `Claude skill catalog is invalid: ${error instanceof Error ? error.message : String(error)}`,
+        retryable: true,
+      },
+    };
+  }
+}
+
 const DEFAULT_CLOSE_TIMEOUT_MS = 7_000;
 const DEFAULT_CANCEL_TIMEOUT_MS = 2_000;
 const DEFAULT_TOOL_OUTPUT_LIMIT = 64_000;
@@ -491,6 +544,7 @@ class ClaudeHarnessSession implements HarnessSession {
     subagents: { observe: true, readTranscript: true },
   };
   readonly commands: HarnessCommandCapability;
+  readonly skills: HarnessCommandCapability;
   readonly initialState: HarnessSessionState;
   readonly initialUsage = null;
   readonly outputs: AsyncIterable<HarnessOutput>;
@@ -582,6 +636,38 @@ class ClaudeHarnessSession implements HarnessSession {
     this.commands = {
       list: async () => ({ ok: true, value: claudeCommandCatalog }),
       execute: (command) => this.#executeHarnessCommand(command),
+    };
+    this.skills = {
+      list: async () => {
+        if (this.#phase !== "open") {
+          return { ok: false, error: invalidState("Claude Code Session is not open") };
+        }
+        const transport = this.#transport;
+        if (!transport) {
+          if (
+            this.#acceptingTurn ||
+            this.#active ||
+            this.#configurationTask ||
+            this.#readingHistory
+          ) {
+            return { ok: true, value: { commands: [] } };
+          }
+          this.#acceptingTurn = true;
+          const startingTransport = this.#transport === null;
+          try {
+            await this.#ensureTransport();
+            if (startingTransport && this.#phase === "open") this.#publishState();
+          } catch {
+            return { ok: true, value: { commands: [] } };
+          } finally {
+            this.#acceptingTurn = false;
+          }
+        }
+        const active = this.#transport;
+        if (!active) return { ok: true, value: { commands: [] } };
+        return projectClaudeSkillCatalog(await active.listSkills());
+      },
+      execute: (command) => this.#executeSkillCommand(command),
     };
     this.initialState = this.#openMode === "resume" ? { nativeRef: this.#nativeRef } : {};
     this.#state = this.initialState;
@@ -797,6 +883,92 @@ class ClaudeHarnessSession implements HarnessSession {
     }
     const parsed = parseClaudeHarnessCommand(command);
     if (!parsed.ok) return parsed;
+    return this.#beginCommandTurn(command, { kind: "native", native: parsed.value });
+  }
+
+  async #executeSkillCommand(
+    command: HarnessCommandInvocation,
+  ): Promise<HarnessResult<HarnessCommandAccepted>> {
+    if (!command.commandId.startsWith("claude.skill.")) {
+      return {
+        ok: false,
+        error: { code: "unsupported", message: "Not a Claude skill command", retryable: false },
+      };
+    }
+    // Match the native command path: a busy Session is retryable `sessionBusy`,
+    // never a permanent `unsupported` from an empty startup-window catalog.
+    if (this.#acceptingTurn || this.#active || this.#configurationTask || this.#readingHistory) {
+      return {
+        ok: false,
+        error: {
+          code: "sessionBusy",
+          message: "Claude Code Session already has an active operation",
+          retryable: true,
+        },
+      };
+    }
+    const listed = await this.skills.list();
+    if (!listed.ok) return listed;
+    const descriptor = listed.value.commands.find(({ id }) => id === command.commandId);
+    if (!descriptor) {
+      return {
+        ok: false,
+        error: {
+          code: "unsupported",
+          message: `Claude Code does not expose skill '${command.commandId}'`,
+          retryable: false,
+        },
+      };
+    }
+    const name = descriptor.invocation.slice(1);
+    const args = command.arguments;
+    if (descriptor.argumentMode === "none" && args && Object.keys(args).length > 0) {
+      return {
+        ok: false,
+        error: {
+          code: "invalidRequest",
+          message: `Claude Code skill '${name}' does not accept arguments`,
+          retryable: false,
+        },
+      };
+    }
+    if (args && Object.keys(args).some((key) => key !== "text")) {
+      return {
+        ok: false,
+        error: {
+          code: "invalidRequest",
+          message: `Claude Code skill '${name}' has an unknown argument`,
+          retryable: false,
+        },
+      };
+    }
+    const text = args?.text;
+    if (text !== undefined && typeof text !== "string") {
+      return {
+        ok: false,
+        error: {
+          code: "invalidRequest",
+          message: `Claude Code skill '${name}' argument 'text' must be a string`,
+          retryable: false,
+        },
+      };
+    }
+    // #beginCommandTurn repeats the phase check after its first await; the listing
+    // above is asynchronous, so the Session may have closed in the meantime.
+    return this.#beginCommandTurn(command, {
+      kind: "skill",
+      name,
+      text: typeof text === "string" ? text : undefined,
+    });
+  }
+
+  async #beginCommandTurn(
+    command: HarnessCommandInvocation,
+    parsed: ClaudeCommandTurn,
+  ): Promise<HarnessResult<HarnessCommandAccepted>> {
+    if (this.#phase !== "open") {
+      return { ok: false, error: invalidState("Claude Code Session is not open") };
+    }
     if (this.#acceptingTurn || this.#active || this.#configurationTask || this.#readingHistory) {
       return {
         ok: false,
@@ -830,7 +1002,7 @@ class ClaudeHarnessSession implements HarnessSession {
       resolveCompletion = resolve;
     });
     const nativeTurnKey = this.#randomUUID();
-    const startAgentItem = parsed.value.id !== "claude.compact";
+    const startAgentItem = parsed.kind === "skill" || parsed.native.id !== "claude.compact";
     const item: HostAgentMessageItem | null = startAgentItem
       ? {
           type: "agentMessage",
@@ -879,13 +1051,19 @@ class ClaudeHarnessSession implements HarnessSession {
     this.#event({ type: "turn.started", turnId: command.turnId });
     if (item) this.#event({ type: "item.started", turnId: command.turnId, item });
     const running =
-      parsed.value.id === "claude.compact"
-        ? transport.compact(nativeTurnKey, parsed.value.text, (event) =>
-            this.#handleTurnEvent(active, event),
+      parsed.kind === "skill"
+        ? transport.runTurn(
+            parsed.text ? `/${parsed.name} ${parsed.text}` : `/${parsed.name}`,
+            nativeTurnKey,
+            (event) => this.#handleTurnEvent(active, event),
           )
-        : parsed.value.id === "claude.init"
-          ? transport.init(nativeTurnKey, (event) => this.#handleTurnEvent(active, event))
-          : transport.recap(nativeTurnKey, (event) => this.#handleTurnEvent(active, event));
+        : parsed.native.id === "claude.compact"
+          ? transport.compact(nativeTurnKey, parsed.native.text, (event) =>
+              this.#handleTurnEvent(active, event),
+            )
+          : parsed.native.id === "claude.init"
+            ? transport.init(nativeTurnKey, (event) => this.#handleTurnEvent(active, event))
+            : transport.recap(nativeTurnKey, (event) => this.#handleTurnEvent(active, event));
     try {
       void running.then(
         (result) => this.#finishResult(active, result),

--- a/packages/adapters/claude-code/src/sdk-transport.ts
+++ b/packages/adapters/claude-code/src/sdk-transport.ts
@@ -27,6 +27,7 @@ import type {
   ClaudeModelInspector,
   ClaudePlanLimitEvent,
   ClaudeQuestion,
+  ClaudeSkillCommand,
   ClaudeTransportContextUsage,
   ClaudeTransportTurnResult,
   ClaudeTurnEvent,
@@ -368,6 +369,8 @@ export class ClaudeSdkTransport implements ClaudeTurnTransport {
   #interactionOrdinal = 0;
   #provider: string | undefined;
   #query: Query | null = null;
+  #skillNames = new Set<string>();
+  #builtInCommandNames = new Set<string>();
   #started = false;
 
   constructor(options: ClaudeSdkTransportOptions) {
@@ -425,7 +428,7 @@ export class ClaudeSdkTransport implements ClaudeTurnTransport {
           : { type: "disabled" },
         ...(thinking.effort ? { effort: thinking.effort } : {}),
         pathToClaudeCodeExecutable: executable,
-        settingSources: ["user"],
+        settingSources: ["user", "project", "local"],
         permissionMode: this.#permissionMode,
         ...(allowsDangerouslySkipPermissions() ? { allowDangerouslySkipPermissions: true } : {}),
         canUseTool: (toolName, input, options) => this.#canUseTool(toolName, input, options),
@@ -513,6 +516,42 @@ export class ClaudeSdkTransport implements ClaudeTurnTransport {
     onEvent: (event: ClaudeTurnEvent) => void,
   ): Promise<ClaudeTransportTurnResult> {
     return this.runTurn("/recap", userMessageId, onEvent);
+  }
+
+  async listSkills(): Promise<readonly ClaudeSkillCommand[]> {
+    const activeQuery = this.#query;
+    if (!this.#started || !activeQuery) return [];
+    // Preferred: the native skill-list request. It answers on the control
+    // channel, so it works before the first queued user message — the real
+    // CLI does not flush the stream init message until then, which used to
+    // leave a freshly opened Thread with an empty Skills catalog.
+    const reload = (activeQuery as Partial<Pick<Query, "reloadSkills">>).reloadSkills;
+    if (typeof reload === "function") {
+      try {
+        const { skills } = await reload.call(activeQuery);
+        return skills
+          .filter(
+            (skill) =>
+              typeof skill.name === "string" &&
+              typeof skill.description === "string" &&
+              typeof skill.argumentHint === "string",
+          )
+          .map(({ name, description, argumentHint }) => ({ name, description, argumentHint }));
+      } catch {
+        // Fall through to the supportedCommands() seam for diagnosis below.
+        console.error("codexhost Claude reloadSkills() failed; falling back to init filtering");
+      }
+    }
+    const supported = (activeQuery as Partial<Pick<Query, "supportedCommands">>).supportedCommands;
+    if (typeof supported !== "function") return [];
+    try {
+      const commands = await supported.call(activeQuery);
+      return commands
+        .filter((command) => this.#skillNames.has(command.name))
+        .map(({ name, description, argumentHint }) => ({ name, description, argumentHint }));
+    } catch {
+      return [];
+    }
   }
 
   runTurn(
@@ -784,6 +823,31 @@ export class ClaudeSdkTransport implements ClaudeTurnTransport {
           this.#permissionMode = permissionMode;
           this.#onPermissionModeChanged(permissionMode);
         }
+        if (isRecord(message) && message.type === "system") {
+          if (
+            message.subtype === "init" &&
+            Array.isArray(message.skills) &&
+            Array.isArray(message.slash_commands)
+          ) {
+            this.#skillNames = new Set(
+              message.skills.filter((name: unknown): name is string => typeof name === "string"),
+            );
+            this.#builtInCommandNames = new Set(
+              (message.slash_commands as unknown[])
+                .filter((name: unknown): name is string => typeof name === "string")
+                .map((name) => (name.startsWith("/") ? name.slice(1) : name)),
+            );
+          } else if (message.subtype === "commands_changed" && Array.isArray(message.commands)) {
+            for (const command of message.commands as readonly Record<string, unknown>[]) {
+              if (
+                typeof command.name === "string" &&
+                !this.#builtInCommandNames.has(command.name)
+              ) {
+                this.#skillNames.add(command.name);
+              }
+            }
+          }
+        }
         const planLimit = parseClaudePlanLimitEvent(message);
         if (planLimit) this.#onPlanLimit(planLimit);
         const active = this.#active;
@@ -912,7 +976,7 @@ export class ClaudeSdkModelInspector implements ClaudeModelInspector {
       options: {
         cwd: this.#cwd,
         pathToClaudeCodeExecutable: executable,
-        settingSources: ["user"],
+        settingSources: ["user", "project", "local"],
         permissionMode: "default",
         tools: [],
         persistSession: false,

--- a/packages/adapters/claude-code/src/transport.ts
+++ b/packages/adapters/claude-code/src/transport.ts
@@ -162,6 +162,12 @@ export interface ClaudePlanLimitEvent {
   sevenDay?: ClaudePlanLimitWindow;
 }
 
+export interface ClaudeSkillCommand {
+  readonly name: string;
+  readonly description: string;
+  readonly argumentHint: string;
+}
+
 export interface ClaudeAutonomousTurn {
   nativeTurnKey: string;
   events: ClaudeTurnEvent[];
@@ -179,6 +185,7 @@ export interface ClaudeTurnTransport {
   setIdleTurnHandler(handler: ClaudeIdleTurnHandler | null): void;
   setIdleLive(live: boolean): void;
   start(): Promise<void>;
+  listSkills(): Promise<readonly ClaudeSkillCommand[]>; // [] when transport unstarted or enumeration unsupported
   getContextUsage(): Promise<ClaudeTransportContextUsage | null>;
   getPermissionMode(): ClaudePermissionMode;
   setModel(model?: string): Promise<void>;

--- a/packages/adapters/claude-code/test/claude-code-adapter.test.ts
+++ b/packages/adapters/claude-code/test/claude-code-adapter.test.ts
@@ -23,6 +23,7 @@ import type {
   ClaudeInteractionResponse,
   ClaudePlanLimitEvent,
   ClaudeQuestionRequest,
+  ClaudeSkillCommand,
   ClaudeTransportContextUsage,
   ClaudeTransportTurnResult,
   ClaudeTurnEvent,
@@ -65,6 +66,8 @@ class FakeClaudeTransport implements ClaudeTurnTransport {
     });
   });
   readonly start = vi.fn(async () => undefined);
+  skills: ClaudeSkillCommand[] = [];
+  readonly listSkills = vi.fn(async () => this.skills);
   readonly compactCalls: Array<{ userMessageId: string; customInstructions: string | undefined }> =
     [];
   readonly initCalls: string[] = [];
@@ -1369,6 +1372,222 @@ describe("Claude Code HarnessAdapter", () => {
     });
     expect(transport.recapCalls).toEqual([expect.any(String)]);
     expect(transport.turns).toEqual([]);
+    await session.close();
+  });
+
+  it("projects native skills into a claude.skill catalog", async () => {
+    const { adapter, transports } = fixture();
+    const session = await openSession(adapter);
+    const commands = session.commands;
+    if (!commands) throw new Error("Claude Code Session did not expose commands");
+    const skills = session.skills;
+    if (!skills) throw new Error("Claude Code Session did not expose skills");
+    await commands.execute({
+      turnId: hostTurnIdSchema.parse("prime"),
+      commandId: "claude.recap",
+    }); // force transport creation through any command path
+    const transport = transports[0];
+    if (!transport) throw new Error("Fake transport missing");
+    transport.finish({ status: "succeeded" });
+    transport.skills = [
+      { name: "render-html", description: "Render HTML", argumentHint: "<file>" },
+      { name: "no-arg.skill", description: "Dots escape", argumentHint: "" },
+    ];
+    await expect(skills.list()).resolves.toMatchObject({
+      ok: true,
+      value: {
+        commands: [
+          {
+            id: "claude.skill.render-html",
+            invocation: "/render-html",
+            label: "render-html",
+            description: "Render HTML",
+            argumentMode: "text",
+          },
+          {
+            id: "claude.skill.no-arg..skill",
+            invocation: "/no-arg.skill",
+            label: "no-arg.skill",
+            description: "Dots escape",
+            argumentMode: "none",
+          },
+        ],
+      },
+    });
+    await session.close();
+  });
+
+  it("bounds overlong native skill descriptions instead of rejecting the catalog", async () => {
+    // Real user/project skills carry multi-paragraph trigger descriptions
+    // beyond the 512-char contract limit; the catalog must still project.
+    const { adapter, transports } = fixture();
+    const session = await openSession(adapter);
+    const commands = session.commands;
+    if (!commands) throw new Error("Claude Code Session did not expose commands");
+    const skills = session.skills;
+    if (!skills) throw new Error("Claude Code Session did not expose skills");
+    await commands.execute({
+      turnId: hostTurnIdSchema.parse("prime"),
+      commandId: "claude.recap",
+    });
+    const transport = transports[0];
+    if (!transport) throw new Error("Fake transport missing");
+    transport.finish({ status: "succeeded" });
+    transport.skills = [
+      { name: "short", description: "Fine", argumentHint: "" },
+      { name: "verbose", description: "x".repeat(600), argumentHint: "" },
+    ];
+    const listed = await skills.list();
+    expect(listed.ok).toBe(true);
+    if (!listed.ok) throw new Error("projection rejected: " + JSON.stringify(listed.error));
+    const verbose = listed.value.commands.find((entry) => entry.label === "verbose");
+    expect(verbose?.description).toHaveLength(512);
+    expect(verbose?.description).toBe("x".repeat(512));
+    await session.close();
+  });
+
+  it("rejects duplicate projected skill IDs instead of dropping entries", async () => {
+    const { adapter, transports } = fixture();
+    const session = await openSession(adapter);
+    const skills = session.skills;
+    if (!skills) throw new Error("Claude Code Session did not expose skills");
+    await skills.list(); // lazily creates transports[0]
+    const transport = transports[0];
+    if (!transport) throw new Error("Fake transport missing");
+    transport.skills = [
+      { name: "dup", description: "A", argumentHint: "" },
+      { name: "dup", description: "B", argumentHint: "" },
+    ];
+    await expect(skills.list()).resolves.toMatchObject({
+      ok: false,
+      error: { code: "protocolError" },
+    });
+    await session.close();
+  });
+
+  it("executes a skill as a native slash turn with optional text argument", async () => {
+    const { adapter, transports } = fixture();
+    const session = await openSession(adapter);
+    const skills = session.skills;
+    if (!skills) throw new Error("Claude Code Session did not expose skills");
+    await skills.list();
+    const transport = transports[0];
+    if (!transport) throw new Error("Fake transport missing");
+    transport.skills = [{ name: "render-html", description: "d", argumentHint: "<file>" }];
+    const iterator = session.outputs[Symbol.asyncIterator]();
+    await expect(
+      skills.execute({
+        turnId: hostTurnIdSchema.parse("skill-turn-1"),
+        commandId: "claude.skill.render-html",
+        arguments: { text: "report.html" },
+      }),
+    ).resolves.toEqual({ ok: true, value: { turnId: "skill-turn-1" } });
+    expect(transport.turns.at(-1)?.text).toBe("/render-html report.html");
+    // The earlier `skills.list()` lazily started the Transport and published state.
+    expect((await nextEvent(iterator)).type).toBe("session.state.changed");
+    // A skill Turn is a normal visible agent reply, never an ephemeral compaction lane.
+    expect(await nextEvent(iterator)).toEqual({ type: "turn.started", turnId: "skill-turn-1" });
+    expect(await nextEvent(iterator)).toMatchObject({
+      type: "item.started",
+      turnId: "skill-turn-1",
+      item: { type: "agentMessage", text: "" },
+    });
+    transport.delta("Rendered report", "skill-assistant");
+    expect(await nextEvent(iterator)).toMatchObject({
+      type: "item.updated",
+      update: { type: "text.append", text: "Rendered report" },
+    });
+    transport.finish({ status: "succeeded" });
+    expect(await nextEvent(iterator)).toMatchObject({
+      type: "item.completed",
+      snapshot: { item: { type: "agentMessage", text: "Rendered report" } },
+    });
+    expect(await nextEvent(iterator)).toEqual({
+      type: "turn.completed",
+      turnId: "skill-turn-1",
+      outcome: { status: "succeeded" },
+    });
+    await session.close();
+  });
+
+  it("rejects skill execution for unknown id and for arguments on a none skill", async () => {
+    const { adapter, transports } = fixture();
+    const session = await openSession(adapter);
+    const skills = session.skills;
+    if (!skills) throw new Error("Claude Code Session did not expose skills");
+    await skills.list();
+    const transport = transports[0];
+    if (!transport) throw new Error("Fake transport missing");
+    transport.skills = [{ name: "plain", description: "d", argumentHint: "" }];
+    await expect(
+      skills.execute({
+        turnId: hostTurnIdSchema.parse("t0"),
+        commandId: "claude.skill.ghost",
+      }),
+    ).resolves.toMatchObject({ ok: false, error: { code: "unsupported" } });
+    await expect(
+      skills.execute({
+        turnId: hostTurnIdSchema.parse("t1"),
+        commandId: "claude.skill.plain",
+        arguments: { text: "nope" },
+      }),
+    ).resolves.toMatchObject({ ok: false, error: { code: "invalidRequest" } });
+    await session.close();
+  });
+
+  it("reports sessionBusy when a skill executes during an active Turn", async () => {
+    const { adapter, transports } = fixture();
+    const session = await openSession(adapter);
+    void session.execute(textTurn("busy-turn")); // file helper at :288
+    const skills = session.skills;
+    if (!skills) throw new Error("Claude Code Session did not expose skills");
+    await skills.list(); // ensure transports exist
+    const transport = transports[0];
+    if (!transport) throw new Error("Fake transport missing");
+    transport.skills = [{ name: "plain", description: "d", argumentHint: "" }];
+    await expect(
+      skills.execute({
+        turnId: hostTurnIdSchema.parse("t2"),
+        commandId: "claude.skill.plain",
+      }),
+    ).resolves.toMatchObject({ ok: false, error: { code: "sessionBusy" } });
+    expect(transports).toHaveLength(1);
+    transport.finish({ status: "succeeded" });
+    await session.close();
+  });
+
+  it("publishes the initial state when listing skills lazily starts a create-mode Transport", async () => {
+    const { adapter } = fixture();
+    const session = await openSession(adapter);
+    const iterator = session.outputs[Symbol.asyncIterator]();
+    const skills = session.skills;
+    if (!skills) throw new Error("Claude Code Session did not expose skills");
+    await expect(skills.list()).resolves.toMatchObject({
+      ok: true,
+      value: { commands: [] },
+    });
+    expect(await nextEvent(iterator)).toMatchObject({
+      type: "session.state.changed",
+      state: { nativeRef: { harnessId: "claude-code", nativeSessionId: expect.any(String) } },
+    });
+    await session.close();
+  });
+
+  it("reports retryable sessionBusy when a skill executes during startup before the Transport is bound", async () => {
+    const { adapter, transports } = fixture();
+    const session = await openSession(adapter);
+    // `execute` suspends inside `#ensureTransport` awaiting `transport.start()`,
+    // so `#acceptingTurn` is set while `#transport` is still unbound.
+    void session.execute(textTurn("startup-window"));
+    const skills = session.skills;
+    if (!skills) throw new Error("Claude Code Session did not expose skills");
+    await expect(
+      skills.execute({
+        turnId: hostTurnIdSchema.parse("t3"),
+        commandId: "claude.skill.any",
+      }),
+    ).resolves.toMatchObject({ ok: false, error: { code: "sessionBusy", retryable: true } });
+    transports[0]?.finish({ status: "succeeded" });
     await session.close();
   });
 
@@ -4643,6 +4862,7 @@ describe("Claude Code HarnessAdapter", () => {
         start: async () => {
           throw new ClaudeCodeExecutableError("Claude Code is not installed");
         },
+        listSkills: async () => [],
         getContextUsage: async () => null,
         getPermissionMode: () => "default",
         setModel: async () => undefined,

--- a/packages/adapters/claude-code/test/sdk-transport.test.ts
+++ b/packages/adapters/claude-code/test/sdk-transport.test.ts
@@ -1,7 +1,12 @@
 import path from "node:path";
 
 import { describe, expect, it, vi } from "vitest";
-import type { PermissionUpdate, Query, SDKMessage } from "@anthropic-ai/claude-agent-sdk";
+import type {
+  PermissionUpdate,
+  Query,
+  SDKMessage,
+  SlashCommand,
+} from "@anthropic-ai/claude-agent-sdk";
 import { harnessThinkingOptionIdSchema } from "@codexhost/shared-contracts";
 
 import {
@@ -43,6 +48,13 @@ class FakeQuery {
   readonly setModel = vi.fn(async () => undefined);
   readonly applyFlagSettings = vi.fn(async () => undefined);
   readonly setPermissionMode = vi.fn(async () => undefined);
+  supportedCommands = vi.fn(async (): Promise<SlashCommand[]> => [
+    { name: "render-html", description: "Render HTML", argumentHint: "<file>", aliases: [] },
+    { name: "compact", description: "built-in", argumentHint: "", aliases: [] },
+  ]);
+  reloadSkills = vi.fn(async (): Promise<{ skills: SlashCommand[] }> => {
+    throw new Error("FakeQuery does not implement reloadSkills");
+  });
   #closed = false;
   #messages: SDKMessage[] = [];
   #waiters: Array<(result: IteratorResult<SDKMessage>) => void> = [];
@@ -203,6 +215,118 @@ describe("ClaudeSdkTransport context Usage", () => {
     value.fakeQuery.getContextUsage.mockRejectedValueOnce(new Error("context unavailable"));
     await expect(value.transport.getContextUsage()).rejects.toThrow("context unavailable");
     await value.transport.close();
+  });
+});
+
+describe("ClaudeSdkTransport skill enumeration", () => {
+  it("starts the session with CLI-aligned setting sources", async () => {
+    const value = fixture();
+    await value.transport.start();
+    expect(options(value).settingSources).toEqual(["user", "project", "local"]);
+  });
+
+  it("listSkills returns only natively reported skill names", async () => {
+    const value = fixture();
+    await value.transport.start();
+    value.fakeQuery.push({
+      type: "system",
+      subtype: "init",
+      skills: ["render-html"],
+      slash_commands: ["/compact"],
+      session_id: "s1",
+      uuid: "u1",
+    } as unknown as SDKMessage);
+    await vi.waitFor(async () => {
+      await expect(value.transport.listSkills()).resolves.toEqual([
+        { name: "render-html", description: "Render HTML", argumentHint: "<file>" },
+      ]);
+    });
+  });
+
+  it("listSkills includes skills announced by commands_changed pushes", async () => {
+    const value = fixture();
+    await value.transport.start();
+    value.fakeQuery.push({
+      type: "system",
+      subtype: "init",
+      skills: ["render-html"],
+      slash_commands: ["/compact"],
+      session_id: "s1",
+      uuid: "u1",
+    } as unknown as SDKMessage);
+    value.fakeQuery.supportedCommands.mockResolvedValue([
+      { name: "render-html", description: "Render HTML", argumentHint: "<file>" },
+      { name: "pdf-tools:extract", description: "Extract text", argumentHint: "" },
+      { name: "compact", description: "built-in", argumentHint: "" },
+    ]);
+    value.fakeQuery.push({
+      type: "system",
+      subtype: "commands_changed",
+      commands: [
+        { name: "render-html", description: "Render HTML", argumentHint: "<file>" },
+        { name: "pdf-tools:extract", description: "Extract text", argumentHint: "" },
+        { name: "compact", description: "built-in", argumentHint: "" },
+      ],
+      session_id: "s1",
+      uuid: "u2",
+    } as unknown as SDKMessage);
+    await vi.waitFor(async () => {
+      await expect(value.transport.listSkills()).resolves.toEqual([
+        { name: "render-html", description: "Render HTML", argumentHint: "<file>" },
+        { name: "pdf-tools:extract", description: "Extract text", argumentHint: "" },
+      ]);
+    });
+  });
+
+  it("listSkills degrades to empty when the installed CLI lacks enumeration", async () => {
+    const value = fixture();
+    delete (value.fakeQuery as { supportedCommands?: unknown }).supportedCommands;
+    delete (value.fakeQuery as { reloadSkills?: unknown }).reloadSkills;
+    await value.transport.start();
+    await expect(value.transport.listSkills()).resolves.toEqual([]);
+  });
+
+  it("listSkills returns native skills before the first user message is queued", async () => {
+    // The real CLI only flushes the stream init message once a user message is
+    // queued, so the old stream-init path cannot serve the inspect-before-first-turn
+    // case; reloadSkills answers on the control channel instead.
+    const value = fixture();
+    await value.transport.start();
+    value.fakeQuery.reloadSkills.mockResolvedValue({
+      skills: [
+        { name: "render-html", description: "Render HTML", argumentHint: "<file>", aliases: [] },
+        {
+          name: "smoke-project",
+          description: "Project skill (project)",
+          argumentHint: "",
+          aliases: [],
+        },
+      ],
+    });
+    await expect(value.transport.listSkills()).resolves.toEqual([
+      { name: "render-html", description: "Render HTML", argumentHint: "<file>" },
+      { name: "smoke-project", description: "Project skill (project)", argumentHint: "" },
+    ]);
+    expect(value.fakeQuery.supportedCommands).not.toHaveBeenCalled();
+  });
+
+  it("listSkills keeps stream-init filtering when the CLI lacks reloadSkills", async () => {
+    const value = fixture();
+    delete (value.fakeQuery as { reloadSkills?: unknown }).reloadSkills;
+    await value.transport.start();
+    value.fakeQuery.push({
+      type: "system",
+      subtype: "init",
+      skills: ["render-html"],
+      slash_commands: ["/compact"],
+      session_id: "s1",
+      uuid: "u1",
+    } as unknown as SDKMessage);
+    await vi.waitFor(async () => {
+      await expect(value.transport.listSkills()).resolves.toEqual([
+        { name: "render-html", description: "Render HTML", argumentHint: "<file>" },
+      ]);
+    });
   });
 });
 
@@ -1015,7 +1139,7 @@ describe("ClaudeSdkTransport Model control", () => {
       persistSession: false,
       includePartialMessages: false,
       tools: [],
-      settingSources: ["user"],
+      settingSources: ["user", "project", "local"],
     });
     expect(options(value).env?.PATH?.split(path.delimiter)).toContain(
       path.dirname(process.execPath),

--- a/packages/harness-adapter/src/testing.ts
+++ b/packages/harness-adapter/src/testing.ts
@@ -157,6 +157,7 @@ export class FakeHarnessSession implements HarnessSession {
   readonly initialState: HarnessSessionState;
   readonly initialUsage: HostUsage | null;
   commands?: HarnessCommandCapability;
+  skills?: HarnessCommandCapability;
   readonly interactionResponses: InteractionRespondCommand[] = [];
   readonly outputs: AsyncIterable<HarnessOutput>;
   snapshotReads = 0;

--- a/packages/harness-adapter/src/text-session.ts
+++ b/packages/harness-adapter/src/text-session.ts
@@ -495,6 +495,7 @@ export interface HarnessSession {
   readonly initialUsage: HostUsage | null;
   readonly outputs: AsyncIterable<HarnessOutput>;
   readonly commands?: HarnessCommandCapability;
+  readonly skills?: HarnessCommandCapability;
 
   refreshUsage?(): Promise<void>;
   readSnapshot(): Promise<HarnessResult<HostThreadSnapshot>>;

--- a/packages/host-runtime/src/app-server-host.ts
+++ b/packages/host-runtime/src/app-server-host.ts
@@ -4,6 +4,7 @@ import type { Readable, Writable } from "node:stream";
 
 import type {
   HarnessAdapter,
+  HarnessCommandCapability,
   HarnessOutput,
   HarnessSession,
   HostApprovalInteraction,
@@ -830,6 +831,10 @@ export class AppServerHost {
       }
       if (request.method === "codexhost/thread/commands/inspect") {
         await this.#inspectThreadCommands(request);
+        continue;
+      }
+      if (request.method === "codexhost/thread/skills/inspect") {
+        this.#dispatchDesktopRequest(() => this.#inspectThreadSkills(request));
         continue;
       }
       if (request.method === "codexhost/thread/command/execute") {
@@ -2127,6 +2132,38 @@ export class AppServerHost {
     }
   }
 
+  async #inspectThreadSkills(request: JsonRpcRequest): Promise<void> {
+    const params = threadCommandsInspectParamsSchema.safeParse(request.params);
+    if (!params.success) {
+      await this.#writer.json(
+        rpcError(request, -32602, "Invalid Thread command inspection params"),
+      );
+      return;
+    }
+    const resolution = await this.#resolveExternalThread(params.data.threadId);
+    if (await this.#writeResolutionError(request, resolution)) return;
+    if (resolution.kind !== "external" || !resolution.thread.session.skills) {
+      await this.#writer.json(rpcEnvelope(request, { result: { commands: [] } }));
+      return;
+    }
+    const result = await resolution.thread.session.skills.list();
+    if (!result.ok) {
+      await this.#writer.json(rpcError(request, -32078, result.error.message));
+      return;
+    }
+    try {
+      await this.#writer.json(
+        rpcEnvelope(request, {
+          result: jsonValueSchema.parse(harnessCommandCatalogSchema.parse(result.value)),
+        }),
+      );
+    } catch (error) {
+      await this.#writer.json(
+        rpcError(request, -32078, `Harness command catalog is invalid: ${errorMessage(error)}`),
+      );
+    }
+  }
+
   async #executeThreadCommand(request: JsonRpcRequest): Promise<void> {
     const params = threadCommandExecuteParamsSchema.safeParse(request.params);
     if (!params.success) {
@@ -2149,32 +2186,57 @@ export class AppServerHost {
     this.#pendingExternalCommandRequests.add(thread.id);
     try {
       const commands = thread.session.commands;
-      if (!commands) {
+      const skills = thread.session.skills;
+      if (!commands && !skills) {
         await this.#writer.json(
           rpcError(request, -32078, "External Harness does not expose commands"),
         );
         return;
       }
-      const catalog = await commands.list();
-      if (!catalog.ok) {
-        await this.#writer.json(rpcError(request, -32078, catalog.error.message));
-        return;
+      let capability: HarnessCommandCapability | undefined;
+      if (commands) {
+        const catalog = await commands.list();
+        if (!catalog.ok) {
+          await this.#writer.json(rpcError(request, -32078, catalog.error.message));
+          return;
+        }
+        if (catalog.value.commands.some(({ id }) => id === params.data.commandId)) {
+          capability = commands;
+        }
       }
-      const descriptor = catalog.value.commands.find(({ id }) => id === params.data.commandId);
-      if (!descriptor) {
-        await this.#writer.json(
-          rpcError(
-            request,
-            -32078,
-            `External Harness does not expose command '${params.data.commandId}'`,
-          ),
-        );
-        return;
+      if (!capability) {
+        if (!skills) {
+          await this.#writer.json(
+            rpcError(
+              request,
+              -32078,
+              `External Harness does not expose command '${params.data.commandId}'`,
+            ),
+          );
+          return;
+        }
+        const listed = await skills.list();
+        if (!listed.ok) {
+          await this.#writer.json(rpcError(request, -32078, listed.error.message));
+          return;
+        }
+        if (!listed.value.commands.some(({ id }) => id === params.data.commandId)) {
+          await this.#writer.json(
+            rpcError(
+              request,
+              -32078,
+              `External Harness does not expose command '${params.data.commandId}'`,
+            ),
+          );
+          return;
+        }
+        capability = skills;
       }
       try {
         await this.#startExternalCommand(
           request,
           thread,
+          capability,
           params.data.commandId,
           params.data.arguments,
           params.data.turnId,
@@ -2194,18 +2256,12 @@ export class AppServerHost {
   async #startExternalCommand(
     request: JsonRpcRequest,
     thread: ExternalThread,
+    capability: HarnessCommandCapability,
     commandId: string,
     arguments_: JsonObject | undefined,
     requestedTurnId: HostTurnId | undefined,
     responseKind: "command" | "turn",
   ): Promise<void> {
-    const commands = thread.session.commands;
-    if (!commands) {
-      await this.#writer.json(
-        rpcError(request, -32078, "External Harness does not expose commands"),
-      );
-      return;
-    }
     if (thread.running) {
       await this.#writer.json(
         rpcError(request, -32072, "External Thread already has an active operation"),
@@ -2228,9 +2284,9 @@ export class AppServerHost {
     thread.responseGates.set(turnId, gate);
     thread.ephemeralTurnIds.add(turnId);
 
-    let result: Awaited<ReturnType<NonNullable<HarnessSession["commands"]>["execute"]>>;
+    let result: Awaited<ReturnType<HarnessCommandCapability["execute"]>>;
     try {
-      result = await commands.execute({
+      result = await capability.execute({
         turnId,
         commandId,
         ...(arguments_ ? { arguments: arguments_ } : {}),
@@ -3120,41 +3176,68 @@ export class AppServerHost {
       return;
     }
     const commandCandidate = text.trimStart();
-    if (thread.session.commands && /^\/[^\s/]+(?:\s|$)/u.test(commandCandidate)) {
+    if (
+      (thread.session.commands || thread.session.skills) &&
+      /^\/[^\s/]+(?:\s|$)/u.test(commandCandidate)
+    ) {
       const commandText = commandCandidate.trimEnd();
+      const interceptionCapabilities: Array<{
+        kind: "commands" | "skills";
+        capability: HarnessCommandCapability;
+      }> = [];
+      if (thread.session.commands) {
+        interceptionCapabilities.push({ kind: "commands", capability: thread.session.commands });
+      }
+      if (thread.session.skills) {
+        interceptionCapabilities.push({ kind: "skills", capability: thread.session.skills });
+      }
       this.#pendingExternalCommandRequests.add(thread.id);
       try {
-        const catalog = await thread.session.commands.list();
-        if (!catalog.ok) {
-          await this.#writer.json(rpcError(request, -32073, catalog.error.message));
-          return;
-        }
-        const matched = catalog.value.commands
-          .toSorted((left, right) => right.invocation.length - left.invocation.length)
-          .find((command) => {
-            if (commandText === command.invocation) return true;
-            return (
-              command.argumentMode === "text" && commandText.startsWith(`${command.invocation} `)
+        for (const { kind, capability } of interceptionCapabilities) {
+          const catalog = await capability.list();
+          if (!catalog.ok) {
+            if (kind === "commands") {
+              await this.#writer.json(rpcError(request, -32073, catalog.error.message));
+              return;
+            }
+            console.error(
+              `codexhost skills catalog failed during text interception: ${catalog.error.message}`,
             );
-          });
-        if (matched) {
-          const argumentText = commandText.slice(matched.invocation.length).trimStart();
-          try {
-            await this.#startExternalCommand(
-              request,
-              thread,
-              matched.id,
-              argumentText.length > 0 ? { text: argumentText } : undefined,
-              undefined,
-              "turn",
-            );
-          } catch (error) {
-            this.#diagnose(error);
-            await this.#writer.json(
-              rpcError(request, -32073, `External Harness command failed: ${errorMessage(error)}`),
-            );
+            continue;
           }
-          return;
+          const matched = catalog.value.commands
+            .toSorted((left, right) => right.invocation.length - left.invocation.length)
+            .find((command) => {
+              if (commandText === command.invocation) return true;
+              return (
+                command.argumentMode === "text" &&
+                commandText.startsWith(`${command.invocation} `)
+              );
+            });
+          if (matched) {
+            const argumentText = commandText.slice(matched.invocation.length).trimStart();
+            try {
+              await this.#startExternalCommand(
+                request,
+                thread,
+                capability,
+                matched.id,
+                argumentText.length > 0 ? { text: argumentText } : undefined,
+                undefined,
+                "turn",
+              );
+            } catch (error) {
+              this.#diagnose(error);
+              await this.#writer.json(
+                rpcError(
+                  request,
+                  -32073,
+                  `External Harness command failed: ${errorMessage(error)}`,
+                ),
+              );
+            }
+            return;
+          }
         }
         await this.#writer.json(
           rpcError(request, -32078, "External Harness does not expose the requested command"),

--- a/packages/host-runtime/src/app-server-host.ts
+++ b/packages/host-runtime/src/app-server-host.ts
@@ -3210,8 +3210,7 @@ export class AppServerHost {
             .find((command) => {
               if (commandText === command.invocation) return true;
               return (
-                command.argumentMode === "text" &&
-                commandText.startsWith(`${command.invocation} `)
+                command.argumentMode === "text" && commandText.startsWith(`${command.invocation} `)
               );
             });
           if (matched) {

--- a/packages/host-runtime/test/app-server-host.claude.real.test.ts
+++ b/packages/host-runtime/test/app-server-host.claude.real.test.ts
@@ -157,6 +157,7 @@ describe("AppServerHost hermetic Claude projection", () => {
           setIdleTurnHandler: () => undefined,
           setIdleLive: () => undefined,
           start: async () => undefined,
+          listSkills: async () => [],
           getContextUsage: async () => ({
             usedTokens: 30,
             maxTokens: 200,

--- a/packages/host-runtime/test/app-server-host.test.ts
+++ b/packages/host-runtime/test/app-server-host.test.ts
@@ -4195,7 +4195,6 @@ describe("AppServerHost HarnessAdapter projection", () => {
     await stopFixture(fixture);
   });
 
-
   it("projects a Harness command's native compaction Item through the existing UI lane", async () => {
     const fixture = createFixture();
     const threadId = await startPiThread(fixture);

--- a/packages/host-runtime/test/app-server-host.test.ts
+++ b/packages/host-runtime/test/app-server-host.test.ts
@@ -3893,6 +3893,309 @@ describe("AppServerHost HarnessAdapter projection", () => {
     }
   });
 
+  it("returns an empty skills catalog for Harnesses without the capability", async () => {
+    const fixture = createFixture();
+    const threadId = await startPiThread(fixture);
+    writeRequest(fixture.desktopInput, {
+      id: 3,
+      method: "codexhost/thread/skills/inspect",
+      params: { threadId },
+    });
+    await expect(
+      fixture.collector.waitFor((message) => requestId(message, 3)),
+    ).resolves.toMatchObject({ result: { commands: [] } });
+    await stopFixture(fixture);
+  });
+
+  it("inspects and executes a skill through the unified command route", async () => {
+    const fixture = createFixture();
+    const threadId = await startPiThread(fixture);
+    const session = fixture.adapter.sessions[0];
+    if (!session) throw new Error("Fake Pi Session was not opened");
+    let skillsExecuted = false;
+    session.commands = {
+      list: async () => ({
+        ok: true,
+        value: {
+          commands: [
+            harnessCommandDescriptorSchema.parse({
+              id: "fake.compact",
+              invocation: "/compact",
+              label: "Compact",
+              argumentMode: "none" as const,
+            }),
+          ],
+        },
+      }),
+      execute: async ({ turnId }) => ({ ok: true, value: { turnId } }),
+    };
+    session.skills = {
+      list: async () => ({
+        ok: true,
+        value: {
+          commands: [
+            harnessCommandDescriptorSchema.parse({
+              id: "fake.skill.render",
+              invocation: "/render",
+              label: "render",
+              argumentMode: "text" as const,
+            }),
+          ],
+        },
+      }),
+      execute: async ({ turnId, commandId, arguments: arguments_ }) => {
+        skillsExecuted = true;
+        expect(commandId).toBe("fake.skill.render");
+        expect(arguments_).toEqual({ text: "a.html" });
+        session.publishEphemeralCommand(turnId, {
+          type: "contextCompaction",
+          itemId: hostItemIdSchema.parse("fake-skill-item"),
+        });
+        return { ok: true, value: { turnId } };
+      },
+    };
+
+    writeRequest(fixture.desktopInput, {
+      id: 4,
+      method: "codexhost/thread/command/execute",
+      params: {
+        threadId,
+        commandId: "fake.skill.render",
+        arguments: { text: "a.html" },
+      },
+    });
+    const executeResponse = await fixture.collector.waitFor((message) => requestId(message, 4));
+    expect(executeResponse).toMatchObject({ result: { accepted: true } });
+    const acceptedTurnId = String((executeResponse.result as JsonObject).turnId);
+    await fixture.collector.waitFor((message) =>
+      turnEvent(message, "turn/completed", acceptedTurnId),
+    );
+
+    writeRequest(fixture.desktopInput, {
+      id: 5,
+      method: "codexhost/thread/skills/inspect",
+      params: { threadId },
+    });
+    await expect(
+      fixture.collector.waitFor((message) => requestId(message, 5)),
+    ).resolves.toMatchObject({
+      result: { commands: [{ id: "fake.skill.render", invocation: "/render" }] },
+    });
+    expect(skillsExecuted).toBe(true);
+    await stopFixture(fixture);
+  });
+
+  it("rejects command execution absent from both catalogs", async () => {
+    const fixture = createFixture();
+    const threadId = await startPiThread(fixture);
+    const session = fixture.adapter.sessions[0];
+    if (!session) throw new Error("Fake Pi Session was not opened");
+    let skillsExecuted = false;
+    session.commands = {
+      list: async () => ({
+        ok: true,
+        value: {
+          commands: [
+            harnessCommandDescriptorSchema.parse({
+              id: "fake.compact",
+              invocation: "/compact",
+              label: "Compact",
+              argumentMode: "none" as const,
+            }),
+          ],
+        },
+      }),
+      execute: async ({ turnId }) => ({ ok: true, value: { turnId } }),
+    };
+    session.skills = {
+      list: async () => ({
+        ok: true,
+        value: {
+          commands: [
+            harnessCommandDescriptorSchema.parse({
+              id: "fake.skill.render",
+              invocation: "/render",
+              label: "render",
+              argumentMode: "text" as const,
+            }),
+          ],
+        },
+      }),
+      execute: async ({ turnId }) => {
+        skillsExecuted = true;
+        return { ok: true, value: { turnId } };
+      },
+    };
+
+    writeRequest(fixture.desktopInput, {
+      id: 6,
+      method: "codexhost/thread/command/execute",
+      params: { threadId, commandId: "fake.ghost" },
+    });
+    await expect(
+      fixture.collector.waitFor((message) => requestId(message, 6)),
+    ).resolves.toMatchObject({
+      error: {
+        code: -32078,
+        message: "External Harness does not expose command 'fake.ghost'",
+      },
+    });
+    expect(skillsExecuted).toBe(false);
+    await stopFixture(fixture);
+  });
+
+  it("intercepts a skill invocation typed as a text Turn without forwarding the raw text", async () => {
+    const fixture = createFixture();
+    const threadId = await startPiThread(fixture);
+    const session = fixture.adapter.sessions[0];
+    if (!session) throw new Error("Fake Pi Session was not opened");
+    let skillsExecuted = false;
+    session.commands = {
+      list: async () => ({
+        ok: true,
+        value: {
+          commands: [
+            harnessCommandDescriptorSchema.parse({
+              id: "fake.compact",
+              invocation: "/compact",
+              label: "Compact",
+              argumentMode: "none" as const,
+            }),
+          ],
+        },
+      }),
+      execute: async ({ turnId }) => ({ ok: true, value: { turnId } }),
+    };
+    session.skills = {
+      list: async () => ({
+        ok: true,
+        value: {
+          commands: [
+            harnessCommandDescriptorSchema.parse({
+              id: "fake.skill.render",
+              invocation: "/render",
+              label: "render",
+              argumentMode: "text" as const,
+            }),
+          ],
+        },
+      }),
+      execute: async ({ turnId, commandId, arguments: arguments_ }) => {
+        skillsExecuted = true;
+        expect(commandId).toBe("fake.skill.render");
+        expect(arguments_).toEqual({ text: "a.html" });
+        session.publishEphemeralCommand(turnId, {
+          type: "contextCompaction",
+          itemId: hostItemIdSchema.parse("fake-skill-item"),
+        });
+        return { ok: true, value: { turnId } };
+      },
+    };
+
+    writeRequest(fixture.desktopInput, {
+      id: 2,
+      method: "turn/start",
+      params: { threadId, input: [{ type: "text", text: "/render a.html" }] },
+    });
+    await expect(
+      fixture.collector.waitFor((message) => requestId(message, 2)),
+    ).resolves.toMatchObject({ result: { turn: { status: "inProgress" } } });
+    await fixture.collector.waitFor((message) => method(message, "turn/completed"));
+    expect(skillsExecuted).toBe(true);
+    expect(session.persistedSnapshot().turns).toHaveLength(0);
+    await stopFixture(fixture);
+  });
+
+  it("still forwards text matching no catalog entry as an ordinary Turn", async () => {
+    const fixture = createFixture();
+    const threadId = await startPiThread(fixture);
+    const session = fixture.adapter.sessions[0];
+    if (!session) throw new Error("Fake Pi Session was not opened");
+    let skillsExecuted = false;
+    session.commands = {
+      list: async () => ({
+        ok: true,
+        value: {
+          commands: [
+            harnessCommandDescriptorSchema.parse({
+              id: "fake.compact",
+              invocation: "/compact",
+              label: "Compact",
+              argumentMode: "none" as const,
+            }),
+          ],
+        },
+      }),
+      execute: async ({ turnId }) => ({ ok: true, value: { turnId } }),
+    };
+    session.skills = {
+      list: async () => ({
+        ok: true,
+        value: {
+          commands: [
+            harnessCommandDescriptorSchema.parse({
+              id: "fake.skill.render",
+              invocation: "/render",
+              label: "render",
+              argumentMode: "text" as const,
+            }),
+          ],
+        },
+      }),
+      execute: async ({ turnId }) => {
+        skillsExecuted = true;
+        return { ok: true, value: { turnId } };
+      },
+    };
+
+    writeRequest(fixture.desktopInput, {
+      id: 2,
+      method: "turn/start",
+      params: { threadId, input: [{ type: "text", text: "just a question" }] },
+    });
+    const response = await fixture.collector.waitFor((message) => requestId(message, 2));
+    const turnId = String(((response.result as JsonObject).turn as JsonObject).id);
+    await fixture.collector.waitFor((message) => turnEvent(message, "turn/started", turnId));
+    session.appendText("answer");
+    session.succeedTurn();
+    await fixture.collector.waitFor((message) => turnEvent(message, "turn/completed", turnId));
+    expect(skillsExecuted).toBe(false);
+    await stopFixture(fixture);
+  });
+
+  it("completes an ordinary text Turn when the skills catalog fails to list", async () => {
+    const fixture = createFixture();
+    const threadId = await startPiThread(fixture);
+    const session = fixture.adapter.sessions[0];
+    if (!session) throw new Error("Fake Pi Session was not opened");
+    session.skills = {
+      list: async () => ({
+        ok: false,
+        error: {
+          code: "nativeFailure" as const,
+          message: "synthetic catalog failure",
+          retryable: false,
+        },
+      }),
+      execute: async ({ turnId }) => ({ ok: true, value: { turnId } }),
+    };
+
+    writeRequest(fixture.desktopInput, {
+      id: 2,
+      method: "turn/start",
+      params: { threadId, input: [{ type: "text", text: "just a question" }] },
+    });
+    const response = await fixture.collector.waitFor((message) => requestId(message, 2));
+    const turnId = String(((response.result as JsonObject).turn as JsonObject).id);
+    await fixture.collector.waitFor((message) => turnEvent(message, "turn/started", turnId));
+    session.appendText("answer");
+    session.succeedTurn();
+    await fixture.collector.waitFor((message) => turnEvent(message, "turn/completed", turnId));
+    expect(response.error).toBeUndefined();
+    await stopFixture(fixture);
+  });
+
+
   it("projects a Harness command's native compaction Item through the existing UI lane", async () => {
     const fixture = createFixture();
     const threadId = await startPiThread(fixture);

--- a/packages/renderer-extension/src/index.ts
+++ b/packages/renderer-extension/src/index.ts
@@ -65,6 +65,8 @@ export {
 export type { RendererHarnessMessages } from "./renderer-harness-localization.js";
 export { mountRendererHarnessCommandControl } from "./renderer-harness-command-control.js";
 export type { RendererHarnessCommandControl } from "./renderer-harness-command-control.js";
+export { mountRendererHarnessSkillControl } from "./renderer-harness-skill-control.js";
+export type { RendererHarnessSkillControl } from "./renderer-harness-skill-control.js";
 export {
   creditsPeriodLabel,
   formatRendererCreditsReset,

--- a/packages/renderer-extension/src/renderer-binding-probe.ts
+++ b/packages/renderer-extension/src/renderer-binding-probe.ts
@@ -825,6 +825,59 @@ export function installRendererBindingProbe(
     console.error("codexhost Harness command could not claim the current Composer editor");
   };
 
+  const refreshSkills = async (mounted: MountedComposer): Promise<void> => {
+    const state = controller.get(mounted.composer);
+    const threadId = threadIdFromComposerModelTarget(mounted.modelTarget);
+    if (state.agent === "codex" || !threadId || !modelControl) {
+      mounted.control.harnessSkills.setSkills([]);
+      return;
+    }
+    try {
+      const catalog = await modelControl.inspectThreadSkills({ threadId });
+      if (
+        disposed ||
+        mountedByComposer.get(mounted.composer) !== mounted ||
+        threadIdFromComposerModelTarget(mounted.modelTarget) !== threadId ||
+        controller.get(mounted.composer).agent === "codex"
+      ) {
+        return;
+      }
+      mounted.control.harnessSkills.setSkills(catalog.commands);
+    } catch (error) {
+      console.error(
+        "codexhost Harness skills catalog failed",
+        error instanceof Error ? error.message : String(error),
+      );
+      if (mountedByComposer.get(mounted.composer) === mounted) {
+        mounted.control.harnessSkills.setSkills([]);
+      }
+    }
+  };
+
+  const executeSkill = async (
+    mounted: MountedComposer,
+    skill: HarnessCommandDescriptor,
+    argument: string | undefined,
+  ): Promise<void> => {
+    const threadId = threadIdFromComposerModelTarget(mounted.modelTarget);
+    if (!threadId || !modelControl || controller.get(mounted.composer).agent === "codex") return;
+    mounted.control.harnessSkills.setExecuting(skill.id);
+    try {
+      await modelControl.executeThreadCommand({
+        threadId,
+        commandId: skill.id,
+        ...(argument === undefined ? {} : { arguments: { text: argument } }),
+      });
+    } catch (error) {
+      console.error(
+        "codexhost Harness skill failed",
+        error instanceof Error ? error.message : String(error),
+      );
+    } finally {
+      mounted.control.harnessSkills.setExecuting(null);
+    }
+  };
+
   const applyThreadUsageUpdate = (update: ThreadUsageInspection): void => {
     for (const mounted of mountedByComposer.values()) {
       if (threadIdFromComposerModelTarget(mounted.modelTarget) !== update.threadId) continue;
@@ -1006,7 +1059,10 @@ export function installRendererBindingProbe(
     } finally {
       if (isCurrentOwnershipRequest(mounted, generation)) {
         renderMounted(mounted);
-        if (mounted.ownershipStatus !== "error") void refreshCommands(mounted);
+        if (mounted.ownershipStatus !== "error") {
+          void refreshCommands(mounted);
+          void refreshSkills(mounted);
+        }
         sidebarAgentIcons.refresh();
         if (mounted.ownershipStatus !== "error") {
           const agent = controller.get(mounted.composer).agent;
@@ -2115,6 +2171,11 @@ export function installRendererBindingProbe(
         const mounted = mountedByComposer.get(composer);
         if (mounted) selectCommand(mounted, command);
       },
+      (skill, argument) => {
+        const mounted = mountedByComposer.get(composer);
+        if (!composer.isConnected || !mounted) return;
+        void executeSkill(mounted, skill, argument);
+      },
     );
     const mounted: MountedComposer = {
       composer,
@@ -2169,6 +2230,7 @@ export function installRendererBindingProbe(
       void loadExternalCatalog(mounted);
     }
     void refreshCommands(mounted);
+    void refreshSkills(mounted);
   };
 
   const scan = (): void => {
@@ -2363,6 +2425,20 @@ export function installRendererBindingProbe(
     notifySubmission(composer, "submit");
   };
   const onKeyDown = (event: KeyboardEvent): void => {
+    if (
+      (event.metaKey || event.ctrlKey) &&
+      event.shiftKey &&
+      event.key.toLowerCase() === "s" &&
+      !event.isComposing
+    ) {
+      const composer = composerForTarget(event.target);
+      const mounted = composer ? mountedByComposer.get(composer) : undefined;
+      if (mounted && mounted.control.harnessSkills.hasSkills()) {
+        blockEvent(event);
+        mounted.control.harnessSkills.open();
+        return;
+      }
+    }
     const composer = isComposerInputIntent(event) ? composerForTarget(event.target) : null;
     const mounted = composer ? mountedByComposer.get(composer) : undefined;
     if (composer && controller.isSwitching(composer)) {

--- a/packages/renderer-extension/src/renderer-composer-dom.ts
+++ b/packages/renderer-extension/src/renderer-composer-dom.ts
@@ -47,6 +47,10 @@ import {
   mountRendererHarnessCommandControl,
   type RendererHarnessCommandControl,
 } from "./renderer-harness-command-control.js";
+import {
+  mountRendererHarnessSkillControl,
+  type RendererHarnessSkillControl,
+} from "./renderer-harness-skill-control.js";
 
 export { CONTROL_ATTRIBUTE };
 export type ExternalModelControlView = RendererModelControlView;
@@ -92,6 +96,7 @@ export interface ComposerAgentControl {
   usage: RendererUsageControl | null;
   composerId: string;
   harnessCommands: RendererHarnessCommandControl;
+  harnessSkills: RendererHarnessSkillControl;
   sendButton: HTMLButtonElement;
   sendDisabledBeforeSwitch: boolean | null;
 }
@@ -122,7 +127,8 @@ function isOwnedRendererControl(element: Element): boolean {
     element.hasAttribute("data-codexhost-permission-mode-control") ||
     element.hasAttribute("data-codexhost-usage-control") ||
     element.hasAttribute("data-codexhost-credits-control") ||
-    element.hasAttribute("data-codexhost-harness-command-control")
+    element.hasAttribute("data-codexhost-harness-command-control") ||
+    element.hasAttribute("data-codexhost-harness-skill-control")
   );
 }
 
@@ -514,7 +520,10 @@ function refreshUsagePlacement(control: ComposerAgentControl): void {
   const usagePositionChanged =
     previousUsageParent !== control.usage.root.parentElement ||
     previousUsageNextSibling !== control.usage.root.nextElementSibling;
-  if (usagePositionChanged) control.harnessCommands?.placeBefore(control.usage.root);
+  if (usagePositionChanged) {
+    control.harnessSkills.placeBefore(control.usage.root);
+    control.harnessCommands.placeBefore(control.harnessSkills.root);
+  }
 }
 
 // Deliberately independent of `refreshUsagePlacement`: Credits no longer
@@ -607,6 +616,7 @@ export function mountComposerAgentControl(
   onSelectThinking: (thinkingOptionId: string) => void,
   onSelectPermissionMode: (permissionModeId: string) => void,
   onSelectCommand: (command: HarnessCommandDescriptor) => void,
+  onSelectSkill: (skill: HarnessCommandDescriptor, argument: string | undefined) => void,
 ): ComposerAgentControl {
   const nativeModelControl = captureNativeControl(nativeModelControlForComposer(composer));
   const nativeContextUsageControl = captureNativeControl(
@@ -632,6 +642,11 @@ export function mountComposerAgentControl(
     trailingActionAnchor(sendButton),
     onSelectCommand,
   );
+  const harnessSkills = mountRendererHarnessSkillControl(
+    toolbar ?? composer,
+    harnessCommands.root,
+    onSelectSkill,
+  );
 
   const permissionParent = nativePermissionModeControl?.element.parentElement;
   if (permissionParent && nativePermissionModeControl && nativePermissionModeControlVerified) {
@@ -655,6 +670,7 @@ export function mountComposerAgentControl(
     credits,
     usage: null,
     harnessCommands,
+    harnessSkills,
     sendButton,
     sendDisabledBeforeSwitch: null,
   } satisfies ComposerAgentControl;
@@ -737,6 +753,7 @@ export function renderComposerAgentControl(
   control.harnessCommands.root.hidden = state.agent === "codex";
   control.harnessCommands.root.style.display = state.agent === "codex" ? "none" : "inline-flex";
   if (state.agent === "codex") control.harnessCommands.close();
+  control.harnessSkills.setLocale(locale);
   renderRendererCreditsControl(control.credits, accountCredits);
 }
 
@@ -751,6 +768,7 @@ export function disposeComposerAgentControl(control: ComposerAgentControl): void
   control.usage?.dispose();
   control.usage = null;
   control.harnessCommands.dispose();
+  control.harnessSkills.dispose();
   control.permissionModePicker.dispose();
   control.modelPicker.dispose();
   control.picker.dispose();

--- a/packages/renderer-extension/src/renderer-harness-localization.ts
+++ b/packages/renderer-extension/src/renderer-harness-localization.ts
@@ -8,6 +8,9 @@ export interface RendererHarnessMessages {
   readonly commandsUnavailable: string;
   readonly commandRequiresConversation: string;
   readonly textArgument: string;
+  readonly skills: string;
+  readonly filterSkills: string;
+  readonly back: string;
   readonly permissionMode: string;
   readonly permissions: string;
   readonly loadingPermissions: string;
@@ -22,6 +25,9 @@ const ENGLISH_HARNESS_MESSAGES: RendererHarnessMessages = Object.freeze({
   commandsUnavailable: "No Harness commands available yet",
   commandRequiresConversation: "Start a conversation before running this command",
   textArgument: "Text",
+  skills: "Skills",
+  filterSkills: "Filter skills",
+  back: "Back",
   permissionMode: "Permission mode",
   permissions: "Permissions",
   loadingPermissions: "Loading permissions...",
@@ -37,6 +43,9 @@ const CHINESE_HARNESS_MESSAGES: RendererHarnessMessages = Object.freeze({
   commandsUnavailable: "暂无可用的 Harness 命令",
   commandRequiresConversation: "请先开始对话，再执行此命令",
   textArgument: "文本",
+  skills: "技能",
+  filterSkills: "过滤技能",
+  back: "返回",
   permissionMode: "权限模式",
   permissions: "权限",
   loadingPermissions: "正在加载权限...",

--- a/packages/renderer-extension/src/renderer-harness-skill-control.ts
+++ b/packages/renderer-extension/src/renderer-harness-skill-control.ts
@@ -1,0 +1,534 @@
+import type { HarnessCommandDescriptor } from "@codexhost/shared-contracts";
+
+import {
+  rendererHarnessCommandPresentation,
+  rendererHarnessMessages,
+} from "./renderer-harness-localization.js";
+import type { RendererSettingsLocale } from "./settings/localization.js";
+
+const CONTROL_ATTRIBUTE = "data-codexhost-harness-skill-control";
+const MENU_ATTRIBUTE = "data-codexhost-harness-skill-menu";
+const ARGUMENT_INPUT_ATTRIBUTE = "data-codexhost-harness-skill-argument";
+const MENU_WIDTH = 320;
+const VIEWPORT_MARGIN = 8;
+const MENU_GAP = 8;
+const SVG_NS = "http://www.w3.org/2000/svg";
+// Distinct glyph: the rounded-frame path from the Harness command icon set,
+// drawn alone instead of with the command grid overlay.
+const SKILL_ICON_PATHS = [
+  "M640 970.666667H384c-118.186667 0-198.272-25.002667-251.946667-78.72S53.333333 758.186667 53.333333 640V384c0-118.186667 25.002667-198.272 78.72-251.946667S265.813333 53.333333 384 53.333333h256c118.186667 0 198.272 25.002667 251.946667 78.72S970.666667 265.813333 970.666667 384v256c0 118.186667-25.002667 198.272-78.72 251.946667S758.186667 970.666667 640 970.666667z m-256-853.333334c-100.096 0-165.802667 19.2-206.72 59.946667S117.333333 283.904 117.333333 384v256c0 100.096 19.072 165.802667 59.946667 206.72S283.904 906.666667 384 906.666667h256c100.096 0 165.802667-19.072 206.72-59.946667S906.666667 740.096 906.666667 640V384c0-100.096-19.072-165.802667-59.946667-206.72S740.096 117.333333 640 117.333333z",
+];
+
+function skillIcon(ownerDocument: Document): SVGSVGElement {
+  const svg = ownerDocument.createElementNS(SVG_NS, "svg");
+  svg.setAttribute("viewBox", "0 0 1024 1024");
+  svg.setAttribute("width", "15");
+  svg.setAttribute("height", "15");
+  svg.setAttribute("fill", "currentColor");
+  svg.setAttribute("aria-hidden", "true");
+  for (const path of SKILL_ICON_PATHS) {
+    const element = ownerDocument.createElementNS(SVG_NS, "path");
+    element.setAttribute("d", path);
+    svg.append(element);
+  }
+  return svg;
+}
+
+export interface RendererHarnessSkillControl {
+  readonly root: HTMLElement;
+  setSkills(skills: readonly HarnessCommandDescriptor[]): void;
+  setExecuting(commandId: string | null): void;
+  setLocale(locale: RendererSettingsLocale): void;
+  placeBefore(reference: Element | null): boolean;
+  open(): void;
+  hasSkills(): boolean;
+  close(): void;
+  dispose(): void;
+}
+
+function clamp(value: number, minimum: number, maximum: number): number {
+  return Math.max(minimum, Math.min(value, maximum));
+}
+
+function setButtonClass(button: HTMLButtonElement): void {
+  button.style.display = "inline-flex";
+  button.style.alignItems = "center";
+  button.style.justifyContent = "center";
+  button.style.gap = "0";
+  button.style.width = "28px";
+  button.style.height = "28px";
+  button.style.padding = "0";
+  button.style.border = "0";
+  button.style.borderRadius = "8px";
+  button.style.background = "transparent";
+  button.style.color = "inherit";
+  button.style.cursor = "pointer";
+  button.style.whiteSpace = "nowrap";
+}
+
+function textInputStyle(input: HTMLInputElement): void {
+  input.style.display = "block";
+  input.style.width = "100%";
+  input.style.boxSizing = "border-box";
+  input.style.padding = "6px";
+  input.style.border = "0";
+  input.style.borderRadius = "6px";
+  input.style.background = "rgba(127, 127, 127, 0.08)";
+  input.style.color = "inherit";
+  input.style.font = "13px/18px system-ui, sans-serif";
+  input.style.outline = "none";
+}
+
+export function mountRendererHarnessSkillControl(
+  parent: Element,
+  insertBefore: Element | null,
+  onSelectSkill: (skill: HarnessCommandDescriptor, argument: string | undefined) => void,
+  initialLocale: RendererSettingsLocale = "en",
+): RendererHarnessSkillControl {
+  const ownerDocument = parent.ownerDocument;
+  let locale = initialLocale;
+  let messages = rendererHarnessMessages(locale);
+  const root = ownerDocument.createElement("div");
+  root.setAttribute(CONTROL_ATTRIBUTE, "true");
+  root.style.display = "inline-flex";
+  root.style.alignItems = "center";
+  root.style.minWidth = "0";
+
+  const trigger = ownerDocument.createElement("button");
+  trigger.type = "button";
+  trigger.setAttribute("aria-haspopup", "menu");
+  trigger.setAttribute("aria-expanded", "false");
+  trigger.setAttribute("aria-label", messages.skills);
+  trigger.title = messages.skills;
+  setButtonClass(trigger);
+  trigger.append(skillIcon(ownerDocument));
+  root.append(trigger);
+
+  const menu = ownerDocument.createElement("div");
+  menu.setAttribute(MENU_ATTRIBUTE, "true");
+  menu.setAttribute("role", "menu");
+  menu.setAttribute("aria-label", messages.skills);
+  menu.hidden = true;
+  menu.style.position = "fixed";
+  menu.style.inset = "auto";
+  menu.style.zIndex = "2147483647";
+  menu.style.width = `${MENU_WIDTH}px`;
+  menu.style.maxWidth = `calc(100vw - ${VIEWPORT_MARGIN * 2}px)`;
+  menu.style.maxHeight = "min(360px, calc(100vh - 16px))";
+  menu.style.overflowY = "auto";
+  menu.style.padding = "4px";
+  menu.style.border = "1px solid rgba(127, 127, 127, 0.24)";
+  menu.style.borderRadius = "10px";
+  menu.style.background = "Canvas";
+  menu.style.color = "CanvasText";
+  menu.style.boxShadow = "0 12px 32px rgba(0, 0, 0, 0.22)";
+  ownerDocument.body.append(menu);
+
+  if (insertBefore?.parentElement === parent) parent.insertBefore(root, insertBefore);
+  else parent.append(root);
+
+  let skills: readonly HarnessCommandDescriptor[] = [];
+  let items: HTMLButtonElement[] = [];
+  let activeIndex = 0;
+  let filterTerm = "";
+  let executingSkillId: string | null = null;
+  let triggerHovered = false;
+  let disposed = false;
+  let argumentSkill: HarnessCommandDescriptor | null = null;
+  let filterInput: HTMLInputElement | null = null;
+  let argumentInput: HTMLInputElement | null = null;
+
+  const positionMenu = (): void => {
+    const rect = trigger.getBoundingClientRect();
+    const menuHeight = menu.getBoundingClientRect().height;
+    const opensAbove = rect.top >= menuHeight + MENU_GAP + VIEWPORT_MARGIN;
+    const left = clamp(
+      rect.left,
+      VIEWPORT_MARGIN,
+      window.innerWidth - MENU_WIDTH - VIEWPORT_MARGIN,
+    );
+    menu.style.left = `${left}px`;
+    menu.style.top = opensAbove
+      ? `${Math.max(VIEWPORT_MARGIN, rect.top - menuHeight - MENU_GAP)}px`
+      : `${Math.min(window.innerHeight - menuHeight - VIEWPORT_MARGIN, rect.bottom + MENU_GAP)}px`;
+  };
+
+  const focusActive = (): void => {
+    const item = items[activeIndex];
+    if (!item || item.disabled) return;
+    item.focus();
+    item.scrollIntoView({ block: "nearest" });
+  };
+
+  const syncTriggerBackground = (): void => {
+    trigger.style.background =
+      !trigger.disabled && (triggerHovered || !menu.hidden)
+        ? "rgba(127, 127, 127, 0.16)"
+        : "transparent";
+  };
+
+  const close = (): void => {
+    menu.hidden = true;
+    argumentSkill = null;
+    filterTerm = "";
+    trigger.setAttribute("aria-expanded", "false");
+    syncTriggerBackground();
+  };
+
+  let openInternal: (shouldFocus: boolean) => void = () => undefined;
+
+  const select = (skill: HarnessCommandDescriptor, argument: string | undefined): void => {
+    close();
+    onSelectSkill(skill, argument);
+  };
+
+  const matchesFilter = (skill: HarnessCommandDescriptor): boolean => {
+    const term = filterTerm.toLowerCase();
+    if (term === "") return true;
+    const presentation = rendererHarnessCommandPresentation(skill, locale);
+    return `${skill.invocation} ${presentation.label} ${presentation.description}`
+      .toLowerCase()
+      .includes(term);
+  };
+
+  const menuItem = (skill: HarnessCommandDescriptor): HTMLButtonElement => {
+    const presentation = rendererHarnessCommandPresentation(skill, locale);
+    const item = ownerDocument.createElement("button");
+    item.type = "button";
+    item.setAttribute("role", "menuitem");
+    item.setAttribute("data-skill-id", skill.id);
+    item.setAttribute("aria-label", `${skill.invocation} ${presentation.label}`);
+    item.style.display = "flex";
+    item.style.alignItems = "center";
+    item.style.width = "100%";
+    item.style.minHeight = "38px";
+    item.style.gap = "8px";
+    item.style.padding = "6px 8px";
+    item.style.border = "0";
+    item.style.borderRadius = "6px";
+    item.style.background = "transparent";
+    item.style.color = "inherit";
+    item.style.textAlign = "left";
+    item.style.cursor = "pointer";
+
+    const updateHighlight = (active: boolean): void => {
+      item.style.background = active ? "rgba(127, 127, 127, 0.12)" : "transparent";
+    };
+    item.addEventListener("pointerenter", () => updateHighlight(true));
+    item.addEventListener("pointerleave", () => updateHighlight(false));
+    item.addEventListener("focus", () => updateHighlight(true));
+    item.addEventListener("blur", () => updateHighlight(false));
+    item.addEventListener("click", () => {
+      if (skill.argumentMode === "text") showArgumentPhase(skill);
+      else select(skill, undefined);
+    });
+
+    const copy = ownerDocument.createElement("span");
+    copy.style.display = "flex";
+    copy.style.flexDirection = "column";
+    copy.style.minWidth = "0";
+    copy.style.flex = "1 1 auto";
+
+    const title = ownerDocument.createElement("span");
+    title.textContent = skill.invocation;
+    title.style.font = "600 13px/18px system-ui, sans-serif";
+    title.style.whiteSpace = "nowrap";
+
+    const description = ownerDocument.createElement("span");
+    description.textContent = presentation.description;
+    description.style.overflow = "hidden";
+    description.style.color = "rgba(127, 127, 127, 0.9)";
+    description.style.font = "400 11px/16px system-ui, sans-serif";
+    description.style.textOverflow = "ellipsis";
+    description.style.whiteSpace = "nowrap";
+
+    const hint = ownerDocument.createElement("span");
+    hint.textContent = skill.argumentMode === "text" ? messages.textArgument : "↵";
+    hint.style.flex = "0 0 auto";
+    hint.style.color = "rgba(127, 127, 127, 0.75)";
+    hint.style.font = "400 11px/16px ui-monospace, SFMono-Regular, Menlo, monospace";
+
+    copy.append(title, description);
+    item.append(copy, hint);
+    return item;
+  };
+
+  let listContainer: HTMLElement | null = null;
+
+  const renderFilteredItems = (): void => {
+    const container = listContainer;
+    if (!container) return;
+    items = skills.filter(matchesFilter).map(menuItem);
+    activeIndex = clamp(activeIndex, 0, Math.max(0, items.length - 1));
+    if (executingSkillId !== null) {
+      for (const item of items) {
+        const isExecuting = item.dataset.skillId === executingSkillId;
+        item.disabled = true;
+        item.style.opacity = isExecuting ? "1" : "0.5";
+        if (isExecuting) item.setAttribute("aria-busy", "true");
+      }
+    }
+    container.replaceChildren(...items);
+  };
+
+  const renderListPhase = (): void => {
+    argumentSkill = null;
+    const header = ownerDocument.createElement("div");
+    header.style.padding = "4px";
+    const filter = ownerDocument.createElement("input");
+    filter.type = "text";
+    filter.setAttribute("role", "searchbox");
+    filter.setAttribute("aria-label", messages.filterSkills);
+    filter.placeholder = messages.filterSkills;
+    textInputStyle(filter);
+    filter.value = filterTerm;
+    filter.addEventListener("input", () => {
+      filterTerm = filter.value;
+      activeIndex = 0;
+      renderFilteredItems();
+    });
+    filterInput = filter;
+    header.append(filter);
+
+    const container = ownerDocument.createElement("div");
+    listContainer = container;
+
+    menu.replaceChildren(header, container);
+    renderFilteredItems();
+  };
+
+  const showArgumentPhase = (skill: HarnessCommandDescriptor): void => {
+    argumentSkill = skill;
+    filterInput = null;
+    listContainer = null;
+    items = [];
+
+    const back = ownerDocument.createElement("button");
+    back.type = "button";
+    back.textContent = `← ${messages.back}`;
+    back.style.border = "0";
+    back.style.background = "transparent";
+    back.style.color = "rgba(127, 127, 127, 0.9)";
+    back.style.font = "600 11px/16px system-ui, sans-serif";
+    back.style.padding = "5px 8px 2px";
+    back.style.cursor = "pointer";
+    back.style.textAlign = "left";
+    back.addEventListener("click", () => {
+      renderListPhase();
+      positionMenu();
+      queueMicrotask(() => filterInput?.focus());
+    });
+
+    const title = ownerDocument.createElement("div");
+    title.textContent = skill.invocation;
+    title.style.padding = "2px 8px 6px";
+    title.style.font = "600 13px/18px system-ui, sans-serif";
+    title.style.whiteSpace = "nowrap";
+
+    const argument = ownerDocument.createElement("input");
+    argument.type = "text";
+    argument.setAttribute(ARGUMENT_INPUT_ATTRIBUTE, "true");
+    argument.setAttribute("aria-label", skill.invocation);
+    textInputStyle(argument);
+    argumentInput = argument;
+
+    menu.replaceChildren(back, title, argument);
+    positionMenu();
+    queueMicrotask(() => argument.focus());
+  };
+
+  const submitArgument = (): void => {
+    const skill = argumentSkill;
+    if (!skill) return;
+    const value = (argumentInput?.value ?? "").trim();
+    argumentSkill = null;
+    argumentInput = null;
+    select(skill, value || undefined);
+  };
+
+  const isExecutingGate = (): boolean => executingSkillId !== null;
+
+  openInternal = (shouldFocus: boolean): void => {
+    if (skills.length === 0 || isExecutingGate()) return;
+    if (menu.hidden) renderListPhase();
+    menu.hidden = false;
+    positionMenu();
+    trigger.setAttribute("aria-expanded", "true");
+    syncTriggerBackground();
+    if (shouldFocus) queueMicrotask(() => filterInput?.focus());
+  };
+
+  let closeTimer: number | null = null;
+  const cancelClose = (): void => {
+    if (closeTimer === null) return;
+    window.clearTimeout(closeTimer);
+    closeTimer = null;
+  };
+  const scheduleClose = (): void => {
+    cancelClose();
+    closeTimer = window.setTimeout(() => {
+      closeTimer = null;
+      if (!trigger.matches(":hover") && !menu.matches(":hover")) close();
+    }, 140);
+  };
+
+  const onKeyDown = (event: KeyboardEvent): void => {
+    if (menu.hidden) return;
+    const target = event.target;
+    if (argumentSkill !== null) {
+      if (event.key === "Escape") {
+        event.preventDefault();
+        event.stopPropagation();
+        renderListPhase();
+        queueMicrotask(() => filterInput?.focus());
+        return;
+      }
+      if (event.key === "Enter" && !event.shiftKey) {
+        event.preventDefault();
+        event.stopPropagation();
+        submitArgument();
+      }
+      return;
+    }
+    if (event.key === "Escape") {
+      event.preventDefault();
+      const input = filterInput;
+      if (input !== null && event.target === input) {
+        input.blur();
+        return;
+      }
+      close();
+      trigger.focus();
+      return;
+    }
+    // Navigation keys only act within the popover surface: focus may sit on the
+    // filter input, an item, or (after blur) nowhere in the document, in which
+    // case Escape above still closes.
+    if (target !== filterInput && !menu.contains(target as Node)) return;
+    if (event.key === "ArrowDown" || event.key === "ArrowUp") {
+      event.preventDefault();
+      if (items.length === 0) return;
+      const delta = event.key === "ArrowDown" ? 1 : -1;
+      activeIndex = (activeIndex + delta + items.length) % items.length;
+      focusActive();
+      return;
+    }
+    if (event.key === "Enter") {
+      event.preventDefault();
+      items[activeIndex]?.click();
+    }
+  };
+  const onTriggerKeyDown = (event: KeyboardEvent): void => {
+    if (menu.hidden && (event.key === "ArrowDown" || event.key === "Enter" || event.key === " ")) {
+      event.preventDefault();
+      openInternal(true);
+    }
+  };
+  const onDocumentPointerDown = (event: PointerEvent): void => {
+    if (
+      !menu.hidden &&
+      !root.contains(event.target as Node) &&
+      !menu.contains(event.target as Node)
+    ) {
+      close();
+    }
+  };
+  const onViewportChange = (): void => {
+    if (!menu.hidden) positionMenu();
+  };
+
+  trigger.addEventListener("click", () => {
+    cancelClose();
+    openInternal(true);
+  });
+  trigger.addEventListener("pointerenter", () => {
+    triggerHovered = true;
+    syncTriggerBackground();
+    cancelClose();
+    if (menu.hidden) openInternal(false);
+  });
+  trigger.addEventListener("pointerleave", () => {
+    triggerHovered = false;
+    syncTriggerBackground();
+    scheduleClose();
+  });
+  trigger.addEventListener("keydown", onTriggerKeyDown);
+  menu.addEventListener("pointerenter", cancelClose);
+  menu.addEventListener("pointerleave", scheduleClose);
+  ownerDocument.addEventListener("keydown", onKeyDown);
+  ownerDocument.addEventListener("pointerdown", onDocumentPointerDown, true);
+  ownerDocument.defaultView?.addEventListener("resize", onViewportChange);
+  ownerDocument.defaultView?.addEventListener("scroll", onViewportChange, true);
+
+  const control: RendererHarnessSkillControl = {
+    root,
+    placeBefore(reference) {
+      if (!reference?.parentElement) return false;
+      if (root.parentElement === reference.parentElement && root.nextElementSibling === reference) {
+        return true;
+      }
+      reference.parentElement.insertBefore(root, reference);
+      return true;
+    },
+    setSkills(nextSkills) {
+      skills = [...nextSkills];
+      root.hidden = skills.length === 0;
+      root.style.display = skills.length === 0 ? "none" : "inline-flex";
+      if (skills.length === 0) close();
+      // Keep the catalog data fresh but leave the argument input DOM intact;
+      // the list phase rebuilds on Escape/back or the next open.
+      if (!menu.hidden && argumentSkill === null) renderListPhase();
+    },
+    setExecuting(commandId) {
+      executingSkillId = commandId;
+      for (const item of items) {
+        const isExecuting = item.dataset.skillId === commandId;
+        item.disabled = commandId !== null;
+        item.style.opacity = commandId !== null && !isExecuting ? "0.5" : "1";
+        if (isExecuting) item.setAttribute("aria-busy", "true");
+        else item.removeAttribute("aria-busy");
+      }
+      trigger.disabled = commandId !== null;
+      trigger.style.opacity = commandId !== null ? "0.65" : "1";
+      syncTriggerBackground();
+    },
+    setLocale(nextLocale) {
+      if (locale === nextLocale) return;
+      locale = nextLocale;
+      messages = rendererHarnessMessages(locale);
+      trigger.setAttribute("aria-label", messages.skills);
+      trigger.title = messages.skills;
+      menu.setAttribute("aria-label", messages.skills);
+      if (!menu.hidden) {
+        if (argumentSkill) showArgumentPhase(argumentSkill);
+        else renderListPhase();
+      }
+    },
+    open() {
+      openInternal(true);
+    },
+    hasSkills() {
+      return skills.length > 0;
+    },
+    close,
+    dispose() {
+      if (disposed) return;
+      disposed = true;
+      cancelClose();
+      close();
+      ownerDocument.removeEventListener("keydown", onKeyDown);
+      ownerDocument.removeEventListener("pointerdown", onDocumentPointerDown, true);
+      ownerDocument.defaultView?.removeEventListener("resize", onViewportChange);
+      ownerDocument.defaultView?.removeEventListener("scroll", onViewportChange, true);
+      trigger.removeEventListener("keydown", onTriggerKeyDown);
+      menu.removeEventListener("pointerenter", cancelClose);
+      menu.removeEventListener("pointerleave", scheduleClose);
+      menu.remove();
+      root.remove();
+    },
+  };
+
+  root.hidden = true;
+  root.style.display = "none";
+  return control;
+}

--- a/packages/renderer-extension/src/renderer-model-client.ts
+++ b/packages/renderer-extension/src/renderer-model-client.ts
@@ -66,6 +66,7 @@ export const THREAD_FORK_METHOD = "codexhost/thread/fork";
 export const THREAD_INSPECT_METHOD = "codexhost/thread/inspect";
 export const HARNESS_COMMANDS_INSPECT_METHOD = "codexhost/harness/commands/inspect";
 export const THREAD_COMMANDS_INSPECT_METHOD = "codexhost/thread/commands/inspect";
+export const THREAD_SKILLS_INSPECT_METHOD = "codexhost/thread/skills/inspect";
 export const THREAD_COMMAND_EXECUTE_METHOD = "codexhost/thread/command/execute";
 export const THREAD_MODEL_SELECT_METHOD = "codexhost/thread/model/select";
 export const THREAD_THINKING_SELECT_METHOD = "codexhost/thread/thinking/select";
@@ -121,6 +122,7 @@ export interface RendererModelClient extends Partial<RendererSessionImportClient
   inspectThread(input: ThreadInspectionParams): Promise<ThreadInspection>;
   inspectHarnessCommands(input: HarnessCommandsInspectParams): Promise<HarnessCommandCatalog>;
   inspectThreadCommands(input: ThreadCommandsInspectParams): Promise<HarnessCommandCatalog>;
+  inspectThreadSkills(input: ThreadCommandsInspectParams): Promise<HarnessCommandCatalog>;
   executeThreadCommand(input: ThreadCommandExecuteParams): Promise<ThreadCommandExecuteResult>;
   listThreadOwnership(input: ThreadOwnershipListParams): Promise<ThreadOwnershipListResult>;
   inspectThreadUsage(input: ThreadUsageInspectionParams): Promise<ThreadUsageInspection>;
@@ -203,6 +205,13 @@ export function createRendererModelClient(
     const result = await manager.sendRequest(THREAD_COMMANDS_INSPECT_METHOD, params);
     return harnessCommandCatalogSchema.parse(result);
   };
+  const inspectThreadSkills = async (
+    input: ThreadCommandsInspectParams,
+  ): Promise<HarnessCommandCatalog> => {
+    const params = threadCommandsInspectParamsSchema.parse(input);
+    const result = await manager.sendRequest(THREAD_SKILLS_INSPECT_METHOD, params);
+    return harnessCommandCatalogSchema.parse(result);
+  };
   const executeThreadCommand = async (
     input: ThreadCommandExecuteParams,
   ): Promise<ThreadCommandExecuteResult> => {
@@ -266,6 +275,7 @@ export function createRendererModelClient(
     },
     inspectHarnessCommands,
     inspectThreadCommands,
+    inspectThreadSkills,
     executeThreadCommand,
     async listThreadOwnership(
       input: ThreadOwnershipListParams,

--- a/packages/renderer-extension/src/versioned-renderer-adapter.ts
+++ b/packages/renderer-extension/src/versioned-renderer-adapter.ts
@@ -1013,6 +1013,8 @@ export function installCurrentRendererAdapter(): {
       currentModelClient().inspectHarnessCommands(input),
     inspectThreadCommands: (input: ThreadCommandsInspectParams) =>
       currentModelClient().inspectThreadCommands(input),
+    inspectThreadSkills: (input: ThreadCommandsInspectParams) =>
+      currentModelClient().inspectThreadSkills(input),
     executeThreadCommand: (input: ThreadCommandExecuteParams) =>
       currentModelClient().executeThreadCommand(input),
     inspectThreadUsage: (input: ThreadUsageInspectionParams) =>

--- a/packages/renderer-extension/test/renderer-binding-probe-host-catalog.test.ts
+++ b/packages/renderer-extension/test/renderer-binding-probe-host-catalog.test.ts
@@ -46,6 +46,16 @@ vi.mock("../src/renderer-composer-dom.js", async (importOriginal) => {
         placeBefore: vi.fn(),
         dispose: vi.fn(),
       },
+      harnessSkills: {
+        setSkills: vi.fn(),
+        setExecuting: vi.fn(),
+        setLocale: vi.fn(),
+        placeBefore: vi.fn(),
+        open: vi.fn(),
+        hasSkills: () => false,
+        close: vi.fn(),
+        dispose: vi.fn(),
+      },
       sendButton: testState.sendButton,
       sendDisabledBeforeSwitch: null,
     }),
@@ -362,6 +372,7 @@ describe("Renderer binding Host-scoped Claude catalogs", () => {
         locked: true,
       })),
       inspectThreadCommands: vi.fn(async () => ({ commands: [] })),
+      inspectThreadSkills: vi.fn(async () => ({ commands: [] })),
       inspectThreadUsage: vi.fn(async () => ({
         threadId: "thread-a",
         usage: null,
@@ -377,6 +388,7 @@ describe("Renderer binding Host-scoped Claude catalogs", () => {
       inspectHarness: genericHostB.inspectHarness,
       inspectThread: vi.fn(),
       inspectThreadCommands: vi.fn(async () => ({ commands: [] })),
+      inspectThreadSkills: vi.fn(async () => ({ commands: [] })),
       inspectThreadUsage: vi.fn(),
       subscribeThreadUsage: () => () => undefined,
     };
@@ -432,6 +444,7 @@ describe("Renderer binding Host-scoped Claude catalogs", () => {
         locked: true,
       })),
       inspectThreadCommands: vi.fn(async () => ({ commands: [] })),
+      inspectThreadSkills: vi.fn(async () => ({ commands: [] })),
       inspectThreadUsage: vi.fn(async () => ({
         threadId: "thread-a",
         usage: null,
@@ -448,6 +461,7 @@ describe("Renderer binding Host-scoped Claude catalogs", () => {
       inspectHarness: originalHost.inspectHarness,
       inspectThread: vi.fn(),
       inspectThreadCommands: vi.fn(async () => ({ commands: [] })),
+      inspectThreadSkills: vi.fn(async () => ({ commands: [] })),
       inspectThreadUsage: vi.fn(),
       subscribeThreadUsage: () => () => undefined,
     };
@@ -493,6 +507,7 @@ describe("Renderer binding Host-scoped Claude catalogs", () => {
       inspectHarness: hostA.inspectHarness,
       inspectThread: vi.fn(),
       inspectThreadCommands: vi.fn(async () => ({ commands: [] })),
+      inspectThreadSkills: vi.fn(async () => ({ commands: [] })),
       inspectThreadUsage: vi.fn(),
       subscribeThreadUsage: () => () => undefined,
     };
@@ -531,6 +546,7 @@ describe("Renderer binding Host-scoped Claude catalogs", () => {
         locked: true,
       })),
       inspectThreadCommands: vi.fn(async () => ({ commands: [] })),
+      inspectThreadSkills: vi.fn(async () => ({ commands: [] })),
       inspectThreadUsage: vi.fn(async () => ({
         threadId: "thread-a",
         usage: null,
@@ -544,6 +560,7 @@ describe("Renderer binding Host-scoped Claude catalogs", () => {
       inspectHarness: local.inspectHarness,
       inspectThread: vi.fn(),
       inspectThreadCommands: vi.fn(async () => ({ commands: [] })),
+      inspectThreadSkills: vi.fn(async () => ({ commands: [] })),
       inspectThreadUsage: vi.fn(),
       subscribeThreadUsage: () => () => undefined,
     };

--- a/packages/renderer-extension/test/renderer-fork-control.test.ts
+++ b/packages/renderer-extension/test/renderer-fork-control.test.ts
@@ -38,6 +38,7 @@ function clientWith(inspection: ThreadInspection): RendererModelClient {
     inspectThread: vi.fn(async () => inspection),
     inspectHarnessCommands: vi.fn(),
     inspectThreadCommands: vi.fn(),
+    inspectThreadSkills: vi.fn(),
     executeThreadCommand: vi.fn(),
     inspectThreadUsage: vi.fn(),
     listThreadOwnership: vi.fn(),

--- a/packages/renderer-extension/test/renderer-harness-command-control.test.ts
+++ b/packages/renderer-extension/test/renderer-harness-command-control.test.ts
@@ -29,6 +29,9 @@ describe("Renderer Harness command localization", () => {
       commands: "命令",
       harnessCommands: "Harness 命令",
       textArgument: "文本",
+      skills: "技能",
+      filterSkills: "过滤技能",
+      back: "返回",
     });
     expect(rendererHarnessCommandPresentation(compactCommand, "zh-CN")).toEqual({
       label: "压缩上下文",
@@ -41,6 +44,9 @@ describe("Renderer Harness command localization", () => {
       commands: "Commands",
       harnessCommands: "Harness commands",
       textArgument: "Text",
+      skills: "Skills",
+      filterSkills: "Filter skills",
+      back: "Back",
     });
     expect(rendererHarnessCommandPresentation(compactCommand, "en")).toEqual({
       label: "Compact context",

--- a/packages/renderer-extension/test/renderer-model-client.test.ts
+++ b/packages/renderer-extension/test/renderer-model-client.test.ts
@@ -16,6 +16,7 @@ import {
   THREAD_FORK_METHOD,
   THREAD_INSPECT_METHOD,
   THREAD_MODEL_SELECT_METHOD,
+  THREAD_SKILLS_INSPECT_METHOD,
   THREAD_PERMISSION_MODE_SELECT_METHOD,
   THREAD_THINKING_SELECT_METHOD,
   THREAD_OWNERSHIP_LIST_METHOD,
@@ -173,6 +174,7 @@ describe("Renderer fixed Model request client", () => {
       "inspectHarnessCommands",
       "inspectThread",
       "inspectThreadCommands",
+      "inspectThreadSkills",
       "inspectThreadUsage",
       "listHarnessPlugins",
       "listHarnessSessions",
@@ -471,6 +473,30 @@ describe("Renderer fixed Model request client", () => {
     unsubscribe();
     expect(removeNotification).toHaveBeenCalledOnce();
     relay.dispose();
+  });
+
+  it("inspects the Thread skills catalog through the fixed skills method", async () => {
+    const catalog = {
+      commands: [
+        {
+          id: "claude.skill.commit",
+          invocation: "/commit",
+          label: "Commit",
+          description: "Create a git commit",
+          argumentMode: "text",
+        },
+      ],
+    };
+    const sendRequest = vi.fn(async () => catalog);
+    const client = createRendererModelClient([{ sendRequest }]);
+    if (!client) throw new Error("Synthetic Model client was not created");
+
+    await expect(
+      client.inspectThreadSkills({ threadId: hostThreadIdSchema.parse("thread-1") }),
+    ).resolves.toEqual(catalog);
+    expect(sendRequest).toHaveBeenCalledWith(THREAD_SKILLS_INSPECT_METHOD, {
+      threadId: "thread-1",
+    });
   });
 
   it("fails closed when request manager ownership is absent or ambiguous", () => {

--- a/packages/renderer-extension/test/renderer-sidebar-agent-icons.test.ts
+++ b/packages/renderer-extension/test/renderer-sidebar-agent-icons.test.ts
@@ -96,6 +96,7 @@ function clientWith(
     inspectThread: vi.fn(),
     inspectHarnessCommands: vi.fn(),
     inspectThreadCommands: vi.fn(),
+    inspectThreadSkills: vi.fn(),
     executeThreadCommand: vi.fn(),
     inspectThreadUsage: vi.fn(),
     listThreadOwnership: vi.fn(listThreadOwnership),

--- a/tests/e2e/renderer-binding-startup.spec.ts
+++ b/tests/e2e/renderer-binding-startup.spec.ts
@@ -147,8 +147,11 @@ test("a new conversation shows the Harness command button before a Thread exists
   await trigger.click();
   const menu = page.locator("[data-codexhost-harness-command-menu]");
   await expect(menu).toBeVisible();
-  await menu.locator('[data-command-id="pi.compact"]').click();
-  await expect(page.locator("[data-codex-composer]")).toHaveText("/compact ");
+  // A draft has no Thread yet, so direct-executable commands stay disabled.
+  const compact = menu.locator('[data-command-id="pi.compact"]');
+  await expect(compact).toBeDisabled();
+  await expect(compact).toHaveAttribute("title", "Start a conversation before running this command");
+  await expect(menu.locator('[role="menuitem"]')).toHaveCount(1);
   expect(await page.evaluate(() => Reflect.get(globalThis, "threadCommandRequests"))).toEqual([]);
 });
 

--- a/tests/e2e/renderer-binding-startup.spec.ts
+++ b/tests/e2e/renderer-binding-startup.spec.ts
@@ -150,7 +150,10 @@ test("a new conversation shows the Harness command button before a Thread exists
   // A draft has no Thread yet, so direct-executable commands stay disabled.
   const compact = menu.locator('[data-command-id="pi.compact"]');
   await expect(compact).toBeDisabled();
-  await expect(compact).toHaveAttribute("title", "Start a conversation before running this command");
+  await expect(compact).toHaveAttribute(
+    "title",
+    "Start a conversation before running this command",
+  );
   await expect(menu.locator('[role="menuitem"]')).toHaveCount(1);
   expect(await page.evaluate(() => Reflect.get(globalThis, "threadCommandRequests"))).toEqual([]);
 });

--- a/tests/e2e/renderer-chat-composer-isolation.spec.ts
+++ b/tests/e2e/renderer-chat-composer-isolation.spec.ts
@@ -29,7 +29,7 @@ const { outputFiles } = await build({
   format: "iife",
   platform: "browser",
   target: "es2024",
-  loader: { ".css": "text", ".png": "dataurl" },
+  loader: { ".css": "text", ".png": "dataurl", ".svg": "dataurl" },
   write: false,
 });
 

--- a/tests/e2e/renderer-harness-skill-control.spec.ts
+++ b/tests/e2e/renderer-harness-skill-control.spec.ts
@@ -1,0 +1,274 @@
+import { expect, test, type Page } from "@playwright/test";
+import { build } from "esbuild";
+import path from "node:path";
+
+const repositoryRoot = path.resolve(import.meta.dirname, "../..");
+const browserExecutable = process.env.CODEXHOST_PLAYWRIGHT_EXECUTABLE_PATH;
+if (browserExecutable) test.use({ launchOptions: { executablePath: browserExecutable } });
+
+const { outputFiles } = await build({
+  stdin: {
+    contents: `
+      import { mountRendererHarnessSkillControl } from "./packages/renderer-extension/src/renderer-harness-skill-control.ts";
+
+      const NONE_SKILL = {
+        id: "claude.skill.review",
+        invocation: "/review",
+        label: "Review",
+        description: "Review the current diff",
+        argumentMode: "none",
+      };
+      const TEXT_SKILL = {
+        id: "claude.skill.commit",
+        invocation: "/commit",
+        label: "Commit",
+        description: "Create a git commit",
+        argumentMode: "text",
+      };
+
+      globalThis.setupRendererHarnessSkillControl = (initialLocale) => {
+        const selections = [];
+        globalThis.__skillSelections = selections;
+        const toolbar = document.createElement("div");
+        document.body.append(toolbar);
+        const control = mountRendererHarnessSkillControl(
+          toolbar,
+          null,
+          (skill, argument) => {
+            selections.push({ id: skill.id, argument });
+          },
+          initialLocale,
+        );
+        globalThis.__skillSetSkills = (skills) => control.setSkills(skills);
+        globalThis.__skillSetExecuting = (commandId) => control.setExecuting(commandId);
+        globalThis.__skillOpen = () => control.open();
+        globalThis.__skillHasSkills = () => control.hasSkills();
+        globalThis.__skillClearSelections = () => {
+          selections.length = 0;
+        };
+        control.setSkills([NONE_SKILL, TEXT_SKILL]);
+      };
+    `,
+    resolveDir: repositoryRoot,
+    sourcefile: "renderer-harness-skill-control-entry.ts",
+    loader: "ts",
+  },
+  bundle: true,
+  format: "iife",
+  platform: "browser",
+  target: "es2024",
+  write: false,
+});
+
+const browserBundle = outputFiles[0]?.text;
+if (!browserBundle) throw new Error("Renderer Harness skill control bundle was not generated");
+
+const mountSkillControl = async (page: Page, locale = "en"): Promise<void> => {
+  await page.setContent('<!doctype html><body style="margin:0"></body>');
+  await page.addScriptTag({ content: browserBundle });
+  await page.evaluate((setLocale: string) => {
+    const setup = Reflect.get(globalThis, "setupRendererHarnessSkillControl");
+    if (typeof setup !== "function") throw new Error("Skill control setup is unavailable");
+    (setup as (locale: string) => void)(setLocale);
+  }, locale);
+};
+
+async function callBrowser(page: Page, name: string, ...args: unknown[]): Promise<unknown> {
+  return page.evaluate(
+    ([target, callArgs]) => {
+      const fn = Reflect.get(globalThis, target);
+      if (typeof fn !== "function") throw new Error(`${target} is unavailable`);
+      return (fn as (...values: unknown[]) => unknown)(...callArgs);
+    },
+    [name, args] as [string, unknown[]],
+  );
+}
+
+function selections(page: Page): Promise<Array<{ id: string; argument: string | undefined }>> {
+  return page.evaluate(
+    () =>
+      Reflect.get(globalThis, "__skillSelections") as Array<{
+        id: string;
+        argument: string | undefined;
+      }>,
+  );
+}
+
+const trigger = (page: Page) => page.locator("[data-codexhost-harness-skill-control] button");
+const menu = (page: Page) => page.locator("[data-codexhost-harness-skill-menu]");
+const items = (page: Page) => page.locator('[data-codexhost-harness-skill-menu] [role="menuitem"]');
+
+test("hides the control for an empty catalog and reveals it when skills arrive", async ({
+  page,
+}) => {
+  await mountSkillControl(page);
+  await callBrowser(page, "__skillSetSkills", []);
+  // The empty gate is real visibility: the root carries both the `hidden`
+  // attribute and a `display: none` inline style, since the mount-time
+  // `display: inline-flex` would otherwise defeat the UA [hidden] rule.
+  await expect(page.locator("[data-codexhost-harness-skill-control]")).toBeHidden();
+  expect(await callBrowser(page, "__skillHasSkills")).toBe(false);
+  // open() is a no-op while the catalog is empty: the popover stays hidden.
+  await callBrowser(page, "__skillOpen");
+  await expect(menu(page)).toBeHidden();
+
+  await callBrowser(page, "__skillSetSkills", [
+    {
+      id: "claude.skill.review",
+      invocation: "/review",
+      label: "Review",
+      description: "Review the current diff",
+      argumentMode: "none",
+    },
+  ]);
+  await expect(page.locator("[data-codexhost-harness-skill-control]")).toBeVisible();
+  expect(await callBrowser(page, "__skillHasSkills")).toBe(true);
+});
+
+test("opens with invocations and descriptions and toggles aria-expanded", async ({ page }) => {
+  await mountSkillControl(page);
+  await expect(trigger(page)).toHaveAttribute("aria-expanded", "false");
+  await trigger(page).click();
+  await expect(trigger(page)).toHaveAttribute("aria-expanded", "true");
+  await expect(menu(page)).toBeVisible();
+  await expect(items(page)).toHaveCount(2);
+  await expect(menu(page)).toContainText("/review");
+  await expect(menu(page)).toContainText("Review the current diff");
+  await expect(menu(page)).toContainText("/commit");
+  await expect(menu(page)).toContainText("Create a git commit");
+});
+
+test("narrows the items with the filter input by name or description", async ({ page }) => {
+  await mountSkillControl(page);
+  await trigger(page).click();
+  const filter = page.locator('[role="searchbox"]');
+  await expect(filter).toBeVisible();
+  await expect(filter).toHaveAttribute("aria-label", "Filter skills");
+  await filter.fill("git");
+  await expect(items(page)).toHaveCount(1);
+  await expect(menu(page)).toContainText("/commit");
+  await filter.fill("COMMIT the current");
+  await expect(items(page)).toHaveCount(0);
+  await filter.fill("");
+  await expect(items(page)).toHaveCount(2);
+});
+
+test("selects an argument-less skill on click and closes the popover", async ({ page }) => {
+  await mountSkillControl(page);
+  await trigger(page).click();
+  await items(page).first().click();
+  await expect(menu(page)).toBeHidden();
+  await expect(trigger(page)).toHaveAttribute("aria-expanded", "false");
+  expect(await selections(page)).toEqual([{ id: "claude.skill.review", argument: undefined }]);
+});
+
+test("enters the argument phase for a text skill and submits the trimmed value on Enter", async ({
+  page,
+}) => {
+  await mountSkillControl(page);
+  await trigger(page).click();
+  await items(page).nth(1).click();
+  const argument = page.locator("[data-codexhost-harness-skill-argument]");
+  await expect(argument).toBeVisible();
+  await expect(argument).toBeFocused();
+  await expect(menu(page)).toContainText("/commit");
+  await argument.fill("  fix login flake  ");
+  await argument.press("Enter");
+  await expect(menu(page)).toBeHidden();
+  expect(await selections(page)).toEqual([
+    { id: "claude.skill.commit", argument: "fix login flake" },
+  ]);
+
+  // A blank argument submits as undefined, the same as the none-mode path.
+  await callBrowser(page, "__skillClearSelections");
+  await trigger(page).click();
+  await items(page).nth(1).click();
+  await argument.fill("   ");
+  await argument.press("Enter");
+  await expect(menu(page)).toBeHidden();
+  expect(await selections(page)).toEqual([{ id: "claude.skill.commit", argument: undefined }]);
+});
+
+test("Escape in the argument phase returns to the list without selecting", async ({ page }) => {
+  await mountSkillControl(page);
+  await trigger(page).click();
+  await items(page).nth(1).click();
+  const argument = page.locator("[data-codexhost-harness-skill-argument]");
+  await argument.fill("draft");
+  await argument.press("Escape");
+  await expect(menu(page)).toBeVisible();
+  await expect(items(page)).toHaveCount(2);
+  await expect(argument).toBeHidden();
+  expect(await selections(page)).toEqual([]);
+});
+
+test("keeps the argument input across a catalog refresh and shows the new list after Escape", async ({
+  page,
+}) => {
+  await mountSkillControl(page);
+  await trigger(page).click();
+  await items(page).nth(1).click();
+  const argument = page.locator("[data-codexhost-harness-skill-argument]");
+  await expect(argument).toBeVisible();
+  await argument.fill("  keep me  ");
+  await callBrowser(page, "__skillSetSkills", [
+    {
+      id: "claude.skill.deploy",
+      invocation: "/deploy",
+      label: "Deploy",
+      description: "Deploy the app",
+      argumentMode: "none",
+    },
+  ]);
+  await expect(argument).toBeVisible();
+  await expect(argument).toHaveValue("  keep me  ");
+  expect(await selections(page)).toEqual([]);
+
+  await argument.press("Escape");
+  await expect(menu(page)).toBeVisible();
+  await expect(items(page)).toHaveCount(1);
+  await expect(menu(page)).toContainText("/deploy");
+  await expect(menu(page)).not.toContainText("/commit");
+});
+
+test("Escape closes from the list and outside pointerdown dismisses the popover", async ({
+  page,
+}) => {
+  await mountSkillControl(page);
+  await trigger(page).click();
+  await expect(menu(page)).toBeVisible();
+  // First Escape leaves the filter input; the second closes the popover.
+  await page.keyboard.press("Escape");
+  await expect(menu(page)).toBeVisible();
+  await page.keyboard.press("Escape");
+  await expect(menu(page)).toBeHidden();
+
+  await trigger(page).click();
+  await expect(menu(page)).toBeVisible();
+  await page.mouse.click(600, 600);
+  await expect(menu(page)).toBeHidden();
+});
+
+test("ignores item clicks while a skill is executing", async ({ page }) => {
+  await mountSkillControl(page);
+  await callBrowser(page, "__skillSetExecuting", "claude.skill.commit");
+  await callBrowser(page, "__skillOpen");
+  await expect(menu(page)).toBeHidden();
+
+  await callBrowser(page, "__skillSetExecuting", null);
+  await trigger(page).click();
+  await expect(menu(page)).toBeVisible();
+  await callBrowser(page, "__skillSetExecuting", "claude.skill.commit");
+  await expect(items(page).first()).toBeDisabled();
+  await items(page).first().click({ force: true });
+  expect(await selections(page)).toEqual([]);
+});
+
+test("localizes the Skills chrome in Chinese", async ({ page }) => {
+  await mountSkillControl(page, "zh-CN");
+  await expect(trigger(page)).toHaveAttribute("aria-label", "技能");
+  await trigger(page).click();
+  await expect(page.locator('[role="searchbox"]')).toHaveAttribute("aria-label", "过滤技能");
+  await items(page).nth(1).click();
+  await expect(menu(page)).toContainText("返回");
+});

--- a/tests/e2e/renderer-model-picker.spec.ts
+++ b/tests/e2e/renderer-model-picker.spec.ts
@@ -48,7 +48,6 @@ const { outputFiles } = await build({
         let control;
         control = mountRendererModelPicker(
           "test-composer",
-          undefined,
           (modelId) => {
             view = { ...view, status: "selecting" };
             renderRendererModelPicker(control, view, true);
@@ -62,7 +61,6 @@ const { outputFiles } = await build({
               renderRendererModelPicker(control, view, true);
             }, 250);
           },
-          () => {},
         );
         document.body.append(control.root);
         renderRendererModelPicker(control, view, true);
@@ -98,12 +96,7 @@ const { outputFiles } = await build({
           resolvedModelLabel: "Runtime custom",
           thinkingSelectionSupported: false,
         };
-        const control = mountRendererModelPicker(
-          "claude-composer",
-          "native-model-trigger",
-          () => {},
-          () => {},
-        );
+        const control = mountRendererModelPicker("claude-composer", () => {}, () => {});
         document.body.append(control.root);
         renderRendererModelPicker(control, view, true);
       };
@@ -122,9 +115,7 @@ const { outputFiles } = await build({
 const browserBundle = outputFiles[0]?.text;
 if (!browserBundle) throw new Error("Renderer Model picker E2E bundle was not generated");
 
-test("selecting a Model keeps the main menu open and refreshes Thinking options", async ({
-  page,
-}) => {
+test("selecting a Model closes the picker and refreshes Thinking options", async ({ page }) => {
   await page.setContent(
     '<!doctype html><body style="display:flex;align-items:flex-end;min-height:100vh;margin:0"></body>',
   );
@@ -137,15 +128,15 @@ test("selecting a Model keeps the main menu open and refreshes Thinking options"
 
   const root = page.locator('[data-codexhost-model-control="test-composer"]');
   const trigger = root.locator(':scope > button[aria-haspopup="menu"]');
-  const mainMenu = root.locator('[aria-label="Model and Thinking"]');
-  const modelMenu = root.locator('[aria-label="Model"]');
+  const mainMenu = page.locator("#test-composer-model-menu");
+  const modelMenu = page.locator("#test-composer-model-submenu");
 
   await trigger.click();
   await expect(mainMenu).toBeVisible();
   const [triggerBox, mainBox] = await Promise.all([trigger.boundingBox(), mainMenu.boundingBox()]);
   if (!triggerBox || !mainBox) throw new Error("Model picker main menu geometry is unavailable");
   expect(mainBox.y + mainBox.height).toBeLessThanOrEqual(triggerBox.y + 1);
-  await root.locator("button[data-open-model-menu]").click();
+  await mainMenu.locator("button[data-open-model-menu]").click();
   await expect(modelMenu).toBeVisible();
   const [openedMainBox, modelBox] = await Promise.all([
     mainMenu.boundingBox(),
@@ -157,14 +148,15 @@ test("selecting a Model keeps the main menu open and refreshes Thinking options"
   expect(modelBox.height).toBeLessThanOrEqual(360);
   await modelMenu.locator('button[data-model-id="model-b"]').click();
 
+  // Selecting a Model dismisses the picker while the selection is applied;
+  // the refreshed Thinking options are confirmed on the next open.
   await expect(modelMenu).toBeHidden();
-  await expect(mainMenu).toBeVisible();
-  await expect(trigger).toBeDisabled();
-  await expect(root.locator("button[data-thinking-option-id]:not(:disabled)")).toHaveCount(0);
+  await expect(mainMenu).toBeHidden();
 
   await expect(trigger).toBeEnabled();
+  await trigger.click();
   await expect(mainMenu).toBeVisible();
-  const thinkingOptions = root.locator("button[data-thinking-option-id]");
+  const thinkingOptions = mainMenu.locator("button[data-thinking-option-id]");
   await expect(thinkingOptions).toHaveCount(3);
   await expect
     .poll(() =>
@@ -212,25 +204,21 @@ test("Claude aliases show actual runtime Model without exposing Thinking", async
     labelTriggerBox.x + labelTriggerBox.width - (secondaryLabelBox.x + secondaryLabelBox.width);
   expect(trailingSpace).toBeLessThanOrEqual(16);
 
+  // Thinking selection is unsupported for Claude, so opening jumps straight
+  // to the Model submenu without the Thinking stage.
   await trigger.click();
-  await expect(root.locator("button[data-thinking-option-id]")).toHaveCount(0);
-  await root.locator("button[data-open-model-menu]").click();
-  const mainMenu = root.locator('[aria-label="Model and Thinking"]');
-  const modelMenu = root.locator('[aria-label="Model"]');
+  const mainMenu = page.locator("#claude-composer-model-menu");
+  const modelMenu = page.locator("#claude-composer-model-submenu");
+  await expect(mainMenu).toBeHidden();
+  await expect(modelMenu).toBeVisible();
   await expect(modelMenu.locator("button[data-model-id]")).toHaveCount(2);
   const geometry = await Promise.all([
     trigger.boundingBox(),
-    mainMenu.boundingBox(),
     modelMenu.boundingBox(),
     page.evaluate(() => ({ height: window.innerHeight, width: window.innerWidth })),
   ]);
-  const [claudeTriggerBox, mainBox, modelBox, viewport] = geometry;
-  if (!claudeTriggerBox || !mainBox || !modelBox)
-    throw new Error("Model picker geometry is unavailable");
-  expect(mainBox.y + mainBox.height).toBeLessThanOrEqual(claudeTriggerBox.y + 1);
-  expect(modelBox.x).toBeCloseTo(mainBox.x + mainBox.width + 4, 0);
-  expect(modelBox.y + modelBox.height).toBeCloseTo(mainBox.y + mainBox.height, 0);
-  expect(modelBox.height).toBeLessThanOrEqual(360);
+  const [claudeTriggerBox, modelBox, viewport] = geometry;
+  if (!claudeTriggerBox || !modelBox) throw new Error("Model picker geometry is unavailable");
   expect(modelBox.x + modelBox.width).toBeLessThanOrEqual(viewport.width - 8);
   expect(modelBox.y).toBeGreaterThanOrEqual(8);
   expect(modelBox.y + modelBox.height).toBeLessThanOrEqual(viewport.height - 8);

--- a/tests/e2e/renderer-usage-notification.spec.ts
+++ b/tests/e2e/renderer-usage-notification.spec.ts
@@ -45,6 +45,7 @@ const { outputFiles } = await build({
       Object.defineProperty(editor, "__reactFiber$usage", {
         configurable: true,
         value: {
+          memoizedProps: { conversationId: threadId },
           updateQueue: {
             memoCache: {
               data: [
@@ -128,7 +129,7 @@ const { outputFiles } = await build({
   format: "iife",
   platform: "browser",
   target: "es2024",
-  loader: { ".css": "text", ".png": "dataurl" },
+  loader: { ".css": "text", ".png": "dataurl", ".svg": "dataurl" },
   write: false,
 });
 


### PR DESCRIPTION
Introduces a Renderer Skills control exposing Harness-provided Skills as a second, independent catalog alongside Commands.

- Claude Code Adapter enumerates Skills from the native control channel and projects them through the Host.
- Host validates and routes Skill invocations against the union of Commands and Skills catalogs.
- Renderer presents Skills in a dedicated Composer control; SKILL.md files are never parsed or executed client-side.
- Aligns stale e2e specs with current renderer behavior so the full Playwright suite passes.

Validation: typecheck, lint, vitest (2562 passed / 12 skipped), Playwright e2e (37/37).