### PR TITLE
fix(host-runtime): keep a Subagent Thread active while its Subagent runs

### DIFF
--- a/packages/host-runtime/src/app-server-host.ts
+++ b/packages/host-runtime/src/app-server-host.ts
@@ -599,6 +599,7 @@ export class AppServerHost {
       repository: this.#repository,
       consumeOutputs: (thread) => this.#consumeHarnessOutputs(thread),
       diagnose: (error) => this.#diagnose(error),
+      subagentRunning: (threadId) => this.#subagentThreadStatuses.get(threadId) === "active",
     });
     this.#delegationCoordinator = new HarnessDelegationCoordinator({
       adapters: this.#externalAdapters,

--- a/packages/host-runtime/src/external-thread-runtime.ts
+++ b/packages/host-runtime/src/external-thread-runtime.ts
@@ -192,6 +192,7 @@ export class ExternalThreadRuntime {
   readonly #environment: NodeJS.ProcessEnv;
   readonly #repository: ExternalThreadRepository;
   readonly #restores = new Map<string, Promise<ExternalThread>>();
+  readonly #subagentRunning: (threadId: string) => boolean;
   readonly #threads = new Map<string, ExternalThread>();
 
   constructor(input: {
@@ -200,12 +201,14 @@ export class ExternalThreadRuntime {
     repository: ExternalThreadRepository;
     consumeOutputs(thread: ExternalThread): Promise<void>;
     diagnose(error: unknown): void;
+    subagentRunning?(threadId: string): boolean;
   }) {
     this.#adapters = input.adapters;
     this.#environment = input.environment ?? process.env;
     this.#repository = input.repository;
     this.#consumeOutputs = input.consumeOutputs;
     this.#diagnose = input.diagnose;
+    this.#subagentRunning = input.subagentRunning ?? (() => false);
   }
 
   get(threadId: string): ExternalThread | undefined {
@@ -253,6 +256,10 @@ export class ExternalThreadRuntime {
       ...(effectiveThinkingOptionId ? { effectiveThinkingOptionId } : {}),
       ...(effectivePermissionModeId ? { effectivePermissionModeId } : {}),
     };
+    // A Subagent Thread can be opened while its Subagent is still running. Its
+    // live status lives in the Host, not in the stored record, so seed it here
+    // instead of publishing a Thread that claims to be idle.
+    const running = this.#subagentRunning(input.record.hostThreadId);
     const externalThread: ExternalThread = {
       id: input.record.hostThreadId,
       cwd: input.record.cwd,
@@ -269,11 +276,13 @@ export class ExternalThreadRuntime {
       record: input.record,
       sessionId: input.sessionId,
       stateObserver: new SessionStateObserver(observerState),
-      thread: input.thread,
+      thread: running
+        ? { ...input.thread, status: { type: "active", activeFlags: [] } }
+        : input.thread,
       transportModelId: input.transportModelId ?? input.record.transportModelId,
       turns: input.turns,
       historyHydrated: true,
-      running: false,
+      running,
       activeTurnId: null,
       latestUsage: input.session.initialUsage,
       usageTurnId: null,

--- a/packages/host-runtime/test/app-server-host.test.ts
+++ b/packages/host-runtime/test/app-server-host.test.ts
@@ -1674,6 +1674,87 @@ describe("AppServerHost HarnessAdapter projection", () => {
     await stopFixture(fixture);
   });
 
+  it("keeps a Subagent Thread active when it is opened while its Subagent runs", async () => {
+    const base = new FakeHarnessAdapter(harnessIdSchema.parse("pi"));
+    const adapter = Object.assign(base, {
+      subagents: {
+        readSnapshot: vi.fn(async (input: { parent: { nativeSessionId: string } }) => ({
+          ok: true as const,
+          value: {
+            turns: [
+              {
+                nativeTurnRef: {
+                  harnessId: harnessIdSchema.parse("pi"),
+                  nativeSessionId: input.parent.nativeSessionId,
+                  nativeTurnKey: "open-while-running-turn",
+                  formatVersion: 1,
+                },
+                input: [{ type: "text", text: "Inspect files" }],
+                items: [],
+                outcome: { status: "unknown" as const, reason: "Background work" },
+              },
+            ],
+          },
+        })),
+      },
+    });
+    const fixture = createFixture({
+      externalAdapters: new Map([["pi", adapter]]) as ReadonlyMap<
+        ExternalHarnessId,
+        FakeHarnessAdapter
+      >,
+    });
+    const threadId = await startPiThread(fixture);
+    const turnId = await startPiTurn(fixture, threadId);
+    const session = adapter.sessions[0];
+    if (!session) throw new Error("Fake Session was not opened");
+    await fixture.collector.waitFor((message) => turnEvent(message, "turn/started", turnId));
+    const childStartedPromise = fixture.collector.waitFor(
+      (message) =>
+        method(message, "thread/started") &&
+        (messageParams(message).thread as JsonObject | undefined)?.parentThreadId === threadId,
+    );
+    session.startSubagentDelegation({
+      subagentId: "open-while-running-call",
+      nativeSubagentId: "native-open-while-running",
+      description: "Inspect files",
+      background: true,
+      status: "running",
+    });
+    const childStarted = await childStartedPromise;
+    const childThread = messageParams(childStarted).thread as JsonObject;
+    const childThreadId = childThread.id as string;
+    expect(childThread.status).toEqual({ type: "active", activeFlags: [] });
+
+    writeRequest(fixture.desktopInput, {
+      id: 96,
+      method: "thread/resume",
+      params: { threadId: childThreadId, excludeTurns: true },
+    });
+    const opened = await fixture.collector.waitFor((message) => requestId(message, 96));
+    expect((opened.result as JsonObject).thread).toEqual(
+      expect.objectContaining({ id: childThreadId, status: { type: "active", activeFlags: [] } }),
+    );
+    expect(
+      fixture.collector.messages.some((message) => threadStatus(message, childThreadId, "idle")),
+    ).toBe(false);
+
+    session.emitSubagentState("native-open-while-running", "completed", "Inspection complete");
+    await expect(
+      fixture.collector.waitFor((message) => threadStatus(message, childThreadId, "idle")),
+    ).resolves.toBeTruthy();
+    writeRequest(fixture.desktopInput, {
+      id: 97,
+      method: "thread/resume",
+      params: { threadId: childThreadId, excludeTurns: true },
+    });
+    const reopened = await fixture.collector.waitFor((message) => requestId(message, 97));
+    expect((reopened.result as JsonObject).thread).toEqual(
+      expect.objectContaining({ id: childThreadId, status: { type: "idle" } }),
+    );
+    await stopFixture(fixture);
+  });
+
   it("terminates the official app-server when its Host session closes", async () => {
     const fixture = createFixture();
     fixture.official.kill.mockImplementationOnce(() => {


### PR DESCRIPTION
Fixes #247. Refs #238.

## What

`ExternalThreadRuntime.register()` now seeds `running` from the Host's tracked Subagent status instead of hardcoding `false`, and publishes the Thread value with the matching status.

## Why

A Subagent Thread was reported `active` exactly once — in the `thread/started` payload built by `#materializeSubagent`:

```ts
const thread = externalThreadValue({ record, turns: [], sessionId: parent.sessionId, running: status === "active" });
this.#subagentThreadStatuses.set(record.hostThreadId, status);
```

Everything that publishes the Thread afterwards re-derives its status from `ExternalThread.running`. `register()` hardcodes that to `false` and builds the published value with `externalThreadValue({ record, turns, sessionId })` — no `running` — so the moment the user opens a running Subagent Thread, Codex is told `{"type":"idle"}`.

`#setSubagentThreadStatus` cannot repair it: nothing changed on the Host's side, so `if (previousStatus === status) return;` keeps it silent while Codex holds the wrong value.

Measured on my machine before the fix: two Claude Code Subagent Threads spawned from the same parent both reported `threadRuntimeStatus: {"type":"idle"}` in the live Renderer while one of them was still producing output. Details and Thread IDs are in #247.

## Scope

Deliberately narrow.

- Non-Subagent Threads are unaffected: `subagentRunning` returns `false` for every Thread the Host is not tracking, so `register()` behaves exactly as before for them.
- `thread/list` is untouched. `includesExternalRecord` drops every record with a `subagent` block, so Subagent Threads never appear there and a fallback would have been dead code.
- One consequence worth flagging: `#resumeExternalThread` skips its refresh when `thread.running` is true, so re-opening a *running* Subagent Thread no longer forces a snapshot read. That matches how every other running Thread already behaves, and `#setSubagentThreadStatus` clears `historyHydrated` and runs the terminal refresh cascade once the Subagent settles.

## Not in this PR

While writing this I checked the root-cause theory in #238 (the parent Thread staying `active` forever) and it does not hold: `transport.setIdleLive(true)` is only ever called for a *held* Turn, where `this.#active` is non-null, so the `if (active)` guard in `setIdleTurnHandler.onEvent` never actually drops a Subagent event. I have posted a correction on #238 rather than shipping a speculative patch here.

## Verification

- `npm run typecheck`, `npm run lint`, `npx prettier --check` on the touched files: clean.
- `npm run test:typescript`: **3240 passed, 23 skipped, 270 files**. One unrelated pre-existing failure, `packages/adapters/opencode/test/command.test.ts > reports an unavailable installation without falling back to the SDK launcher`, which fails identically on a clean `origin/main` checkout on this machine because OpenCode *is* installed here.
- New regression test `keeps a Subagent Thread active when it is opened while its Subagent runs` in `packages/host-runtime/test/app-server-host.test.ts`: it opens the child via `thread/resume` while the background Subagent runs, asserts the returned Thread is `active` and that no `idle` status was published, then settles the Subagent and asserts it goes `idle`. Verified red on `origin/main` and green with the fix.
- Running on my machine: built from a local integration branch and installed over `@codexhost/cli` 0.6.1.
