### PR TITLE
fix(renderer): mount settings trigger before native header actions

### DIFF
--- a/openspec/specs/extensible-settings-shell/spec.md
+++ b/openspec/specs/extensible-settings-shell/spec.md
@@ -4,7 +4,7 @@
 Define the browser-safe, window-scoped codexhost settings shell, validated page extension contract, application-header trigger, lifecycle isolation, responsive presentation, and honest unavailable-state boundary for future runtime settings.
 ## Requirements
 ### Requirement: Codex Renderer exposes one codexhost settings shell
-The Renderer Extension SHALL install one window-scoped codexhost settings shell and one owned settings trigger as the first control in the verified Codex application-header right-side action group. The trigger SHALL remain present when that group has no native actions in a blank Thread and SHALL appear immediately before the native Open Location control when it is available. The shell and trigger SHALL remain independent of Composer, Thread, Harness, Model, Thinking, and submission state.
+The Renderer Extension SHALL install one window-scoped codexhost settings shell and one owned settings trigger as the first control in the verified Codex application-header right-side action group. The trigger SHALL mount immediately before that native action group so native header controls keep their own positions and owned controls extend away from them. The trigger SHALL remain present when the header renders no native action group for a blank Thread, mounting in the structurally verified right-side action position instead. The shell and trigger SHALL remain independent of Composer, Thread, Harness, Model, Thinking, and submission state.
 
 #### Scenario: User opens settings from the application header
 - **WHEN** the user activates the owned codexhost icon in the Codex application header
@@ -12,14 +12,18 @@ The Renderer Extension SHALL install one window-scoped codexhost settings shell 
 - **AND** Agent, Model, Composer phase, and native create state SHALL remain unchanged
 
 #### Scenario: Blank Thread has no native header actions
-- **WHEN** the application header does not render Open Location or the context menu for a blank Thread
+- **WHEN** the application header renders no native action group for a blank Thread
 - **THEN** the settings trigger SHALL remain mounted in the structurally verified right-side action position
-- **AND** it SHALL remain immediately before Open Location if native actions later appear
+- **AND** it SHALL move immediately before the native action group if native actions later appear
 
 #### Scenario: Codex replaces the application header
 - **WHEN** Renderer mutation scanning observes that the mounted header trigger is disconnected
-- **THEN** Renderer SHALL mount one replacement trigger immediately before Open Location in the next verified header action group
+- **THEN** Renderer SHALL mount one replacement trigger immediately before the native action group of the next verified header
 - **AND** it SHALL NOT create a second dialog, trigger, or configuration state store
+
+#### Scenario: Another extension mounts its own header control
+- **WHEN** a control that Renderer does not own is inserted between the owned trigger and the start of the header action area
+- **THEN** Renderer SHALL keep the owned trigger immediately before the native action group instead of reclaiming the first position
 
 #### Scenario: Verified header action group is unavailable
 - **WHEN** Renderer cannot identify either a visible bounded native action group or its structurally verified empty action position

--- a/packages/renderer-extension/src/settings/trigger.ts
+++ b/packages/renderer-extension/src/settings/trigger.ts
@@ -9,6 +9,8 @@ export const SETTINGS_HEADER_SURFACE_SELECTOR =
   '[data-testid="app-shell-header-context-menu-surface"]';
 const SETTINGS_APPLICATION_HEADER_SELECTOR = 'header[data-pip-obstacle="app-shell-header"]';
 const SETTINGS_HEADER_SLOT_SELECTOR = ':scope > [data-test-id="header-shell-slot"]';
+const SETTINGS_HEADER_NATIVE_ACTION_GROUP_SELECTOR =
+  ':scope > [data-app-shell-header-obstacle="true"]';
 
 export interface RendererSettingsTriggerControl {
   root: HTMLElement;
@@ -113,6 +115,15 @@ export function inspectRendererSettingsContract(
   };
 }
 
+function findNativeHeaderActionGroup(header: HTMLElement): HTMLElement | null {
+  const surface = header.querySelector<HTMLElement>(SETTINGS_HEADER_SURFACE_SELECTOR);
+  if (!surface) return null;
+  const groups = [
+    ...surface.querySelectorAll<HTMLElement>(SETTINGS_HEADER_NATIVE_ACTION_GROUP_SELECTOR),
+  ];
+  return groups.at(-1) ?? null;
+}
+
 function findRendererSettingsHeaderInsertionPoint(
   ownerDocument: Document,
 ): RendererSettingsHeaderInsertionPoint | null {
@@ -121,6 +132,11 @@ function findRendererSettingsHeaderInsertionPoint(
 
   const headerBounds = measuredBounds(header);
   if (headerBounds.width <= 0 || headerBounds.height <= 0) return null;
+
+  const nativeActionGroup = findNativeHeaderActionGroup(header);
+  if (nativeActionGroup?.parentElement) {
+    return { parent: nativeActionGroup.parentElement, before: nativeActionGroup };
+  }
 
   const endSlot = [...header.querySelectorAll<HTMLElement>(SETTINGS_HEADER_SLOT_SELECTOR)]
     .filter((slot) => {

--- a/packages/renderer-extension/test/settings/trigger.test.ts
+++ b/packages/renderer-extension/test/settings/trigger.test.ts
@@ -18,6 +18,147 @@ function bounds(left: number, top: number, width: number, height: number): Rende
   };
 }
 
+class FakeHeaderElement {
+  readonly attributes = new Map<string, string>();
+  readonly children: FakeHeaderElement[] = [];
+  readonly listeners = new Map<string, (event: { stopPropagation(): void }) => void>();
+  readonly classList = { add: vi.fn() };
+  readonly style: Record<string, string | ((name: string, value: string) => void)> = {};
+  disabled = false;
+  isConnected = true;
+  parentElement: FakeHeaderElement | null = null;
+  title = "";
+  type = "";
+
+  constructor(
+    readonly left = 0,
+    readonly width = 80,
+  ) {
+    this.style.setProperty = (name: string, value: string) => {
+      this.style[name] = value;
+    };
+  }
+
+  get firstChild(): FakeHeaderElement | null {
+    return this.children[0] ?? null;
+  }
+  get nextSibling(): FakeHeaderElement | null {
+    if (!this.parentElement) return null;
+    const index = this.parentElement.children.indexOf(this);
+    return this.parentElement.children[index + 1] ?? null;
+  }
+  addEventListener(name: string, listener: (event: { stopPropagation(): void }) => void): void {
+    this.listeners.set(name, listener);
+  }
+  append(...children: FakeHeaderElement[]): void {
+    for (const child of children) this.insertBefore(child, null);
+  }
+  appendChild(child: FakeHeaderElement): FakeHeaderElement {
+    return this.insertBefore(child, null);
+  }
+  getBoundingClientRect(): DOMRect {
+    return {
+      left: this.left,
+      right: this.left + this.width,
+      top: 0,
+      bottom: 46,
+      width: this.width,
+      height: 46,
+    } as DOMRect;
+  }
+  insertBefore(child: FakeHeaderElement, before: FakeHeaderElement | null): FakeHeaderElement {
+    child.remove();
+    child.parentElement = this;
+    child.isConnected = true;
+    const index = before ? this.children.indexOf(before) : -1;
+    if (index < 0) this.children.push(child);
+    else this.children.splice(index, 0, child);
+    return child;
+  }
+  matches(selector: string): boolean {
+    const attribute = /^\[([^=\]]+)="([^"]*)"\]$/.exec(selector);
+    if (!attribute) return false;
+    const [, name, value] = attribute;
+    return name !== undefined && this.attributes.get(name) === value;
+  }
+  querySelector(selector: string): FakeHeaderElement | null {
+    return this.querySelectorAll(selector)[0] ?? null;
+  }
+  querySelectorAll(selector: string): FakeHeaderElement[] {
+    const scoped = selector.startsWith(":scope > ");
+    const target = scoped ? selector.slice(":scope > ".length) : selector;
+    if (scoped) return this.children.filter((child) => child.matches(target));
+    return this.children.flatMap((child) => [
+      ...(child.matches(target) ? [child] : []),
+      ...child.querySelectorAll(selector),
+    ]);
+  }
+  remove(): void {
+    if (this.parentElement) {
+      const index = this.parentElement.children.indexOf(this);
+      if (index >= 0) this.parentElement.children.splice(index, 1);
+    }
+    this.parentElement = null;
+    this.isConnected = false;
+  }
+  removeEventListener(name: string): void {
+    this.listeners.delete(name);
+  }
+  setAttribute(name: string, value: string): void {
+    this.attributes.set(name, value);
+  }
+  toggleAttribute(name: string, force: boolean): void {
+    if (force) this.attributes.set(name, "");
+    else this.attributes.delete(name);
+  }
+}
+
+interface FakeHeader {
+  header: FakeHeaderElement;
+  startSlot: FakeHeaderElement;
+  surface: FakeHeaderElement;
+  pageHeader: FakeHeaderElement;
+  actionGroup: FakeHeaderElement | null;
+  endSlot: FakeHeaderElement;
+}
+
+// Mirrors Codex Desktop 0.153.4: both shell slots carry the obstacle attribute, and the native
+// action group is the trailing obstacle child of the header context menu surface.
+function createFakeHeader(options: { nativeActions: boolean }): FakeHeader {
+  const header = new FakeHeaderElement(0, 1510);
+  const startSlot = new FakeHeaderElement(0, 216);
+  startSlot.setAttribute("data-test-id", "header-shell-slot");
+  startSlot.setAttribute("data-app-shell-header-obstacle", "true");
+  const surface = new FakeHeaderElement(216, 1119);
+  surface.setAttribute("data-testid", "app-shell-header-context-menu-surface");
+  const pageHeader = new FakeHeaderElement(223, 1071);
+  pageHeader.setAttribute("data-app-shell-page-header", "true");
+  surface.append(pageHeader);
+  let actionGroup: FakeHeaderElement | null = null;
+  if (options.nativeActions) {
+    actionGroup = new FakeHeaderElement(1299, 31);
+    actionGroup.setAttribute("data-app-shell-header-obstacle", "true");
+    surface.append(actionGroup);
+  }
+  const endSlot = new FakeHeaderElement(1447, 63);
+  endSlot.setAttribute("data-test-id", "header-shell-slot");
+  endSlot.setAttribute("data-app-shell-header-obstacle", "true");
+  header.append(startSlot, surface, endSlot);
+  return { header, startSlot, surface, pageHeader, actionGroup, endSlot };
+}
+
+function stubHeaderDocument(current: () => FakeHeaderElement): Document {
+  const document = {
+    createElement: () => new FakeHeaderElement(),
+    createElementNS: () => new FakeHeaderElement(),
+    querySelector: (selector: string) =>
+      selector === 'header[data-pip-obstacle="app-shell-header"]' ? current() : null,
+    querySelectorAll: () => [],
+  } as unknown as Document;
+  vi.stubGlobal("document", document);
+  return document;
+}
+
 describe("Renderer settings header trigger", () => {
   const header = bounds(240, 36, 942, 46);
 
@@ -123,102 +264,9 @@ describe("Renderer settings header trigger", () => {
     vi.unstubAllGlobals();
   });
 
-  it("mounts directly before the application header end slot without Thread actions", () => {
-    class FakeElement {
-      readonly attributes = new Map<string, string>();
-      readonly children: FakeElement[] = [];
-      readonly listeners = new Map<string, (event: { stopPropagation(): void }) => void>();
-      readonly classList = { add: vi.fn() };
-      readonly style: Record<string, string | ((name: string, value: string) => void)> = {};
-      disabled = false;
-      isConnected = true;
-      parentElement: FakeElement | null = null;
-      title = "";
-      type = "";
-
-      constructor(readonly left = 0) {
-        this.style.setProperty = (name: string, value: string) => {
-          this.style[name] = value;
-        };
-      }
-
-      get firstChild(): FakeElement | null {
-        return this.children[0] ?? null;
-      }
-      get nextSibling(): FakeElement | null {
-        if (!this.parentElement) return null;
-        const index = this.parentElement.children.indexOf(this);
-        return this.parentElement.children[index + 1] ?? null;
-      }
-      addEventListener(name: string, listener: (event: { stopPropagation(): void }) => void): void {
-        this.listeners.set(name, listener);
-      }
-      append(...children: FakeElement[]): void {
-        for (const child of children) this.insertBefore(child, null);
-      }
-      appendChild(child: FakeElement): FakeElement {
-        return this.insertBefore(child, null);
-      }
-      getBoundingClientRect(): DOMRect {
-        return {
-          left: this.left,
-          right: this.left + 80,
-          top: 0,
-          bottom: 46,
-          width: 80,
-          height: 46,
-        } as DOMRect;
-      }
-      insertBefore(child: FakeElement, before: FakeElement | null): FakeElement {
-        child.remove();
-        child.parentElement = this;
-        child.isConnected = true;
-        const index = before ? this.children.indexOf(before) : -1;
-        if (index < 0) this.children.push(child);
-        else this.children.splice(index, 0, child);
-        return child;
-      }
-      querySelectorAll(selector: string): FakeElement[] {
-        return selector === ':scope > [data-test-id="header-shell-slot"]'
-          ? this.children.filter((child) => child.attributes.has("data-test-id"))
-          : [];
-      }
-      remove(): void {
-        if (this.parentElement) {
-          const index = this.parentElement.children.indexOf(this);
-          if (index >= 0) this.parentElement.children.splice(index, 1);
-        }
-        this.parentElement = null;
-        this.isConnected = false;
-      }
-      removeEventListener(name: string): void {
-        this.listeners.delete(name);
-      }
-      setAttribute(name: string, value: string): void {
-        this.attributes.set(name, value);
-      }
-      toggleAttribute(name: string, force: boolean): void {
-        if (force) this.attributes.set(name, "");
-        else this.attributes.delete(name);
-      }
-    }
-
-    const header = new FakeElement();
-    const startSlot = new FakeElement(0);
-    startSlot.setAttribute("data-test-id", "header-shell-slot");
-    const content = new FakeElement(240);
-    const endSlot = new FakeElement(1120);
-    endSlot.setAttribute("data-test-id", "header-shell-slot");
-    header.append(startSlot, content, endSlot);
-    let currentHeader = header;
-    const document = {
-      createElement: () => new FakeElement(),
-      createElementNS: () => new FakeElement(),
-      querySelector: (selector: string) =>
-        selector === 'header[data-pip-obstacle="app-shell-header"]' ? currentHeader : null,
-      querySelectorAll: () => [],
-    } as unknown as Document;
-    vi.stubGlobal("document", document);
+  it("mounts directly before the native header action group", () => {
+    const shell = createFakeHeader({ nativeActions: true });
+    const document = stubHeaderDocument(() => shell.header);
 
     try {
       const control = installRendererSettingsHeaderTrigger({
@@ -228,24 +276,87 @@ describe("Renderer settings header trigger", () => {
       });
 
       expect(control.root).not.toBeNull();
-      expect(header.children).toEqual([startSlot, content, control.root, endSlot]);
+      expect(shell.surface.children).toEqual([shell.pageHeader, control.root, shell.actionGroup]);
+      expect(shell.header.children).toEqual([shell.startSlot, shell.surface, shell.endSlot]);
+      control.dispose();
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
 
-      const replacementHeader = new FakeElement();
-      const replacementStartSlot = new FakeElement(0);
-      replacementStartSlot.setAttribute("data-test-id", "header-shell-slot");
-      const replacementContent = new FakeElement(240);
-      const replacementEndSlot = new FakeElement(1120);
-      replacementEndSlot.setAttribute("data-test-id", "header-shell-slot");
-      replacementHeader.append(replacementStartSlot, replacementContent, replacementEndSlot);
-      currentHeader = replacementHeader;
+  it("mounts directly before the application header end slot without Thread actions", () => {
+    const shell = createFakeHeader({ nativeActions: false });
+    const document = stubHeaderDocument(() => shell.header);
+
+    try {
+      const control = installRendererSettingsHeaderTrigger({
+        available: true,
+        onOpen: vi.fn(),
+        ownerDocument: document,
+      });
+
+      expect(control.root).not.toBeNull();
+      expect(shell.header.children).toEqual([
+        shell.startSlot,
+        shell.surface,
+        control.root,
+        shell.endSlot,
+      ]);
+      expect(shell.surface.children).toEqual([shell.pageHeader]);
+      control.dispose();
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+
+  it("remounts before the native action group when Codex replaces the application header", () => {
+    const shell = createFakeHeader({ nativeActions: true });
+    let current = shell.header;
+    const document = stubHeaderDocument(() => current);
+
+    try {
+      const control = installRendererSettingsHeaderTrigger({
+        available: true,
+        onOpen: vi.fn(),
+        ownerDocument: document,
+      });
+      expect(shell.surface.children).toEqual([shell.pageHeader, control.root, shell.actionGroup]);
+
+      const replacement = createFakeHeader({ nativeActions: true });
+      current = replacement.header;
 
       expect(control.refresh()).toBe(true);
-      expect(header.children).toEqual([startSlot, content, endSlot]);
-      expect(replacementHeader.children).toEqual([
-        replacementStartSlot,
-        replacementContent,
+      expect(shell.surface.children).toEqual([shell.pageHeader, shell.actionGroup]);
+      expect(replacement.surface.children).toEqual([
+        replacement.pageHeader,
         control.root,
-        replacementEndSlot,
+        replacement.actionGroup,
+      ]);
+      control.dispose();
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+
+  it("stays put when another injected control mounts before the owned trigger", () => {
+    const shell = createFakeHeader({ nativeActions: true });
+    const document = stubHeaderDocument(() => shell.header);
+
+    try {
+      const control = installRendererSettingsHeaderTrigger({
+        available: true,
+        onOpen: vi.fn(),
+        ownerDocument: document,
+      });
+      const foreign = new FakeHeaderElement(1200, 24);
+      shell.surface.insertBefore(foreign, control.root as unknown as FakeHeaderElement);
+
+      expect(control.refresh()).toBe(true);
+      expect(shell.surface.children).toEqual([
+        shell.pageHeader,
+        foreign,
+        control.root,
+        shell.actionGroup,
       ]);
       control.dispose();
     } finally {


### PR DESCRIPTION
Fixes #248

## What

The application-header settings trigger now mounts immediately **before** Codex's native header action group instead of after it.

`findRendererSettingsHeaderInsertionPoint()` anchored on the right-most visible `:scope > [data-test-id="header-shell-slot"]` of the header. On Codex Desktop 0.153.4 that slot holds the window-layout toggles and sits to the right of `[data-testid="app-shell-header-context-menu-surface"]`, so the trigger landed after everything the surface renders — including the native pinned-summary toggle.

The new anchor is the trailing `[data-app-shell-header-obstacle="true"]` child of that surface, i.e. the native action group itself. The previous slot anchor is kept as the fallback for the blank-Thread case where no native action group is rendered, which is the "structurally verified empty action position" the spec already describes.

Note that both `header-shell-slot` elements also carry `data-app-shell-header-obstacle="true"`, so the lookup is deliberately scoped through the context-menu surface rather than searching the header for that attribute.

## Why

The `extensible-settings-shell` spec already required this placement:

> … one owned settings trigger **as the first control in the verified Codex application-header right-side action group** … and SHALL appear **immediately before the native Open Location control** when it is available.

so this restores the documented contract rather than changing it. Beyond that, anchoring plugin controls to the left of the native group means native controls keep fixed positions: today the trigger's width changes with locale and with the update badge, and each change shifts Codex's own buttons. It also gives any other renderer injection a stable rule — grow leftwards, never displace native controls.

Because the anchor is now a native element rather than an ordinal position, the trigger also stays put when another injected control is inserted before it, instead of fighting it for first place on every mutation scan.

Spec text updated in the same commit: the requirement and the blank-Thread / header-replacement scenarios now name the native action group instead of Open Location, plus one new scenario for a foreign injected control.

## Verification

**Tests** (`npx vitest run --config tests/vitest.config.js`):

- `packages/renderer-extension`: 385 passed / 38 files.
- Whole suite: 3232 passed, 23 skipped, 11 failed in `packages/adapters/opencode/test/command.test.ts` and `packages/host-runtime/test/installed-harness-plugins.test.ts` — these 11 fail identically on unmodified `origin/main` in my environment (they probe locally installed harness CLIs), so they are unrelated to this change.
- `npm run typecheck` and `npm run lint` clean; `npm run build:renderer` builds.

Three new cases in `test/settings/trigger.test.ts` (all three fail against the old implementation, verified by reverting only the source file): mounts before the native action group; remounts before it when Codex replaces the header; stays put when a foreign control is inserted before it. The existing blank-Thread fallback case is unchanged and still passes.

**Real DOM**, Codex Desktop app-server 0.153.4, macOS, zh-CN, window width 1510. Measured through a read-only CDP session against the running app by previewing the new insertion point:

| element | before | after |
|---|---|---|
| `[data-codexhost-settings-trigger]` | x=1335, w=112 | **x=1294, w=112** |
| native group `.ms-auto[data-app-shell-header-obstacle]` (pinned-summary toggle) | x=1299, w=31 | **x=1411, w=31** |
| window-layout `header-shell-slot` | x=1447, w=63 | x=1447, w=63 |

Header order goes from `… [summary toggle] [CodexHost] [window layout]` to `… [CodexHost] [summary toggle] [window layout]`; the native controls stay flush against the right edge and the plugin control extends leftwards. Screenshots of both states were captured locally; I can attach them here if useful.
