### PR TITLE
ci: 并行启动全部平台检查

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,6 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
-      max-parallel: 2
       matrix:
         os:
           - ubuntu-22.04


### PR DESCRIPTION
## Summary

`ci.yml` 的 matrix 有 3 个 OS，但 `strategy.max-parallel: 2` 只允许同时跑 2 个，于是第三个（windows-latest，恰好是最慢的那个）必须先等前两个中的任意一个结束后才能进场，白白闲置约 148s。

这一行是 `ci.yml` 初版（847fc139 "feat: add Linux x64 support"）随模板带进来的，没有注释也没有 commit 说明，不是有意约束。

改动：删除 `max-parallel: 2`，让 4 个 job（3 个 matrix + `check-linux-arm64`）同时开始。

**实测（run 34678315908，#274）**

```
现在：  +148s windows 才开始 → 148 + 307 = 总长 455s
改后：  +0s   windows 开始   →           总长 307s
```

省约 148s（−33%）。注意省的是墙钟，不是 runner 分钟（job 总量不变）；仓库是 public，分钟免费。

## Related issues

无 / N/A

## Test plan

- `npx prettier --check .github/workflows/ci.yml` → All matched files use Prettier code style
- `npx vitest run --config tests/vitest.config.js packages/repository-automation/test/workflows.test.mjs` → 10 passed
  （该测试固定 `CI_JOBS` 与 ci.yml matrix 的名字对应关系，确认 job 名与数量未变，`repository-automation` 的 CI 结果解析不受影响）

未验证：真实并发墙钟收益需合并后在 `main` 的下一次 run 观察（CI 无法在本地复现）。若并行度反而变差，revert 这一行即可。

影响范围仅限调度时机：不改跑哪些 job、不改结论、不动缓存 key、`ci.yml` 无 `needs:` 依赖、`main` 无分支保护。未包含其他优化（Rust 缓存、路径过滤跳过 Rust、`concurrency` 取消过期 run），留作后续单独评估。