### PR TITLE
fix(remote-control): recover native threads through POSIX relays

### DIFF
--- a/packages/desktop-control/src/renderer-draft-prewarm-runtime.ts
+++ b/packages/desktop-control/src/renderer-draft-prewarm-runtime.ts
@@ -75,6 +75,19 @@ export function installDraftPrewarmPolicyBridge(
   let selectedCodexAccountId: string | null = null;
   const isRecord = (value: unknown): value is Record<string, unknown> =>
     typeof value === "object" && value !== null && !Array.isArray(value);
+  const isUnsupportedPosixBridgeSpawn = (value: unknown): boolean => {
+    if (typeof value === "string") {
+      return value.includes("AbsolutePathBuf deserialized without a base path");
+    }
+    if (!isRecord(value)) return false;
+    if (
+      typeof value.message === "string" &&
+      value.message.includes("AbsolutePathBuf deserialized without a base path")
+    ) {
+      return true;
+    }
+    return value.cause !== value && isUnsupportedPosixBridgeSpawn(value.cause);
+  };
   const isRemoteControlHost = hostId.startsWith("remote-control:");
   const knownExternalThreadIds = new Set<string>();
   const knownOfficialThreadIds = new Set<string>();
@@ -524,8 +537,28 @@ export function installDraftPrewarmPolicyBridge(
         : originalSend.call(bridge, method, routedParameters, options);
     const unresolvedThreadId = shouldResolveThreadOwnership(method, routedParameters);
     if (unresolvedThreadId) {
-      return resolveThreadOwnership(unresolvedThreadId).then((owner) =>
-        owner === "external" ? sendBridged() : sendDirect(),
+      return resolveThreadOwnership(unresolvedThreadId).then(
+        (owner) => (owner === "external" ? sendBridged() : sendDirect()),
+        (error) => {
+          // The bridge exists only on a controlled Windows Host. A POSIX Remote
+          // Control relay rejects its Windows `cwd` before it can inspect
+          // ownership, but the same unknown Thread may still be a native Codex
+          // Thread. Keep this narrowly limited to the relay's exact
+          // deserialization error and the two native recovery requests; other
+          // bridge failures must remain visible so an external Thread is never
+          // silently routed to the stock app-server.
+          if (
+            (method === "thread/read" || method === "thread/resume") &&
+            isUnsupportedPosixBridgeSpawn(error)
+          ) {
+            return Promise.resolve(sendDirect()).then((result) => {
+              knownOfficialThreadIds.add(unresolvedThreadId);
+              knownExternalThreadIds.delete(unresolvedThreadId);
+              return result;
+            });
+          }
+          throw error;
+        },
       );
     }
     return shouldUseBridge(method, routedParameters) ? sendBridged() : sendDirect();

--- a/packages/desktop-control/src/renderer-draft-prewarm-runtime.ts
+++ b/packages/desktop-control/src/renderer-draft-prewarm-runtime.ts
@@ -76,15 +76,13 @@ export function installDraftPrewarmPolicyBridge(
   const isRecord = (value: unknown): value is Record<string, unknown> =>
     typeof value === "object" && value !== null && !Array.isArray(value);
   const isUnsupportedPosixBridgeSpawn = (value: unknown): boolean => {
+    const marker = "AbsolutePathBuf deserialized without a base path";
     if (typeof value === "string") {
-      return value.includes("AbsolutePathBuf deserialized without a base path");
+      return value.startsWith("Invalid request:") && value.includes(marker);
     }
     if (!isRecord(value)) return false;
-    if (
-      typeof value.message === "string" &&
-      value.message.includes("AbsolutePathBuf deserialized without a base path")
-    ) {
-      return true;
+    if (typeof value.message === "string" && value.message.includes(marker)) {
+      if (value.code === -32600 || value.message.startsWith("Invalid request:")) return true;
     }
     return value.cause !== value && isUnsupportedPosixBridgeSpawn(value.cause);
   };

--- a/packages/desktop-control/test/renderer-draft-prewarm-policy.test.ts
+++ b/packages/desktop-control/test/renderer-draft-prewarm-policy.test.ts
@@ -846,10 +846,12 @@ describe("Renderer draft prewarm policy", () => {
   it("does not fall back after an unrelated Remote Control bridge failure", async () => {
     const manager = requestManagerFixture();
     const { bridge, directSend } = remoteRequestBridgeFixture();
+    const unrelatedError = Object.assign(
+      new Error("transport: AbsolutePathBuf deserialized without a base path"),
+      { code: -1 },
+    );
     directSend.mockImplementation((method: string) =>
-      method === "process/spawn"
-        ? Promise.reject(new Error("CodexHost Remote Control runtime is not running"))
-        : Promise.resolve({}),
+      method === "process/spawn" ? Promise.reject(unrelatedError) : Promise.resolve({}),
     );
     installDraftPrewarmPolicyBridge(
       manager,
@@ -862,7 +864,7 @@ describe("Renderer draft prewarm policy", () => {
     );
 
     await expect(bridge.sendRequest("thread/read", { threadId: "unknown-thread" })).rejects.toThrow(
-      "CodexHost Remote Control runtime is not running",
+      "transport: AbsolutePathBuf deserialized without a base path",
     );
     expect(directSend).not.toHaveBeenCalledWith("thread/read", { threadId: "unknown-thread" });
   });

--- a/packages/desktop-control/test/renderer-draft-prewarm-policy.test.ts
+++ b/packages/desktop-control/test/renderer-draft-prewarm-policy.test.ts
@@ -810,6 +810,63 @@ describe("Renderer draft prewarm policy", () => {
     expect(writtenBridgeFrames(directSend)).toHaveLength(3);
   });
 
+  it.each(["thread/read", "thread/resume"] as const)(
+    "falls back to the stock app-server for native recovery after the POSIX bridge rejection: %s",
+    async (method) => {
+      const manager = requestManagerFixture();
+      const { bridge, directSend } = remoteRequestBridgeFixture();
+      const posixError = Object.assign(
+        new Error("Invalid request: AbsolutePathBuf deserialized without a base path"),
+        { code: -32600 },
+      );
+      directSend.mockImplementation((requestedMethod: string) =>
+        requestedMethod === "process/spawn"
+          ? Promise.reject(posixError)
+          : Promise.resolve({ thread: { id: "native-posix-thread" } }),
+      );
+      installDraftPrewarmPolicyBridge(
+        manager,
+        bridge,
+        "remote-control:fixture-host",
+        {},
+        {
+          discardAllPrewarmedThreads: vi.fn(),
+        },
+      );
+
+      await expect(
+        bridge.sendRequest(method, { threadId: "native-posix-thread" }),
+      ).resolves.toEqual({
+        thread: { id: "native-posix-thread" },
+      });
+      expect(directSend).toHaveBeenNthCalledWith(2, method, { threadId: "native-posix-thread" });
+    },
+  );
+
+  it("does not fall back after an unrelated Remote Control bridge failure", async () => {
+    const manager = requestManagerFixture();
+    const { bridge, directSend } = remoteRequestBridgeFixture();
+    directSend.mockImplementation((method: string) =>
+      method === "process/spawn"
+        ? Promise.reject(new Error("CodexHost Remote Control runtime is not running"))
+        : Promise.resolve({}),
+    );
+    installDraftPrewarmPolicyBridge(
+      manager,
+      bridge,
+      "remote-control:fixture-host",
+      {},
+      {
+        discardAllPrewarmedThreads: vi.fn(),
+      },
+    );
+
+    await expect(bridge.sendRequest("thread/read", { threadId: "unknown-thread" })).rejects.toThrow(
+      "CodexHost Remote Control runtime is not running",
+    );
+    expect(directSend).not.toHaveBeenCalledWith("thread/read", { threadId: "unknown-thread" });
+  });
+
   it("leaves stock Remote Control requests direct and terminates its bridge on dispose", async () => {
     const manager = requestManagerFixture();
     const { bridge, directSend } = remoteRequestBridgeFixture();


### PR DESCRIPTION
## 目的

修复 Windows Codex Desktop 作为控制端连接 POSIX/macOS Remote Control relay 时，原生 Codex Thread 无法执行 `thread/read` / `thread/resume` 的问题。

## 根因与证据

- 对应 Issue #225：<https://github.com/BytePioneer-AI/codex-host/issues/225>
- Windows 专用 Remote Control bridge 在未知 Thread ownership 查询时会启动 Windows bridge。
- POSIX relay 会在解析 Windows 专用工作目录时返回：`AbsolutePathBuf deserialized without a base path`。
- 该错误发生在 ownership 查询阶段，因此此前请求无法恢复到官方 app-server。

## 修改

- 仅针对 `thread/read` 和 `thread/resume`。
- 仅当错误及其 `cause` 链包含上述精确反序列化错误时，回退到 stock app-server direct request。
- direct request 成功后缓存该 Thread 为官方 Thread，后续请求不再重复查询。
- 其他 Remote Control bridge 错误继续抛出，避免把外部 Harness 请求错误地路由到官方 app-server。

## 验证

- focused policy tests：34 项通过。
- `npm run typecheck`：通过。
- `npm run lint`：通过。
- `git diff --check`：通过。
- 未具备真实跨机器 Windows→macOS relay 环境，因此真实跨主机连接仍需 CI/维护者环境复测。
