### PR TITLE
fix(claude-code): preserve background Subagent settlement order

### DIFF
--- a/packages/adapters/claude-code/src/claude-code-adapter.ts
+++ b/packages/adapters/claude-code/src/claude-code-adapter.ts
@@ -1399,10 +1399,33 @@ class ClaudeHarnessSession implements HarnessSession {
       });
       this.#transport = transport;
       transport.setAutonomousTurnHandler((turn) => this.#handleAutonomousTurn(turn));
+      transport.setThreadEventHandler((event) => {
+        // Thread-level events (e.g. a background Subagent settling) are not
+        // Turn-scoped and must not be gated on an active Turn.
+        if (event.type === "subagent.settled") {
+          this.#settleBackgroundSubagent(
+            event.status,
+            event.nativeSubagentId,
+            event.callId,
+            event.resultSummary,
+          );
+        }
+      });
       transport.setIdleTurnHandler({
         onEvent: (event) => {
           const active = this.#active;
-          if (active) this.#handleTurnEvent(active, event);
+          if (active) {
+            this.#handleTurnEvent(active, event);
+            return;
+          }
+          if (event.type === "subagent.settled") {
+            this.#settleBackgroundSubagent(
+              event.status,
+              event.nativeSubagentId,
+              event.callId,
+              event.resultSummary,
+            );
+          }
         },
         onTerminal: (result) => {
           const active = this.#active;

--- a/packages/adapters/claude-code/src/sdk-transport.ts
+++ b/packages/adapters/claude-code/src/sdk-transport.ts
@@ -936,8 +936,11 @@ export class ClaudeSdkTransport implements ClaudeTurnTransport {
         }
         const interpreted = autonomous.accumulator.consume(message);
         for (const event of interpreted.events) {
-          if (canDeliverSettlementImmediately(event, autonomous.events)) {
-            this.#threadEventHandler?.(event);
+          if (
+            this.#threadEventHandler &&
+            canDeliverSettlementImmediately(event, autonomous.events)
+          ) {
+            this.#threadEventHandler(event);
             continue;
           }
           autonomous.events.push(event);

--- a/packages/adapters/claude-code/src/sdk-transport.ts
+++ b/packages/adapters/claude-code/src/sdk-transport.ts
@@ -337,10 +337,28 @@ function allowed(
   };
 }
 
-function isThreadLevelEvent(event: ClaudeTurnEvent): boolean {
-  // A background Subagent settles outside any Turn, and its task-notification
-  // Segment may never produce a Terminal; Turn batching would swallow it.
-  return event.type === "subagent.settled";
+function canDeliverSettlementImmediately(
+  event: ClaudeTurnEvent,
+  pendingEvents: readonly ClaudeTurnEvent[],
+): boolean {
+  if (event.type !== "subagent.settled") return false;
+  // A notification without a continuation may never produce a Terminal. Deliver
+  // it now unless this batch still owes the child its creation/reactivation.
+  // Otherwise Host would discard the unknown child's terminal state and later
+  // replay its buffered lifecycle as running.
+  return !pendingEvents.some((pending) => {
+    if (
+      pending.type !== "subagent.started" &&
+      pending.type !== "subagent.updated" &&
+      pending.type !== "subagent.completed"
+    ) {
+      return false;
+    }
+    return (
+      (event.callId !== undefined && pending.callId === event.callId) ||
+      pending.nativeSubagentId === event.nativeSubagentId
+    );
+  });
 }
 
 export class ClaudeSdkTransport implements ClaudeTurnTransport {
@@ -918,7 +936,7 @@ export class ClaudeSdkTransport implements ClaudeTurnTransport {
         }
         const interpreted = autonomous.accumulator.consume(message);
         for (const event of interpreted.events) {
-          if (isThreadLevelEvent(event)) {
+          if (canDeliverSettlementImmediately(event, autonomous.events)) {
             this.#threadEventHandler?.(event);
             continue;
           }

--- a/packages/adapters/claude-code/src/sdk-transport.ts
+++ b/packages/adapters/claude-code/src/sdk-transport.ts
@@ -337,6 +337,12 @@ function allowed(
   };
 }
 
+function isThreadLevelEvent(event: ClaudeTurnEvent): boolean {
+  // A background Subagent settles outside any Turn, and its task-notification
+  // Segment may never produce a Terminal; Turn batching would swallow it.
+  return event.type === "subagent.settled";
+}
+
 export class ClaudeSdkTransport implements ClaudeTurnTransport {
   readonly sessionId: string;
   readonly #children: ChildProcessWithoutNullStreams[] = [];
@@ -362,6 +368,7 @@ export class ClaudeSdkTransport implements ClaudeTurnTransport {
   } | null = null;
   #autonomousTurnHandler: ((turn: ClaudeAutonomousTurn) => void) | null = null;
   #idleHandler: ClaudeIdleTurnHandler | null = null;
+  #threadEventHandler: ((event: ClaudeTurnEvent) => void) | null = null;
   #idleLive = false;
   #idleAccumulator: ClaudeNativeTurnAccumulator | null = null;
   #closePromise: Promise<void> | null = null;
@@ -396,6 +403,10 @@ export class ClaudeSdkTransport implements ClaudeTurnTransport {
 
   setIdleTurnHandler(handler: ClaudeIdleTurnHandler | null): void {
     this.#idleHandler = handler;
+  }
+
+  setThreadEventHandler(handler: ((event: ClaudeTurnEvent) => void) | null): void {
+    this.#threadEventHandler = handler;
   }
 
   setIdleLive(live: boolean): void {
@@ -906,7 +917,13 @@ export class ClaudeSdkTransport implements ClaudeTurnTransport {
           autonomous.nativeTurnKey = message.uuid;
         }
         const interpreted = autonomous.accumulator.consume(message);
-        autonomous.events.push(...interpreted.events);
+        for (const event of interpreted.events) {
+          if (isThreadLevelEvent(event)) {
+            this.#threadEventHandler?.(event);
+            continue;
+          }
+          autonomous.events.push(event);
+        }
         if (interpreted.terminal) {
           this.#autonomous = null;
           const nativeTurnKey = autonomous.nativeTurnKey ?? `autonomous-${Date.now()}`;

--- a/packages/adapters/claude-code/src/transport.ts
+++ b/packages/adapters/claude-code/src/transport.ts
@@ -182,10 +182,10 @@ export interface ClaudeTurnTransport {
   setAutonomousTurnHandler(handler: (turn: ClaudeAutonomousTurn) => void): void;
   setIdleTurnHandler(handler: ClaudeIdleTurnHandler | null): void;
   /**
-   * Receives Thread-level events the moment they are observed, independent of
-   * Turn or Segment boundaries. A background Subagent's settlement arrives in
-   * a task-notification Segment that may never produce a Terminal, so Turn
-   * batching would swallow it.
+   * Receives settlements that have no preceding buffered Subagent lifecycle.
+   * A task-notification Segment may never produce a Terminal, so independent
+   * settlements must not wait for Turn batching. Settlements that depend on a
+   * buffered creation/reactivation stay in that batch to preserve causal order.
    */
   setThreadEventHandler(handler: ((event: ClaudeTurnEvent) => void) | null): void;
   setIdleLive(live: boolean): void;

--- a/packages/adapters/claude-code/src/transport.ts
+++ b/packages/adapters/claude-code/src/transport.ts
@@ -181,6 +181,13 @@ export interface ClaudeTurnTransport {
   readonly sessionId: string;
   setAutonomousTurnHandler(handler: (turn: ClaudeAutonomousTurn) => void): void;
   setIdleTurnHandler(handler: ClaudeIdleTurnHandler | null): void;
+  /**
+   * Receives Thread-level events the moment they are observed, independent of
+   * Turn or Segment boundaries. A background Subagent's settlement arrives in
+   * a task-notification Segment that may never produce a Terminal, so Turn
+   * batching would swallow it.
+   */
+  setThreadEventHandler(handler: ((event: ClaudeTurnEvent) => void) | null): void;
   setIdleLive(live: boolean): void;
   start(): Promise<void>;
   getContextUsage(): Promise<ClaudeTransportContextUsage | null>;

--- a/packages/adapters/claude-code/src/transport.ts
+++ b/packages/adapters/claude-code/src/transport.ts
@@ -186,6 +186,7 @@ export interface ClaudeTurnTransport {
    * A task-notification Segment may never produce a Terminal, so independent
    * settlements must not wait for Turn batching. Settlements that depend on a
    * buffered creation/reactivation stay in that batch to preserve causal order.
+   * Without a Thread handler, settlements remain in the autonomous Turn batch.
    */
   setThreadEventHandler(handler: ((event: ClaudeTurnEvent) => void) | null): void;
   setIdleLive(live: boolean): void;

--- a/packages/adapters/claude-code/test/claude-code-adapter.test.ts
+++ b/packages/adapters/claude-code/test/claude-code-adapter.test.ts
@@ -2270,6 +2270,79 @@ describe("Claude Code HarnessAdapter", () => {
     await session.close();
   });
 
+  it.each(["completed", "failed", "interrupted"] as const)(
+    "finishes an autonomous Turn after its newly created child is %s",
+    async (status) => {
+      const { adapter, transports } = fixture();
+      const session = await openSession(adapter);
+      const events: Array<Extract<HarnessOutput, { kind: "event" }>["event"]> = [];
+      const drain = (async () => {
+        for await (const output of session.outputs) {
+          if (output.kind === "event") events.push(output.event);
+        }
+      })();
+      try {
+        await session.execute(textTurn("initial"));
+        const transport = transports[0];
+        if (!transport) throw new Error("Fake Claude transport was not created");
+        transport.finish({ status: "succeeded" });
+        await vi.waitFor(() =>
+          expect(events.some((event) => event.type === "turn.completed")).toBe(true),
+        );
+        events.length = 0;
+        transport.autonomousTurnHandler?.({
+          nativeTurnKey: "continuation-with-child",
+          events: [
+            {
+              type: "subagent.started",
+              operation: "spawn",
+              callId: "spawn-child",
+              description: "Inspect",
+              background: true,
+            },
+            {
+              type: "subagent.completed",
+              callId: "spawn-child",
+              isError: false,
+              continuesInBackground: true,
+              nativeSubagentId: "fast-child",
+            },
+            {
+              type: "subagent.settled",
+              nativeSubagentId: "fast-child",
+              status,
+              resultSummary: "Child finished",
+            },
+          ],
+          result: { status: "succeeded" },
+        });
+        await vi.waitFor(() =>
+          expect(events.some((event) => event.type === "turn.completed")).toBe(true),
+        );
+        expect(events.filter((event) => event.type === "subagent.state.changed")).toEqual([
+          {
+            type: "subagent.state.changed",
+            nativeSubagentId: "fast-child",
+            status,
+            resultSummary: "Child finished",
+          },
+        ]);
+        const creation = events.findIndex(
+          (event) =>
+            event.type === "item.completed" && event.snapshot.item.type === "subagentDelegation",
+        );
+        const settlement = events.findIndex((event) => event.type === "subagent.state.changed");
+        expect(creation).toBeGreaterThanOrEqual(0);
+        expect(settlement).toBeGreaterThan(creation);
+        expect(await session.execute(textTurn("next-user-turn"))).toMatchObject({ ok: true });
+        transport.finish({ status: "succeeded" });
+      } finally {
+        await session.close();
+        await drain;
+      }
+    },
+  );
+
   it("publishes a background Subagent settlement that arrives outside any Turn", async () => {
     const { adapter, transports } = fixture();
     const session = await openSession(adapter);

--- a/packages/adapters/claude-code/test/claude-code-adapter.test.ts
+++ b/packages/adapters/claude-code/test/claude-code-adapter.test.ts
@@ -33,12 +33,16 @@ class FakeClaudeTransport implements ClaudeTurnTransport {
   readonly sessionId: string;
   autonomousTurnHandler: ((turn: ClaudeAutonomousTurn) => void) | null = null;
   idleHandler: ClaudeIdleTurnHandler | null = null;
+  threadHandler: ((event: ClaudeTurnEvent) => void) | null = null;
   idleLive = false;
   setAutonomousTurnHandler(handler: (turn: ClaudeAutonomousTurn) => void): void {
     this.autonomousTurnHandler = handler;
   }
   setIdleTurnHandler(handler: ClaudeIdleTurnHandler | null): void {
     this.idleHandler = handler;
+  }
+  setThreadEventHandler(handler: ((event: ClaudeTurnEvent) => void) | null): void {
+    this.threadHandler = handler;
   }
   setIdleLive(live: boolean): void {
     this.idleLive = live;
@@ -156,6 +160,10 @@ class FakeClaudeTransport implements ClaudeTurnTransport {
       return;
     }
     throw new Error("No active fake Claude Turn");
+  }
+
+  threadEvent(event: ClaudeTurnEvent): void {
+    this.threadHandler?.(event);
   }
 
   approval(request: ClaudeApprovalRequest): void {
@@ -2258,6 +2266,40 @@ describe("Claude Code HarnessAdapter", () => {
       type: "turn.completed",
       outcome: { status: "succeeded" },
       nativeTurnRef: { nativeTurnKey: "task-notification-1" },
+    });
+    await session.close();
+  });
+
+  it("publishes a background Subagent settlement that arrives outside any Turn", async () => {
+    const { adapter, transports } = fixture();
+    const session = await openSession(adapter);
+    const iterator = session.outputs[Symbol.asyncIterator]();
+
+    await session.execute(textTurn("delegate in background"));
+    await nextEvent(iterator);
+    await nextEvent(iterator);
+    await nextEvent(iterator);
+    const transport = transports[0];
+    if (!transport) throw new Error("Fake Claude transport was not created");
+    transport.delta("Background task launched");
+    await nextEvent(iterator);
+    transport.finish({ status: "succeeded" });
+    await nextEvent(iterator);
+    await nextEvent(iterator);
+
+    // The Turn is complete and idle. Claude may enqueue the task notification
+    // without a continuation, so the settlement no longer rides a Turn.
+    transport.threadEvent({
+      type: "subagent.settled",
+      nativeSubagentId: "native-agent-late",
+      status: "completed",
+      resultSummary: "Analysis complete",
+    });
+    expect(await nextEvent(iterator)).toMatchObject({
+      type: "subagent.state.changed",
+      nativeSubagentId: "native-agent-late",
+      status: "completed",
+      resultSummary: "Analysis complete",
     });
     await session.close();
   });
@@ -4778,6 +4820,7 @@ describe("Claude Code HarnessAdapter", () => {
         sessionId: "claude-id",
         setAutonomousTurnHandler: () => undefined,
         setIdleTurnHandler: () => undefined,
+        setThreadEventHandler: () => undefined,
         setIdleLive: () => undefined,
         start: async () => {
           throw new ClaudeCodeExecutableError("Claude Code is not installed");

--- a/packages/adapters/claude-code/test/claude-rollback.test.ts
+++ b/packages/adapters/claude-code/test/claude-rollback.test.ts
@@ -102,6 +102,7 @@ async function fixture(turns = 1) {
         abort: vi.fn(async () => undefined),
         setAutonomousTurnHandler: () => undefined,
         setIdleTurnHandler: () => undefined,
+        setThreadEventHandler: () => undefined,
         setIdleLive: () => undefined,
         getContextUsage: async () => null,
         getPermissionMode: () => permissionMode,

--- a/packages/adapters/claude-code/test/sdk-transport.test.ts
+++ b/packages/adapters/claude-code/test/sdk-transport.test.ts
@@ -1980,3 +1980,207 @@ describe("Claude history replacement fence", () => {
     },
   );
 });
+
+// A native continuation may launch another child before its own result arrives.
+function pushBackgroundDelegation(
+  fakeQuery: FakeQuery,
+  callId: string,
+  nativeSubagentId: string | undefined,
+  operation: "spawn" | "send" = "spawn",
+): void {
+  fakeQuery.push({
+    type: "assistant",
+    uuid: `assistant-${callId}`,
+    parent_tool_use_id: null,
+    message: {
+      id: `message-${callId}`,
+      content: [
+        {
+          type: "tool_use",
+          id: callId,
+          name: operation === "spawn" ? "Agent" : "SendMessage",
+          input:
+            operation === "spawn"
+              ? { description: "Analyze", prompt: "Analyze", run_in_background: true }
+              : { to: nativeSubagentId, summary: "Analyze", message: "Analyze" },
+        },
+      ],
+    },
+  } as unknown as SDKMessage);
+  fakeQuery.push({
+    type: "user",
+    parent_tool_use_id: null,
+    message: {
+      role: "user",
+      content: [{ type: "tool_result", tool_use_id: callId, content: "Launched", is_error: false }],
+    },
+    ...(operation === "spawn"
+      ? { tool_use_result: { status: "async_launched", agentId: nativeSubagentId } }
+      : {}),
+  } as unknown as SDKMessage);
+}
+
+function pushSettlement(
+  fakeQuery: FakeQuery,
+  nativeSubagentId: string,
+  status = "completed",
+  callId?: string,
+): void {
+  fakeQuery.push({
+    type: "system",
+    subtype: "task_notification",
+    task_id: nativeSubagentId,
+    status,
+    summary: "Analysis finished",
+    ...(callId ? { tool_use_id: callId } : {}),
+  } as unknown as SDKMessage);
+}
+
+describe("ClaudeSdkTransport autonomous Subagent settlement ordering", () => {
+  it.each(["completed", "failed", "stopped"])(
+    "keeps a fast %s child settlement after its buffered creation",
+    async (status) => {
+      const value = fixture();
+      const turns: ClaudeAutonomousTurn[] = [];
+      const immediate: ClaudeTurnEvent[] = [];
+      value.transport.setAutonomousTurnHandler((turn) => turns.push(turn));
+      value.transport.setThreadEventHandler((event) => immediate.push(event));
+      await value.transport.start();
+      try {
+        pushBackgroundDelegation(value.fakeQuery, "spawn-1", "child-1");
+        // No callId: the native ID learned from the launch result must suffice.
+        pushSettlement(value.fakeQuery, "child-1", status);
+        completeTurn(value.fakeQuery);
+        await vi.waitFor(() => expect(turns).toHaveLength(1));
+        expect(immediate).toEqual([]);
+        const turn = turns[0];
+        if (!turn) throw new Error("Autonomous Turn was not delivered");
+        const events = turn.events;
+        const created = events.findIndex((event) => event.type === "subagent.completed");
+        expect(created).toBeGreaterThanOrEqual(0);
+        expect(events.findIndex((event) => event.type === "subagent.settled")).toBeGreaterThan(
+          created,
+        );
+        expect(events.filter((event) => event.type === "subagent.settled")).toEqual([
+          {
+            type: "subagent.settled",
+            nativeSubagentId: "child-1",
+            status: status === "stopped" ? "interrupted" : status,
+            resultSummary: "Analysis finished",
+          },
+        ]);
+      } finally {
+        await value.transport.close();
+      }
+    },
+  );
+
+  it("uses the call ID when the launch result has not supplied a native child ID", async () => {
+    const value = fixture();
+    const turns: ClaudeAutonomousTurn[] = [];
+    const immediate: ClaudeTurnEvent[] = [];
+    value.transport.setAutonomousTurnHandler((turn) => turns.push(turn));
+    value.transport.setThreadEventHandler((event) => immediate.push(event));
+    await value.transport.start();
+    try {
+      pushBackgroundDelegation(value.fakeQuery, "spawn-call-only", undefined);
+      pushSettlement(value.fakeQuery, "child-from-notification", "completed", "spawn-call-only");
+      completeTurn(value.fakeQuery);
+      await vi.waitFor(() => expect(turns).toHaveLength(1));
+      expect(immediate).toEqual([]);
+      const turn = turns[0];
+      if (!turn) throw new Error("Autonomous Turn was not delivered");
+      const created = turn.events.findIndex((event) => event.type === "subagent.completed");
+      expect(turn.events[created]).not.toHaveProperty("nativeSubagentId");
+      expect(turn.events.findIndex((event) => event.type === "subagent.settled")).toBeGreaterThan(
+        created,
+      );
+    } finally {
+      await value.transport.close();
+    }
+  });
+
+  it("orders repeated sends to one native child independently across batches", async () => {
+    const value = fixture();
+    const turns: ClaudeAutonomousTurn[] = [];
+    const immediate: ClaudeTurnEvent[] = [];
+    value.transport.setAutonomousTurnHandler((turn) => turns.push(turn));
+    value.transport.setThreadEventHandler((event) => immediate.push(event));
+    await value.transport.start();
+    try {
+      for (let index = 0; index < 2; index += 1) {
+        pushBackgroundDelegation(value.fakeQuery, `send-${index}`, "existing-child", "send");
+        pushSettlement(value.fakeQuery, "existing-child");
+        completeTurn(value.fakeQuery);
+        await vi.waitFor(() => expect(turns).toHaveLength(index + 1));
+        const turn = turns[index];
+        if (!turn) throw new Error("Autonomous Turn was not delivered");
+        const events = turn.events;
+        expect(events.findIndex((event) => event.type === "subagent.settled")).toBeGreaterThan(
+          events.findIndex((event) => event.type === "subagent.completed"),
+        );
+      }
+      expect(immediate).toEqual([]);
+      // No creation in this new batch: do not retain a stale dependency.
+      pushSettlement(value.fakeQuery, "existing-child");
+      await vi.waitFor(() => expect(immediate).toHaveLength(1));
+    } finally {
+      await value.transport.close();
+    }
+  });
+
+  it("does not make unrelated settlements wait for a buffered creation or Terminal", async () => {
+    const value = fixture();
+    const turns: ClaudeAutonomousTurn[] = [];
+    const immediate: ClaudeTurnEvent[] = [];
+    value.transport.setAutonomousTurnHandler((turn) => turns.push(turn));
+    value.transport.setThreadEventHandler((event) => immediate.push(event));
+    await value.transport.start();
+    try {
+      pushBackgroundDelegation(value.fakeQuery, "spawn-new", "new-child");
+      pushSettlement(value.fakeQuery, "new-child");
+      pushSettlement(value.fakeQuery, "existing-child");
+      await vi.waitFor(() =>
+        expect(immediate).toEqual([
+          expect.objectContaining({ nativeSubagentId: "existing-child" }),
+        ]),
+      );
+      expect(turns).toEqual([]);
+      completeTurn(value.fakeQuery);
+      await vi.waitFor(() => expect(turns).toHaveLength(1));
+      const turn = turns[0];
+      if (!turn) throw new Error("Autonomous Turn was not delivered");
+      expect(turn.events.filter((event) => event.type === "subagent.settled")).toEqual([
+        expect.objectContaining({ nativeSubagentId: "new-child" }),
+      ]);
+    } finally {
+      await value.transport.close();
+    }
+  });
+
+  it("discards unpublished lifecycle events on close without flushing orphan terminal states", async () => {
+    const value = fixture();
+    const turns: ClaudeAutonomousTurn[] = [];
+    const immediate: ClaudeTurnEvent[] = [];
+    value.transport.setAutonomousTurnHandler((turn) => turns.push(turn));
+    value.transport.setThreadEventHandler((event) => immediate.push(event));
+    await value.transport.start();
+    pushBackgroundDelegation(value.fakeQuery, "spawn-close", "unpublished-child");
+    pushSettlement(value.fakeQuery, "unpublished-child");
+    pushSettlement(value.fakeQuery, "existing-child");
+    try {
+      await vi.waitFor(() =>
+        expect(
+          immediate.some(
+            (event) =>
+              event.type === "subagent.settled" && event.nativeSubagentId === "existing-child",
+          ),
+        ).toBe(true),
+      );
+    } finally {
+      await value.transport.close();
+    }
+    expect(turns).toEqual([]);
+    expect(immediate).toEqual([expect.objectContaining({ nativeSubagentId: "existing-child" })]);
+  });
+});

--- a/packages/adapters/claude-code/test/sdk-transport.test.ts
+++ b/packages/adapters/claude-code/test/sdk-transport.test.ts
@@ -2037,6 +2037,38 @@ function pushSettlement(
 }
 
 describe("ClaudeSdkTransport autonomous Subagent settlement ordering", () => {
+  it.each(["unset", "cleared"])(
+    "keeps settlements in the autonomous batch when the Thread handler is %s",
+    async (handlerState) => {
+      const value = fixture();
+      const turns: ClaudeAutonomousTurn[] = [];
+      const immediate = vi.fn();
+      value.transport.setAutonomousTurnHandler((turn) => turns.push(turn));
+      if (handlerState === "cleared") {
+        value.transport.setThreadEventHandler(immediate);
+        value.transport.setThreadEventHandler(null);
+      }
+      await value.transport.start();
+      try {
+        pushSettlement(value.fakeQuery, "existing-child", "completed", "existing-call");
+        completeTurn(value.fakeQuery);
+        await vi.waitFor(() => expect(turns).toHaveLength(1));
+        expect(turns[0]?.events).toEqual([
+          {
+            type: "subagent.settled",
+            nativeSubagentId: "existing-child",
+            callId: "existing-call",
+            status: "completed",
+            resultSummary: "Analysis finished",
+          },
+        ]);
+        expect(immediate).not.toHaveBeenCalled();
+      } finally {
+        await value.transport.close();
+      }
+    },
+  );
+
   it.each(["completed", "failed", "stopped"])(
     "keeps a fast %s child settlement after its buffered creation",
     async (status) => {

--- a/packages/adapters/claude-code/test/sdk-transport.test.ts
+++ b/packages/adapters/claude-code/test/sdk-transport.test.ts
@@ -722,7 +722,9 @@ describe("ClaudeSdkTransport autonomous task continuation", () => {
   it("publishes Root output produced after a background task notification", async () => {
     const value = fixture();
     const autonomous: ClaudeAutonomousTurn[] = [];
+    const threadEvents: ClaudeTurnEvent[] = [];
     value.transport.setAutonomousTurnHandler((turn) => autonomous.push(turn));
+    value.transport.setThreadEventHandler((event) => threadEvents.push(event));
     await value.transport.start();
 
     value.fakeQuery.push({
@@ -750,16 +752,19 @@ describe("ClaudeSdkTransport autonomous task continuation", () => {
     completeTurn(value.fakeQuery);
 
     await vi.waitFor(() => expect(autonomous).toHaveLength(1));
+    expect(threadEvents).toEqual([
+      {
+        type: "subagent.settled",
+        callId: "send-1",
+        nativeSubagentId: "native-agent-1",
+        status: "completed",
+        resultSummary: "Analysis complete",
+      },
+    ]);
     expect(autonomous[0]).toMatchObject({
       nativeTurnKey: "00000000-0000-4000-8000-000000000040",
       result: { status: "succeeded" },
       events: [
-        {
-          type: "subagent.settled",
-          nativeSubagentId: "native-agent-1",
-          status: "completed",
-          resultSummary: "Analysis complete",
-        },
         { type: "text.delta", delta: "Background analysis result" },
         { type: "message.completed" },
       ],
@@ -770,7 +775,9 @@ describe("ClaudeSdkTransport autonomous task continuation", () => {
   it("preserves a failed task-notification whose user content is text blocks", async () => {
     const value = fixture();
     const autonomous: ClaudeAutonomousTurn[] = [];
+    const threadEvents: ClaudeTurnEvent[] = [];
     value.transport.setAutonomousTurnHandler((turn) => autonomous.push(turn));
+    value.transport.setThreadEventHandler((event) => threadEvents.push(event));
     await value.transport.start();
 
     value.fakeQuery.push({
@@ -793,7 +800,7 @@ describe("ClaudeSdkTransport autonomous task continuation", () => {
     completeTurn(value.fakeQuery);
 
     await vi.waitFor(() => expect(autonomous).toHaveLength(1));
-    expect(autonomous[0]?.events.filter((event) => event.type === "subagent.settled")).toEqual([
+    expect(threadEvents).toEqual([
       {
         type: "subagent.settled",
         nativeSubagentId: "a78414260bd2f9554",
@@ -801,6 +808,45 @@ describe("ClaudeSdkTransport autonomous task continuation", () => {
         resultSummary: "Agent failed",
       },
     ]);
+    expect(autonomous[0]?.events.filter((event) => event.type === "subagent.settled")).toEqual([]);
+    await value.transport.close();
+  });
+
+  it("delivers a background task settlement whose Segment never produces a Terminal", async () => {
+    const value = fixture();
+    const autonomous: ClaudeAutonomousTurn[] = [];
+    const threadEvents: ClaudeTurnEvent[] = [];
+    value.transport.setAutonomousTurnHandler((turn) => autonomous.push(turn));
+    value.transport.setThreadEventHandler((event) => threadEvents.push(event));
+    await value.transport.start();
+
+    // Claude may enqueue the notification without a continuation Turn: no
+    // Assistant output and no Result follow. The settlement is Thread-level
+    // and must still be delivered instead of being swallowed by Turn batching.
+    value.fakeQuery.push({
+      type: "user",
+      uuid: "00000000-0000-4000-8000-000000000060",
+      session_id: "00000000-0000-4000-8000-000000000001",
+      parent_tool_use_id: null,
+      origin: { kind: "task-notification" },
+      message: {
+        role: "user",
+        content:
+          "<task-notification><task-id>native-agent-late</task-id><summary>Late analysis</summary></task-notification>",
+      },
+    } as unknown as SDKMessage);
+
+    await vi.waitFor(() =>
+      expect(threadEvents).toEqual([
+        {
+          type: "subagent.settled",
+          nativeSubagentId: "native-agent-late",
+          status: "completed",
+          resultSummary: "Late analysis",
+        },
+      ]),
+    );
+    expect(autonomous).toEqual([]);
     await value.transport.close();
   });
 

--- a/packages/host-runtime/test/app-server-host.claude.real.test.ts
+++ b/packages/host-runtime/test/app-server-host.claude.real.test.ts
@@ -155,6 +155,7 @@ describe("AppServerHost hermetic Claude projection", () => {
           sessionId: input.sessionId,
           setAutonomousTurnHandler: () => undefined,
           setIdleTurnHandler: () => undefined,
+          setThreadEventHandler: () => undefined,
           setIdleLive: () => undefined,
           start: async () => undefined,
           getContextUsage: async () => ({


### PR DESCRIPTION
## 问题与修复

后台子任务在 Turn 外完成且没有后续 `result` 时，完成通知可能滞留在 autonomous 批次，导致父线程一直显示 active。本 PR 基于 @YanYunCY 的 #246：保留其即时 Thread 事件通道，并修复该方案可能造成的生命周期顺序回归。

具体触发：autonomous 续轮启动后台 Agent，该 Agent 在续轮 `result` 前结束。若立即发送 `subagent.settled`，此前仍缓存的创建事件尚未到达 Host，Host 会丢弃未知子任务的结束通知；随后重放创建事件又将其标为 running。

现在仅当缓存中没有同一子任务的前置生命周期事件时，才立即派发 settlement。通过 call ID 或 native Subagent ID 识别尚未发布的创建/再次启动，相关事件保持批内顺序；不相关任务的通知仍无需等待 Terminal。保留原始完成/失败/中断状态及现有关闭清理行为。

## 与 #246 的关系

- 第一条提交保留 @YanYunCY 的原始作者信息，并记录原提交 `274862b5` 的 cherry-pick 来源。
- 第二条提交补充顺序修正、更新传输接口说明和回归测试。
- 若 #246 先合并，可单独应用第二条修正提交。

Fixes #238
Refs #246

## 验证

- 新增 7 个 SDK 时序用例和 3 个 Adapter 状态收尾用例；其中首批 6 个 SDK 用例在原 #246 上全部失败，修正后通过。
- Claude Adapter 与相关 Host 定向测试共 403 项通过；4 项需显式启用真实 Claude 环境的既有测试跳过。
- `npm run typecheck`、`npm run build:typescript`、变更文件 ESLint/Prettier、`git diff --check` 通过。
- 覆盖无 Terminal 的独立通知、快速成功/失败/中断、ID 关联、重复 send、跨批复用、任务交错及关闭后不补发未登记子任务。
- 尚未进行安装版 Desktop 手动回归；本次没有修改安装中的应用。
