### PR TITLE
feat(renderer): add optional soft wrap for thinking transcripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,10 @@ xattr -dr com.apple.quarantine /Applications/codexhost.app
 
 </details>
 
+### 外观设置
+
+在 `设置 → 外观` 中可以开启 **换行显示思考文本**，让思考块中的长行自动换行。该选项默认关闭，选择保存在本机并立即生效，普通 Shell 输出不受影响。
+
 ### 交互展示
 
 <table>

--- a/docs/README.en.md
+++ b/docs/README.en.md
@@ -94,6 +94,10 @@ Fully quit Codex Desktop, open a new terminal, and start codexhost.
 
 </details>
 
+### Appearance settings
+
+In `Settings → Appearance`, enable **Wrap thinking text** to wrap long lines in the persisted thinking transcript. It is off by default, saved locally, and takes effect immediately. Ordinary shell output is unchanged.
+
 ### Interaction examples
 
 <table>

--- a/packages/renderer-extension/src/renderer-binding-probe.ts
+++ b/packages/renderer-extension/src/renderer-binding-probe.ts
@@ -44,6 +44,7 @@ import {
   type ExternalPermissionModeControlView,
 } from "./renderer-composer-dom.js";
 import { rendererHarnessMessages } from "./renderer-harness-localization.js";
+import { installReasoningTranscriptSoftWrap } from "./renderer-transcript-dom.js";
 import { RendererCodexAccountState } from "./renderer-codex-account-state.js";
 import {
   decodeAntigravityTransportModelId,
@@ -622,6 +623,7 @@ export function installRendererBindingProbe(
   const mountedByComposer = new Map<Element, MountedComposer>();
   const pendingReplacements = new Map<Element, PendingComposerReplacement>();
   let disposed = false;
+  const disposeReasoningSoftWrap = installReasoningTranscriptSoftWrap(document);
   let scanScheduled = false;
   let refreshTargetsOnNextScan = false;
   let adapterDispose: (() => void) | null = null;
@@ -2828,6 +2830,7 @@ export function installRendererBindingProbe(
       applyAdapterAgent = null;
       modelControl = null;
       mutationObserver.disconnect();
+      disposeReasoningSoftWrap();
       sidebarAgentIcons.dispose();
       settingsLifecycle.dispose();
       document.removeEventListener("beforeinput", onBeforeInput, true);

--- a/packages/renderer-extension/src/renderer-transcript-dom.ts
+++ b/packages/renderer-extension/src/renderer-transcript-dom.ts
@@ -1,6 +1,53 @@
+import { REASONING_TRANSCRIPT_COMMAND } from "@codexhost/shared-contracts";
+
 export const TRANSCRIPT_ITEM_SELECTOR = "[data-local-conversation-item-target-ids]";
 export const TRANSCRIPT_ITEM_IDS_ATTRIBUTE = "data-local-conversation-item-target-ids";
 export const TRANSCRIPT_TEXT_BODY_SELECTOR = '[data-testid="exec-shell-body"]';
+export const REASONING_SOFT_WRAP_STORAGE_KEY = "codexhost.reasoning-soft-wrap.v1";
+export const REASONING_SOFT_WRAP_CHANGE_EVENT = "codexhost:reasoning-soft-wrap-changed";
+
+export function readReasoningTranscriptSoftWrap(ownerWindow: Window): boolean {
+  return ownerWindow.localStorage.getItem(REASONING_SOFT_WRAP_STORAGE_KEY) === "true";
+}
+
+export function setReasoningTranscriptSoftWrap(ownerWindow: Window, enabled: boolean): void {
+  ownerWindow.localStorage.setItem(REASONING_SOFT_WRAP_STORAGE_KEY, String(enabled));
+  ownerWindow.dispatchEvent(new Event(REASONING_SOFT_WRAP_CHANGE_EVENT));
+}
+
+export function installReasoningTranscriptSoftWrap(ownerDocument: Document): () => void {
+  const ownerWindow = ownerDocument.defaultView!;
+  const style = ownerDocument.createElement("style");
+  style.setAttribute("data-codexhost-reasoning-soft-wrap", "true");
+  // Scope to the sentinel command, not ordinary terminal output. The native
+  // output scroller's w-max child must also shrink for wrapping to take effect.
+  const body = `${TRANSCRIPT_TEXT_BODY_SELECTOR}:has([aria-label="$ ${REASONING_TRANSCRIPT_COMMAND}"])`;
+  style.textContent = `
+    ${body} .whitespace-pre {
+      white-space: pre-wrap;
+      overflow-wrap: anywhere;
+    }
+    ${body} .whitespace-pre > .w-max {
+      width: 100%;
+      min-width: 0;
+    }
+  `;
+  ownerDocument.head.append(style);
+  const refresh = (): void => {
+    style.disabled = !readReasoningTranscriptSoftWrap(ownerWindow);
+  };
+  const onStorage = (event: StorageEvent): void => {
+    if (event.key === REASONING_SOFT_WRAP_STORAGE_KEY || event.key === null) refresh();
+  };
+  refresh();
+  ownerWindow.addEventListener(REASONING_SOFT_WRAP_CHANGE_EVENT, refresh);
+  ownerWindow.addEventListener("storage", onStorage);
+  return () => {
+    ownerWindow.removeEventListener(REASONING_SOFT_WRAP_CHANGE_EVENT, refresh);
+    ownerWindow.removeEventListener("storage", onStorage);
+    style.remove();
+  };
+}
 
 export interface RendererTranscriptContractInspection {
   /** Rendered Turn containers, used to tell an empty Thread from a missing contract. */

--- a/packages/renderer-extension/src/renderer-transcript-dom.ts
+++ b/packages/renderer-extension/src/renderer-transcript-dom.ts
@@ -16,7 +16,8 @@ export function setReasoningTranscriptSoftWrap(ownerWindow: Window, enabled: boo
 }
 
 export function installReasoningTranscriptSoftWrap(ownerDocument: Document): () => void {
-  const ownerWindow = ownerDocument.defaultView!;
+  const ownerWindow = ownerDocument.defaultView;
+  if (!ownerWindow) return () => {};
   const style = ownerDocument.createElement("style");
   style.setAttribute("data-codexhost-reasoning-soft-wrap", "true");
   // Scope to the sentinel command, not ordinary terminal output. The native

--- a/packages/renderer-extension/src/settings/appearance-page.ts
+++ b/packages/renderer-extension/src/settings/appearance-page.ts
@@ -15,7 +15,8 @@ export function createAppearanceSettingsPage(
     icon: "settings",
     mount(context: RendererSettingsPageMountContext) {
       const document = context.content.ownerDocument;
-      const ownerWindow = document.defaultView!;
+      const ownerWindow = document.defaultView;
+      if (!ownerWindow) return;
       const heading = document.createElement("div");
       heading.className = "settings-section-label";
       heading.textContent = messages.pageLabels.appearance;

--- a/packages/renderer-extension/src/settings/appearance-page.ts
+++ b/packages/renderer-extension/src/settings/appearance-page.ts
@@ -1,0 +1,56 @@
+import {
+  REASONING_SOFT_WRAP_CHANGE_EVENT,
+  readReasoningTranscriptSoftWrap,
+  setReasoningTranscriptSoftWrap,
+} from "../renderer-transcript-dom.js";
+import type { RendererSettingsPageDefinition, RendererSettingsPageMountContext } from "./core.js";
+import type { RendererSettingsMessages } from "./localization.js";
+
+export function createAppearanceSettingsPage(
+  messages: RendererSettingsMessages,
+): RendererSettingsPageDefinition {
+  return Object.freeze({
+    id: "appearance",
+    label: messages.pageLabels.appearance,
+    icon: "settings",
+    mount(context: RendererSettingsPageMountContext) {
+      const document = context.content.ownerDocument;
+      const ownerWindow = document.defaultView!;
+      const heading = document.createElement("div");
+      heading.className = "settings-section-label";
+      heading.textContent = messages.pageLabels.appearance;
+
+      const description = document.createElement("p");
+      description.className = "settings-page-description";
+      description.textContent = messages.appearanceDescription;
+
+      const row = document.createElement("label");
+      row.className = "settings-preference-row";
+      const copy = document.createElement("span");
+      copy.className = "settings-preference-row__copy";
+      const title = document.createElement("strong");
+      title.textContent = messages.reasoningSoftWrapTitle;
+      const detail = document.createElement("span");
+      detail.textContent = messages.reasoningSoftWrapDescription;
+      copy.append(title, detail);
+
+      const checkbox = document.createElement("input");
+      checkbox.type = "checkbox";
+      checkbox.className = "settings-preference-checkbox";
+      checkbox.checked = readReasoningTranscriptSoftWrap(ownerWindow);
+      checkbox.setAttribute("aria-label", messages.reasoningSoftWrapTitle);
+      checkbox.addEventListener("change", () => {
+        setReasoningTranscriptSoftWrap(ownerWindow, checkbox.checked);
+      });
+
+      const sync = (): void => {
+        checkbox.checked = readReasoningTranscriptSoftWrap(ownerWindow);
+      };
+      ownerWindow.addEventListener(REASONING_SOFT_WRAP_CHANGE_EVENT, sync);
+
+      row.append(copy, checkbox);
+      context.content.append(heading, description, row);
+      return () => ownerWindow.removeEventListener(REASONING_SOFT_WRAP_CHANGE_EVENT, sync);
+    },
+  });
+}

--- a/packages/renderer-extension/src/settings/localization.ts
+++ b/packages/renderer-extension/src/settings/localization.ts
@@ -25,6 +25,9 @@ export interface RendererSettingsMessages {
   readonly sectionsLabel: string;
   readonly generalSection: string;
   readonly otherSection: string;
+  readonly appearanceDescription: string;
+  readonly reasoningSoftWrapTitle: string;
+  readonly reasoningSoftWrapDescription: string;
   readonly pageUnavailable: string;
   readonly inDevelopment: string;
   readonly notAvailable: string;
@@ -220,6 +223,10 @@ const ENGLISH_MESSAGES: RendererSettingsMessages = Object.freeze({
   sectionsLabel: "Settings sections",
   generalSection: "General",
   otherSection: "Other",
+  appearanceDescription: "Adjust how thinking text is displayed in the conversation.",
+  reasoningSoftWrapTitle: "Wrap thinking text",
+  reasoningSoftWrapDescription:
+    "Wrap long thinking lines in the transcript. Ordinary shell output is unaffected. Off by default.",
   pageUnavailable: "Page unavailable",
   inDevelopment: "In development",
   notAvailable: "Not available",
@@ -427,6 +434,7 @@ const ENGLISH_MESSAGES: RendererSettingsMessages = Object.freeze({
   aboutRepository: "Open-source repository",
   pageLabels: Object.freeze({
     connections: "Connections",
+    appearance: "Appearance",
     accounts: "Accounts",
     "session-import": "Session Import",
     updates: "Updates",
@@ -442,6 +450,9 @@ const CHINESE_MESSAGES: RendererSettingsMessages = Object.freeze({
   sectionsLabel: "设置分类",
   generalSection: "通用",
   otherSection: "其他",
+  appearanceDescription: "调整会话中思考文本的显示方式。",
+  reasoningSoftWrapTitle: "换行显示思考文本",
+  reasoningSoftWrapDescription: "让思考块中的长行自动换行。普通 Shell 输出不受影响。默认关闭。",
   pageUnavailable: "页面不可用",
   inDevelopment: "开发中",
   notAvailable: "暂不可用",
@@ -641,6 +652,7 @@ const CHINESE_MESSAGES: RendererSettingsMessages = Object.freeze({
   aboutRepository: "开源仓库",
   pageLabels: Object.freeze({
     connections: "连接",
+    appearance: "外观",
     accounts: "账号",
     "session-import": "会话导入",
     updates: "更新",

--- a/packages/renderer-extension/src/settings/pages.ts
+++ b/packages/renderer-extension/src/settings/pages.ts
@@ -26,6 +26,7 @@ import {
   type RendererSessionImportClient,
   type RendererImportedThreadOpener,
 } from "./session-import-page.js";
+import { createAppearanceSettingsPage } from "./appearance-page.js";
 import { createReleaseNotesElement } from "./release-notes.js";
 import { createAccountsSettingsPage, type RendererCodexAccountClient } from "./accounts-page.js";
 
@@ -71,6 +72,7 @@ function windowsInstallerDownloadUrl(window: Window | null | undefined, version:
 
 export const DEFAULT_RENDERER_SETTINGS_PAGE_IDS = [
   "connections",
+  "appearance",
   "accounts",
   "session-import",
   "updates",
@@ -585,6 +587,7 @@ export function createDefaultRendererSettingsPages(
 ): readonly RendererSettingsPageDefinition[] {
   return Object.freeze([
     createConnectionsSettingsPage(messages, getDiagnostics),
+    createAppearanceSettingsPage(messages),
     createAccountsSettingsPage(messages, getAccountClient),
     createSessionImportSettingsPage(messages, getSessionImportClient, openImportedThread),
     updatesPage(messages, getUpdateClient),

--- a/packages/renderer-extension/src/settings/pages.ts
+++ b/packages/renderer-extension/src/settings/pages.ts
@@ -72,9 +72,9 @@ function windowsInstallerDownloadUrl(window: Window | null | undefined, version:
 
 export const DEFAULT_RENDERER_SETTINGS_PAGE_IDS = [
   "connections",
-  "appearance",
   "accounts",
   "session-import",
+  "appearance",
   "updates",
   "about",
 ] as const;
@@ -587,9 +587,9 @@ export function createDefaultRendererSettingsPages(
 ): readonly RendererSettingsPageDefinition[] {
   return Object.freeze([
     createConnectionsSettingsPage(messages, getDiagnostics),
-    createAppearanceSettingsPage(messages),
     createAccountsSettingsPage(messages, getAccountClient),
     createSessionImportSettingsPage(messages, getSessionImportClient, openImportedThread),
+    createAppearanceSettingsPage(messages),
     updatesPage(messages, getUpdateClient),
     aboutPage(messages),
   ]);

--- a/packages/renderer-extension/src/settings/shell.css
+++ b/packages/renderer-extension/src/settings/shell.css
@@ -731,6 +731,20 @@ button {
   box-shadow: 0 1px 3px rgb(0 0 0 / 24%);
 }
 
+.settings-preference-checkbox {
+  width: 18px;
+  height: 18px;
+  flex: none;
+  margin: 0;
+  accent-color: var(--settings-focus);
+  cursor: pointer;
+}
+
+.settings-preference-checkbox:focus-visible {
+  outline: 2px solid var(--settings-focus);
+  outline-offset: 2px;
+}
+
 .settings-connection-page-header {
   display: flex;
   align-items: flex-start;

--- a/packages/renderer-extension/test/renderer-transcript-dom.test.ts
+++ b/packages/renderer-extension/test/renderer-transcript-dom.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from "vitest";
+
+import { installReasoningTranscriptSoftWrap } from "../src/renderer-transcript-dom.js";
+
+describe("Reasoning transcript soft wrap", () => {
+  it("does not install styling when the owner document has no Window", () => {
+    const dispose = installReasoningTranscriptSoftWrap({ defaultView: null } as unknown as Document);
+
+    expect(dispose).not.toThrow();
+    expect(() => dispose()).not.toThrow();
+  });
+});

--- a/packages/renderer-extension/test/settings/appearance-page.test.ts
+++ b/packages/renderer-extension/test/settings/appearance-page.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from "vitest";
+
+import { createAppearanceSettingsPage } from "../../src/settings/appearance-page.js";
+import { rendererSettingsMessages } from "../../src/settings/localization.js";
+
+describe("Appearance settings page", () => {
+  it("does not access preferences when its document has no Window", () => {
+    const page = createAppearanceSettingsPage(rendererSettingsMessages("en"));
+    const context = {
+      content: { ownerDocument: { defaultView: null } },
+    } as unknown as Parameters<typeof page.mount>[0];
+
+    expect(page.mount(context)).toBeUndefined();
+  });
+});

--- a/packages/renderer-extension/test/settings/localization.test.ts
+++ b/packages/renderer-extension/test/settings/localization.test.ts
@@ -75,6 +75,6 @@ describe("Renderer settings localization", () => {
       createDefaultRendererSettingsPages(rendererSettingsMessages("zh-CN")).map(
         ({ label }) => label,
       ),
-    ).toEqual(["连接", "账号", "会话导入", "更新", "关于"]);
+    ).toEqual(["连接", "外观", "账号", "会话导入", "更新", "关于"]);
   });
 });

--- a/packages/renderer-extension/test/settings/localization.test.ts
+++ b/packages/renderer-extension/test/settings/localization.test.ts
@@ -75,6 +75,6 @@ describe("Renderer settings localization", () => {
       createDefaultRendererSettingsPages(rendererSettingsMessages("zh-CN")).map(
         ({ label }) => label,
       ),
-    ).toEqual(["连接", "外观", "账号", "会话导入", "更新", "关于"]);
+    ).toEqual(["连接", "账号", "会话导入", "外观", "更新", "关于"]);
   });
 });

--- a/packages/renderer-extension/test/settings/shell.test.ts
+++ b/packages/renderer-extension/test/settings/shell.test.ts
@@ -22,17 +22,17 @@ describe("Renderer settings foundation", () => {
     expect(pages.map(({ id }) => id)).toEqual(DEFAULT_RENDERER_SETTINGS_PAGE_IDS);
     expect(pages.map(({ label }) => label)).toEqual([
       "Connections",
-      "Appearance",
       "Accounts",
       "Session Import",
+      "Appearance",
       "Updates",
       "About",
     ]);
     expect(pages.map(({ icon }) => icon)).toEqual([
       "connections",
-      "settings",
       "accounts",
       "session-import",
+      "settings",
       "updates",
       "about",
     ]);
@@ -64,9 +64,9 @@ describe("Renderer settings foundation", () => {
 
     expect(pages.map(({ id }) => id)).toEqual([
       "connections",
-      "appearance",
       "accounts",
       "session-import",
+      "appearance",
       "updates",
       "about",
     ]);

--- a/packages/renderer-extension/test/settings/shell.test.ts
+++ b/packages/renderer-extension/test/settings/shell.test.ts
@@ -22,6 +22,7 @@ describe("Renderer settings foundation", () => {
     expect(pages.map(({ id }) => id)).toEqual(DEFAULT_RENDERER_SETTINGS_PAGE_IDS);
     expect(pages.map(({ label }) => label)).toEqual([
       "Connections",
+      "Appearance",
       "Accounts",
       "Session Import",
       "Updates",
@@ -29,6 +30,7 @@ describe("Renderer settings foundation", () => {
     ]);
     expect(pages.map(({ icon }) => icon)).toEqual([
       "connections",
+      "settings",
       "accounts",
       "session-import",
       "updates",
@@ -62,6 +64,7 @@ describe("Renderer settings foundation", () => {
 
     expect(pages.map(({ id }) => id)).toEqual([
       "connections",
+      "appearance",
       "accounts",
       "session-import",
       "updates",


### PR DESCRIPTION
## Summary
Add an opt-in **Wrap thinking text** checkbox under **Settings → Appearance**. This is an optional display feature, disabled by default so the existing transcript layout remains unchanged unless the user enables it.

## Behavior
- Save the preference locally and apply changes immediately, including already-rendered and newly mounted thinking blocks.
- Wrap only the synthetic `thinking` command transcript. Ordinary shell output retains its native layout.
- Preserve the collapsible card, original text, copy behavior, and reasoning protocol semantics; no conversion to assistant messages.
- Include English and Simplified Chinese settings text and brief documentation.

## Implementation
Scope CSS to `exec-shell-body` containing the sentinel command label. Override the output scroller white-space and its intrinsic-width child so long lines actually wrap. Remove the stylesheet and preference listeners when the renderer binding is disposed.

## Validation
- `npm run build:typescript`
- `npm run build:renderer`
- `npx tsc -b packages/renderer-extension --pretty false`
- `npx vitest run --config tests/vitest.config.js packages/renderer-extension/test/settings` — 8 files, 72 tests passed
- Chromium fixture using the observed native shell DOM structure: default off, enable/disable, persisted preference, unchanged text, ordinary shell isolation.

The browser check used a DOM fixture, not a full restarted Codex Desktop session. The selector follows the currently observed native shell markup; future Desktop markup changes may require an update.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an **Appearance** settings page.
  - Added a **Wrap thinking text** option to automatically wrap long lines in thinking transcripts.
  - The option is disabled by default, saved locally, and takes effect immediately.
  - Available in English and Chinese.
  - Normal Shell output remains unaffected.

- **Documentation**
  - Updated the English and Chinese README files with details about the new appearance setting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->