### PR TITLE
fix(host): preserve exact page limits when merging thread catalogs

### DIFF
--- a/packages/host-runtime/src/multi-account-thread-list.ts
+++ b/packages/host-runtime/src/multi-account-thread-list.ts
@@ -117,6 +117,9 @@ export async function aggregateOfficialAccountThreadListPage(input: {
   requestAccountPage(accountId: string, params: JsonObject): Promise<OfficialThreadListPage>;
   observeThread?(threadId: string, accountId: string): Promise<void>;
 }): Promise<OfficialThreadListPage> {
+  // The outer merger may re-request only its consumed prefix. The decoded
+  // desktop query still carries the original, larger page size in that case.
+  const pageLimit = typeof input.params.limit === "number" ? input.params.limit : input.query.limit;
   const cursorValue = typeof input.params.cursor === "string" ? input.params.cursor : null;
   const cursor = cursorValue
     ? decodeCursor(cursorValue)
@@ -155,7 +158,7 @@ export async function aggregateOfficialAccountThreadListPage(input: {
         if (source.done) return null;
       }
       source.batchStart = source.cursor;
-      const page = await request(source, source.cursor, Math.max(1, input.query.limit));
+      const page = await request(source, source.cursor, Math.max(1, pageLimit));
       if (!source.requestedThisPage) {
         source.backwardsCursor = page.backwardsCursor;
         source.requestedThisPage = true;
@@ -178,7 +181,7 @@ export async function aggregateOfficialAccountThreadListPage(input: {
 
   const output: JsonObject[] = [];
   const emitted = new Set<string>();
-  while (output.length < input.query.limit) {
+  while (output.length < pageLimit) {
     const candidates = await Promise.all(
       sources.map(async (source) => ({ source, entry: await ensure(source) })),
     );

--- a/packages/host-runtime/test/multi-account-thread-list.test.ts
+++ b/packages/host-runtime/test/multi-account-thread-list.test.ts
@@ -29,6 +29,33 @@ function source(rows: Record<string, JsonObject[]>) {
 }
 
 describe("Multi-Account official Thread list", () => {
+  it("honors a smaller prefix request without changing the outer query limit", async () => {
+    const decoded = query();
+    const requestAccountPage = source({
+      a: [
+        { id: "a-3", createdAt: 3 },
+        { id: "a-1", createdAt: 1 },
+      ],
+      b: [{ id: "b-2", createdAt: 2 }],
+    });
+    const first = await aggregateOfficialAccountThreadListPage({
+      query: decoded,
+      accountIds: ["a", "b"],
+      params: { ...decoded.params, limit: 1 },
+      requestAccountPage,
+    });
+    expect(first.data.map((thread) => thread.id)).toEqual(["a-3"]);
+    expect(first.nextCursor).not.toBeNull();
+    const next = await aggregateOfficialAccountThreadListPage({
+      query: decoded,
+      accountIds: ["a", "b"],
+      params: { ...decoded.params, cursor: first.nextCursor },
+      requestAccountPage,
+    });
+    expect(next.data.map((thread) => thread.id)).toEqual(["b-2", "a-1"]);
+    expect(next.nextCursor).toBeNull();
+  });
+
   it("merges and paginates Account sources without duplicates or omissions", async () => {
     const requestAccountPage = source({
       a: [

--- a/packages/host-runtime/test/thread-list-aggregator.test.ts
+++ b/packages/host-runtime/test/thread-list-aggregator.test.ts
@@ -16,6 +16,7 @@ import {
   aggregateThreadList,
   officialThreadListPageFromResponse,
 } from "../src/thread-list-aggregator.js";
+import { aggregateOfficialAccountThreadListPage } from "../src/multi-account-thread-list.js";
 
 const harnessId = harnessIdSchema.parse("pi");
 
@@ -93,6 +94,37 @@ function directionalOfficialSource(rowsAscending: JsonObject[]) {
 }
 
 describe("aggregated Thread list", () => {
+  it("paginates mixed Harness and multi-Account pages through exact prefix queries", async () => {
+    const sources = {
+      a: officialSource([official("a-5", 5), official("a-2", 2)]),
+      b: officialSource([official("b-4", 4), official("b-1", 1)]),
+    };
+    const records = [external("external-6", 6), external("external-3", 3)];
+    const ids: unknown[] = [];
+    let cursor: string | null = null;
+    for (let index = 0; index < 4; index += 1) {
+      const decoded = query({ cursor, limit: 2, sortDirection: "desc" });
+      const page = await aggregateThreadList({
+        query: decoded,
+        records,
+        runtimeFor: () => null,
+        requestOfficialPage: (params) =>
+          aggregateOfficialAccountThreadListPage({
+            query: decoded,
+            accountIds: ["a", "b"],
+            params,
+            requestAccountPage: (accountId, params) =>
+              sources[accountId as "a" | "b"].request(params),
+          }),
+      });
+      ids.push(...page.data.map((thread) => thread.id));
+      cursor = page.nextCursor;
+      if (cursor === null) break;
+    }
+    expect(ids).toEqual(["external-6", "a-5", "b-4", "external-3", "a-2", "b-1"]);
+    expect(cursor).toBeNull();
+  });
+
   it("terminates after an empty final official page", async () => {
     const source = officialSource([]);
     const page = await aggregateThreadList({


### PR DESCRIPTION
## Summary

Fix `Thread list aggregation failed` when a page mixes native Codex Threads and external Harness Threads. The outer merger re-requests the exact prefix it consumed, but the multi-Account merger used the original Desktop query limit instead of that smaller request limit. It returned too many rows, so the outer merger rejected the page and Desktop catalog synchronization stayed incomplete.

Use the current page request's limit for both per-Account fetches and merged output. Two regressions cover reduced-prefix continuation and the composed external/multi-Account pagination path, including ordering and no missing or duplicated Threads.

## Related issues

No dedicated tracking issue. Observed while recovering remote Mac conversation discovery after the CodeBuddy/Cursor integrations (#254, #255).

## Validated commit

a188ebaa7de70ff1aa16e4da791048c454901097

## Test plan

- Both new tests failed before the fix (oversized prefix and the exact production aggregation error), then passed.
- Focused Host and pagination tests: **157 passed**.
- Full TypeScript suite: **3521 passed, 35 skipped**.
- Typecheck, lint/boundaries and format checks passed.
- A read-only Mac reproduction with real official app-server pages and existing external metadata failed with the old merger and returned the expected 100-row page after substituting only the corrected account merger. Neither the native database nor mapping records were modified by that probe.
- After updating only the SSH Remote Host, Desktop catalog sync completed with **379 unique Threads across 4 pages**. An existing remote project conversation is visible in the sidebar and its completed history reads successfully. The Mac Desktop process and profile content outside the managed SSH block remained unchanged.
- Exact-head CI passed Windows, macOS, Ubuntu x64 and Linux ARM64. The unchanged Windows Claude Hermetic wrapper timed out once; its owning tests passed locally and the single bounded failed-job rerun passed.
