### PR TITLE
fix: 按请求的行数返回 Account 聚合页

### DIFF
--- a/packages/host-runtime/src/multi-account-thread-list.ts
+++ b/packages/host-runtime/src/multi-account-thread-list.ts
@@ -117,6 +117,15 @@ export async function aggregateOfficialAccountThreadListPage(input: {
   requestAccountPage(accountId: string, params: JsonObject): Promise<OfficialThreadListPage>;
   observeThread?(threadId: string, accountId: string): Promise<void>;
 }): Promise<OfficialThreadListPage> {
+  // The caller asks for an exact row count when it resolves a partially
+  // consumed batch into a resumable cursor, and that count is smaller than the
+  // page size of the originating query. Honouring `query.limit` instead would
+  // over-deliver and break the caller's prefix accounting.
+  const requestedLimit = input.params.limit;
+  const pageLimit =
+    typeof requestedLimit === "number" && Number.isSafeInteger(requestedLimit) && requestedLimit > 0
+      ? requestedLimit
+      : input.query.limit;
   const cursorValue = typeof input.params.cursor === "string" ? input.params.cursor : null;
   const cursor = cursorValue
     ? decodeCursor(cursorValue)
@@ -155,7 +164,7 @@ export async function aggregateOfficialAccountThreadListPage(input: {
         if (source.done) return null;
       }
       source.batchStart = source.cursor;
-      const page = await request(source, source.cursor, Math.max(1, input.query.limit));
+      const page = await request(source, source.cursor, Math.max(1, pageLimit));
       if (!source.requestedThisPage) {
         source.backwardsCursor = page.backwardsCursor;
         source.requestedThisPage = true;
@@ -178,7 +187,7 @@ export async function aggregateOfficialAccountThreadListPage(input: {
 
   const output: JsonObject[] = [];
   const emitted = new Set<string>();
-  while (output.length < input.query.limit) {
+  while (output.length < pageLimit) {
     const candidates = await Promise.all(
       sources.map(async (source) => ({ source, entry: await ensure(source) })),
     );

--- a/packages/host-runtime/test/multi-account-thread-list.test.ts
+++ b/packages/host-runtime/test/multi-account-thread-list.test.ts
@@ -62,6 +62,28 @@ describe("Multi-Account official Thread list", () => {
     expect(observed).toEqual(["a-5:a", "b-4:b", "a-2:a", "b-1:b"]);
   });
 
+  it("returns exactly the requested row count when it differs from the query page size", async () => {
+    // The aggregator resolves a partially consumed batch by re-requesting the
+    // consumed prefix, so `params.limit` is smaller than `query.limit` and must
+    // win. Serving `query.limit` rows instead breaks its prefix accounting.
+    const decoded = query();
+    const requestAccountPage = source({
+      a: [
+        { id: "a-3", createdAt: 3, updatedAt: 3 },
+        { id: "a-2", createdAt: 2, updatedAt: 2 },
+        { id: "a-1", createdAt: 1, updatedAt: 1 },
+      ],
+    });
+    const page = await aggregateOfficialAccountThreadListPage({
+      query: decoded,
+      accountIds: ["a"],
+      params: { ...decoded.params, cursor: null, limit: 1 },
+      requestAccountPage,
+    });
+    expect(page.data.map((thread) => thread.id)).toEqual(["a-3"]);
+    expect(page.nextCursor).not.toBeNull();
+  });
+
   it("keeps the Account snapshot inside the opaque cursor", async () => {
     const decoded = query();
     const first = await aggregateOfficialAccountThreadListPage({

--- a/packages/host-runtime/test/thread-list-aggregator.test.ts
+++ b/packages/host-runtime/test/thread-list-aggregator.test.ts
@@ -12,6 +12,7 @@ import {
 } from "@codexhost/shared-contracts";
 import { describe, expect, it } from "vitest";
 
+import { aggregateOfficialAccountThreadListPage } from "../src/multi-account-thread-list.js";
 import {
   aggregateThreadList,
   officialThreadListPageFromResponse,
@@ -93,6 +94,39 @@ function directionalOfficialSource(rowsAscending: JsonObject[]) {
 }
 
 describe("aggregated Thread list", () => {
+  it("resolves a partially consumed official batch sourced through Account aggregation", async () => {
+    // `thread list` reaches the official source through the Account aggregator.
+    // An external Thread sorted ahead of the official rows leaves that batch
+    // partially consumed, so the aggregator re-requests the consumed prefix at
+    // a smaller limit than the query page size. Serving the query page size
+    // there failed the whole command with an exact-prefix error.
+    const decoded = query({ limit: 3, sortKey: "created_at", sortDirection: "desc" });
+    const source = officialSource([
+      official("codex-5", 5),
+      official("codex-4", 4),
+      official("codex-3", 3),
+      official("codex-2", 2),
+    ]);
+    const page = await aggregateThreadList({
+      query: decoded,
+      records: [external("aaaaaaaa-0000-4000-8000-00000000000e", 6)],
+      runtimeFor: () => null,
+      requestOfficialPage: (params) =>
+        aggregateOfficialAccountThreadListPage({
+          query: decoded,
+          accountIds: ["account-a"],
+          params,
+          requestAccountPage: async (_accountId, accountParams) => source.request(accountParams),
+        }),
+    });
+    expect(page.data.map((thread) => thread.id)).toEqual([
+      "aaaaaaaa-0000-4000-8000-00000000000e",
+      "codex-5",
+      "codex-4",
+    ]);
+    expect(page.nextCursor).not.toBeNull();
+  });
+
   it("terminates after an empty final official page", async () => {
     const source = officialSource([]);
     const page = await aggregateThreadList({


### PR DESCRIPTION
## 问题

任何同时存在外部 Harness Thread 和原生 Codex Thread 的环境，`codexhost thread list` 必然失败：

```console
$ codexhost thread list --limit 3
{
  "error": {
    "code": "INTERNAL_ERROR",
    "message": "Official thread/list did not return an exact consumed prefix cursor"
  }
}
```

`thread read` / `wait` / `send` 不受影响，它们不走分页聚合。

## 根因

official 数据要穿过两层聚合：

```
thread-list-aggregator      合并 external Thread 与 official Thread
        ↓ requestOfficialPage(params)   params.limit = 已消费的行数
multi-account-thread-list   合并多个 Codex Account
        ↓ thread/list
官方 app-server
```

上层在批次被部分消费时，会重新请求这段已消费的前缀，换取一个可续页的游标，并要求返回行数精确匹配：

```ts
// thread-list-aggregator.ts:189
const exact = await requestOfficial(officialBatchStart, officialIndex);
if (exact.data.length !== officialIndex || exact.nextCursor === null) {
  throw new Error("Official thread/list did not return an exact consumed prefix cursor");
}
```

但 Account 聚合层从未读取 `params.limit`，取数和产出都用 `query.limit`：

```ts
const page = await request(source, source.cursor, Math.max(1, input.query.limit));
while (output.length < input.query.limit) {
```

上层请求 2 行，拿回 3 行，前缀核对失败，整条命令中断。

## 触发条件

1. 同时存在外部 Harness Thread 与原生 Codex Thread；
2. 外部 Thread 排序靠前，把 official 批次挤成部分消费；
3. 上层补精确游标 → 必现。

纯原生 Codex 环境不会混排，因此一直没有暴露。

已实测确认官方 `thread/list` 本身行为正常，`limit=N` 返回 N 行并给出时间戳游标，问题不在官方侧：

```
limit=3 -> data=3 nextCursor="2026-09-09T11:45:00Z"
limit=1 -> data=1 nextCursor="2026-09-10T09:29:37Z"
```

## 既有用例为何没覆盖

现有用例传的是 `params: decoded.params`，此时 `params.limit === query.limit`，两者恒等，无法产生分歧。

## 改动

优先采用调用方请求的行数，缺失或非法时才回退到 `query.limit`；无参数的调用行为不变。

## 影响的需求

`external-thread-list-archive-routing` 的分页与游标语义。未改动游标编码、排序、去重或跨 Account 合并顺序，仅修正单次请求的取数行数。

## 验证

- `npm run test:typescript` — 2908 passed / 251 files，0 failures
- `npm run typecheck`、`npm run lint` — 均通过
- 新增两个回归用例：Account 聚合层在 `params.limit` 与 `query.limit` 不一致时返回精确行数；跨两层复现 `thread list` 的真实形态（外部 Thread 排序靠前 + official 批次部分消费）
- 已用 stash 撤销修复反向验证：新增的两个用例失败，其中跨层用例复现的正是上述 `INTERNAL_ERROR` 原文；恢复修复后全绿

🤖 Generated with [Claude Code](https://claude.com/claude-code)