### PR TITLE
fix(opencode): isolate managed server working directory

### DIFF
--- a/openspec/specs/opencode-managed-server/spec.md
+++ b/openspec/specs/opencode-managed-server/spec.md
@@ -1,0 +1,28 @@
+# opencode-managed-server Specification
+
+## Purpose
+
+Define the managed OpenCode Server process boundary used by the OpenCode Harness Adapter.
+
+## Requirements
+
+### Requirement: Managed Server startup directory is explicit and writable
+
+The OpenCode Adapter SHALL start its managed OpenCode Server with an explicit, existing,
+readable and writable neutral working directory. It SHALL NOT allow that Server to inherit the
+Host process working directory. The requested workspace directory SHALL continue to be passed
+only to the OpenCode SDK client as its directory scope.
+
+#### Scenario: Host runs from a protected application directory
+
+- **GIVEN** the Host process has a protected or otherwise unsuitable current working directory
+- **WHEN** the Adapter starts its managed OpenCode Server for a writable workspace
+- **THEN** the Server starts from an explicit neutral writable directory
+- **AND** Provider discovery retains the requested workspace as its SDK directory scope
+
+#### Scenario: No safe Server startup directory is available
+
+- **WHEN** the Adapter cannot find a readable and writable neutral directory for the managed
+  Server
+- **THEN** it SHALL fail with an unavailable error before spawning the Server
+- **AND** it SHALL NOT fall back to inheriting the Host process working directory

--- a/packages/adapters/opencode/src/server-connection.ts
+++ b/packages/adapters/opencode/src/server-connection.ts
@@ -1,5 +1,8 @@
 import { randomBytes } from "node:crypto";
 import { spawn, spawnSync, type ChildProcessWithoutNullStreams } from "node:child_process";
+import fs from "node:fs";
+import { homedir, tmpdir } from "node:os";
+import path from "node:path";
 
 import { createOpencodeClient, type OpencodeClient } from "@opencode-ai/sdk/v2/client";
 
@@ -28,6 +31,7 @@ interface SpawnOptions {
   detached: boolean;
   windowsHide: boolean;
   windowsVerbatimArguments?: boolean;
+  cwd?: string;
 }
 
 export interface OpenCodeServerDependencies {
@@ -39,6 +43,7 @@ export interface OpenCodeServerDependencies {
   randomPassword(): string;
   spawn(command: string, args: string[], options: SpawnOptions): ChildProcessWithoutNullStreams;
   sleep(milliseconds: number): Promise<void>;
+  resolveServerCwd?(environment: NodeJS.ProcessEnv): string | undefined;
 }
 
 const DEFAULT_STARTUP_TIMEOUT_MS = 20_000;
@@ -121,6 +126,21 @@ function signalProcessTree(child: ChildProcessWithoutNullStreams, signal: NodeJS
   } catch (error) {
     if (!isRecord(error) || error.code !== "ESRCH") throw error;
   }
+}
+
+function safeOpenCodeServerCwd(environment: NodeJS.ProcessEnv): string | undefined {
+  const candidates = [environment.USERPROFILE, environment.HOME, homedir(), tmpdir()];
+  for (const candidate of candidates) {
+    if (!candidate || !path.isAbsolute(candidate)) continue;
+    try {
+      if (!fs.statSync(candidate).isDirectory()) continue;
+      fs.accessSync(candidate, fs.constants.R_OK | fs.constants.W_OK);
+      return candidate;
+    } catch {
+      // Try the next user-writable candidate.
+    }
+  }
+  return undefined;
 }
 
 export interface OpenCodeServerConnectionLike {
@@ -249,6 +269,13 @@ export class OpenCodeServerConnection implements OpenCodeServerConnectionLike {
       OPENCODE_SERVER_PASSWORD: password,
     };
     const invocation = openCodeServerInvocation(executable, environment);
+    const serverCwd = (this.#dependencies.resolveServerCwd ?? safeOpenCodeServerCwd)(environment);
+    if (!serverCwd) {
+      throw new OpenCodeTransportError(
+        "unavailable",
+        "OpenCode Server requires a writable startup directory",
+      );
+    }
     let child: ChildProcessWithoutNullStreams;
     try {
       child = this.#dependencies.spawn(invocation.command, invocation.arguments, {
@@ -257,6 +284,7 @@ export class OpenCodeServerConnection implements OpenCodeServerConnectionLike {
         detached: process.platform !== "win32",
         windowsHide: true,
         windowsVerbatimArguments: invocation.windowsVerbatimArguments,
+        cwd: serverCwd,
       });
     } catch (error) {
       throw new OpenCodeTransportError(

--- a/packages/adapters/opencode/test/sdk-transport.test.ts
+++ b/packages/adapters/opencode/test/sdk-transport.test.ts
@@ -88,7 +88,12 @@ describe("OpenCode SDK transport", () => {
       },
       randomPassword: () => "synthetic-password",
       spawn: (command, args, options) => {
-        spawnCalls.push({ command, args, env: options.env, cwd: options.cwd });
+        spawnCalls.push({
+          command,
+          args,
+          env: options.env,
+          ...(options.cwd === undefined ? {} : { cwd: options.cwd }),
+        });
         const child = new FakeChild();
         child.pid += children.length;
         children.push(child);

--- a/packages/adapters/opencode/test/sdk-transport.test.ts
+++ b/packages/adapters/opencode/test/sdk-transport.test.ts
@@ -1,4 +1,7 @@
 import { EventEmitter } from "node:events";
+import fs from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
 import { PassThrough } from "node:stream";
 import type { ChildProcessWithoutNullStreams } from "node:child_process";
 
@@ -72,7 +75,12 @@ describe("OpenCode SDK transport", () => {
       directory?: string;
       headers: Record<string, string>;
     }> = [];
-    const spawnCalls: Array<{ command: string; args: string[]; env: NodeJS.ProcessEnv }> = [];
+    const spawnCalls: Array<{
+      command: string;
+      args: string[];
+      env: NodeJS.ProcessEnv;
+      cwd?: string;
+    }> = [];
     const dependencies: OpenCodeServerDependencies = {
       createClient: (options) => {
         clientOptions.push(options);
@@ -80,7 +88,7 @@ describe("OpenCode SDK transport", () => {
       },
       randomPassword: () => "synthetic-password",
       spawn: (command, args, options) => {
-        spawnCalls.push({ command, args, env: options.env });
+        spawnCalls.push({ command, args, env: options.env, cwd: options.cwd });
         const child = new FakeChild();
         child.pid += children.length;
         children.push(child);
@@ -94,7 +102,10 @@ describe("OpenCode SDK transport", () => {
       sleep: async () => undefined,
     };
     const connection = new OpenCodeServerConnection(
-      { command: process.execPath, environment: { PATH: process.env.PATH } },
+      {
+        command: process.execPath,
+        environment: { PATH: process.env.PATH, USERPROFILE: tmpdir() },
+      },
       dependencies,
     );
 
@@ -103,6 +114,7 @@ describe("OpenCode SDK transport", () => {
     expect(spawnCalls[0]).toMatchObject({
       command: process.execPath,
       args: ["serve", "--hostname=127.0.0.1", "--port=0"],
+      cwd: tmpdir(),
       env: {
         OPENCODE_SERVER_USERNAME: "codexhost",
         OPENCODE_SERVER_PASSWORD: "synthetic-password",
@@ -129,6 +141,59 @@ describe("OpenCode SDK transport", () => {
     const second = children[1] as FakeChild;
     second.exitCode = 0;
     await connection.close();
+  });
+
+  it("fails before spawn when no writable startup directory is available", async () => {
+    const spawn = vi.fn();
+    const connection = new OpenCodeServerConnection(
+      { command: process.execPath, environment: { PATH: process.env.PATH } },
+      {
+        createClient: () => clientWith(),
+        randomPassword: () => "synthetic-password",
+        resolveServerCwd: () => undefined,
+        spawn,
+        sleep: async () => undefined,
+      },
+    );
+
+    await expect(connection.client()).rejects.toMatchObject({
+      code: "unavailable",
+      message: "OpenCode Server requires a writable startup directory",
+    });
+    expect(spawn).not.toHaveBeenCalled();
+  });
+
+  it("uses an absolute writable home instead of a relative profile directory", async () => {
+    const serverCwd = fs.mkdtempSync(path.join(tmpdir(), "codexhost-opencode-server-"));
+    const child = new FakeChild();
+    let spawnedCwd: string | undefined;
+    const connection = new OpenCodeServerConnection(
+      {
+        command: process.execPath,
+        environment: { PATH: process.env.PATH, USERPROFILE: ".", HOME: serverCwd },
+      },
+      {
+        createClient: () => clientWith(),
+        randomPassword: () => "synthetic-password",
+        spawn: (_command, _args, options) => {
+          spawnedCwd = options.cwd;
+          queueMicrotask(() => {
+            child.stdout.write("opencode server listening on http://127.0.0.1:4011\n");
+          });
+          return child as unknown as ChildProcessWithoutNullStreams;
+        },
+        sleep: async () => undefined,
+      },
+    );
+
+    try {
+      await expect(connection.client("/workspace")).resolves.toBeDefined();
+      expect(spawnedCwd).toBe(serverCwd);
+      child.exitCode = 0;
+      await connection.close();
+    } finally {
+      fs.rmSync(serverCwd, { recursive: true, force: true });
+    }
   });
 
   it("allows a later retry after startup fails before a child is available", async () => {


### PR DESCRIPTION
## 总结

OpenCode 的受管 Server 之前继承 Host 当前工作目录。在 Windows 上，如果 Host 从受保护的 WindowsApps 目录启动，Provider discovery 可能因 EPERM 失败，最终表现为 OpenCode Harness 不可用。

本 PR：

- 为受管 OpenCode Server 选择明确、存在且可读写的中立启动目录。
- 保留用户工作区作为 OpenCode SDK 的 `directory` 参数，不改变工作区语义。
- 找不到安全启动目录时，在 spawn 前返回 unavailable，不继承受保护 cwd。
- 增加绝对路径、可写目录和 fail-closed 回归测试。

## 引用与关联

- 问题背景引用 [Issue #265](https://github.com/BytePioneer-AI/codex-host/issues/265)。
- 实现参考 [Cresscendoll 的 PR #266](https://github.com/BytePioneer-AI/codex-host/pull/266) 及其提交 `7a6fb671`；本 PR 保留原作者思路并补充相对路径拒绝和无安全目录时的 fail-closed 行为。
- 本机已安装 OpenCode 1.18.27，实际启动与 provider endpoint 检查通过；Issue 报告的是 1.18.18，因此该旧版本 EPERM 未在本机二进制上重现。源码层面的 cwd 继承问题已确认。

Refs #265

## 测试

- OpenCode SDK transport focused tests：15 项通过
- OpenCode TypeScript typecheck：通过
- Prettier、ESLint、git diff --check：通过