### PR TITLE
fix: recover unbound legacy Codex Threads on read and resume

### DIFF
--- a/packages/host-runtime/src/account/thread-account-store.ts
+++ b/packages/host-runtime/src/account/thread-account-store.ts
@@ -63,8 +63,11 @@ export class ThreadAccountStore implements ThreadAccountStoreLike {
     try {
       await this.#persist();
     } catch (error) {
-      // Roll back the in-memory binding: it must not outlive its own failed persistence.
+      // Roll back the in-memory binding: it must not outlive its own failed
+      // persistence. Persist again so a write queued before the rollback
+      // cannot leave the rolled-back binding on disk.
       this.#bindings.delete(threadId);
+      await this.#persist().catch(() => undefined);
       throw error;
     }
   }
@@ -98,11 +101,13 @@ export class ThreadAccountStore implements ThreadAccountStoreLike {
   }
 
   #persist(): Promise<void> {
-    const value: StoredThreadAccountsV1 = {
-      formatVersion: 1,
-      bindings: Object.fromEntries(this.#bindings),
-    };
     const operation = this.#writeTail.then(async () => {
+      // Snapshot at execution time: a binding rolled back after a later write
+      // was queued must not be revived by that write's stale snapshot.
+      const value: StoredThreadAccountsV1 = {
+        formatVersion: 1,
+        bindings: Object.fromEntries(this.#bindings),
+      };
       const temporary = `${this.#file}.${process.pid}.${randomUUID()}.tmp`;
       await writeFile(temporary, `${JSON.stringify(value, null, 2)}\n`, { mode: 0o600 });
       await rename(temporary, this.#file);

--- a/packages/host-runtime/src/account/thread-account-store.ts
+++ b/packages/host-runtime/src/account/thread-account-store.ts
@@ -60,7 +60,13 @@ export class ThreadAccountStore implements ThreadAccountStoreLike {
     }
     if (existing === accountId) return;
     this.#bindings.set(threadId, accountId);
-    await this.#persist();
+    try {
+      await this.#persist();
+    } catch (error) {
+      // Roll back the in-memory binding: it must not outlive its own failed persistence.
+      this.#bindings.delete(threadId);
+      throw error;
+    }
   }
 
   async listByAccount(accountId: string): Promise<string[]> {

--- a/packages/host-runtime/src/app-server-host.ts
+++ b/packages/host-runtime/src/app-server-host.ts
@@ -1479,9 +1479,13 @@ export class AppServerHost {
     else await this.#writer.json(forwarded);
   }
 
-  async #requestOfficial(method: string, params: JsonObject): Promise<JsonObject> {
+  async #requestOfficial(
+    method: string,
+    params: JsonObject,
+    options?: { recoverUnboundThread?: boolean },
+  ): Promise<JsonObject> {
     return typeof params.threadId === "string"
-      ? this.#codexRuntimePool.requestForThread(params.threadId, method, params)
+      ? this.#codexRuntimePool.requestForThread(params.threadId, method, params, options)
       : this.#codexRuntimePool.requestActive(method, params);
   }
 
@@ -2165,10 +2169,14 @@ export class AppServerHost {
   }
 
   async #readOfficialDelegationThread(input: ThreadReadInput): Promise<DelegationThreadSnapshot> {
-    const response = await this.#requestOfficial("thread/read", {
-      threadId: input.threadId,
-      includeTurns: true,
-    });
+    const response = await this.#requestOfficial(
+      "thread/read",
+      {
+        threadId: input.threadId,
+        includeTurns: true,
+      },
+      { recoverUnboundThread: true },
+    );
     if (isRecord(response.error)) {
       throw new DelegationControlError(
         "THREAD_NOT_FOUND",

--- a/packages/host-runtime/src/app-server-host.ts
+++ b/packages/host-runtime/src/app-server-host.ts
@@ -1295,8 +1295,13 @@ export class AppServerHost {
       const threadId = params && typeof params.threadId === "string" ? params.threadId : null;
       const loginId = params && typeof params.loginId === "string" ? params.loginId : null;
       const loginAccountId = loginId ? await this.#resolveLoginAccountId(loginId) : undefined;
+      // Legacy pre-pool Threads may lack an Account binding. Reading or
+      // resuming such a Thread may recover ownership via official discovery;
+      // other requests on unbound Threads keep failing fast.
+      const recoverUnboundThread =
+        request.method === "thread/read" || request.method === "thread/resume";
       const runtime = threadId
-        ? await this.#codexRuntimePool.forThread(threadId)
+        ? await this.#codexRuntimePool.forThread(threadId, { recoverUnboundThread })
         : loginAccountId
           ? await this.#codexRuntimePool.get(loginAccountId)
           : requestedAccountId

--- a/packages/host-runtime/src/codex-runtime/codex-runtime-pool.ts
+++ b/packages/host-runtime/src/codex-runtime/codex-runtime-pool.ts
@@ -72,10 +72,16 @@ export class CodexRuntimePool {
     return this.#ensureInitialized(await this.#load(accountId));
   }
 
-  async forThread(threadId: string): Promise<CodexRuntime> {
+  async forThread(
+    threadId: string,
+    options?: { recoverUnboundThread?: boolean },
+  ): Promise<CodexRuntime> {
     const accountId =
       (await this.#threadAccounts.getAccountId(threadId)) ??
-      (await this.#discoverHistoricalThreadAccount(threadId));
+      (await this.#discoverHistoricalThreadAccount(
+        threadId,
+        options?.recoverUnboundThread === true,
+      ));
     if (!accountId) throw new UnknownCodexThreadAccountError(threadId);
     return this.get(accountId);
   }
@@ -206,12 +212,18 @@ export class CodexRuntimePool {
     return runtime;
   }
 
-  async #discoverHistoricalThreadAccount(threadId: string): Promise<string | null> {
+  async #discoverHistoricalThreadAccount(
+    threadId: string,
+    includeSingleAccount: boolean,
+  ): Promise<string | null> {
+    // Discovery is a migration path for pre-pool Threads that never received
+    // a binding. With several Accounts every CODEX_HOME is consulted; with a
+    // single Account it runs only for explicit recovery requests (thread
+    // read/resume) so mutating requests on unbound Threads keep failing fast.
+    // A binding is written only after an official thread/read confirms the
+    // Thread, never assumed.
     const accounts = await this.#accounts.list();
-    // A missing binding in a single-account installation remains an explicit
-    // error. Discovery is a migration path for pre-pool tasks once multiple
-    // isolated CODEX_HOMEs exist.
-    if (accounts.length < 2) return null;
+    if (accounts.length === 0 || (accounts.length === 1 && !includeSingleAccount)) return null;
     const loadedAccounts = accounts.filter((account) => this.#runtimes.has(account.accountId));
     const unloadedAccounts = accounts.filter((account) => !this.#runtimes.has(account.accountId));
     for (const candidates of [loadedAccounts, unloadedAccounts]) {

--- a/packages/host-runtime/src/codex-runtime/codex-runtime-pool.ts
+++ b/packages/host-runtime/src/codex-runtime/codex-runtime-pool.ts
@@ -130,8 +130,9 @@ export class CodexRuntimePool {
     threadId: string,
     method: string,
     params: JsonObject,
+    options?: { recoverUnboundThread?: boolean },
   ): Promise<JsonObject> {
-    return (await this.forThread(threadId)).request(method, params);
+    return (await this.forThread(threadId, options)).request(method, params);
   }
 
   async close(): Promise<void> {
@@ -257,7 +258,14 @@ export class CodexRuntimePool {
       if (matches.length > 1) return null;
       const accountId = matches[0];
       if (!accountId) continue;
-      await this.#threadAccounts.bind(threadId, accountId);
+      try {
+        await this.#threadAccounts.bind(threadId, accountId);
+      } catch (error) {
+        // A failed binding write must not kill the Host or leave the caller
+        // hanging: report the Thread as unbound so the request fails cleanly.
+        this.#diagnose(error);
+        return null;
+      }
       return accountId;
     }
     return null;

--- a/packages/host-runtime/test/account-routing.test.ts
+++ b/packages/host-runtime/test/account-routing.test.ts
@@ -1,8 +1,9 @@
 import { mkdtemp, readFile, rm, stat } from "node:fs/promises";
+import type * as nodeFsPromises from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import type { JsonObject } from "@codexhost/protocol-core";
 
@@ -13,6 +14,22 @@ import {
   UnknownCodexThreadAccountError,
   type CodexAccount,
 } from "../src/index.js";
+
+const fsFailures = vi.hoisted(() => ({ remaining: 0 }));
+
+vi.mock("node:fs/promises", async (importOriginal) => {
+  const actual = await importOriginal<typeof nodeFsPromises>();
+  return {
+    ...actual,
+    writeFile: vi.fn((...args: Parameters<typeof nodeFsPromises.writeFile>) => {
+      if (fsFailures.remaining > 0) {
+        fsFailures.remaining -= 1;
+        return Promise.reject(new Error("simulated persistence failure"));
+      }
+      return actual.writeFile(...args);
+    }),
+  };
+});
 import type { OfficialAppServerConnection } from "../src/official-app-server-connection.js";
 import { PassThrough } from "node:stream";
 
@@ -212,6 +229,28 @@ describe("Codex Account routing persistence", () => {
     await expect(threads.bind("thread-b", "account-a")).rejects.toThrow();
     await expect(threads.getAccountId("thread-b")).resolves.toBeNull();
     await expect(threads.getAccountId("thread-a")).resolves.toBe("account-a");
+  });
+
+  it("keeps memory and disk consistent when a raced persistence fails", async () => {
+    const directory = await mkdtemp(path.join(tmpdir(), "codexhost-account-binding-test-"));
+    directories.push(directory);
+    const threads = new ThreadAccountStore({ directory });
+    await threads.initialize();
+
+    // The second bind queues its write before the first bind's failure is
+    // known; its write must not resurrect the rolled-back binding on disk.
+    fsFailures.remaining = 1;
+    const first = threads.bind("thread-a", "account-a");
+    const second = threads.bind("thread-b", "account-a");
+    await expect(first).rejects.toThrow("simulated persistence failure");
+    await expect(second).resolves.toBeUndefined();
+
+    await expect(threads.getAccountId("thread-a")).resolves.toBeNull();
+    await expect(threads.getAccountId("thread-b")).resolves.toBe("account-a");
+    const persisted = JSON.parse(
+      await readFile(path.join(directory, "thread-accounts.json"), "utf8"),
+    ) as { bindings: Record<string, string> };
+    expect(persisted.bindings).toEqual({ "thread-b": "account-a" });
   });
 
   it("removes Thread ownership bindings for a deleted Account", async () => {

--- a/packages/host-runtime/test/account-routing.test.ts
+++ b/packages/host-runtime/test/account-routing.test.ts
@@ -200,6 +200,20 @@ describe("Codex Account routing persistence", () => {
     await expect(accounts.list()).resolves.toMatchObject([{ accountId: "account-a" }]);
   });
 
+  it("rolls back an in-memory binding when its persistence fails", async () => {
+    const directory = await mkdtemp(path.join(tmpdir(), "codexhost-account-binding-test-"));
+    directories.push(directory);
+    const storeDirectory = path.join(directory, "store");
+    const threads = new ThreadAccountStore({ directory: storeDirectory });
+    await threads.initialize();
+    await threads.bind("thread-a", "account-a");
+
+    await rm(storeDirectory, { recursive: true });
+    await expect(threads.bind("thread-b", "account-a")).rejects.toThrow();
+    await expect(threads.getAccountId("thread-b")).resolves.toBeNull();
+    await expect(threads.getAccountId("thread-a")).resolves.toBe("account-a");
+  });
+
   it("removes Thread ownership bindings for a deleted Account", async () => {
     const directory = await mkdtemp(path.join(tmpdir(), "codexhost-account-binding-delete-test-"));
     directories.push(directory);

--- a/packages/host-runtime/test/account-routing.test.ts
+++ b/packages/host-runtime/test/account-routing.test.ts
@@ -4,14 +4,56 @@ import path from "node:path";
 
 import { afterEach, describe, expect, it } from "vitest";
 
+import type { JsonObject } from "@codexhost/protocol-core";
+
 import {
   AccountRepository,
   CodexRuntimePool,
   ThreadAccountStore,
+  UnknownCodexThreadAccountError,
   type CodexAccount,
 } from "../src/index.js";
 import type { OfficialAppServerConnection } from "../src/official-app-server-connection.js";
 import { PassThrough } from "node:stream";
+
+function fakeAppServerConnection(
+  knownThreadIds: readonly string[],
+  receivedRequests?: string[],
+): OfficialAppServerConnection {
+  const stdin = new PassThrough();
+  const stdout = new PassThrough();
+  const stderr = new PassThrough();
+  const closed = Promise.withResolvers<{ code: number | null; signal: NodeJS.Signals | null }>();
+  stdin.setEncoding("utf8");
+  stdin.on("data", (chunk: string) => {
+    for (const line of chunk.split("\n").filter(Boolean)) {
+      const request = JSON.parse(line) as { id?: string; method?: string; params?: JsonObject };
+      if (request.method) receivedRequests?.push(request.method);
+      if (request.method !== "thread/read" || !request.id) continue;
+      const threadId = (request.params as { threadId?: unknown } | undefined)?.threadId;
+      const found = typeof threadId === "string" && knownThreadIds.includes(threadId);
+      stdout.write(
+        `${JSON.stringify(
+          found
+            ? { id: request.id, result: { thread: { id: threadId } } }
+            : { id: request.id, error: { code: -32000, message: "not found" } },
+        )}\n`,
+      );
+    }
+  });
+  return {
+    stdin,
+    stdout,
+    stderr,
+    closed: closed.promise,
+    close() {
+      stdin.end();
+      stdout.end();
+      stderr.end();
+      closed.resolve({ code: 0, signal: null });
+    },
+  };
+}
 
 describe("Codex Account routing persistence", () => {
   const directories: string[] = [];
@@ -242,6 +284,93 @@ describe("Codex Account routing persistence", () => {
     });
     expect(spawned).toEqual(["account-a", "account-b"]);
     await expect(threadAccounts.getAccountId("historical-thread-b")).resolves.toBe("account-b");
+    await pool.close();
+  });
+
+  it("discovers a historical Thread that predates bindings in a single-Account installation", async () => {
+    const directory = await mkdtemp(path.join(tmpdir(), "codexhost-history-discovery-test-"));
+    directories.push(directory);
+    const metadata = path.join(directory, "metadata");
+    const accounts = new AccountRepository({
+      directory: metadata,
+      defaultAccount: { accountId: "account-a", codexHome: path.join(directory, "home-a") },
+    });
+    const threadAccounts = new ThreadAccountStore({ directory: metadata });
+    const pool = new CodexRuntimePool({
+      accounts,
+      threadAccounts,
+      createConnection: async () => fakeAppServerConnection(["historical-thread"]),
+      diagnosticOutput: new PassThrough(),
+      onOutput: async () => undefined,
+      diagnose: () => undefined,
+    });
+
+    await pool.initialize();
+    await pool.active();
+    await expect(
+      pool.forThread("historical-thread", { recoverUnboundThread: true }),
+    ).resolves.toMatchObject({
+      account: { accountId: "account-a" },
+    });
+    await expect(threadAccounts.getAccountId("historical-thread")).resolves.toBe("account-a");
+    await pool.close();
+  });
+
+  it("rejects an unknown Thread in a single-Account installation without inventing a binding", async () => {
+    const directory = await mkdtemp(path.join(tmpdir(), "codexhost-history-discovery-test-"));
+    directories.push(directory);
+    const metadata = path.join(directory, "metadata");
+    const accounts = new AccountRepository({
+      directory: metadata,
+      defaultAccount: { accountId: "account-a", codexHome: path.join(directory, "home-a") },
+    });
+    const threadAccounts = new ThreadAccountStore({ directory: metadata });
+    const probedRequests: string[] = [];
+    const pool = new CodexRuntimePool({
+      accounts,
+      threadAccounts,
+      createConnection: async () => fakeAppServerConnection([], probedRequests),
+      diagnosticOutput: new PassThrough(),
+      onOutput: async () => undefined,
+      diagnose: () => undefined,
+    });
+
+    await pool.initialize();
+    await pool.active();
+    await expect(
+      pool.forThread("unknown-thread", { recoverUnboundThread: true }),
+    ).rejects.toBeInstanceOf(UnknownCodexThreadAccountError);
+    expect(probedRequests).toEqual(["thread/read"]);
+    await expect(threadAccounts.getAccountId("unknown-thread")).resolves.toBeNull();
+    await pool.close();
+  });
+
+  it("fails fast for an unbound Thread in a single-Account installation without recovery", async () => {
+    const directory = await mkdtemp(path.join(tmpdir(), "codexhost-history-discovery-test-"));
+    directories.push(directory);
+    const metadata = path.join(directory, "metadata");
+    const accounts = new AccountRepository({
+      directory: metadata,
+      defaultAccount: { accountId: "account-a", codexHome: path.join(directory, "home-a") },
+    });
+    const threadAccounts = new ThreadAccountStore({ directory: metadata });
+    const probedRequests: string[] = [];
+    const pool = new CodexRuntimePool({
+      accounts,
+      threadAccounts,
+      createConnection: async () => fakeAppServerConnection([], probedRequests),
+      diagnosticOutput: new PassThrough(),
+      onOutput: async () => undefined,
+      diagnose: () => undefined,
+    });
+
+    await pool.initialize();
+    await pool.active();
+    await expect(pool.forThread("unknown-thread")).rejects.toBeInstanceOf(
+      UnknownCodexThreadAccountError,
+    );
+    expect(probedRequests).toEqual([]);
+    await expect(threadAccounts.getAccountId("unknown-thread")).resolves.toBeNull();
     await pool.close();
   });
 });

--- a/packages/host-runtime/test/account-routing.test.ts
+++ b/packages/host-runtime/test/account-routing.test.ts
@@ -345,6 +345,37 @@ describe("Codex Account routing persistence", () => {
     await pool.close();
   });
 
+  it("reports an unbound Thread instead of crashing when recovery cannot persist the binding", async () => {
+    const directory = await mkdtemp(path.join(tmpdir(), "codexhost-history-discovery-test-"));
+    directories.push(directory);
+    const metadata = path.join(directory, "metadata");
+    const accounts = new AccountRepository({
+      directory: metadata,
+      defaultAccount: { accountId: "account-a", codexHome: path.join(directory, "home-a") },
+    });
+    const threadAccounts = new ThreadAccountStore({ directory: metadata });
+    const diagnosed: unknown[] = [];
+    const pool = new CodexRuntimePool({
+      accounts,
+      threadAccounts,
+      createConnection: async () => fakeAppServerConnection(["historical-thread"]),
+      diagnosticOutput: new PassThrough(),
+      onOutput: async () => undefined,
+      diagnose: (error) => diagnosed.push(error),
+    });
+
+    await pool.initialize();
+    threadAccounts.bind = async () => {
+      throw new Error("disk is read-only");
+    };
+    await expect(
+      pool.forThread("historical-thread", { recoverUnboundThread: true }),
+    ).rejects.toBeInstanceOf(UnknownCodexThreadAccountError);
+    expect(diagnosed.map(String)).toEqual([expect.stringContaining("disk is read-only")]);
+    await expect(pool.active()).resolves.toMatchObject({ account: { accountId: "account-a" } });
+    await pool.close();
+  });
+
   it("fails fast for an unbound Thread in a single-Account installation without recovery", async () => {
     const directory = await mkdtemp(path.join(tmpdir(), "codexhost-history-discovery-test-"));
     directories.push(directory);

--- a/packages/host-runtime/test/app-server-host.test.ts
+++ b/packages/host-runtime/test/app-server-host.test.ts
@@ -6031,6 +6031,45 @@ describe("AppServerHost HarnessAdapter projection", () => {
     await stopFixture(fixture);
   });
 
+  it("recovers an unbound legacy Thread through the delegation thread read", async () => {
+    let delegationApi: DelegationControlApi | undefined;
+    const fixture = createFixture({
+      onDelegationApi: (api) => {
+        delegationApi = api;
+        return undefined;
+      },
+    });
+    await vi.waitFor(() => expect(delegationApi).toBeDefined());
+    await vi.waitFor(async () => expect(await fixture.mappingStore.listThreads()).toEqual([]));
+    if (!delegationApi) throw new Error("Delegation API was not registered");
+
+    const read = delegationApi.read({ threadId: "legacy-thread", view: "result" });
+    const probe = await readJsonLine(fixture.official.stdin);
+    expect(probe).toMatchObject({
+      method: "thread/read",
+      params: { threadId: "legacy-thread", includeTurns: false },
+    });
+    writeRequest(fixture.official.stdout, {
+      id: requiredMessageId(probe),
+      result: { thread: { id: "legacy-thread" } },
+    });
+    const forwarded = await readJsonLine(fixture.official.stdin);
+    expect(forwarded).toMatchObject({
+      method: "thread/read",
+      params: { threadId: "legacy-thread", includeTurns: true },
+    });
+    writeRequest(fixture.official.stdout, {
+      id: requiredMessageId(forwarded),
+      result: { thread: { id: "legacy-thread", turns: [] } },
+    });
+    await expect(read).resolves.toMatchObject({
+      threadId: "legacy-thread",
+      harnessId: "codex",
+    });
+    await expect(fixture.threadAccountStore.getAccountId("legacy-thread")).resolves.toBe("default");
+    await stopFixture(fixture);
+  });
+
   it("tail-Forks the latest completed Checkpoint while the source Turn is active", async () => {
     const fixture = createFixture();
     const officialWrite = vi.fn();

--- a/packages/host-runtime/test/app-server-host.test.ts
+++ b/packages/host-runtime/test/app-server-host.test.ts
@@ -5996,6 +5996,41 @@ describe("AppServerHost HarnessAdapter projection", () => {
     await stopFixture(fixture);
   });
 
+  it("recovers an unbound legacy Codex Thread on thread/read via single-Account discovery", async () => {
+    const fixture = createFixture();
+    writeRequest(fixture.desktopInput, {
+      id: 90,
+      method: "thread/read",
+      params: { threadId: "legacy-thread", includeTurns: true },
+    });
+
+    const discoveryProbe = await readJsonLine(fixture.official.stdin);
+    expect(discoveryProbe).toMatchObject({
+      method: "thread/read",
+      params: { threadId: "legacy-thread", includeTurns: false },
+    });
+    writeRequest(fixture.official.stdout, {
+      id: requiredMessageId(discoveryProbe),
+      result: { thread: { id: "legacy-thread" } },
+    });
+
+    const forwarded = await readJsonLine(fixture.official.stdin);
+    expect(forwarded).toMatchObject({
+      method: "thread/read",
+      params: { threadId: "legacy-thread", includeTurns: true },
+    });
+    writeRequest(fixture.official.stdout, {
+      id: requiredMessageId(forwarded),
+      result: { thread: { id: "legacy-thread", turns: [] } },
+    });
+
+    await expect(
+      fixture.collector.waitFor((message) => requestId(message, 90)),
+    ).resolves.toMatchObject({ result: { thread: { id: "legacy-thread" } } });
+    await expect(fixture.threadAccountStore.getAccountId("legacy-thread")).resolves.toBe("default");
+    await stopFixture(fixture);
+  });
+
   it("tail-Forks the latest completed Checkpoint while the source Turn is active", async () => {
     const fixture = createFixture();
     const officialWrite = vi.fn();


### PR DESCRIPTION
## 问题（Fixes #229）

0.6.1 单账号安装无法恢复缺少账号绑定的历史 Codex 会话，报 `Official Thread '<id>' has no Codex Account binding`（-32084）。根因在 `CodexRuntimePool.#discoverHistoricalThreadAccount`：`accounts.length < 2` 直接返回 null，把发现机制限制在多账号迁移场景，而单账号用户同样存在 pre-pool 遗留的无绑定会话。

## 修复

- `forThread(threadId, { recoverUnboundThread })`：仅对 `thread/read` / `thread/resume` 请求放开单账号发现；两种请求正是恢复会话的入口。
- 发现逻辑不变：向唯一账号的官方 Runtime 发 `thread/read` 验证会话确实存在后**才持久化绑定**，不会把未知 ID 盲目绑到当前账号。
- 其余对未绑定 Thread 的请求（`thread/fork` / `thread/revert` / `thread/rollback`、`turn/start` 等）仍保持原有的快速失败语义（-32084），与既有的 ownership 测试断言一致。
- 成功恢复一次后绑定即落盘，后续所有操作（fork/revert/rollback 等）自然恢复可用。

## 测试

- `account-routing.test.ts` +3：单账号已知 Thread 发现并落绑定；单账号未知 Thread 仅探测一次后拒绝且不落绑定；未启用恢复时单账号未绑定 Thread 快速失败且不发起任何探测请求（锁定原有设计意图）。
- `app-server-host.test.ts` +1：端到端复现 #229 —— Desktop 发 `thread/read` → Host 向官方 Runtime 探测 → 建立 `default` 绑定 → 原请求成功返回。
- 全量：host-runtime 受影响文件 154/154 通过；`tsc -b`、ESLint、Prettier 通过。仓库另有 9 个与本改动无关的预存量失败（插件 manifest/编译产物类，已在干净 origin/main 上复现确认）。