### PR TITLE
docs(antigravity): align leadingBucket comment with 5-hour priority

### DIFF
--- a/packages/adapters/antigravity/src/quota.ts
+++ b/packages/adapters/antigravity/src/quota.ts
@@ -92,8 +92,11 @@ function parseBuckets(groups: readonly unknown[]): ParsedBucket[] {
 }
 
 /**
- * Picks the bucket that actually constrains the next Turn: prefers the 5-hour
- * window (most actionable and resets soonest), breaking ties by consumption.
+ * Picks the headline bucket: a 5-hour window always leads because it is the
+ * most actionable and resets soonest, even when a longer window is more
+ * consumed (those stay visible as product usage). Among 5-hour windows, or
+ * among the remaining windows when no 5-hour window exists, the most consumed
+ * bucket leads.
  */
 function leadingBucket(buckets: readonly ParsedBucket[]): ParsedBucket | undefined {
   return [...buckets].sort((left, right) => {


### PR DESCRIPTION
## 背景

#256 改成 5 小时额度优先后，`leadingBucket` 的注释仍写着"选出真正限制下一轮 Turn 的额度"（picks the bucket that actually constrains the next Turn）。现在即使周额度用得更多，也会优先选 5 小时额度，这句话已经不准确。

## 改动

- 只改注释，不改逻辑：说明 5 小时额度总是优先，其他额度放在用量明细里；5 小时额度之间，或没有 5 小时额度时，选用得最多的那个。

## 验证

- Prettier、ESLint 检查通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
