### PR TITLE
fix: settle held Claude turns after background completion

### DIFF
--- a/openspec/specs/claude-code-text-session/spec.md
+++ b/openspec/specs/claude-code-text-session/spec.md
@@ -597,6 +597,13 @@ Claude Code SHALL advertise Subagent observation and SHALL map Root `Agent` or `
 - **AND** occupancy SHALL be settled only when the native Session stops opening Segments for this user task, since the number of Segments Claude spends on queued notifications is not observable
 - **AND** Root text, reasoning, Tool Use, or a Segment start SHALL cancel any pending idle decision so a slow continuation cannot close the Turn early
 
+#### Scenario: A held Root Turn receives settlement without a continuation
+- **WHEN** the Root has reached its native Result and a later task notification or live background task level marks an occupied Subagent as settled
+- **THEN** Claude Adapter SHALL start the existing continuation quiescence period while the Root is idle
+- **AND** if no Root continuation starts during that period, it SHALL release the settled Subagents' pending continuation occupancy
+- **AND** it SHALL complete the held Turn and accept another user Turn once no running background Subagents remain
+- **AND** Root output, compaction, or an interaction request SHALL cancel the pending idle decision, and later Subagent settlement SHALL NOT restart it until the Root reaches its next native Result
+
 #### Scenario: Agent Tool result returns
 - **WHEN** the correlated Root Agent or Task Tool Result returns with a stable `agentId`
 - **THEN** Claude Adapter SHALL preserve that native identity for Child Host Thread registration and complete the spawn operation according to the Tool Result outcome
@@ -783,4 +790,3 @@ The Adapter MUST map SDK `rate_limit_event` payloads whose `rateLimitType` is `f
 - **WHEN** utilization is missing, out of range, or `rateLimitType` is not `five_hour` or `seven_day`
 - **THEN** the Adapter MUST ignore that event
 - **AND** Turn outcome and the latest still-applicable Usage MUST remain unchanged
-

--- a/packages/adapters/claude-code/src/claude-code-adapter.ts
+++ b/packages/adapters/claude-code/src/claude-code-adapter.ts
@@ -183,6 +183,8 @@ interface ActiveTurn {
   usageTokensCalibrated: boolean;
   usageCostCalibrated: boolean;
   held: boolean;
+  /** True while Claude can still produce a native result for the current Root Segment. */
+  rootSegmentActive: boolean;
   completion: Promise<void>;
   resolveCompletion(): void;
 }
@@ -829,6 +831,7 @@ class ClaudeHarnessSession implements HarnessSession {
       usageTokensCalibrated: false,
       usageCostCalibrated: false,
       held: false,
+      rootSegmentActive: true,
       completion,
       resolveCompletion,
     };
@@ -941,6 +944,7 @@ class ClaudeHarnessSession implements HarnessSession {
       usageTokensCalibrated: false,
       usageCostCalibrated: false,
       held: false,
+      rootSegmentActive: true,
       completion,
       resolveCompletion,
     };
@@ -1509,23 +1513,25 @@ class ClaudeHarnessSession implements HarnessSession {
     if (this.#active !== active || this.#phase === "closed" || this.#phase === "faulted") return;
     switch (event.type) {
       case "segment.started":
-        this.#observeRootOutput();
+        this.#observeRootOutput(active);
         return;
       case "subagents.live":
         this.#occupancy.observeLive(event.nativeSubagentIds);
+        this.#armContinuationQuiescence(active);
         return;
       case "compaction.started":
+        this.#observeRootOutput(active);
         this.#startCompaction(active);
         return;
       case "compaction.completed":
         this.#completeCompaction(active, event.outcome);
         return;
       case "text.delta":
-        if (event.delta.length > 0) this.#observeRootOutput();
+        if (event.delta.length > 0) this.#observeRootOutput(active);
         this.#appendText(active, event.messageId, event.delta);
         return;
       case "reasoning.delta":
-        if (event.delta.length > 0) this.#observeRootOutput();
+        if (event.delta.length > 0) this.#observeRootOutput(active);
         this.#activateAssistantMessage(active, event.messageId);
         this.#appendReasoning(active, event.messageId, event.delta);
         return;
@@ -1533,6 +1539,10 @@ class ClaudeHarnessSession implements HarnessSession {
         this.#completeReasoning(active, event.messageId, { status: "succeeded" });
         return;
       case "message.completed": {
+        // A continuation may complete its message without emitting text (for example
+        // after a tool or interaction). Keep the quiescence timer from closing the
+        // held Turn until the native result confirms this Segment is done.
+        this.#observeRootOutput(active);
         if (event.lastRequestUsage) {
           this.#requestUsageBoundary += 1;
           this.#applyLatestRequestUsage(active, event.lastRequestUsage);
@@ -1553,7 +1563,7 @@ class ClaudeHarnessSession implements HarnessSession {
         return;
       }
       case "tool.started":
-        this.#observeRootOutput();
+        this.#observeRootOutput(active);
         for (const messageId of [...active.reasoningItems.keys()]) {
           this.#completeReasoning(active, messageId, { status: "succeeded" });
         }
@@ -1567,7 +1577,7 @@ class ClaudeHarnessSession implements HarnessSession {
         active.tools.complete(active.command.turnId, event, active.cancellationRequested);
         return;
       case "subagent.started":
-        this.#observeRootOutput();
+        this.#observeRootOutput(active);
         for (const messageId of [...active.reasoningItems.keys()]) {
           this.#completeReasoning(active, messageId, { status: "succeeded" });
         }
@@ -1634,6 +1644,7 @@ class ClaudeHarnessSession implements HarnessSession {
         return;
       }
       case "interaction.requested":
+        this.#observeRootOutput(active);
         this.#startInteraction(active, event.request);
         return;
       case "interaction.closed":
@@ -1925,6 +1936,7 @@ class ClaudeHarnessSession implements HarnessSession {
       usageTokensCalibrated: false,
       usageCostCalibrated: false,
       held: false,
+      rootSegmentActive: true,
       completion,
       resolveCompletion,
     };
@@ -1949,6 +1961,8 @@ class ClaudeHarnessSession implements HarnessSession {
   ): void {
     // The Subagent stopped, but its Root continuation runs in a later Segment.
     this.#occupancy.notify(callId, nativeSubagentId);
+    const active = this.#active;
+    if (active?.held) this.#armContinuationQuiescence(active);
     if (!nativeSubagentId) return;
     this.#event({
       type: "subagent.state.changed",
@@ -1967,6 +1981,7 @@ class ClaudeHarnessSession implements HarnessSession {
   #finishResult(active: ActiveTurn, result: ClaudeTransportTurnResult): void {
     // A late native terminal cannot substitute for the process shutdown already in progress.
     if (this.#active !== active || this.#hardCancelTask) return;
+    active.rootSegmentActive = false;
     if (result.status === "succeeded" && (active.tools.size > 0 || active.subagents.size > 0)) {
       this.#finishFailed(active, transportFailure("protocol"));
     } else if (result.status === "succeeded") {
@@ -2251,11 +2266,26 @@ class ClaudeHarnessSession implements HarnessSession {
 
   /** Completes held work after a quiet period with no further Root output. */
   #armContinuationQuiescence(active: ActiveTurn): void {
+    if (
+      this.#active !== active ||
+      !active.held ||
+      active.rootSegmentActive ||
+      this.#phase !== "open" ||
+      !this.#occupancy.awaitingContinuation
+    ) {
+      return;
+    }
     this.#clearContinuationQuiescence();
-    if (!this.#occupancy.awaitingContinuation) return;
     const quiescence = setTimeout(() => {
       this.#continuationQuiescence = null;
-      if (this.#active !== active || !active.held || this.#phase !== "open") return;
+      if (
+        this.#active !== active ||
+        !active.held ||
+        active.rootSegmentActive ||
+        this.#phase !== "open"
+      ) {
+        return;
+      }
       this.#occupancy.releaseContinuations();
       if (this.#occupancy.unsettled) return;
       this.#finish(active, { status: "succeeded" });
@@ -2270,7 +2300,8 @@ class ClaudeHarnessSession implements HarnessSession {
     this.#continuationQuiescence = null;
   }
 
-  #observeRootOutput(): void {
+  #observeRootOutput(active: ActiveTurn): void {
+    active.rootSegmentActive = true;
     this.#clearContinuationQuiescence();
   }
 

--- a/packages/adapters/claude-code/test/claude-code-adapter.test.ts
+++ b/packages/adapters/claude-code/test/claude-code-adapter.test.ts
@@ -2474,6 +2474,57 @@ describe("Claude Code HarnessAdapter", () => {
     await session.close();
   });
 
+  it("releases a held Root Turn when a background Subagent settles without a continuation", async () => {
+    const { adapter, transports } = fixture();
+    const session = await openSession(adapter);
+    const iterator = session.outputs[Symbol.asyncIterator]();
+
+    await session.execute(textTurn("launch in background"));
+    await nextEvent(iterator);
+    await nextEvent(iterator);
+    await nextEvent(iterator);
+    const transport = transports[0];
+    if (!transport) throw new Error("Fake Claude transport was not created");
+    transport.event({
+      type: "subagent.started",
+      operation: "spawn",
+      callId: "agent-1",
+      description: "Inspect directory",
+      background: true,
+    });
+    await nextEvent(iterator);
+    transport.event({
+      type: "subagent.completed",
+      callId: "agent-1",
+      isError: false,
+      continuesInBackground: true,
+      nativeSubagentId: "native-agent-1",
+    });
+    await nextEvent(iterator);
+    await nextEvent(iterator);
+    transport.delta("The Subagent is running", "root-1");
+    await nextEvent(iterator);
+    transport.event({ type: "message.completed", messageId: "root-1" });
+    await nextEvent(iterator);
+    transport.finish({ status: "succeeded" });
+    await new Promise((resolve) => {
+      setTimeout(resolve, 0);
+    });
+
+    // The idle notification may carry only the original callId. It still has to
+    // release the held Turn after the native Root result has already arrived.
+    transport.event({ type: "subagent.updated", callId: "agent-1", status: "completed" });
+    await new Promise((resolve) => {
+      setTimeout(resolve, 80);
+    });
+
+    await expect(session.execute(textTurn("after-settlement"))).resolves.toMatchObject({
+      ok: true,
+    });
+    transport.finish({ status: "succeeded" });
+    await session.close();
+  });
+
   it("holds the Root Turn when background Subagents settle before the native result", async () => {
     const { adapter, transports } = fixture();
     const session = await openSession(adapter);


### PR DESCRIPTION
## 总结

Claude 的 Root Turn 在后台 Subagent 已结束、但 Claude 没有产生续轮时，可能会一直保持 held 状态。原因是原有静默计时器启动时，后台任务仍被标记为 running；任务随后结束后没有重新启动计时器。

本 PR 在现有 hold 生命周期上增加 Root Segment 执行状态跟踪：

- Root 原生结果到达后，后台任务通知或 live task level 变化可以重新启动现有静默期。
- Root 正在输出、执行工具、压缩上下文、等待交互或处理续轮消息时，不会被静默计时器提前关闭。
- 增加回归测试，验证没有续轮时 Turn 最终完成，并且下一条用户消息可以正常开始。

## 引用与关联

- 问题诊断引用自维护者在 [PR #253 的合并说明](https://github.com/BytePioneer-AI/codex-host/pull/253#issuecomment-5635701225)：Root Turn 在只收到 task-notification、没有续轮时仍可能挂起。
- 需求背景引用 [Issue #234](https://github.com/BytePioneer-AI/codex-host/issues/234)。
- 实现思路参考 [Daily-AC 的公开分支 `claude-code-async-subagent-no-hold`](https://github.com/Daily-AC/codex-host/tree/claude-code-async-subagent-no-hold)，尤其是对后台任务生命周期和续轮边界的分析。
- 本 PR 没有直接复制该分支的提交；而是基于最新 `main` 和已合并的 #253，保留当前 hold 语义并实现兼容性更好的窄范围修复。该分支涉及的更大范围生命周期重构，以及图片输入问题，仍应单独处理。

Refs #234

## 测试

- `npm exec -- vitest run --config tests/vitest.config.js packages/adapters/claude-code/test/claude-code-adapter.test.ts`（100 项通过）
- `npm exec -- vitest run --config tests/vitest.config.js packages/adapters/claude-code/test`（260 项通过，4 项既有跳过）
- `npm run typecheck`
- `npm run build:typescript`
- `npm run lint`
- `npm run format:check`：Prettier 通过；本机没有 `cargo`，Rust 格式检查未执行。