### PR TITLE
fix(renderer): 识别 Desktop 26.908 的 Request Manager 包装与 draft 身份

### DIFF
--- a/docs/archive/codex-desktop-incidents/26.908-request-manager-wrapper.md
+++ b/docs/archive/codex-desktop-incidents/26.908-request-manager-wrapper.md
@@ -1,0 +1,82 @@
+# Codex Desktop 26.908 Request Manager 包装
+
+本文记录 Codex Desktop `26.908.40834`（build `8881`）把 Composer Fiber 里的 Request Manager 改成 hook 包装对象后，codexhost 连接检查失败的现场结论。本文不是 Codex Desktop 内部 API 的稳定契约；更新 Desktop 后应重新做现场探针。
+
+## 现场环境
+
+- Codex Desktop：`26.908.40834` / build `8881`
+- Codex Framework：`152.0.7977.83`
+- codexhost：`0.7.0`，macOS DMG
+- 路径：本地 Host，`app://-/index.html` 主窗口
+
+## 用户现象
+
+Renderer 扩展已经注入，设置页可打开。CH Renderer 适配器停留在「安装中」，原因是 `draft-routing-policy-unavailable`。Pi、Grok、DeepSeek Harness 等外部 Agent 的连接检查全部失败：
+
+```text
+error.code: internalError
+error.message: Renderer Model request manager is unavailable
+retryable: true
+stage: request
+```
+
+`window.__codexhostDraftPrewarmPolicyV1` 不存在。这不是某一个 Harness 的安装或账号问题。
+
+## 根因
+
+`26.814` 确认的结构是 hook state **本身**就是 outer manager：
+
+```text
+hook.memoizedState = outer manager
+  - requestClient -> inner bridge（sendRequest / prewarmThreadStart / enqueueRequest）
+  - sendRequest
+  - prewarmedThreadManager.discardAllPrewarmedThreads
+  - getHostId()
+```
+
+`26.908.40834` 把同一对象放进包装 hook：
+
+```text
+hook.memoizedState = {
+  hostId: "local",
+  manager: <原 outer manager>,
+  status: "ready"
+}
+```
+
+现场只读探测：现行 finder 匹配 0 个；解开 `.manager` 后匹配 1 个，且 `executionTargetHostId` / `permissionsHostId` 均为 `local`。inner bridge 的 `sendRequest`、`prewarmThreadStart`、`enqueueRequest` 以及 `discardAllPrewarmedThreads` 仍在。不能用压缩类名识别。
+
+因此草稿路由策略装不上，Adapter 无法变为 `ready / request-bridge`，`currentModelClient()` 在连接检查的 request 阶段失败。
+
+codexhost `0.6.2` 与 `0.7.0` 的 finder 无 diff。这是 Desktop Fiber 关系变化，不是 0.7.0 自己改坏查找。
+
+Request Manager 可识别之后，外部 Agent 菜单能打开，但切到 Grok 等 Agent 时会出现 `Models unavailable` / `权限不可用`，标题为 `External configuration could not be applied to the Composer`。原因是另一条 26.908 契约：Composer Fiber memo cache 里的 `client-new-thread:` 身份不再是七槽 atom 包装。
+
+```text
+旧：长度 7，value[2] 为 draft id，value[3] === value[5] === value[6] 且 get() 含 modelSettings
+新：同一 draft id 在更长元组中至少出现两次（现场见长度 13 的 [3,5,6] 与长度 19 的 [2,7]）
+```
+
+只认七槽时 `findComposerModelTarget` 返回 `null`，draft 配置无法写入 Composer。查找必须同时接受七槽 atom 和「同一 `client-new-thread:` 字符串重复出现」的 memo 元组；出现多个不同 draft id 时仍 fail closed。
+
+## 当前有效代码
+
+| 文件 | 作用 |
+| --- | --- |
+| `packages/desktop-control/src/renderer-draft-prewarm-policy.ts` | 安装期 CDP finder：hook state 自身或 `.manager` 通过现有 API 形状后才作为候选。 |
+| `packages/renderer-extension/src/versioned-renderer-adapter.ts` | Adapter 回退查找 unwrap Request Manager 包装；draft 身份同时识别七槽 atom 与重复的 `client-new-thread:` memo 元组。 |
+
+查找仍 fail closed：hostId 必须非空且唯一，`prewarmedThreadManager` 必须存在。不根据压缩类名或函数源码回退。
+
+## 验证
+
+定向测试应覆盖：
+
+- hook state 已是 manager 时仍命中；
+- `{ hostId, manager, status }` 包装命中同一 manager；
+- Host manager registry 和无关的 `.manager` 字段不命中。
+- 七槽 atom draft 身份仍命中；
+- 长度 13/19 且同一 `client-new-thread:` 重复出现时命中；
+- 只出现一次的 draft id 不命中。
+
+实机应在当前 Desktop 版本上确认 Adapter 为 `ready / request-bridge`，并对至少一个外部 Agent 重跑连接检查。切到外部 Agent 后模型按钮应显示真实模型名而不是 `Models unavailable`。

--- a/docs/codex-desktop-upgrade-diagnosis-playbook.md
+++ b/docs/codex-desktop-upgrade-diagnosis-playbook.md
@@ -10,6 +10,7 @@
 相关兼容性债务记录见：
 
 - `docs/archive/codex-desktop-incidents/26.814-compatibility-debt.md`
+- `docs/archive/codex-desktop-incidents/26.908-request-manager-wrapper.md`（Fiber hook 把 Request Manager 包进 `{ hostId, manager, status }` 后，连接检查全部失败）
 
 ## 一、先建立分层模型
 
@@ -215,6 +216,16 @@ inner bridge
   - prewarmThreadStart
   - enqueueRequest: 原型方法
 ```
+
+从 Codex Desktop `26.908.40834` 起，上述 outer manager 不一定等于 `hook.memoizedState`。现场见到的包装是：
+
+```text
+hook.memoizedState = { hostId, manager: outer manager, status }
+```
+
+查找必须先按现有 API 形状检查 hook state，再检查 `.manager`。包装对象本身不是 Request Manager；匹配 0 个时不要直接当成 Desktop 删掉了 bridge。
+
+同一版本里，Composer draft 身份也可能从七槽 atom 变成更长 memo 元组里重复的 `client-new-thread:` 字符串。只认旧七槽时会出现 Agent 能选、但模型/权限显示不可用。详见 `docs/archive/codex-desktop-incidents/26.908-request-manager-wrapper.md`。
 
 注意两点：
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -40,6 +40,7 @@
 | 文档 | 作用 |
 |---|---|
 | [`archive/codex-desktop-incidents/26.814-compatibility-debt.md`](archive/codex-desktop-incidents/26.814-compatibility-debt.md) | 归档 Codex Desktop 26.814 更新导致 Renderer Request Bridge 和 Agent/Model 路由异常的事故记录。 |
+| [`archive/codex-desktop-incidents/26.908-request-manager-wrapper.md`](archive/codex-desktop-incidents/26.908-request-manager-wrapper.md) | 归档 Codex Desktop 26.908 把 Request Manager 包进 Fiber hook `{ hostId, manager, status }` 后连接检查失败的记录。 |
 
 ### DeepSeek Harness 接入
 

--- a/packages/desktop-control/src/renderer-draft-prewarm-policy.ts
+++ b/packages/desktop-control/src/renderer-draft-prewarm-policy.ts
@@ -39,11 +39,44 @@ export function selectRendererRequestManager<Manager, RequestClient>(
   return eligible.length === 1 ? (eligible[0] ?? null) : null;
 }
 
+export function requestManagerFromHookState(value: unknown): object | null {
+  const matchesRequestManager = (candidate: unknown): candidate is object => {
+    if (candidate == null || typeof candidate !== "object") return false;
+    const value = candidate as {
+      requestClient?: {
+        prewarmThreadStart?: unknown;
+        sendRequest?: unknown;
+        enqueueRequest?: unknown;
+      };
+      prewarmedThreadManager?: { discardAllPrewarmedThreads?: unknown };
+      sendRequest?: unknown;
+    };
+    return (
+      value.requestClient != null &&
+      typeof value.requestClient.prewarmThreadStart === "function" &&
+      typeof value.requestClient.sendRequest === "function" &&
+      typeof value.requestClient.enqueueRequest === "function" &&
+      typeof value.prewarmedThreadManager?.discardAllPrewarmedThreads === "function" &&
+      typeof value.sendRequest === "function"
+    );
+  };
+  if (matchesRequestManager(value)) return value;
+  if (
+    value != null &&
+    typeof value === "object" &&
+    matchesRequestManager((value as { manager?: unknown }).manager)
+  ) {
+    return (value as { manager: object }).manager;
+  }
+  return null;
+}
+
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
 const FIND_REQUEST_MANAGER_EXPRESSION = `(() => {
+  const requestManagerFromHookState = ${requestManagerFromHookState.toString()};
   const editors = [...document.querySelectorAll(
     '[data-codex-composer], [contenteditable="true"][role="textbox"]',
   )];
@@ -71,19 +104,8 @@ const FIND_REQUEST_MANAGER_EXPRESSION = `(() => {
     }
     let hook = fiber.memoizedState;
     for (let index = 0; hook != null && index < 120; index += 1, hook = hook.next) {
-      const value = hook.memoizedState;
-      if (
-        value != null &&
-        typeof value === 'object' &&
-        value.requestClient != null &&
-        typeof value.requestClient.prewarmThreadStart === 'function' &&
-        typeof value.requestClient.sendRequest === 'function' &&
-        typeof value.requestClient.enqueueRequest === 'function' &&
-        typeof value.prewarmedThreadManager?.discardAllPrewarmedThreads === 'function' &&
-        typeof value.sendRequest === 'function'
-      ) {
-        managers.add(value);
-      }
+      const manager = requestManagerFromHookState(hook.memoizedState);
+      if (manager != null) managers.add(manager);
     }
   }
   const candidates = [...managers].map((manager) => {

--- a/packages/desktop-control/test/renderer-draft-prewarm-policy.test.ts
+++ b/packages/desktop-control/test/renderer-draft-prewarm-policy.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it, vi } from "vitest";
 import {
   installRendererDraftPrewarmPolicy,
   installRendererDraftPrewarmPolicyDirect,
+  requestManagerFromHookState,
   selectRendererRequestManager,
 } from "../src/renderer-draft-prewarm-policy.js";
 import {
@@ -20,6 +21,28 @@ function requestManagerFixture(): RendererHostRequestManager {
     onNotification: vi.fn(),
     onRequest: vi.fn(),
     dispatchAppServerResponse: vi.fn(),
+  };
+}
+
+function fiberRequestManagerFixture(): {
+  sendRequest: ReturnType<typeof vi.fn>;
+  requestClient: {
+    sendRequest: ReturnType<typeof vi.fn>;
+    prewarmThreadStart: ReturnType<typeof vi.fn>;
+    enqueueRequest: ReturnType<typeof vi.fn>;
+  };
+  prewarmedThreadManager: { discardAllPrewarmedThreads: ReturnType<typeof vi.fn> };
+  getHostId: () => string;
+} {
+  return {
+    sendRequest: vi.fn(),
+    requestClient: {
+      sendRequest: vi.fn(),
+      prewarmThreadStart: vi.fn(),
+      enqueueRequest: vi.fn(),
+    },
+    prewarmedThreadManager: { discardAllPrewarmedThreads: vi.fn() },
+    getHostId: () => "local",
   };
 }
 
@@ -258,6 +281,43 @@ describe("Renderer draft prewarm policy", () => {
     expect(selectRendererRequestManager([candidate], [])).toBe(candidate);
   });
 
+  it("recognizes a Fiber hook state that is already the request manager", () => {
+    const manager = fiberRequestManagerFixture();
+    expect(requestManagerFromHookState(manager)).toBe(manager);
+  });
+
+  it("unwraps a Desktop 26.908 host/manager/status Fiber hook wrapper", () => {
+    const manager = fiberRequestManagerFixture();
+    expect(requestManagerFromHookState({ hostId: "local", manager, status: "ready" })).toBe(
+      manager,
+    );
+  });
+
+  it("prefers the outer manager when it already matches the request-manager shape", () => {
+    const inner = fiberRequestManagerFixture();
+    const outer = fiberRequestManagerFixture();
+    Object.assign(outer, { manager: inner });
+    expect(requestManagerFromHookState(outer)).toBe(outer);
+  });
+
+  it("returns null for a Host manager registry and an unrelated nested manager", () => {
+    expect(
+      requestManagerFromHookState({
+        addManager: () => undefined,
+        getForHostId: () => undefined,
+        waitForManagerForHostId: () => undefined,
+        scope: {},
+      }),
+    ).toBeNull();
+    expect(
+      requestManagerFromHookState({
+        hostId: "local",
+        manager: { getHostId: () => "local" },
+        status: "ready",
+      }),
+    ).toBeNull();
+  });
+
   it("generates syntactically valid main-process code", async () => {
     const evaluate = vi.fn(async (expression: string): Promise<unknown> => {
       expect(() => new Function(`return ${expression}`)).not.toThrow();
@@ -276,10 +336,9 @@ describe("Renderer draft prewarm policy", () => {
     expect(evaluate).toHaveBeenCalledOnce();
     const expression = evaluate.mock.calls[0]?.[0] ?? "";
     expect(expression).toContain("webContents.fromId(17)");
-    expect(expression).toContain("typeof value.requestClient.enqueueRequest === 'function'");
-    expect(expression).toContain(
-      "typeof value.prewarmedThreadManager?.discardAllPrewarmedThreads === 'function'",
-    );
+    expect(expression).toContain("value.requestClient.enqueueRequest");
+    expect(expression).toContain("value.prewarmedThreadManager?.discardAllPrewarmedThreads");
+    expect(expression).toContain("matchesRequestManager(value.manager)");
     expect(expression).toContain("executionTargetHostId");
     expect(expression).toContain("permissionsHostId");
   });

--- a/packages/renderer-extension/src/versioned-renderer-adapter.ts
+++ b/packages/renderer-extension/src/versioned-renderer-adapter.ts
@@ -557,6 +557,22 @@ function isCurrentRequestBridge(value: unknown): value is PrewarmTarget {
   );
 }
 
+function requestTargetOwnerFromHookState(value: unknown): PrewarmTarget | null {
+  if (!isRecord(value)) return null;
+  const ownerFrom = (candidate: unknown): PrewarmTarget | null => {
+    if (!isRecord(candidate)) return null;
+    const requestClient = candidate.requestClient;
+    const bridge = isCurrentRequestBridge(requestClient)
+      ? requestClient
+      : isCurrentRequestBridge(candidate)
+        ? candidate
+        : null;
+    if (!bridge) return null;
+    return typeof candidate.sendRequest === "function" ? (candidate as PrewarmTarget) : bridge;
+  };
+  return ownerFrom(value) ?? ownerFrom(value.manager);
+}
+
 export function findActivePrewarmTargets(root: ParentNode): PrewarmTarget[] {
   const editor = root.querySelector<HTMLElement>(
     '[data-codex-composer], [contenteditable="true"][role="textbox"]',
@@ -590,18 +606,8 @@ export function findActivePrewarmTargets(root: ParentNode): PrewarmTarget[] {
   for (let depth = 0; depth < 200; depth += 1) {
     let hook = fiber.memoizedState as { memoizedState?: unknown; next?: unknown } | null;
     for (let hookIndex = 0; hook && hookIndex < 100; hookIndex += 1) {
-      const hookState = hook.memoizedState;
-      if (isRecord(hookState)) {
-        const requestClient = hookState.requestClient;
-        const bridge = isCurrentRequestBridge(requestClient)
-          ? requestClient
-          : isCurrentRequestBridge(hookState)
-            ? hookState
-            : null;
-        if (bridge) {
-          targets.add(typeof hookState.sendRequest === "function" ? hookState : bridge);
-        }
-      }
+      const owner = requestTargetOwnerFromHookState(hook.memoizedState);
+      if (owner) targets.add(owner);
       hook =
         typeof hook.next === "object" && hook.next !== null
           ? (hook.next as { memoizedState?: unknown; next?: unknown })
@@ -663,7 +669,7 @@ function findComposerConversationThreadId(composer?: Element): HostThreadId | nu
   return threadId;
 }
 
-function isCurrentDraftWrapper(value: unknown): value is readonly unknown[] {
+function isLegacySevenSlotDraftWrapper(value: unknown): value is readonly unknown[] {
   if (
     !Array.isArray(value) ||
     value.length !== 7 ||
@@ -681,6 +687,28 @@ function isCurrentDraftWrapper(value: unknown): value is readonly unknown[] {
   } catch {
     return false;
   }
+}
+
+function duplicatedClientNewThreadId(value: unknown): string | null {
+  if (!Array.isArray(value)) return null;
+  const ids = value.filter(
+    (item): item is string => typeof item === "string" && item.startsWith("client-new-thread:"),
+  );
+  if (ids.length < 2 || ids.some((id) => id !== ids[0])) return null;
+  return ids[0] ?? null;
+}
+
+function draftIdFromMemoValue(value: unknown): string | null {
+  if (
+    isLegacySevenSlotDraftWrapper(value) &&
+    typeof value[2] === "string" &&
+    value[2].startsWith("client-new-thread:")
+  ) {
+    return value[2];
+  }
+  // Codex 26.908 stores the same client-new-thread identity twice in a longer
+  // memo-cache tuple (length 13/19 observed) instead of the seven-slot atom.
+  return duplicatedClientNewThreadId(value);
 }
 
 type ComposerDomIdentity =
@@ -716,13 +744,8 @@ function findComposerDraftIds(composer: Element): Set<string> {
     const memoCache = isRecord(updateQueue) ? updateQueue.memoCache : null;
     const data = isRecord(memoCache) && Array.isArray(memoCache.data) ? memoCache.data : [];
     for (const value of data) {
-      if (
-        isCurrentDraftWrapper(value) &&
-        typeof value[2] === "string" &&
-        value[2].startsWith("client-new-thread:")
-      ) {
-        draftIds.add(value[2]);
-      }
+      const draftId = draftIdFromMemoValue(value);
+      if (draftId) draftIds.add(draftId);
     }
     const parent = fiber.return;
     fiber =

--- a/packages/renderer-extension/test/versioned-renderer-adapter.test.ts
+++ b/packages/renderer-extension/test/versioned-renderer-adapter.test.ts
@@ -121,6 +121,74 @@ describe("current Codex Renderer Agent adapter", () => {
     );
   });
 
+  it("unwraps a Desktop 26.908 host/manager/status hook wrapper to the outer manager", () => {
+    const editor = {
+      parentElement: null,
+      querySelectorAll: () => [],
+    } as unknown as Element;
+    const root = { querySelector: () => editor } as unknown as ParentNode;
+    const addNotificationCallback = vi.fn(() => () => undefined);
+    const requestClient = {
+      hostId: "local",
+      sendRequest: vi.fn<(method: string, params: unknown) => void>(),
+      prewarmThreadStart: () => undefined,
+      enqueueRequest: () => undefined,
+    };
+    const manager = {
+      requestClient,
+      sendRequest: async (method: string, params: unknown) =>
+        requestClient.sendRequest(method, params),
+      addNotificationCallback,
+    };
+    const wrapper = { hostId: "local", manager, status: "ready" };
+    Object.defineProperty(editor, "__reactFiber$test", {
+      configurable: true,
+      value: {
+        memoizedState: {
+          memoizedState: wrapper,
+          next: { memoizedState: wrapper, next: null },
+        },
+        return: null,
+      },
+    });
+
+    expect(findActivePrewarmTargets(root)).toEqual([manager]);
+    expect(findActivePrewarmTargets(root)[0]?.addNotificationCallback).toBe(
+      addNotificationCallback,
+    );
+  });
+
+  it("ignores Host manager registries and unrelated nested manager fields", () => {
+    const editor = {
+      parentElement: null,
+      querySelectorAll: () => [],
+    } as unknown as Element;
+    const root = { querySelector: () => editor } as unknown as ParentNode;
+    Object.defineProperty(editor, "__reactFiber$test", {
+      configurable: true,
+      value: {
+        memoizedState: {
+          memoizedState: {
+            addManager: () => undefined,
+            getForHostId: () => undefined,
+            scope: {},
+          },
+          next: {
+            memoizedState: {
+              hostId: "local",
+              manager: { getHostId: () => "local" },
+              status: "ready",
+            },
+            next: null,
+          },
+        },
+        return: null,
+      },
+    });
+
+    expect(findActivePrewarmTargets(root)).toEqual([]);
+  });
+
   it("keeps local and remote request targets independently addressable", () => {
     const local = {
       hostId: "local",
@@ -315,6 +383,35 @@ describe("current Codex Renderer Agent adapter", () => {
     });
 
     expect(findComposerModelTarget(composer)).toEqual(["default", "client-new-thread:opaque"]);
+  });
+
+  it("finds the Desktop 26.908 duplicated client-new-thread memo identity", () => {
+    const nineteenSlot = Array.from({ length: 19 }, () => ({}));
+    nineteenSlot[2] = "client-new-thread:opaque-19";
+    nineteenSlot[7] = "client-new-thread:opaque-19";
+    const thirteenSlot = Array.from({ length: 13 }, () => ({}));
+    thirteenSlot[3] = "client-new-thread:opaque-13";
+    thirteenSlot[5] = "client-new-thread:opaque-13";
+    thirteenSlot[6] = "client-new-thread:opaque-13";
+    const unduplicated = Array.from({ length: 19 }, () => ({}));
+    unduplicated[2] = "client-new-thread:once";
+
+    const nineteen = composerWithFiber({
+      updateQueue: { memoCache: { data: [nineteenSlot] } },
+      return: null,
+    });
+    const thirteen = composerWithFiber({
+      updateQueue: { memoCache: { data: [thirteenSlot] } },
+      return: null,
+    });
+    const missing = composerWithFiber({
+      updateQueue: { memoCache: { data: [unduplicated] } },
+      return: null,
+    });
+
+    expect(findComposerModelTarget(nineteen)).toEqual(["default", "client-new-thread:opaque-19"]);
+    expect(findComposerModelTarget(thirteen)).toEqual(["default", "client-new-thread:opaque-13"]);
+    expect(findComposerModelTarget(missing)).toBeNull();
   });
 
   it("uses the current Composer conversation identity", () => {


### PR DESCRIPTION
## 目的

修复 Codex Desktop `26.908.40834` 上外部 Agent 全部连接失败，以及随后切 Agent 时模型/权限无法写入 Composer 的问题。

## 关联 Issue

Fixes #269  
Related #268

## 实现范围

- 安装期 CDP finder：识别 `{ hostId, manager, status }` hook 包装，对 `.manager` 做与原来相同的 API 形状检查
- Adapter `findActivePrewarmTargets`：同样 unwrap，并继续留下外层 manager
- Composer draft 身份：在七槽 atom 之外，接受同一 `client-new-thread:` 在 memo 元组中至少出现两次（现场长度 13/19）
- 文档：`docs/archive/codex-desktop-incidents/26.908-request-manager-wrapper.md` 与升级诊断手册指向

未改 Harness Adapter、Host Runtime、连接页文案；不按压缩类名识别。本机独立 `dsh web` 占 3080 导致的 DeepSeek unavailable 不在本次代码范围内。

## 验证

自动测试：

```bash
npx vitest run packages/desktop-control/test/renderer-draft-prewarm-policy.test.ts packages/renderer-extension/test/versioned-renderer-adapter.test.ts --config tests/vitest.config.js
npm run typecheck
```

- renderer-draft-prewarm-policy：通过
- versioned-renderer-adapter：32 项通过
- typecheck：通过

实机（macOS arm64，codexhost `0.7.0` 本地修复 DMG 覆盖 `/Applications/codexhost.app`，Codex Desktop `26.908.40834` / build `8881`）：

- Adapter：`ready / request-bridge`
- 连接：Pi / Grok / OpenCode / Claude Code / Cursor CLI 为 ready
- 切到 Grok 后模型显示 Grok 4.6，权限不再是「权限不可用」
- Composer 可输入

未验证：标题生成、Fork、发完整 Turn 的全路径回归；Windows / Linux。
