### PR TITLE
fix(desktop-control): 修复 Remote SSH Renderer 路由

### DIFF
--- a/packages/desktop-control/src/renderer-draft-prewarm-policy.ts
+++ b/packages/desktop-control/src/renderer-draft-prewarm-policy.ts
@@ -39,36 +39,59 @@ export function selectRendererRequestManager<Manager, RequestClient>(
   return eligible.length === 1 ? (eligible[0] ?? null) : null;
 }
 
-export function requestManagerFromHookState(value: unknown): object | null {
+export function requestManagerFromHookState(value: unknown, activeHostId?: string): object | null {
   const matchesRequestManager = (candidate: unknown): candidate is object => {
-    if (candidate == null || typeof candidate !== "object") return false;
-    const value = candidate as {
-      requestClient?: {
-        prewarmThreadStart?: unknown;
-        sendRequest?: unknown;
-        enqueueRequest?: unknown;
-      };
-      prewarmedThreadManager?: { discardAllPrewarmedThreads?: unknown };
-      sendRequest?: unknown;
-    };
+    if (
+      candidate == null ||
+      typeof candidate !== "object" ||
+      !("requestClient" in candidate) ||
+      !("prewarmedThreadManager" in candidate) ||
+      !("sendRequest" in candidate)
+    ) {
+      return false;
+    }
+    const requestClient = candidate.requestClient;
+    const prewarmedThreadManager = candidate.prewarmedThreadManager;
     return (
-      value.requestClient != null &&
-      typeof value.requestClient.prewarmThreadStart === "function" &&
-      typeof value.requestClient.sendRequest === "function" &&
-      typeof value.requestClient.enqueueRequest === "function" &&
-      typeof value.prewarmedThreadManager?.discardAllPrewarmedThreads === "function" &&
-      typeof value.sendRequest === "function"
+      requestClient != null &&
+      typeof requestClient === "object" &&
+      "prewarmThreadStart" in requestClient &&
+      typeof requestClient.prewarmThreadStart === "function" &&
+      "sendRequest" in requestClient &&
+      typeof requestClient.sendRequest === "function" &&
+      "enqueueRequest" in requestClient &&
+      typeof requestClient.enqueueRequest === "function" &&
+      prewarmedThreadManager != null &&
+      typeof prewarmedThreadManager === "object" &&
+      "discardAllPrewarmedThreads" in prewarmedThreadManager &&
+      typeof prewarmedThreadManager.discardAllPrewarmedThreads === "function" &&
+      typeof candidate.sendRequest === "function"
     );
   };
   if (matchesRequestManager(value)) return value;
   if (
     value != null &&
     typeof value === "object" &&
-    matchesRequestManager((value as { manager?: unknown }).manager)
+    "manager" in value &&
+    matchesRequestManager(value.manager)
   ) {
-    return (value as { manager: object }).manager;
+    return value.manager;
   }
-  return null;
+  if (typeof activeHostId !== "string" || activeHostId.length === 0) return null;
+  if (
+    value == null ||
+    typeof value !== "object" ||
+    !("addManager" in value) ||
+    typeof value.addManager !== "function" ||
+    !("getForHostId" in value) ||
+    typeof value.getForHostId !== "function" ||
+    !("waitForManagerForHostId" in value) ||
+    typeof value.waitForManagerForHostId !== "function"
+  ) {
+    return null;
+  }
+  const manager = value.getForHostId.call(value, activeHostId);
+  return matchesRequestManager(manager) ? manager : null;
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -92,19 +115,32 @@ const FIND_REQUEST_MANAGER_EXPRESSION = `(() => {
     if (key != null) fiber = element[key];
     element = element.parentElement;
   }
-  const managers = new Set();
+  const composerFiber = fiber;
   const activeHostIds = new Set();
-  for (let depth = 0; fiber != null && depth < 200; depth += 1, fiber = fiber.return) {
-    const props = fiber.memoizedProps;
+  for (
+    let currentFiber = composerFiber, depth = 0;
+    currentFiber != null && depth < 200;
+    depth += 1, currentFiber = currentFiber.return
+  ) {
+    const props = currentFiber.memoizedProps;
     if (props != null && typeof props === 'object') {
       for (const name of ['executionTargetHostId', 'permissionsHostId']) {
         const value = props[name];
         if (typeof value === 'string' && value.length > 0) activeHostIds.add(value);
       }
     }
-    let hook = fiber.memoizedState;
+  }
+  const activeHostId =
+    activeHostIds.size === 1 ? activeHostIds.values().next().value : undefined;
+  const managers = new Set();
+  for (
+    let currentFiber = composerFiber, depth = 0;
+    currentFiber != null && depth < 200;
+    depth += 1, currentFiber = currentFiber.return
+  ) {
+    let hook = currentFiber.memoizedState;
     for (let index = 0; hook != null && index < 120; index += 1, hook = hook.next) {
-      const manager = requestManagerFromHookState(hook.memoizedState);
+      const manager = requestManagerFromHookState(hook.memoizedState, activeHostId);
       if (manager != null) managers.add(manager);
     }
   }

--- a/packages/desktop-control/test/renderer-draft-prewarm-policy.test.ts
+++ b/packages/desktop-control/test/renderer-draft-prewarm-policy.test.ts
@@ -318,31 +318,6 @@ describe("Renderer draft prewarm policy", () => {
     ).toBeNull();
   });
 
-  it("generates syntactically valid main-process code", async () => {
-    const evaluate = vi.fn(async (expression: string): Promise<unknown> => {
-      expect(() => new Function(`return ${expression}`)).not.toThrow();
-      return { state: "ready", reason: "owned-request-bridge" };
-    });
-    const inspector = {
-      async evaluate<T>(expression: string): Promise<T> {
-        return (await evaluate(expression)) as T;
-      },
-    };
-
-    await expect(installRendererDraftPrewarmPolicy(inspector, 17)).resolves.toEqual({
-      state: "ready",
-      reason: "owned-request-bridge",
-    });
-    expect(evaluate).toHaveBeenCalledOnce();
-    const expression = evaluate.mock.calls[0]?.[0] ?? "";
-    expect(expression).toContain("webContents.fromId(17)");
-    expect(expression).toContain("value.requestClient.enqueueRequest");
-    expect(expression).toContain("value.prewarmedThreadManager?.discardAllPrewarmedThreads");
-    expect(expression).toContain("matchesRequestManager(value.manager)");
-    expect(expression).toContain("executionTargetHostId");
-    expect(expression).toContain("permissionsHostId");
-  });
-
   it("retries while the current Renderer request manager is mounting", async () => {
     const evaluate = vi
       .fn<() => Promise<unknown>>()
@@ -1004,6 +979,73 @@ describe("Renderer draft prewarm policy", () => {
     } finally {
       vi.useRealTimers();
     }
+  });
+
+  it("installs through the active Remote SSH Host manager registry", async () => {
+    const remoteHostId = "remote-ssh-codex-managed:fixture";
+    const localManager = fiberRequestManagerFixture();
+    const remoteManager = {
+      ...fiberRequestManagerFixture(),
+      getHostId: () => remoteHostId,
+    };
+    const getForHostId = vi.fn((hostId: string) =>
+      hostId === remoteHostId ? remoteManager : null,
+    );
+    const registry = {
+      addManager: vi.fn(),
+      getForHostId,
+      waitForManagerForHostId: vi.fn(),
+    };
+    const fiber = {
+      memoizedProps: {
+        executionTargetHostId: remoteHostId,
+        permissionsHostId: remoteHostId,
+      },
+      memoizedState: {
+        memoizedState: registry,
+        next: { memoizedState: localManager, next: null },
+      },
+      return: null,
+    };
+    const editor = { __reactFiber$fixture: fiber, parentElement: null };
+    const document = { querySelectorAll: () => [editor] };
+    const target: Record<string, unknown> = {};
+    const renderer = {
+      async evaluate<T>(expression: string): Promise<T> {
+        try {
+          const run = new Function("document", "window", `return ${expression}`);
+          return (await run(document, target)) as T;
+        } catch (error) {
+          throw new Error("Renderer discovery evaluation failed", { cause: error });
+        }
+      },
+    };
+
+    await expect(installRendererDraftPrewarmPolicyDirect(renderer)).resolves.toEqual({
+      state: "ready",
+      reason: "owned-request-bridge",
+    });
+
+    expect(getForHostId).toHaveBeenCalledOnce();
+    expect(getForHostId).toHaveBeenCalledWith(remoteHostId);
+    const policy = target.__codexhostDraftPrewarmPolicyV1 as {
+      owns(
+        manager: object,
+        requestClient: object,
+        hostId: string,
+        prewarmedThreadManager: object,
+      ): boolean;
+      dispose(): void;
+    };
+    expect(
+      policy.owns(
+        remoteManager,
+        remoteManager.requestClient,
+        remoteHostId,
+        remoteManager.prewarmedThreadManager,
+      ),
+    ).toBe(true);
+    policy.dispose();
   });
 
   it("installs the owned request bridge through direct Renderer evaluation", async () => {


### PR DESCRIPTION
## Summary

Windows Codex Desktop 的 Remote SSH 工作区会将远端 AppServer manager
保存在 Composer Host registry 中，而 Renderer 路由发现此前只能识别直接暴露在
React Hook state 中的 request manager。活动 Host 为远端时，发现结果因此仍只有
Local manager，导致 draft prewarm policy 无法安装，Harness 探测也落到 Local Host。

本次修改：

- 先从 Composer Fiber 收集唯一的活动 Host ID，再扫描 Hook state 中的 request manager。
- 识别包含 `addManager`、`getForHostId` 和 `waitForManagerForHostId` 的 Host registry。
- 使用活动 Host ID 从 registry 取得对应的 Remote SSH manager，并保留原对象作为调用 receiver。
- 对 registry 返回值继续执行完整的 request client 和 prewarmed Thread manager 结构校验。
- 保留多活动 Host、多个候选或结构不完整时的 fail-closed 行为。
- 增加执行真实 Renderer 安装表达式的行为回归测试，覆盖 Local direct manager 与 Remote registry 同时存在的场景。

## Related issues

Closes #281

## Test plan

- [x] `renderer-draft-prewarm-policy.test.ts`：31/31 通过
- [x] `npm run typecheck`
- [x] ESLint：两个变更文件通过
- [x] `npm run build:typescript && npm run build:renderer`
- [x] Release controller bundle 构建及 `node --check`
- [x] `git diff --check`
- [x] Windows 11 Pro x64 / Codex Desktop 26.908.4834.0 实机验证
  - Remote SSH Composer 只有一个活动远端 Host
  - draft prewarm policy 安装成功
  - `requestTarget()` 与活动远端 Host 匹配
  - Connections 选中远端 Host
  - Renderer Adapter 和 Oh My Pi 状态均为正常
  - Oh My Pi Agent 与远端模型选择器可用

未运行完整仓库测试套件；本次验证集中覆盖修改的 Renderer 路由、TypeScript
边界、Renderer 构建及实际 Windows Remote SSH 场景。