### PR TITLE
fix: 避免 Claude 长计划撑满审批面板

### DIFF
--- a/docs/claude-code-plan-mode.md
+++ b/docs/claude-code-plan-mode.md
@@ -8,7 +8,7 @@ Claude Code SDK 原生支持 `permissionMode: "plan"` 和运行中的 `setPermis
 
 Claude 调用 `ExitPlanMode` 时，codexhost 展示独立的 **Review plan** 选择式确认，而不是普通工具的“允许一次”审批：
 
-- 展示 SDK 回调提供的完整计划正文，不套用普通工具审批的 500 字符描述截断。
+- SDK 回调提供的完整计划正文作为独立消息进入对话区，使用正文 Markdown 渲染和对话滚动，不截断。审批面板仅显示简短说明和选择，避免长计划撑满固定输入区域。
 - **Stay in plan mode（保持规划）** 位于第一个选项，拒绝本次退出规划请求。
 - **Approve plan and exit plan mode（批准计划并退出规划）** 明确批准计划并允许原生退出操作。Claude Code 随后恢复进入规划前的权限模式，并可能继续执行计划。
 - 取消确认等同于拒绝退出。任意文本、未声明选项、多选和缺失答案都不能批准退出。

--- a/packages/adapters/claude-code/src/claude-code-adapter.ts
+++ b/packages/adapters/claude-code/src/claude-code-adapter.ts
@@ -1697,6 +1697,21 @@ class ClaudeHarnessSession implements HarnessSession {
       };
       pending = { type: "approval", interaction, request };
     } else if (request.type === "planApproval") {
+      // Question prompts are plain text in a fixed composer panel. Keep the
+      // unabridged Markdown in the transcript so long plans remain readable.
+      if (request.plan) {
+        const item: HostAgentMessageItem = {
+          type: "agentMessage",
+          itemId: hostItemIdSchema.parse(this.#randomUUID()),
+          text: request.plan,
+        };
+        this.#event({ type: "item.started", turnId: active.command.turnId, item });
+        this.#event({
+          type: "item.completed",
+          turnId: active.command.turnId,
+          snapshot: { item, outcome: { status: "succeeded" } },
+        });
+      }
       pending = {
         type: "planApproval",
         interaction: createClaudePlanReview(request, interactionId, active.command.turnId),

--- a/packages/adapters/claude-code/src/plan-review.ts
+++ b/packages/adapters/claude-code/src/plan-review.ts
@@ -27,7 +27,7 @@ export function createClaudePlanReview(
         id: DECISION_ID,
         type: "choice",
         prompt: request.plan
-          ? `${warning}\n\n${request.plan}`
+          ? `Review the full plan in the conversation above. ${warning}`
           : "Claude Code did not provide plan text. Stay in plan mode and ask Claude to present the plan before approving it.",
         options: [
           {

--- a/packages/adapters/claude-code/test/claude-code-adapter.test.ts
+++ b/packages/adapters/claude-code/test/claude-code-adapter.test.ts
@@ -4005,6 +4005,16 @@ describe("Claude Code HarnessAdapter", () => {
         type: "interaction.requested",
         request: { type: "planApproval", requestId: "exit-plan", plan },
       });
+      const planStarted = await nextEvent(iterator);
+      expect(planStarted).toMatchObject({
+        type: "item.started",
+        item: { type: "agentMessage", text: plan },
+      });
+      if (planStarted.type !== "item.started") throw new Error("Expected plan Item");
+      expect(await nextEvent(iterator)).toMatchObject({
+        type: "item.completed",
+        snapshot: { item: planStarted.item, outcome: { status: "succeeded" } },
+      });
       const interaction = await nextInteraction(iterator);
       expect(interaction).toMatchObject({
         type: "question",
@@ -4024,7 +4034,8 @@ describe("Claude Code HarnessAdapter", () => {
         ],
       });
       if (interaction.type !== "question") throw new Error("Expected a plan review Question");
-      expect(interaction.questions[0]?.prompt).toContain(plan);
+      expect(interaction.questions[0]?.prompt).not.toContain(plan);
+      expect(interaction.questions[0]?.prompt.length).toBeLessThan(300);
       expect(interaction.questions[0]?.prompt).toContain(
         "restore the permission mode used before planning",
       );


### PR DESCRIPTION
Claude Code 调用 `ExitPlanMode` 并提供较长计划时，完整 Markdown 被拼进 `requestUserInput` 的问题正文。Desktop 将它显示为固定输入区域中的纯文本，长内容会挤占审批和对话空间，计划也无法正常按 Markdown 阅读。

本 PR 在发出审批问题之前，将完整计划作为独立的 assistant message 投影到对话正文；审批问题只保留简短提示和退出规划的说明。保持规划、明确批准和取消的原生决策映射不变；没有计划正文时仍不提供批准选项。

验证：
- 独立基于上游 `72d6585`，仅修改 Claude Adapter、回归测试和相关文档。
- Claude Adapter / SDK 定向测试 139 项通过，覆盖完整长计划先于审批输出、问题长度以及批准/保持/取消与非法响应。
- `npm run typecheck`、修改文件 ESLint/Prettier、`git diff --check` 通过。
- 用户已在相同修复的本地集成构建中完成手动验收；本独立分支未另行执行官方 CLI 的完整桌面 E2E。