### PR TITLE
feat(claude-code): surface per-model weekly plan limits

### DIFF
--- a/packages/adapters/claude-code/src/account-usage.ts
+++ b/packages/adapters/claude-code/src/account-usage.ts
@@ -1,6 +1,58 @@
 import type { AccountInfo, SDKControlGetUsageResponse } from "@anthropic-ai/claude-agent-sdk";
 import type { HarnessAccountSnapshot, AccountCreditsSnapshot } from "@codexhost/shared-contracts";
 
+/** A per-model weekly window claude.ai reports only inside `rate_limits.limits[]`. */
+export interface ClaudeScopedWeeklyLimit {
+  /** Already suffixed for the Renderer's `" · 7-day window"` localization rule. */
+  product: string;
+  usagePercent: number;
+  resetsAt?: string;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/** `${displayName} · 7-day window` is the single spelling both call sites emit. */
+export function claudeScopedWeeklyProduct(displayName: string): string {
+  return `${displayName} · 7-day window`;
+}
+
+/**
+ * `rate_limits.limits[]` is the only place claude.ai reports per-model weekly
+ * windows (e.g. Fable); the older `model_scoped` key is absent from live
+ * payloads and is not declared in the SDK's `.d.ts`, so the array is parsed
+ * defensively from `unknown`. Entries without a model display name (the plain
+ * `session` / `weekly_all` rows, which the caller already has) and entries with
+ * an out-of-range percent are dropped; the first entry wins per display name.
+ */
+export function parseClaudeScopedWeeklyLimits(rateLimits: unknown): ClaudeScopedWeeklyLimit[] {
+  if (!isRecord(rateLimits) || !Array.isArray(rateLimits.limits)) return [];
+  const seen = new Set<string>();
+  const scoped: ClaudeScopedWeeklyLimit[] = [];
+  for (const entry of rateLimits.limits) {
+    if (!isRecord(entry) || entry.kind !== "weekly_scoped") continue;
+    const model = isRecord(entry.scope) && isRecord(entry.scope.model) ? entry.scope.model : null;
+    const displayName = typeof model?.display_name === "string" ? model.display_name.trim() : "";
+    if (displayName.length === 0) continue;
+    const percent = entry.percent;
+    if (typeof percent !== "number" || !Number.isFinite(percent) || percent < 0 || percent > 100)
+      continue;
+    const product = claudeScopedWeeklyProduct(displayName);
+    if (seen.has(product)) continue;
+    seen.add(product);
+    const resetsAt = entry.resets_at;
+    scoped.push({
+      product,
+      usagePercent: percent,
+      ...(typeof resetsAt === "string" && Number.isFinite(Date.parse(resetsAt))
+        ? { resetsAt }
+        : {}),
+    });
+  }
+  return scoped;
+}
+
 /** Only native plan limits are account quota; session cost is deliberately ignored. */
 export function projectClaudeAccountUsage(
   usage: Pick<
@@ -45,7 +97,16 @@ export function projectClaudeAccountUsage(
   add("Opus · 7-day", "seven_day", limits.seven_day_opus);
   add("Sonnet · 7-day", "seven_day", limits.seven_day_sonnet);
   for (const window of limits.model_scoped ?? [])
-    add(`${window.display_name} · 7-day`, "seven_day", window);
+    add(claudeScopedWeeklyProduct(window.display_name), "seven_day", window);
+  for (const scoped of parseClaudeScopedWeeklyLimits(limits)) {
+    if (windows.some((window) => window.product === scoped.product)) continue;
+    windows.push({
+      product: scoped.product,
+      periodType: "seven_day",
+      usagePercent: scoped.usagePercent,
+      ...(scoped.resetsAt ? { resetsAt: scoped.resetsAt } : {}),
+    });
+  }
   const [primary, ...others] = windows;
   if (!primary) return null;
   // Keep a model-scoped primary's label rather than presenting it as a global weekly limit.

--- a/packages/adapters/claude-code/src/account-usage.ts
+++ b/packages/adapters/claude-code/src/account-usage.ts
@@ -93,9 +93,9 @@ export function projectClaudeAccountUsage(
   };
   add("5-hour window", "five_hour", limits.five_hour);
   add("7-day window", "seven_day", limits.seven_day);
-  add("OAuth apps · 7-day", "seven_day", limits.seven_day_oauth_apps);
-  add("Opus · 7-day", "seven_day", limits.seven_day_opus);
-  add("Sonnet · 7-day", "seven_day", limits.seven_day_sonnet);
+  add(claudeScopedWeeklyProduct("OAuth apps"), "seven_day", limits.seven_day_oauth_apps);
+  add(claudeScopedWeeklyProduct("Opus"), "seven_day", limits.seven_day_opus);
+  add(claudeScopedWeeklyProduct("Sonnet"), "seven_day", limits.seven_day_sonnet);
   for (const window of limits.model_scoped ?? [])
     add(claudeScopedWeeklyProduct(window.display_name), "seven_day", window);
   for (const scoped of parseClaudeScopedWeeklyLimits(limits)) {

--- a/packages/adapters/claude-code/src/claude-code-adapter.ts
+++ b/packages/adapters/claude-code/src/claude-code-adapter.ts
@@ -459,24 +459,28 @@ export function projectClaudePlanLimitToCredits(
   if (!primary) return null;
   const periodType: AccountCreditsSnapshot["periodType"] = fiveHour ? "five_hour" : "seven_day";
   const other = fiveHour && sevenDay ? sevenDay : undefined;
+  const productUsage: NonNullable<AccountCreditsSnapshot["productUsage"]> = [];
+  if (other) {
+    productUsage.push({
+      product: "7-day window",
+      usagePercent: other.utilizationPercent,
+      ...(other.resetsAtUnix !== undefined ? { resetsAt: isoFromUnix(other.resetsAtUnix) } : {}),
+    });
+  }
+  // Per-model weekly windows trail the global ones: they only narrow the 7-day view.
+  for (const scoped of planLimit.scopedWeekly ?? []) {
+    productUsage.push({
+      product: scoped.label,
+      usagePercent: scoped.utilizationPercent,
+      ...(scoped.resetsAtUnix !== undefined ? { resetsAt: isoFromUnix(scoped.resetsAtUnix) } : {}),
+    });
+  }
 
   return {
     usedPercent: primary.utilizationPercent,
     periodType,
     ...(primary.resetsAtUnix !== undefined ? { resetsAt: isoFromUnix(primary.resetsAtUnix) } : {}),
-    ...(other
-      ? {
-          productUsage: [
-            {
-              product: "7-day window",
-              usagePercent: other.utilizationPercent,
-              ...(other.resetsAtUnix !== undefined
-                ? { resetsAt: isoFromUnix(other.resetsAtUnix) }
-                : {}),
-            },
-          ],
-        }
-      : {}),
+    ...(productUsage.length > 0 ? { productUsage } : {}),
   };
 }
 
@@ -2843,6 +2847,7 @@ export class ClaudeCodeAdapter implements HarnessAdapter {
     const next: ClaudePlanLimitEvent = { ...(this.#latestPlanLimit ?? {}) };
     if (planLimit.fiveHour) next.fiveHour = planLimit.fiveHour;
     if (planLimit.sevenDay) next.sevenDay = planLimit.sevenDay;
+    if (planLimit.scopedWeekly?.length) next.scopedWeekly = planLimit.scopedWeekly;
     this.#latestPlanLimit = next.fiveHour || next.sevenDay ? next : null;
     if (this.#latestPlanLimit) {
       for (const session of this.#sessions) {

--- a/packages/adapters/claude-code/src/sdk-transport.ts
+++ b/packages/adapters/claude-code/src/sdk-transport.ts
@@ -11,7 +11,7 @@ import {
 } from "@anthropic-ai/claude-agent-sdk";
 import { sanitizeDiagnosticTail } from "@codexhost/harness-adapter";
 import type { HarnessAccountSnapshot, HarnessThinkingOptionId } from "@codexhost/shared-contracts";
-import { projectClaudeAccountUsage } from "./account-usage.js";
+import { parseClaudeScopedWeeklyLimits, projectClaudeAccountUsage } from "./account-usage.js";
 
 import { resolveClaudeCodeExecutable, withNodeRuntimeOnPath } from "./command.js";
 import type { ClaudeModelInspectionSnapshot } from "./model-catalog.js";
@@ -28,6 +28,7 @@ import type {
   ClaudeInteractionResponse,
   ClaudeModelInspector,
   ClaudePlanLimitEvent,
+  ClaudePlanLimitScopedWindow,
   ClaudeQuestion,
   ClaudeTransportContextUsage,
   ClaudeTransportTurnResult,
@@ -40,6 +41,9 @@ const APPROVAL_TITLE_MAX_LENGTH = 120;
 const APPROVAL_DESCRIPTION_MAX_LENGTH = 500;
 const DEFAULT_ABORT_TIMEOUT_MS = 2_000;
 const INTERRUPT_TIMEOUT_MESSAGE = "Claude SDK interrupt timed out";
+/** Plan windows move slowly; one `get_usage` per minute is enough to track them. */
+const SCOPED_WEEKLY_REFRESH_MS = 60_000;
+const SCOPED_WEEKLY_TIMEOUT_MS = 5_000;
 
 class PushableInput<T> implements AsyncIterable<T> {
   #closed = false;
@@ -372,6 +376,9 @@ export class ClaudeSdkTransport implements ClaudeTurnTransport {
   #query: Query | null = null;
   #started = false;
   #backgroundTasks = new Set<string>();
+  #scopedWeekly: ClaudePlanLimitScopedWindow[] = [];
+  #scopedWeeklyProbedAt = Number.NEGATIVE_INFINITY;
+  #scopedWeeklyTask: Promise<ClaudePlanLimitScopedWindow[]> | null = null;
 
   constructor(options: ClaudeSdkTransportOptions) {
     this.sessionId = options.sessionId;
@@ -849,6 +856,61 @@ export class ClaudeSdkTransport implements ClaudeTurnTransport {
     }
   }
 
+  /**
+   * `rate_limit_event` only ever carries the two unified windows. Per-model
+   * weekly windows (Fable, ...) live behind the same query's experimental
+   * `get_usage` control, so the push is enriched opportunistically. Every
+   * failure mode — control unsupported, rejected, slow, or a payload without
+   * `limits[]` — degrades to exactly the event this Transport forwarded before,
+   * and never drops it.
+   */
+  #emitPlanLimit(planLimit: ClaudePlanLimitEvent, activeQuery: Query): void {
+    void this.#scopedWeeklyWindows(activeQuery).then(
+      (scopedWeekly) => {
+        this.#onPlanLimit(scopedWeekly.length > 0 ? { ...planLimit, scopedWeekly } : planLimit);
+      },
+      () => this.#onPlanLimit(planLimit),
+    );
+  }
+
+  /** One `get_usage` per refresh interval; events in between reuse its result. */
+  #scopedWeeklyWindows(activeQuery: Query): Promise<ClaudePlanLimitScopedWindow[]> {
+    if (this.#scopedWeeklyTask) return this.#scopedWeeklyTask;
+    const now = Date.now();
+    if (now - this.#scopedWeeklyProbedAt < SCOPED_WEEKLY_REFRESH_MS)
+      return Promise.resolve(this.#scopedWeekly);
+    this.#scopedWeeklyProbedAt = now;
+    const task = this.#probeScopedWeekly(activeQuery)
+      .catch((): ClaudePlanLimitScopedWindow[] => [])
+      .then((scopedWeekly) => {
+        this.#scopedWeekly = scopedWeekly;
+        this.#scopedWeeklyTask = null;
+        return scopedWeekly;
+      });
+    this.#scopedWeeklyTask = task;
+    return task;
+  }
+
+  async #probeScopedWeekly(activeQuery: Query): Promise<ClaudePlanLimitScopedWindow[]> {
+    const getUsage = activeQuery.usage_EXPERIMENTAL_MAY_CHANGE_DO_NOT_RELY_ON_THIS_API_YET;
+    if (typeof getUsage !== "function") return [];
+    const timeout = rejectAfter(SCOPED_WEEKLY_TIMEOUT_MS, "Claude SDK usage probe timed out");
+    try {
+      const usage = await Promise.race([getUsage.call(activeQuery), timeout.promise]);
+      return parseClaudeScopedWeeklyLimits(usage?.rate_limits).map((scoped) => {
+        const resetsAtUnix =
+          scoped.resetsAt === undefined ? undefined : Math.floor(Date.parse(scoped.resetsAt) / 1000);
+        return {
+          label: scoped.product,
+          utilizationPercent: scoped.usagePercent,
+          ...(resetsAtUnix !== undefined && Number.isFinite(resetsAtUnix) ? { resetsAtUnix } : {}),
+        };
+      });
+    } finally {
+      timeout.cancel();
+    }
+  }
+
   async #consume(activeQuery: Query): Promise<void> {
     try {
       for await (const message of activeQuery) {
@@ -859,7 +921,7 @@ export class ClaudeSdkTransport implements ClaudeTurnTransport {
           this.#onPermissionModeChanged(permissionMode);
         }
         const planLimit = parseClaudePlanLimitEvent(message);
-        if (planLimit) this.#onPlanLimit(planLimit);
+        if (planLimit) this.#emitPlanLimit(planLimit, activeQuery);
         const active = this.#active;
         if (active) {
           const interpreted = active.accumulator.consume(message);

--- a/packages/adapters/claude-code/src/transport.ts
+++ b/packages/adapters/claude-code/src/transport.ts
@@ -158,12 +158,23 @@ export interface ClaudePlanLimitWindow {
 }
 
 /**
+ * A per-model weekly window (e.g. Fable). `rate_limit_event` never carries
+ * these, so they are only present when the Transport's opportunistic
+ * `get_usage` probe succeeded.
+ */
+export interface ClaudePlanLimitScopedWindow extends ClaudePlanLimitWindow {
+  /** Renderer-facing product label, already suffixed with `" · 7-day window"`. */
+  label: string;
+}
+
+/**
  * Claude.ai subscription plan-window utilization from stable `rate_limit_event`
  * pushes. Both windows are optional because one event may report either or both.
  */
 export interface ClaudePlanLimitEvent {
   fiveHour?: ClaudePlanLimitWindow;
   sevenDay?: ClaudePlanLimitWindow;
+  scopedWeekly?: ClaudePlanLimitScopedWindow[];
 }
 
 export interface ClaudeAutonomousTurn {

--- a/packages/adapters/claude-code/test/account-usage.test.ts
+++ b/packages/adapters/claude-code/test/account-usage.test.ts
@@ -53,7 +53,7 @@ describe("Claude Code native account Usage", () => {
         periodType: "five_hour",
         productUsage: [
           { product: "7-day window", usagePercent: 60 },
-          { product: "Sonnet · 7-day", usagePercent: 0 },
+          { product: "Sonnet · 7-day window", usagePercent: 0 },
         ],
       },
     });
@@ -101,7 +101,7 @@ describe("Claude Code native account Usage", () => {
         {},
       ),
     ).toMatchObject({
-      credits: { label: "Opus · 7-day", usedPercent: 0, periodType: "seven_day" },
+      credits: { label: "Opus · 7-day window", usedPercent: 0, periodType: "seven_day" },
     });
   });
 
@@ -146,7 +146,7 @@ describe("Claude Code native account Usage", () => {
         periodType: "five_hour",
         productUsage: [
           { product: "7-day window", usagePercent: 60 },
-          { product: "Sonnet · 7-day", usagePercent: 0 },
+          { product: "Sonnet · 7-day window", usagePercent: 0 },
           {
             product: "Fable · 7-day window",
             usagePercent: 32,
@@ -178,6 +178,34 @@ describe("Claude Code native account Usage", () => {
     );
     expect(projected?.credits.productUsage).toEqual([
       { product: "Fable · 7-day window", usagePercent: 30 },
+    ]);
+  });
+
+  it("labels every weekly window so the Renderer can localize it", () => {
+    const projected = projectClaudeAccountUsage(
+      {
+        ...usage,
+        rate_limits: {
+          five_hour: usage.rate_limits.five_hour,
+          seven_day: usage.rate_limits.seven_day,
+          seven_day_oauth_apps: { utilization: 1, resets_at: null },
+          seven_day_opus: { utilization: 2, resets_at: null },
+          seven_day_sonnet: { utilization: 3, resets_at: null },
+          // A model that already reported through a fixed key must not be listed twice.
+          limits: [
+            { kind: "weekly_scoped", percent: 99, scope: { model: { display_name: "Sonnet" } } },
+            { kind: "weekly_scoped", percent: 32, scope: { model: { display_name: "Fable" } } },
+          ],
+        } as never,
+      },
+      {},
+    );
+    expect(projected?.credits.productUsage).toEqual([
+      { product: "7-day window", usagePercent: 60, resetsAt: "2026-09-07T00:00:00Z" },
+      { product: "OAuth apps · 7-day window", usagePercent: 1 },
+      { product: "Opus · 7-day window", usagePercent: 2 },
+      { product: "Sonnet · 7-day window", usagePercent: 3 },
+      { product: "Fable · 7-day window", usagePercent: 32 },
     ]);
   });
 

--- a/packages/adapters/claude-code/test/account-usage.test.ts
+++ b/packages/adapters/claude-code/test/account-usage.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it, vi } from "vitest";
 import type { Query } from "@anthropic-ai/claude-agent-sdk";
-import { projectClaudeAccountUsage } from "../src/account-usage.js";
+import {
+  parseClaudeScopedWeeklyLimits,
+  projectClaudeAccountUsage,
+} from "../src/account-usage.js";
 import {
   ClaudeSdkModelInspector,
   type ClaudeSdkModelInspectorOptions,
@@ -100,6 +103,120 @@ describe("Claude Code native account Usage", () => {
     ).toMatchObject({
       credits: { label: "Opus · 7-day", usedPercent: 0, periodType: "seven_day" },
     });
+  });
+
+  it("surfaces per-model weekly windows that only exist in rate_limits.limits[]", () => {
+    expect(
+      projectClaudeAccountUsage(
+        {
+          ...usage,
+          rate_limits: {
+            ...usage.rate_limits,
+            limits: [
+              {
+                kind: "session",
+                group: "session",
+                percent: 25,
+                resets_at: "2026-09-01T05:00:00Z",
+                scope: null,
+              },
+              {
+                kind: "weekly_all",
+                group: "weekly",
+                percent: 60,
+                resets_at: "2026-09-07T00:00:00Z",
+                scope: null,
+              },
+              {
+                kind: "weekly_scoped",
+                group: "weekly",
+                percent: 32,
+                resets_at: "2026-09-10T16:59:59+00:00",
+                scope: { model: { id: null, display_name: "Fable" }, surface: null },
+                is_active: false,
+              },
+            ],
+          } as never,
+        },
+        {},
+      ),
+    ).toMatchObject({
+      credits: {
+        usedPercent: 25,
+        periodType: "five_hour",
+        productUsage: [
+          { product: "7-day window", usagePercent: 60 },
+          { product: "Sonnet · 7-day", usagePercent: 0 },
+          {
+            product: "Fable · 7-day window",
+            usagePercent: 32,
+            resetsAt: "2026-09-10T16:59:59+00:00",
+          },
+        ],
+      },
+    });
+  });
+
+  it("keeps one entry when a model reports through both model_scoped and limits[]", () => {
+    const projected = projectClaudeAccountUsage(
+      {
+        ...usage,
+        rate_limits: {
+          five_hour: usage.rate_limits.five_hour,
+          model_scoped: [{ display_name: "Fable", utilization: 30, resets_at: null }],
+          limits: [
+            {
+              kind: "weekly_scoped",
+              percent: 32,
+              resets_at: null,
+              scope: { model: { display_name: "Fable" } },
+            },
+          ],
+        } as never,
+      },
+      {},
+    );
+    expect(projected?.credits.productUsage).toEqual([
+      { product: "Fable · 7-day window", usagePercent: 30 },
+    ]);
+  });
+
+  it("ignores an absent, malformed or out-of-range limits[] entry", () => {
+    expect(parseClaudeScopedWeeklyLimits(null)).toEqual([]);
+    expect(parseClaudeScopedWeeklyLimits({})).toEqual([]);
+    expect(parseClaudeScopedWeeklyLimits({ limits: null })).toEqual([]);
+    expect(parseClaudeScopedWeeklyLimits({ limits: "weekly_scoped" })).toEqual([]);
+    expect(
+      parseClaudeScopedWeeklyLimits({
+        limits: [
+          null,
+          { kind: "weekly_all", percent: 60, scope: null },
+          { kind: "weekly_scoped", percent: 32, scope: null },
+          { kind: "weekly_scoped", percent: 32, scope: { model: { display_name: "  " } } },
+          { kind: "weekly_scoped", percent: "32", scope: { model: { display_name: "A" } } },
+          { kind: "weekly_scoped", percent: NaN, scope: { model: { display_name: "B" } } },
+          { kind: "weekly_scoped", percent: 101, scope: { model: { display_name: "C" } } },
+          { kind: "weekly_scoped", percent: -1, scope: { model: { display_name: "D" } } },
+          {
+            kind: "weekly_scoped",
+            percent: 0,
+            resets_at: "not-a-date",
+            scope: { model: { display_name: "E" } },
+          },
+        ],
+      }),
+    ).toEqual([{ product: "E · 7-day window", usagePercent: 0 }]);
+  });
+
+  it("projects a payload without limits[] exactly as before", () => {
+    expect(JSON.stringify(projectClaudeAccountUsage(usage, {}))).toBe(
+      JSON.stringify(
+        projectClaudeAccountUsage(
+          { ...usage, rate_limits: { ...usage.rate_limits, limits: [] } as never },
+          {},
+        ),
+      ),
+    );
   });
 
   it("closes inspection on an unsupported native operation or network error", async () => {

--- a/packages/adapters/claude-code/test/claude-code-adapter.test.ts
+++ b/packages/adapters/claude-code/test/claude-code-adapter.test.ts
@@ -351,6 +351,63 @@ describe("projectClaudePlanLimitToCredits", () => {
       resetsAt: new Date(1_756_648_800 * 1000).toISOString(),
     });
   });
+
+  it("appends per-model weekly windows after the seven-day window", () => {
+    expect(
+      projectClaudePlanLimitToCredits({
+        fiveHour: { utilizationPercent: 62, resetsAtUnix: 1_756_130_400 },
+        sevenDay: { utilizationPercent: 18, resetsAtUnix: 1_756_648_800 },
+        scopedWeekly: [
+          {
+            label: "Fable · 7-day window",
+            utilizationPercent: 32,
+            resetsAtUnix: 1_756_648_799,
+          },
+          { label: "Opus · 7-day window", utilizationPercent: 4 },
+        ],
+      }),
+    ).toEqual({
+      usedPercent: 62,
+      periodType: "five_hour",
+      resetsAt: new Date(1_756_130_400 * 1000).toISOString(),
+      productUsage: [
+        {
+          product: "7-day window",
+          usagePercent: 18,
+          resetsAt: new Date(1_756_648_800 * 1000).toISOString(),
+        },
+        {
+          product: "Fable · 7-day window",
+          usagePercent: 32,
+          resetsAt: new Date(1_756_648_799 * 1000).toISOString(),
+        },
+        { product: "Opus · 7-day window", usagePercent: 4 },
+      ],
+    });
+  });
+
+  it("keeps a per-model window visible when only the five-hour window is known", () => {
+    expect(
+      projectClaudePlanLimitToCredits({
+        fiveHour: { utilizationPercent: 8 },
+        scopedWeekly: [{ label: "Fable · 7-day window", utilizationPercent: 32 }],
+      }),
+    ).toEqual({
+      usedPercent: 8,
+      periodType: "five_hour",
+      productUsage: [{ product: "Fable · 7-day window", usagePercent: 32 }],
+    });
+  });
+
+  it("stays byte-identical to the unscoped projection when no per-model window is known", () => {
+    const unscoped = {
+      fiveHour: { utilizationPercent: 62, resetsAtUnix: 1_756_130_400 },
+      sevenDay: { utilizationPercent: 18, resetsAtUnix: 1_756_648_800 },
+    };
+    expect(JSON.stringify(projectClaudePlanLimitToCredits({ ...unscoped, scopedWeekly: [] }))).toBe(
+      JSON.stringify(projectClaudePlanLimitToCredits(unscoped)),
+    );
+  });
 });
 
 describe("Claude Code HarnessAdapter", () => {

--- a/packages/adapters/claude-code/test/sdk-transport.test.ts
+++ b/packages/adapters/claude-code/test/sdk-transport.test.ts
@@ -51,6 +51,9 @@ class FakeQuery {
     }),
   );
   readonly setModel = vi.fn(async () => undefined);
+  readonly usage_EXPERIMENTAL_MAY_CHANGE_DO_NOT_RELY_ON_THIS_API_YET = vi.fn(
+    async (): Promise<unknown> => ({ rate_limits: {} }),
+  );
   readonly applyFlagSettings = vi.fn(async () => undefined);
   readonly setPermissionMode = vi.fn(async () => undefined);
   #closed = false;
@@ -132,6 +135,22 @@ function completeTurn(fakeQuery: FakeQuery): void {
     subtype: "success",
     is_error: false,
     terminal_reason: "completed",
+  } as unknown as SDKMessage);
+}
+
+function pushRateLimitEvent(fakeQuery: FakeQuery): void {
+  fakeQuery.push({
+    type: "rate_limit_event",
+    rate_limit_info: {
+      status: "allowed",
+      rateLimitType: "five_hour",
+      unifiedWindows: {
+        five_hour: { utilization: 0.45, resetsAt: 1_787_674_200 },
+        seven_day: { utilization: 0.1, resetsAt: 1_787_940_000 },
+      },
+    },
+    uuid: "00000000-0000-4000-8000-000000000099",
+    session_id: "00000000-0000-4000-8000-000000000001",
   } as unknown as SDKMessage);
 }
 
@@ -221,19 +240,7 @@ describe("ClaudeSdkTransport plan-limit forwarding", () => {
     const value = fixture();
     await value.transport.start();
 
-    value.fakeQuery.push({
-      type: "rate_limit_event",
-      rate_limit_info: {
-        status: "allowed",
-        rateLimitType: "five_hour",
-        unifiedWindows: {
-          five_hour: { utilization: 0.45, resetsAt: 1_787_674_200 },
-          seven_day: { utilization: 0.1, resetsAt: 1_787_940_000 },
-        },
-      },
-      uuid: "00000000-0000-4000-8000-000000000099",
-      session_id: "00000000-0000-4000-8000-000000000001",
-    } as unknown as SDKMessage);
+    pushRateLimitEvent(value.fakeQuery);
     await vi.waitFor(() => expect(value.onPlanLimit).toHaveBeenCalledOnce());
     expect(value.onPlanLimit).toHaveBeenCalledWith({
       fiveHour: { utilizationPercent: 45, resetsAtUnix: 1_787_674_200 },
@@ -261,6 +268,66 @@ describe("ClaudeSdkTransport plan-limit forwarding", () => {
     completeTurn(value.fakeQuery);
     await turn;
     expect(value.onPlanLimit).not.toHaveBeenCalled();
+    await value.transport.close();
+  });
+
+  it("enriches the push with per-model weekly windows and probes at most once a minute", async () => {
+    const value = fixture();
+    value.fakeQuery.usage_EXPERIMENTAL_MAY_CHANGE_DO_NOT_RELY_ON_THIS_API_YET.mockResolvedValue({
+      rate_limits: {
+        limits: [
+          { kind: "weekly_all", percent: 10, scope: null },
+          {
+            kind: "weekly_scoped",
+            percent: 32,
+            resets_at: "2026-09-10T16:59:59+00:00",
+            scope: { model: { id: null, display_name: "Fable" } },
+          },
+        ],
+      },
+    });
+    await value.transport.start();
+
+    pushRateLimitEvent(value.fakeQuery);
+    await vi.waitFor(() => expect(value.onPlanLimit).toHaveBeenCalledOnce());
+    const scopedWeekly = [
+      {
+        label: "Fable · 7-day window",
+        utilizationPercent: 32,
+        resetsAtUnix: Math.floor(Date.parse("2026-09-10T16:59:59+00:00") / 1000),
+      },
+    ];
+    expect(value.onPlanLimit).toHaveBeenCalledWith({
+      fiveHour: { utilizationPercent: 45, resetsAtUnix: 1_787_674_200 },
+      sevenDay: { utilizationPercent: 10, resetsAtUnix: 1_787_940_000 },
+      scopedWeekly,
+    });
+
+    pushRateLimitEvent(value.fakeQuery);
+    await vi.waitFor(() => expect(value.onPlanLimit).toHaveBeenCalledTimes(2));
+    expect(value.onPlanLimit).toHaveBeenLastCalledWith(expect.objectContaining({ scopedWeekly }));
+    expect(
+      value.fakeQuery.usage_EXPERIMENTAL_MAY_CHANGE_DO_NOT_RELY_ON_THIS_API_YET,
+    ).toHaveBeenCalledOnce();
+    await value.transport.close();
+  });
+
+  it("forwards the unenriched push when the Usage probe fails", async () => {
+    const value = fixture();
+    value.fakeQuery.usage_EXPERIMENTAL_MAY_CHANGE_DO_NOT_RELY_ON_THIS_API_YET.mockRejectedValue(
+      new Error("get_usage unsupported"),
+    );
+    await value.transport.start();
+
+    pushRateLimitEvent(value.fakeQuery);
+    await vi.waitFor(() => expect(value.onPlanLimit).toHaveBeenCalledOnce());
+    expect(value.onPlanLimit).toHaveBeenCalledWith({
+      fiveHour: { utilizationPercent: 45, resetsAtUnix: 1_787_674_200 },
+      sevenDay: { utilizationPercent: 10, resetsAtUnix: 1_787_940_000 },
+    });
+    expect(
+      value.fakeQuery.usage_EXPERIMENTAL_MAY_CHANGE_DO_NOT_RELY_ON_THIS_API_YET,
+    ).toHaveBeenCalledOnce();
     await value.transport.close();
   });
 });


### PR DESCRIPTION
## Problem

The credits popover under the composer can show the 5-hour and 7-day plan windows, but never a per-model weekly window (for example Fable). That is a data-source gap, not a rendering one: `rate_limit_event` — the stable push the Claude Code transport already tracks — only carries `rate_limit_info.unifiedWindows.{five_hour,seven_day}`. claude.ai does report per-model weekly windows, but only in the `rate_limits.limits[]` array returned by the SDK's experimental `get_usage` control:

```json
{
  "kind": "weekly_scoped",
  "group": "weekly",
  "percent": 32,
  "resets_at": "2026-09-10T16:59:59+00:00",
  "scope": { "model": { "id": null, "display_name": "Fable" } }
}
```

The same gap hid those windows from the account settings page, which reads `rate_limits.model_scoped` — a key that is absent from live payloads and is not declared in the SDK's `.d.ts`.

## Approach

- One shared pure parser, `parseClaudeScopedWeeklyLimits`, reads `limits[]` defensively from `unknown`: it keeps entries whose `kind` is `weekly_scoped` and whose `scope.model.display_name` is a non-empty string with a finite `percent` in `0..100`, and de-duplicates by display name. Nothing is keyed on a specific model name, so a new model surfaces without a code change.
- The account inspector merges the parsed windows into its existing window list, skipping any model that already reported through a fixed key.
- The transport enriches each `rate_limit_event` by calling `get_usage` on the *same* active query — no new credential read, no direct HTTP, no new configuration. The probe is throttled to one call per 60 seconds (events in between reuse the cached result) and bounded to 5 seconds. If the control is unsupported, rejects, times out, or returns a payload without `limits[]`, the transport forwards exactly the event it forwarded before; the push is never dropped and never turns into an error.
- The projection appends the scoped windows to `productUsage` after the 7-day window, so the popover keeps its existing ordering and the shared `AccountCreditsSnapshot` schema is unchanged.

A second commit unifies the label suffix: `OAuth apps · 7-day`, `Opus · 7-day` and `Sonnet · 7-day` now read `... · 7-day window`, which is the suffix the renderer's `productLabel` keys off. Without it those tiles stayed English in a Chinese UI, and they could not be de-duplicated against `limits[]` entries for the same model.

## Verification

- `packages/adapters/claude-code` and `packages/renderer-extension` vitest suites: 610 passed / 3 skipped. New cases cover a `weekly_scoped` Fable entry reaching `productUsage`, a missing / null / non-array / display-name-less / non-numeric / out-of-range `limits[]` degrading to byte-identical output, de-duplication against both `model_scoped` and the fixed weekly keys, and three transport cases (the event triggers `get_usage`; a rejected `get_usage` still forwards the plain event; a second event within 60 seconds does not probe again).
- `npm run build:typescript` and `npm run lint` pass.
- Real payload: a live `usage_EXPERIMENTAL_MAY_CHANGE_DO_NOT_RELY_ON_THIS_API_YET()` response fed to the built artifact yields `[{"product":"Fable · 7-day window","usagePercent":34,"resetsAt":"2026-09-10T17:00:00+00:00"}]`, and the account projection lists it after the global 7-day window.
- The renderer needs no new branch: `productLabel("Fable · 7-day window")` already resolves to `Fable · 7-day limit` in English and `Fable · 7 天额度` in Chinese.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
