### PR TITLE
fix(claude-code): deliver background Subagent settlements outside Turns

### DIFF
--- a/packages/adapters/claude-code/src/claude-code-adapter.ts
+++ b/packages/adapters/claude-code/src/claude-code-adapter.ts
@@ -1399,10 +1399,33 @@ class ClaudeHarnessSession implements HarnessSession {
       });
       this.#transport = transport;
       transport.setAutonomousTurnHandler((turn) => this.#handleAutonomousTurn(turn));
+      transport.setThreadEventHandler((event) => {
+        // Thread-level events (e.g. a background Subagent settling) are not
+        // Turn-scoped and must not be gated on an active Turn.
+        if (event.type === "subagent.settled") {
+          this.#settleBackgroundSubagent(
+            event.status,
+            event.nativeSubagentId,
+            event.callId,
+            event.resultSummary,
+          );
+        }
+      });
       transport.setIdleTurnHandler({
         onEvent: (event) => {
           const active = this.#active;
-          if (active) this.#handleTurnEvent(active, event);
+          if (active) {
+            this.#handleTurnEvent(active, event);
+            return;
+          }
+          if (event.type === "subagent.settled") {
+            this.#settleBackgroundSubagent(
+              event.status,
+              event.nativeSubagentId,
+              event.callId,
+              event.resultSummary,
+            );
+          }
         },
         onTerminal: (result) => {
           const active = this.#active;

--- a/packages/adapters/claude-code/src/sdk-transport.ts
+++ b/packages/adapters/claude-code/src/sdk-transport.ts
@@ -337,6 +337,12 @@ function allowed(
   };
 }
 
+function isThreadLevelEvent(event: ClaudeTurnEvent): boolean {
+  // A background Subagent settles outside any Turn, and its task-notification
+  // Segment may never produce a Terminal; Turn batching would swallow it.
+  return event.type === "subagent.settled";
+}
+
 export class ClaudeSdkTransport implements ClaudeTurnTransport {
   readonly sessionId: string;
   readonly #children: ChildProcessWithoutNullStreams[] = [];
@@ -362,6 +368,7 @@ export class ClaudeSdkTransport implements ClaudeTurnTransport {
   } | null = null;
   #autonomousTurnHandler: ((turn: ClaudeAutonomousTurn) => void) | null = null;
   #idleHandler: ClaudeIdleTurnHandler | null = null;
+  #threadEventHandler: ((event: ClaudeTurnEvent) => void) | null = null;
   #idleLive = false;
   #idleAccumulator: ClaudeNativeTurnAccumulator | null = null;
   #closePromise: Promise<void> | null = null;
@@ -396,6 +403,10 @@ export class ClaudeSdkTransport implements ClaudeTurnTransport {
 
   setIdleTurnHandler(handler: ClaudeIdleTurnHandler | null): void {
     this.#idleHandler = handler;
+  }
+
+  setThreadEventHandler(handler: ((event: ClaudeTurnEvent) => void) | null): void {
+    this.#threadEventHandler = handler;
   }
 
   setIdleLive(live: boolean): void {
@@ -906,7 +917,13 @@ export class ClaudeSdkTransport implements ClaudeTurnTransport {
           autonomous.nativeTurnKey = message.uuid;
         }
         const interpreted = autonomous.accumulator.consume(message);
-        autonomous.events.push(...interpreted.events);
+        for (const event of interpreted.events) {
+          if (isThreadLevelEvent(event)) {
+            this.#threadEventHandler?.(event);
+            continue;
+          }
+          autonomous.events.push(event);
+        }
         if (interpreted.terminal) {
           this.#autonomous = null;
           const nativeTurnKey = autonomous.nativeTurnKey ?? `autonomous-${Date.now()}`;

--- a/packages/adapters/claude-code/src/transport.ts
+++ b/packages/adapters/claude-code/src/transport.ts
@@ -181,6 +181,13 @@ export interface ClaudeTurnTransport {
   readonly sessionId: string;
   setAutonomousTurnHandler(handler: (turn: ClaudeAutonomousTurn) => void): void;
   setIdleTurnHandler(handler: ClaudeIdleTurnHandler | null): void;
+  /**
+   * Receives Thread-level events the moment they are observed, independent of
+   * Turn or Segment boundaries. A background Subagent's settlement arrives in
+   * a task-notification Segment that may never produce a Terminal, so Turn
+   * batching would swallow it.
+   */
+  setThreadEventHandler(handler: ((event: ClaudeTurnEvent) => void) | null): void;
   setIdleLive(live: boolean): void;
   start(): Promise<void>;
   getContextUsage(): Promise<ClaudeTransportContextUsage | null>;

--- a/packages/adapters/claude-code/test/claude-code-adapter.test.ts
+++ b/packages/adapters/claude-code/test/claude-code-adapter.test.ts
@@ -33,12 +33,16 @@ class FakeClaudeTransport implements ClaudeTurnTransport {
   readonly sessionId: string;
   autonomousTurnHandler: ((turn: ClaudeAutonomousTurn) => void) | null = null;
   idleHandler: ClaudeIdleTurnHandler | null = null;
+  threadHandler: ((event: ClaudeTurnEvent) => void) | null = null;
   idleLive = false;
   setAutonomousTurnHandler(handler: (turn: ClaudeAutonomousTurn) => void): void {
     this.autonomousTurnHandler = handler;
   }
   setIdleTurnHandler(handler: ClaudeIdleTurnHandler | null): void {
     this.idleHandler = handler;
+  }
+  setThreadEventHandler(handler: ((event: ClaudeTurnEvent) => void) | null): void {
+    this.threadHandler = handler;
   }
   setIdleLive(live: boolean): void {
     this.idleLive = live;
@@ -156,6 +160,10 @@ class FakeClaudeTransport implements ClaudeTurnTransport {
       return;
     }
     throw new Error("No active fake Claude Turn");
+  }
+
+  threadEvent(event: ClaudeTurnEvent): void {
+    this.threadHandler?.(event);
   }
 
   approval(request: ClaudeApprovalRequest): void {
@@ -2258,6 +2266,40 @@ describe("Claude Code HarnessAdapter", () => {
       type: "turn.completed",
       outcome: { status: "succeeded" },
       nativeTurnRef: { nativeTurnKey: "task-notification-1" },
+    });
+    await session.close();
+  });
+
+  it("publishes a background Subagent settlement that arrives outside any Turn", async () => {
+    const { adapter, transports } = fixture();
+    const session = await openSession(adapter);
+    const iterator = session.outputs[Symbol.asyncIterator]();
+
+    await session.execute(textTurn("delegate in background"));
+    await nextEvent(iterator);
+    await nextEvent(iterator);
+    await nextEvent(iterator);
+    const transport = transports[0];
+    if (!transport) throw new Error("Fake Claude transport was not created");
+    transport.delta("Background task launched");
+    await nextEvent(iterator);
+    transport.finish({ status: "succeeded" });
+    await nextEvent(iterator);
+    await nextEvent(iterator);
+
+    // The Turn is complete and idle. Claude may enqueue the task notification
+    // without a continuation, so the settlement no longer rides a Turn.
+    transport.threadEvent({
+      type: "subagent.settled",
+      nativeSubagentId: "native-agent-late",
+      status: "completed",
+      resultSummary: "Analysis complete",
+    });
+    expect(await nextEvent(iterator)).toMatchObject({
+      type: "subagent.state.changed",
+      nativeSubagentId: "native-agent-late",
+      status: "completed",
+      resultSummary: "Analysis complete",
     });
     await session.close();
   });
@@ -4778,6 +4820,7 @@ describe("Claude Code HarnessAdapter", () => {
         sessionId: "claude-id",
         setAutonomousTurnHandler: () => undefined,
         setIdleTurnHandler: () => undefined,
+        setThreadEventHandler: () => undefined,
         setIdleLive: () => undefined,
         start: async () => {
           throw new ClaudeCodeExecutableError("Claude Code is not installed");

--- a/packages/adapters/claude-code/test/claude-rollback.test.ts
+++ b/packages/adapters/claude-code/test/claude-rollback.test.ts
@@ -102,6 +102,7 @@ async function fixture(turns = 1) {
         abort: vi.fn(async () => undefined),
         setAutonomousTurnHandler: () => undefined,
         setIdleTurnHandler: () => undefined,
+        setThreadEventHandler: () => undefined,
         setIdleLive: () => undefined,
         getContextUsage: async () => null,
         getPermissionMode: () => permissionMode,

--- a/packages/adapters/claude-code/test/sdk-transport.test.ts
+++ b/packages/adapters/claude-code/test/sdk-transport.test.ts
@@ -722,7 +722,9 @@ describe("ClaudeSdkTransport autonomous task continuation", () => {
   it("publishes Root output produced after a background task notification", async () => {
     const value = fixture();
     const autonomous: ClaudeAutonomousTurn[] = [];
+    const threadEvents: ClaudeTurnEvent[] = [];
     value.transport.setAutonomousTurnHandler((turn) => autonomous.push(turn));
+    value.transport.setThreadEventHandler((event) => threadEvents.push(event));
     await value.transport.start();
 
     value.fakeQuery.push({
@@ -750,16 +752,19 @@ describe("ClaudeSdkTransport autonomous task continuation", () => {
     completeTurn(value.fakeQuery);
 
     await vi.waitFor(() => expect(autonomous).toHaveLength(1));
+    expect(threadEvents).toEqual([
+      {
+        type: "subagent.settled",
+        callId: "send-1",
+        nativeSubagentId: "native-agent-1",
+        status: "completed",
+        resultSummary: "Analysis complete",
+      },
+    ]);
     expect(autonomous[0]).toMatchObject({
       nativeTurnKey: "00000000-0000-4000-8000-000000000040",
       result: { status: "succeeded" },
       events: [
-        {
-          type: "subagent.settled",
-          nativeSubagentId: "native-agent-1",
-          status: "completed",
-          resultSummary: "Analysis complete",
-        },
         { type: "text.delta", delta: "Background analysis result" },
         { type: "message.completed" },
       ],
@@ -770,7 +775,9 @@ describe("ClaudeSdkTransport autonomous task continuation", () => {
   it("preserves a failed task-notification whose user content is text blocks", async () => {
     const value = fixture();
     const autonomous: ClaudeAutonomousTurn[] = [];
+    const threadEvents: ClaudeTurnEvent[] = [];
     value.transport.setAutonomousTurnHandler((turn) => autonomous.push(turn));
+    value.transport.setThreadEventHandler((event) => threadEvents.push(event));
     await value.transport.start();
 
     value.fakeQuery.push({
@@ -793,7 +800,7 @@ describe("ClaudeSdkTransport autonomous task continuation", () => {
     completeTurn(value.fakeQuery);
 
     await vi.waitFor(() => expect(autonomous).toHaveLength(1));
-    expect(autonomous[0]?.events.filter((event) => event.type === "subagent.settled")).toEqual([
+    expect(threadEvents).toEqual([
       {
         type: "subagent.settled",
         nativeSubagentId: "a78414260bd2f9554",
@@ -801,6 +808,45 @@ describe("ClaudeSdkTransport autonomous task continuation", () => {
         resultSummary: "Agent failed",
       },
     ]);
+    expect(autonomous[0]?.events.filter((event) => event.type === "subagent.settled")).toEqual([]);
+    await value.transport.close();
+  });
+
+  it("delivers a background task settlement whose Segment never produces a Terminal", async () => {
+    const value = fixture();
+    const autonomous: ClaudeAutonomousTurn[] = [];
+    const threadEvents: ClaudeTurnEvent[] = [];
+    value.transport.setAutonomousTurnHandler((turn) => autonomous.push(turn));
+    value.transport.setThreadEventHandler((event) => threadEvents.push(event));
+    await value.transport.start();
+
+    // Claude may enqueue the notification without a continuation Turn: no
+    // Assistant output and no Result follow. The settlement is Thread-level
+    // and must still be delivered instead of being swallowed by Turn batching.
+    value.fakeQuery.push({
+      type: "user",
+      uuid: "00000000-0000-4000-8000-000000000060",
+      session_id: "00000000-0000-4000-8000-000000000001",
+      parent_tool_use_id: null,
+      origin: { kind: "task-notification" },
+      message: {
+        role: "user",
+        content:
+          "<task-notification><task-id>native-agent-late</task-id><summary>Late analysis</summary></task-notification>",
+      },
+    } as unknown as SDKMessage);
+
+    await vi.waitFor(() =>
+      expect(threadEvents).toEqual([
+        {
+          type: "subagent.settled",
+          nativeSubagentId: "native-agent-late",
+          status: "completed",
+          resultSummary: "Late analysis",
+        },
+      ]),
+    );
+    expect(autonomous).toEqual([]);
     await value.transport.close();
   });
 

--- a/packages/host-runtime/test/app-server-host.claude.real.test.ts
+++ b/packages/host-runtime/test/app-server-host.claude.real.test.ts
@@ -155,6 +155,7 @@ describe("AppServerHost hermetic Claude projection", () => {
           sessionId: input.sessionId,
           setAutonomousTurnHandler: () => undefined,
           setIdleTurnHandler: () => undefined,
+          setThreadEventHandler: () => undefined,
           setIdleLive: () => undefined,
           start: async () => undefined,
           getContextUsage: async () => ({


### PR DESCRIPTION
## 问题（Fixes #238）

外部 Harness 线程在后台子代理于 Turn 之外结算后永远停在 `active`：侧边栏一直转圈，且 `#runningSubagentsByParent` 中的子代理永远不会被标记为 idle。

在 Claude Code 适配器中核实后，报告人的方向是对的（Turn 是错误的闸门），但精确的吞失点还需修正一层：传输层 `#consume` 有三条路由——活跃 Turn、idle 累积器（仅 hold 期间 `idleLive=true`，与 `#active` 同步生灭，不会丢）、autonomous 累积器。**autonomous 批次只在 Terminal（`result`）到达时才 flush**，而 Claude 可能把 task-notification 入队后根本不产生 continuation Turn（#234 的时间线正是如此：01:54 通知入队后到用户手动 Stop 之间没有任何 Turn）。于是 `subagent.settled` 永远躺在未 flush 的批次里，`subagent.state.changed` 从未发出。

## 修复

- `ClaudeTurnTransport` 新增 `setThreadEventHandler`：Thread 级事件一经消费立即送达，不经 Turn/Segment 批次。
- `ClaudeSdkTransport`：autonomous 批次消费时把 `subagent.settled` 摘出并即时派发到该通道；有正常 continuation 的批次内容不变（仅 settled 提前送达，顺序对 Host 无影响）。
- 适配器：注册该处理器，收到 `subagent.settled` 即调用 `#settleBackgroundSubagent`（其内部只依赖 occupancy + 事件发射，Turn 外安全）；idle 处理器在 `#active` 为空时也兜底转发，防御未覆盖的路由窗口。

OMP/Antigravity/Grok 各适配器有自己的事件通道，本次未涉及；如果它们在同类路径也有 Turn 闸门问题，需各自另行排查。

## 测试

- sdk-transport 新增回归测试：只推 task-notification、不产生任何 Terminal，断言 settlement 经 Thread 通道送达且 autonomous 批次为空（修复前该场景事件被永久吞没）。
- 两个既有 autonomous 测试更新为新契约（settled 经 Thread 通道，不再出现在批次中）。
- 适配器新增测试：Turn 正常结束后经 Thread 通道送达 settlement，断言 `subagent.state.changed` 立即发出。
- 全套 claude-code 测试 247/248 通过（1 个 skip 为原有），host-runtime 相关套件 148/148，tsc/ESLint/Prettier 全绿。