### PR TITLE
fix(opencode): spawn managed server from a writable cwd

### DIFF
--- a/packages/adapters/opencode/src/server-connection.ts
+++ b/packages/adapters/opencode/src/server-connection.ts
@@ -1,5 +1,7 @@
 import { randomBytes } from "node:crypto";
 import { spawn, spawnSync, type ChildProcessWithoutNullStreams } from "node:child_process";
+import fs from "node:fs";
+import { homedir, tmpdir } from "node:os";
 
 import { createOpencodeClient, type OpencodeClient } from "@opencode-ai/sdk/v2/client";
 
@@ -28,6 +30,7 @@ interface SpawnOptions {
   detached: boolean;
   windowsHide: boolean;
   windowsVerbatimArguments?: boolean;
+  cwd?: string;
 }
 
 export interface OpenCodeServerDependencies {
@@ -121,6 +124,21 @@ function signalProcessTree(child: ChildProcessWithoutNullStreams, signal: NodeJS
   } catch (error) {
     if (!isRecord(error) || error.code !== "ESRCH") throw error;
   }
+}
+
+function safeOpenCodeServerCwd(environment: NodeJS.ProcessEnv): string | undefined {
+  const candidates = [environment.USERPROFILE, environment.HOME, homedir(), tmpdir()];
+  for (const candidate of candidates) {
+    if (!candidate) continue;
+    try {
+      if (!fs.statSync(candidate).isDirectory()) continue;
+      fs.accessSync(candidate, fs.constants.R_OK | fs.constants.W_OK);
+      return candidate;
+    } catch {
+      // Try the next user-writable candidate.
+    }
+  }
+  return undefined;
 }
 
 export interface OpenCodeServerConnectionLike {
@@ -249,6 +267,7 @@ export class OpenCodeServerConnection implements OpenCodeServerConnectionLike {
       OPENCODE_SERVER_PASSWORD: password,
     };
     const invocation = openCodeServerInvocation(executable, environment);
+    const serverCwd = safeOpenCodeServerCwd(environment);
     let child: ChildProcessWithoutNullStreams;
     try {
       child = this.#dependencies.spawn(invocation.command, invocation.arguments, {
@@ -257,6 +276,7 @@ export class OpenCodeServerConnection implements OpenCodeServerConnectionLike {
         detached: process.platform !== "win32",
         windowsHide: true,
         windowsVerbatimArguments: invocation.windowsVerbatimArguments,
+        ...(serverCwd ? { cwd: serverCwd } : {}),
       });
     } catch (error) {
       throw new OpenCodeTransportError(

--- a/packages/adapters/opencode/test/sdk-transport.test.ts
+++ b/packages/adapters/opencode/test/sdk-transport.test.ts
@@ -1,4 +1,5 @@
 import { EventEmitter } from "node:events";
+import { homedir } from "node:os";
 import { PassThrough } from "node:stream";
 import type { ChildProcessWithoutNullStreams } from "node:child_process";
 
@@ -72,7 +73,12 @@ describe("OpenCode SDK transport", () => {
       directory?: string;
       headers: Record<string, string>;
     }> = [];
-    const spawnCalls: Array<{ command: string; args: string[]; env: NodeJS.ProcessEnv }> = [];
+    const spawnCalls: Array<{
+      command: string;
+      args: string[];
+      env: NodeJS.ProcessEnv;
+      cwd?: string;
+    }> = [];
     const dependencies: OpenCodeServerDependencies = {
       createClient: (options) => {
         clientOptions.push(options);
@@ -80,7 +86,12 @@ describe("OpenCode SDK transport", () => {
       },
       randomPassword: () => "synthetic-password",
       spawn: (command, args, options) => {
-        spawnCalls.push({ command, args, env: options.env });
+        spawnCalls.push({
+          command,
+          args,
+          env: options.env,
+          ...(options.cwd ? { cwd: options.cwd } : {}),
+        });
         const child = new FakeChild();
         child.pid += children.length;
         children.push(child);
@@ -103,6 +114,7 @@ describe("OpenCode SDK transport", () => {
     expect(spawnCalls[0]).toMatchObject({
       command: process.execPath,
       args: ["serve", "--hostname=127.0.0.1", "--port=0"],
+      cwd: homedir(),
       env: {
         OPENCODE_SERVER_USERNAME: "codexhost",
         OPENCODE_SERVER_PASSWORD: "synthetic-password",


### PR DESCRIPTION
## Summary

Fixes #265

On Windows, the managed OpenCode server can inherit Codex Desktop's protected
WindowsApps working directory because the adapter previously spawned the child
without an explicit `cwd`.

The OpenCode process itself starts successfully and `/global/health` passes,
but directory-scoped provider discovery can then fail with `EPERM`, causing
CodexHost to surface the generic `External Harness is unavailable` error.

This change gives the managed OpenCode server an explicit writable neutral cwd.
The actual workspace continues to be supplied separately through the OpenCode
SDK `directory` parameter.

## Root cause

Codex Desktop's Host Runtime cwd can be under:

`C:\Program Files\WindowsApps\OpenAI.Codex_<version>\app\`

The OpenCode adapter previously spawned the managed server without an explicit
`cwd`, so the child inherited that protected directory.

With a normal workspace directory, provider discovery could then fail with:

`EPERM: operation not permitted, chdir '<workspace>' -> 'C:\Program Files\WindowsApps\...\app'`

Spawn, stdout handshake, and `/global/health` all succeeded before the failure.

## Fix

Select a writable neutral cwd and pass it explicitly to the managed OpenCode
server spawn.

The requested workspace remains supplied through the OpenCode SDK directory
parameter, so this does not change workspace selection, authentication,
provider semantics, or the existing stdout handshake.

A focused regression test was added for the spawn cwd behavior.

## Validation

Environment:

- CodexHost 0.7.0
- OpenCode 1.18.18
- Windows x64
- Codex Desktop installed under WindowsApps

Before fix:

- child spawn: PASS
- stdout handshake: PASS
- health: PASS
- provider discovery: FAIL
- Thread creation: FAIL
- UI error: `External Harness is unavailable`

After fix, without the user-level OpenCode cwd wrapper:

- child spawn: PASS
- stdout handshake: PASS
- health: PASS
- provider discovery: PASS
- authentication: PASS
- Thread creation: PASS
- real OpenCode model response: PASS

## Checks performed

- `npm.cmd run build:typescript` — PASS
- targeted OpenCode tests — PASS, 9/9
- `npm.cmd run typecheck` — PASS
- formatting checks — PASS
- `npm.cmd run lint` — PASS
- full TypeScript suite — 3531 passed; 7 unrelated Windows symlink/timeout failures

The real Windows regression test was also performed against the source-built
patched adapter, with the external cwd workaround disabled, and a real OpenCode
model response completed successfully.
