### PR TITLE
feat(antigravity): prioritize 5-hour limit in quota display

### DIFF
--- a/packages/adapters/antigravity/src/quota.ts
+++ b/packages/adapters/antigravity/src/quota.ts
@@ -92,16 +92,20 @@ function parseBuckets(groups: readonly unknown[]): ParsedBucket[] {
 }
 
 /**
- * Picks the bucket that actually constrains the next Turn: the most consumed
- * one, breaking ties toward the 5-hour window because it resets soonest.
+ * Picks the bucket that actually constrains the next Turn: prefers the 5-hour
+ * window (most actionable and resets soonest), breaking ties by consumption.
  */
 function leadingBucket(buckets: readonly ParsedBucket[]): ParsedBucket | undefined {
   return [...buckets].sort((left, right) => {
-    if (right.usagePercent !== left.usagePercent) return right.usagePercent - left.usagePercent;
-    return (
-      Number(periodTypeFrom(right.window) === "five_hour") -
-      Number(periodTypeFrom(left.window) === "five_hour")
-    );
+    const leftIsFiveHour = periodTypeFrom(left.window) === "five_hour";
+    const rightIsFiveHour = periodTypeFrom(right.window) === "five_hour";
+    if (leftIsFiveHour !== rightIsFiveHour) {
+      return Number(rightIsFiveHour) - Number(leftIsFiveHour);
+    }
+    if (right.usagePercent !== left.usagePercent) {
+      return right.usagePercent - left.usagePercent;
+    }
+    return 0;
   })[0];
 }
 

--- a/packages/adapters/antigravity/test/antigravity-adapter.test.ts
+++ b/packages/adapters/antigravity/test/antigravity-adapter.test.ts
@@ -123,7 +123,7 @@ describe("Antigravity Adapter", () => {
     const adapter = new AntigravityAdapter({ command: fixture.command, environment: process.env });
     try {
       expect(await adapter.inspectAccount()).toMatchObject({
-        credits: { label: "Gemini Models · Weekly window", usedPercent: 2.65 },
+        credits: { label: "Gemini Models · 5-hour window", usedPercent: 0 },
       });
       expect(adapter.credits()).not.toBeNull();
       await writeFile(
@@ -395,20 +395,20 @@ describe("Antigravity Adapter", () => {
 
   it("projects the CLI /usage command into an account credits snapshot", () => {
     const snapshot = parseAntigravityUsageCommand(USAGE_COMMAND, FETCHED_AT);
-    // The Gemini weekly bucket is the most consumed, so it leads the pill.
+    // The 5-hour window leads (it is the most actionable and resets soonest).
     // Labels come from the window, not the CLI's "… Remaining" naming, because
     // the values are consumed percentages.
     expect(snapshot).toEqual({
-      label: "Gemini Models · Weekly window",
-      usedPercent: 2.65,
-      periodType: "weekly",
-      resetsAt: "2026-09-01T03:17:57Z",
+      label: "Gemini Models · 5-hour window",
+      usedPercent: 0,
+      periodType: "five_hour",
+      resetsAt: "2026-08-31T19:38:13Z",
       fetchedAt: FETCHED_AT,
       productUsage: [
         {
-          product: "Gemini Models · 5-hour window",
-          usagePercent: 0,
-          resetsAt: "2026-08-31T19:38:13Z",
+          product: "Gemini Models · Weekly window",
+          usagePercent: 2.65,
+          resetsAt: "2026-09-01T03:17:57Z",
         },
         {
           product: "Claude and GPT models · Weekly window",
@@ -416,6 +416,73 @@ describe("Antigravity Adapter", () => {
           resetsAt: "2026-09-07T14:38:13Z",
         },
       ],
+    });
+  });
+
+  it("prefers the 5-hour window over weekly even when weekly usage is higher", () => {
+    const commandWithHigherWeekly = {
+      name: "usage",
+      data: {
+        groups: [
+          {
+            name: "Gemini Models",
+            buckets: [
+              {
+                id: "gemini-weekly",
+                window: "weekly",
+                remaining_fraction: 0.46,
+                reset_time: "2026-09-15T00:56:00Z",
+              },
+              {
+                id: "gemini-5h",
+                window: "5h",
+                remaining_fraction: 0.799,
+                reset_time: "2026-09-11T08:47:00Z",
+              },
+            ],
+          },
+        ],
+      },
+    };
+    const snapshot = parseAntigravityUsageCommand(commandWithHigherWeekly, FETCHED_AT);
+    expect(snapshot).toMatchObject({
+      label: "Gemini Models · 5-hour window",
+      periodType: "five_hour",
+      usedPercent: 20.1,
+    });
+    expect(snapshot?.productUsage).toEqual([
+      {
+        product: "Gemini Models · Weekly window",
+        usagePercent: 54,
+        resetsAt: "2026-09-15T00:56:00Z",
+      },
+    ]);
+  });
+
+  it("falls back to the most consumed window when no 5-hour window is present", () => {
+    const commandWithout5h = {
+      name: "usage",
+      data: {
+        groups: [
+          {
+            name: "Gemini Models",
+            buckets: [
+              {
+                id: "gemini-weekly",
+                window: "weekly",
+                remaining_fraction: 0.46,
+                reset_time: "2026-09-15T00:56:00Z",
+              },
+            ],
+          },
+        ],
+      },
+    };
+    const snapshot = parseAntigravityUsageCommand(commandWithout5h, FETCHED_AT);
+    expect(snapshot).toMatchObject({
+      label: "Gemini Models · Weekly window",
+      periodType: "weekly",
+      usedPercent: 54,
     });
   });
 
@@ -457,7 +524,7 @@ describe("Antigravity Adapter", () => {
       return Promise.resolve(stdout);
     }, new Date(FETCHED_AT));
     expect(calls).toEqual([["--print=/usage", "--output-format", "stream-json"]]);
-    expect(snapshot).toMatchObject({ usedPercent: 2.65, periodType: "weekly" });
+    expect(snapshot).toMatchObject({ usedPercent: 0, periodType: "five_hour" });
   });
 
   it("degrades to null when the CLI cannot answer /usage", async () => {

--- a/packages/renderer-extension/src/renderer-credits-control.ts
+++ b/packages/renderer-extension/src/renderer-credits-control.ts
@@ -108,7 +108,7 @@ export function creditsPeriodLabel(
   return messages.account;
 }
 
-function productLabel(product: string, locale: RendererSettingsLocale): string {
+export function productLabel(product: string, locale: RendererSettingsLocale = "en"): string {
   if (product === "GrokBuild") return "Build";
   if (product === "GrokChat") return "Chat";
   if (product === "GrokImagine") return "Imagine";
@@ -116,11 +116,15 @@ function productLabel(product: string, locale: RendererSettingsLocale): string {
   const messages = rendererCreditsMessages(locale);
   if (product === "5-hour window") return messages.fiveHour;
   if (product === "7-day window") return messages.sevenDay;
+  if (product === "Weekly window") return messages.weekly;
   if (product.endsWith(" · 5-hour window")) {
     return `${product.slice(0, -"5-hour window".length)}${messages.fiveHour}`;
   }
   if (product.endsWith(" · 7-day window")) {
     return `${product.slice(0, -"7-day window".length)}${messages.sevenDay}`;
+  }
+  if (product.endsWith(" · Weekly window")) {
+    return `${product.slice(0, -"Weekly window".length)}${messages.weekly}`;
   }
   return product;
 }
@@ -180,7 +184,9 @@ function renderCreditsHeader(
   // reset line always lands under its own label instead of zig-zagging sides.
   const left = document.createElement("div");
   const label = document.createElement("div");
-  label.textContent = creditsPeriodLabel(credits.periodType, locale);
+  label.textContent = credits.label
+    ? productLabel(credits.label, locale)
+    : creditsPeriodLabel(credits.periodType, locale);
   label.style.fontSize = "12.5px";
   label.style.fontWeight = "600";
   left.append(label);
@@ -478,7 +484,10 @@ export function renderRendererCreditsControl(
   }
   const remaining = remainingPercent(accountCredits.usedPercent);
   const percent = formatRendererCreditsPercent(remaining);
-  const title = `${creditsPeriodLabel(accountCredits.periodType)} ${percent}`;
+  const periodLabel = accountCredits.label
+    ? productLabel(accountCredits.label, locale)
+    : creditsPeriodLabel(accountCredits.periodType, locale);
+  const title = `${periodLabel} ${percent}`;
   const tone = rendererCreditsTone(accountCredits.usedPercent);
   const ringSlot = control.trigger.querySelector<HTMLElement>("[data-codexhost-credits-ring]");
   const label = control.trigger.querySelector<HTMLElement>("[data-codexhost-credits-label]");

--- a/packages/renderer-extension/src/renderer-credits-control.ts
+++ b/packages/renderer-extension/src/renderer-credits-control.ts
@@ -126,6 +126,12 @@ export function productLabel(product: string, locale: RendererSettingsLocale = "
   if (product.endsWith(" · Weekly window")) {
     return `${product.slice(0, -"Weekly window".length)}${messages.weekly}`;
   }
+  if (product.endsWith(" · 5-hour")) {
+    return `${product.slice(0, -"5-hour".length)}${messages.fiveHour}`;
+  }
+  if (product.endsWith(" · 7-day")) {
+    return `${product.slice(0, -"7-day".length)}${messages.sevenDay}`;
+  }
   return product;
 }
 

--- a/packages/renderer-extension/test/renderer-credits-control.test.ts
+++ b/packages/renderer-extension/test/renderer-credits-control.test.ts
@@ -49,6 +49,9 @@ describe("Renderer credits control", () => {
     expect(productLabel("Claude and GPT models · 7-day window", "zh-CN")).toBe(
       "Claude and GPT models · 7 天额度",
     );
+    expect(productLabel("Opus · 7-day")).toBe("Opus · 7-day limit");
+    expect(productLabel("Opus · 7-day", "zh-CN")).toBe("Opus · 7 天额度");
+    expect(productLabel("Model group · 5-hour", "zh-CN")).toBe("Model group · 5 小时额度");
   });
 
   it("formats a same-day reset as a precise time and every other reset as a dated time", () => {

--- a/packages/renderer-extension/test/renderer-credits-control.test.ts
+++ b/packages/renderer-extension/test/renderer-credits-control.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   creditsPeriodLabel,
   formatRendererCreditsReset,
+  productLabel,
   rendererCreditsTone,
 } from "../src/renderer-credits-control.js";
 import { formatRendererCreditsPercent } from "../src/renderer-usage-control.js";
@@ -29,6 +30,25 @@ describe("Renderer credits control", () => {
     expect(creditsPeriodLabel("seven_day", "zh-CN")).toBe("7 天额度");
     expect(creditsPeriodLabel("unknown", "zh-CN")).toBe("账号额度");
     expect(formatRendererCreditsReset("not-a-date")).toBe("not-a-date");
+  });
+
+  it("translates product-scoped labels and limit windows into English and Chinese", () => {
+    expect(productLabel("GrokBuild")).toBe("Build");
+    expect(productLabel("5-hour window")).toBe("5-hour limit");
+    expect(productLabel("7-day window")).toBe("7-day limit");
+    expect(productLabel("Weekly window")).toBe("Weekly limit");
+    expect(productLabel("5-hour window", "zh-CN")).toBe("5 小时额度");
+    expect(productLabel("7-day window", "zh-CN")).toBe("7 天额度");
+    expect(productLabel("Weekly window", "zh-CN")).toBe("周额度");
+    expect(productLabel("Gemini Models · 5-hour window", "zh-CN")).toBe(
+      "Gemini Models · 5 小时额度",
+    );
+    expect(productLabel("Claude and GPT models · Weekly window", "zh-CN")).toBe(
+      "Claude and GPT models · 周额度",
+    );
+    expect(productLabel("Claude and GPT models · 7-day window", "zh-CN")).toBe(
+      "Claude and GPT models · 7 天额度",
+    );
   });
 
   it("formats a same-day reset as a precise time and every other reset as a dated time", () => {


### PR DESCRIPTION
## 背景

Antigravity `/usage` 同时返回 5 小时和周额度窗口。原有展示按消耗比例选择主额度，可能把较长期限的周额度放在最前面；同时共享额度控件对部分 Harness 的产品和模型专属标签本地化不完整。

## 改动

- Antigravity 优先展示 5 小时额度窗口。
- 多个 5 小时窗口时按已用比例排序。
- 没有 5 小时窗口时回退到已用比例最高的窗口。
- 保留其他额度窗口作为产品用量明细。
- 增加 Weekly、5-hour、7-day 窗口的中英文本地化。
- Header 和触发器标题展示产品级额度标签。
- 兼容 Claude Code 的 `Opus · 7-day`、`Model group · 5-hour` 等模型专属标签格式。
- 增加 Antigravity 额度选择、回退逻辑和 Renderer 标签本地化测试。

## 验证

- TypeScript 构建通过。
- Antigravity 与 Renderer 相关测试通过，共 34 项。
- 相关文件 ESLint 检查通过。
- `git diff --check` 通过。