### PR TITLE
fix(linux): start managed Desktop in a new session

### DIFF
--- a/crates/platform/src/background.rs
+++ b/crates/platform/src/background.rs
@@ -51,6 +51,29 @@ pub fn detach_from_terminal() -> Result<(), PlatformError> {
     Ok(())
 }
 
+/// Start a child as the leader of a new session without a controlling terminal.
+///
+/// Like `process_group(0)`, the child becomes its own process-group leader
+/// (PGID == PID), so group-based ownership and cleanup are unchanged. A new
+/// process group alone is still a background job of the invoking terminal:
+/// an interactive shell spawned inside it (for example to resolve the login
+/// environment) opens `/dev/tty` and stops its whole group with SIGTTIN or
+/// SIGTTOU. Without a controlling terminal, job control cannot suspend it.
+#[cfg(target_os = "linux")]
+#[allow(unsafe_code)]
+pub(crate) fn start_in_new_session(command: &mut std::process::Command) {
+    use std::os::unix::process::CommandExt;
+
+    // SAFETY: the hook runs in the child between fork and exec and only calls
+    // setsid(2), which is async-signal-safe and does not allocate. A freshly
+    // forked child is never a process-group leader, so setsid cannot fail
+    // with EPERM here; any error aborts the spawn instead of leaving the child
+    // attached to the terminal.
+    unsafe {
+        command.pre_exec(|| nix::unistd::setsid().map(|_| ()).map_err(io::Error::from));
+    }
+}
+
 #[cfg(target_os = "windows")]
 pub fn detach_from_terminal() -> Result<(), PlatformError> {
     use windows::Win32::System::Console::SetConsoleCtrlHandler;

--- a/crates/platform/src/desktop_launch.rs
+++ b/crates/platform/src/desktop_launch.rs
@@ -1,5 +1,5 @@
 use std::ffi::OsString;
-#[cfg(any(target_os = "macos", target_os = "linux"))]
+#[cfg(target_os = "macos")]
 use std::os::unix::process::CommandExt;
 use std::path::Path;
 #[cfg(not(target_os = "windows"))]
@@ -384,7 +384,7 @@ fn desktop_launch_command(
         let mut command = Command::new(program);
         command.args(additional_arguments);
         #[cfg(target_os = "linux")]
-        command.process_group(0);
+        super::background::start_in_new_session(&mut command);
         command
     };
 
@@ -1063,6 +1063,20 @@ mod tests {
         )
         .expect("launch Desktop executable directly");
         assert_eq!(session.root_snapshot().executable, desktop);
+        // A background process group that keeps the invoking terminal can be
+        // stopped by job control (issue #167); the Desktop must lead its own
+        // session, which also keeps PGID == PID for group-based ownership.
+        let root = nix::unistd::Pid::from_raw(
+            i32::try_from(session.root_snapshot().id).expect("Desktop PID fits i32"),
+        );
+        assert_eq!(
+            nix::unistd::getsid(Some(root)).expect("read Desktop session"),
+            root
+        );
+        assert_eq!(
+            session.root_snapshot().process_group_id,
+            session.root_snapshot().id
+        );
         session
             .shutdown(Duration::from_secs(2))
             .expect("stop fake Desktop");


### PR DESCRIPTION
## Summary

在 Linux 交互式终端中运行 `codexhost launch` 时，托管的 ChatGPT 会被 SIGTTIN 挂起，Desktop Controller 等到超时（#167）。

**原因**：Linux 分支用 `process_group(0)` 启动 Desktop。Desktop 有了自己的进程组，但仍留在调用者终端的会话里，相当于该终端的后台作业。Desktop 启动期间拉起的交互式 shell 发现自己不在终端前台，就会通过作业控制把整个进程组挂起。启动器要等 Host chain 就绪后才调用 `detach_from_terminal()`，而 Desktop 在那之前就已启动，所以必然碰上。

**改动**：Linux 上改为在 exec 前调用 `setsid(2)`，让 Desktop 在新会话中启动。
- 子进程仍是自己进程组的组长（PGID == PID），启动归属判断（`select_managed_desktop_root`）和按进程组清理的逻辑不变。
- 新会话没有控制终端，作业控制无法挂起它。效果与报告者验证有效的 `setsid --fork --wait codexhost launch` 等价。
- `unsafe` 只用在 `background.rs` 一个带 `#[allow(unsafe_code)]` 的小函数里，`pre_exec` 回调中只调用 async-signal-safe 的 `setsid`。
- macOS 正式启动走 LaunchServices，不经过这条路径，未改动。

## Related issues

Fixes #167

## Test plan

已执行：
- `cargo fmt --all --check`：通过
- `cargo clippy --workspace --all-targets --locked --features codexhost-shim/test-utils,codexhost-gate-a-native/gate-tools --target x86_64-unknown-linux-gnu -- -D warnings`：通过
- `cargo clippy -p codexhost-platform --all-targets --target aarch64-unknown-linux-gnu -- -D warnings`，以及 macOS 上的 `codexhost-platform`、`codexhost-launcher`：通过
- `cargo test -p codexhost-platform`（macOS）：42 个通过（走的是非 Linux 路径）
- 机制验证（macOS，伪终端 + zsh 5.9）：只放入新进程组、仍连着终端的 `zsh -ilc` 被作业控制挂起（SIGTTOU）；改用 `setsid` 后正常退出。

新增回归断言：`managed_launch_supervises_the_desktop_executable_directly` 检查托管 Desktop 是自己会话的首进程，且 PGID == PID。

**未验证**：
- 新增断言仅在 Linux 上运行，本地无法执行，依赖 CI 的 `Check ubuntu-22.04` / `Check Linux ARM64`。
- 未在 Linux bash 5 上复现原始 SIGTTIN（报告中的 `si_code=SI_USER` 与 bash 作业控制初始化时对整个进程组发 SIGTTIN 的行为一致，属推断）。
- 未在真实 Linux 桌面的交互式终端中端到端验证 `codexhost launch`，希望 #167 报告者（Ubuntu 26.04 / ChatGPT 26.901.41600）用本 PR 构建确认。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
