### PR TITLE
fix(macos): restore node_repl sandbox startup with a sanitized environment

### DIFF
--- a/crates/shim/src/lib.rs
+++ b/crates/shim/src/lib.rs
@@ -723,10 +723,15 @@ fn child_command(
 /// Desktop helpers that persist only the standard `CODEX_CLI_PATH`
 /// override.
 ///
-/// The launcher-provided path remains authoritative. Installation discovery is
-/// deliberately restricted to a re-entry where `CODEX_CLI_PATH` identifies
-/// this exact Shim, so an unrelated or direct invocation still fails closed.
-fn resolve_stock_codex_path(current_executable: &Path) -> ShimResult<PathBuf> {
+/// The launcher-provided path remains authoritative. Discovery requires the
+/// exact self override, except for macOS node_repl's top-level `sandbox` call:
+/// it resolves the executable before clearing both CLI overrides from the child.
+fn resolve_stock_codex_path(
+    current_executable: &Path,
+    arguments: &[OsString],
+) -> ShimResult<PathBuf> {
+    #[cfg(not(any(target_os = "windows", target_os = "macos")))]
+    let _ = arguments;
     let stock_codex_path = match env::var_os(STOCK_CODEX_PATH_ENV) {
         Some(configured) => PathBuf::from(configured),
         None => {
@@ -735,16 +740,21 @@ fn resolve_stock_codex_path(current_executable: &Path) -> ShimResult<PathBuf> {
 
             #[cfg(any(target_os = "windows", target_os = "macos"))]
             {
-                let cli_override = env::var_os(CODEX_CLI_PATH_ENV)
-                    .map(PathBuf::from)
-                    .ok_or_else(|| format!("{STOCK_CODEX_PATH_ENV} is required"))?;
-                let cli_override = canonical_existing_file(&cli_override)?;
-                let current_executable = canonical_existing_file(current_executable)?;
-                if cli_override != current_executable {
-                    return Err(format!(
-                        "{STOCK_CODEX_PATH_ENV} is required when {CODEX_CLI_PATH_ENV} does not identify the running Shim"
-                    )
-                    .into());
+                if let Some(cli_override) = env::var_os(CODEX_CLI_PATH_ENV) {
+                    let cli_override = canonical_existing_file(&PathBuf::from(cli_override))?;
+                    let current_executable = canonical_existing_file(current_executable)?;
+                    if cli_override != current_executable {
+                        return Err(format!(
+                            "{STOCK_CODEX_PATH_ENV} is required when {CODEX_CLI_PATH_ENV} does not identify the running Shim"
+                        )
+                        .into());
+                    }
+                } else if !cfg!(target_os = "macos")
+                    || arguments
+                        .first()
+                        .is_none_or(|argument| argument != "sandbox")
+                {
+                    return Err(format!("{STOCK_CODEX_PATH_ENV} is required").into());
                 }
                 discover_desktop_managed_codex_cli().map_err(|error| {
                     format!(
@@ -766,7 +776,7 @@ pub fn run_proxy_with_observer(
     observer: &impl ProxyObserver,
 ) -> ShimResult<i32> {
     let current_executable = env::current_exe()?;
-    let stock_codex_path = resolve_stock_codex_path(&current_executable)?;
+    let stock_codex_path = resolve_stock_codex_path(&current_executable, arguments)?;
     observer.invocation(arguments, &stock_codex_path);
 
     let started = Instant::now();

--- a/crates/shim/tests/proxy.rs
+++ b/crates/shim/tests/proxy.rs
@@ -465,6 +465,117 @@ fn macos_browser_helper_preserving_only_cli_override_reaches_official_cli() {
 
 #[cfg(target_os = "macos")]
 #[test]
+fn macos_browser_sandbox_without_cli_environment_reaches_official_cli() {
+    let directory = temporary_directory();
+    let bundle = macos_fixture_bundle(&directory);
+    let mut command = Command::new(shim_path());
+    for (key, _) in std::env::vars_os() {
+        if key.to_string_lossy().starts_with("CODEXHOST_") {
+            command.env_remove(key);
+        }
+    }
+    // node_repl resolves CODEX_CLI_PATH before clearing the kernel child's
+    // environment. Neither CLI override reaches this sandbox invocation.
+    let output = command
+        .args([
+            "sandbox",
+            "-c",
+            "shell_environment_policy.inherit=\"all\"",
+            "--",
+            "/official/node",
+            "--experimental-vm-modules",
+            "/official/kernel.js",
+        ])
+        .env_remove(CODEX_CLI_PATH_ENV)
+        .env(CUSTOM_INSTALL_ROOT_ENV, &bundle)
+        .env("FAKE_CODEX_PRINT_INVOCATION", "1")
+        .env("FAKE_CODEX_EXIT_CODE", "7")
+        .stdin(Stdio::null())
+        .output()
+        .unwrap();
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert_eq!(output.status.code(), Some(7), "{stderr}");
+    assert!(output.stdout.is_empty());
+    assert!(
+        stderr.contains(
+            "args=sandbox|-c|shell_environment_policy.inherit=\"all\"|--|/official/node|--experimental-vm-modules|/official/kernel.js"
+        ),
+        "{stderr}"
+    );
+    assert!(stderr.contains("codex_cli_path_present=false"), "{stderr}");
+    assert!(!directory.join("local-host-runtime-owner.lock").exists());
+    fs::remove_dir_all(directory).unwrap();
+}
+
+#[cfg(target_os = "macos")]
+#[test]
+fn macos_browser_sandbox_fallback_keeps_explicit_targets_authoritative() {
+    let directory = temporary_directory();
+    let bundle = macos_fixture_bundle(&directory);
+    for (key, target, error) in [
+        (
+            STOCK_CODEX_PATH_ENV,
+            directory.join("missing-codex"),
+            "does not exist",
+        ),
+        (STOCK_CODEX_PATH_ENV, shim_path(), "Shim itself"),
+        (
+            CODEX_CLI_PATH_ENV,
+            fake_codex_path(),
+            "does not identify the running Shim",
+        ),
+        (
+            CUSTOM_INSTALL_ROOT_ENV,
+            directory.join("missing-bundle"),
+            "Desktop-managed official Codex CLI could not be discovered",
+        ),
+    ] {
+        let output = Command::new(shim_path())
+            .args(["sandbox", "--", "/usr/bin/true"])
+            .env_remove(STOCK_CODEX_PATH_ENV)
+            .env_remove(CODEX_CLI_PATH_ENV)
+            .env(CUSTOM_INSTALL_ROOT_ENV, &bundle)
+            .env(key, target)
+            .env("PATH", fake_codex_path().parent().unwrap())
+            .stdin(Stdio::null())
+            .output()
+            .unwrap();
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        assert!(!output.status.success(), "{key}: {stderr}");
+        assert!(output.stdout.is_empty());
+        assert!(stderr.contains(error), "{key}: {stderr}");
+    }
+    fs::remove_dir_all(directory).unwrap();
+}
+
+#[cfg(target_os = "macos")]
+#[test]
+fn macos_browser_sandbox_fallback_rejects_unrelated_commands() {
+    let directory = temporary_directory();
+    let bundle = macos_fixture_bundle(&directory);
+    for arguments in [
+        vec!["app-server", "--listen", "stdio://"],
+        vec!["exec", "sandbox"],
+        vec!["--model", "sandbox"],
+    ] {
+        let output = Command::new(shim_path())
+            .args(arguments)
+            .env_remove(STOCK_CODEX_PATH_ENV)
+            .env_remove(CODEX_CLI_PATH_ENV)
+            .env(CUSTOM_INSTALL_ROOT_ENV, &bundle)
+            .stdin(Stdio::null())
+            .output()
+            .unwrap();
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        assert!(!output.status.success(), "{stderr}");
+        assert!(output.stdout.is_empty());
+        assert!(stderr.contains("CODEXHOST_STOCK_CODEX_PATH is required"));
+    }
+    fs::remove_dir_all(directory).unwrap();
+}
+
+#[cfg(target_os = "macos")]
+#[test]
 fn macos_native_helpers_do_not_become_host_runtime_owners() {
     for (depth, detached) in [
         (0, false),

--- a/docs/macos-native-tools.md
+++ b/docs/macos-native-tools.md
@@ -4,12 +4,17 @@ codexhost keeps the Desktop's main app-server on the Host Runtime while routing
 private native-tool app-servers to the official CLI. Tool policy, authentication,
 and approvals remain owned by the official CLI and Desktop.
 
-Two independent macOS helper paths need different handling:
+Three independent macOS helper paths need different handling:
 
 - Browser helpers may preserve only `CODEX_CLI_PATH`. When that path resolves to
   the exact running Shim, it can discover the CLI inside a validated official
   Desktop bundle. An explicit `CODEXHOST_INSTALL_ROOT` remains authoritative;
   a missing/invalid bundle is an error. Discovery never falls back to `PATH`.
+- The `node_repl` kernel resolves that CLI path, then clears both CLI overrides
+  before invoking `sandbox -c ... -- <node> <kernel>`. Only this top-level
+  `sandbox` command may also discover the validated official CLI with neither
+  override present. An explicit invalid target still fails closed. Arguments are
+  forwarded unchanged so the official CLI, not the Shim, enforces the sandbox.
 - Native Computer Use inherits the managed Desktop's full environment. Desktop
   launched via LaunchServices is reparented to `launchd`, so Windows-style ancestry
   to the Launcher cannot identify these helpers. On macOS the Shim verifies the


### PR DESCRIPTION
## Problem and change

Fixes #277.

Codex Desktop 26.908.40834's `node_repl` resolves `CODEX_CLI_PATH` to the Shim, then starts `sandbox -c ... -- <node> <kernel>` with both `CODEX_CLI_PATH` and `CODEXHOST_STOCK_CODEX_PATH` absent. The existing exact-self-override fallback from #164 cannot handle this, so the kernel exits before any JavaScript or browser navigation.

On macOS, let only a top-level `sandbox` invocation also use the existing validated Desktop-bundle CLI discovery when both overrides are absent. Explicit targets remain authoritative, invalid or recursive targets still fail, PATH is never searched, and arguments are passed unchanged to the official CLI. Other commands, Host routing, Windows/Linux behavior, and generated user configuration are unchanged.

## Validation

- Added process regression failed against upstream `c55fd9d` with the reported missing-stock-path error, then passed with the fix.
- `cargo test --offline --locked -p codexhost-shim --features test-utils`: 24 unit tests and 43 process tests passed.
- After aligning the fixture to the current CLI's exact command shape, reran all four `macos_browser_` regressions successfully.
- `cargo clippy --offline --locked -p codexhost-shim --all-targets --features test-utils -- -D warnings` passed.
- `cargo fmt --all --check` and `git diff --check` passed.
- Actual bundled `node_repl` MCP server, using the newly built Shim in an isolated process and no stock-path override: `nodeRepl.write(1 + 1)` returned `2` with `isError: false`. The installed 0.7.1 Shim reproduces the startup failure.
- Negative regressions cover unrelated commands, invalid explicit stock path, self-recursion, an unrelated CLI override, and missing installation without PATH fallback. The success regression checks argument and exit-code preservation.

Rust 1.97.1, macOS arm64; Codex Desktop 26.908.40834 (8881), bundled CLI 0.154.0-alpha.6.2. Local checks used an isolated checkout and temporary toolchain/cache.

## Verification boundary

No live Desktop restart, installation, global MCP edit, or business-page operation was performed. This verifies the real JavaScript kernel startup path; it does not claim a full in-app-browser navigation run after deploying the candidate. Windows/Linux checks are left to CI.
